### PR TITLE
Added missing/invalid api key error. Closes #1868

### DIFF
--- a/python/api/src/zapv2/__init__.py
+++ b/python/api/src/zapv2/__init__.py
@@ -134,9 +134,15 @@ class ZAPv2(object):
 
         :Parameters:
            - `url`: the url to GET at.
-           - `get`: the disctionary to turn into GET variables.
+           - `get`: the dictionary to turn into GET variables.
         """
-        return json.loads(self.urlopen(url + '?' + urllib.urlencode(get)))
+        try:
+            req = json.loads(self.urlopen(url + '?' + urllib.urlencode(get)))
+            return req
+        except ValueError, e:
+            # If API KEY is required, but not passed
+            # Raising custom error
+            raise ZapError("Invalid or missing API key")
 
     def _request_other(self, url, get={}):
         """
@@ -144,6 +150,6 @@ class ZAPv2(object):
 
         :Parameters:
            - `url`: the url to GET at.
-           - `get`: the disctionary to turn into GET variables.
+           - `get`: the dictionary to turn into GET variables.
         """
         return self.urlopen(url + '?' + urllib.urlencode(get))


### PR DESCRIPTION
The new error traceback:
```python
>>> zap.spider.scan(target)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "build/bdist.linux-x86_64/egg/zapv2/spider.py", line 135, in scan
  File "build/bdist.linux-x86_64/egg/zapv2/__init__.py", line 145, in _request
zapv2.ZapError: Invalid or missing API key
```
[In reference to this issue](https://github.com/zaproxy/zaproxy/issues/1868)
I also took the liberty to fix a few typos.