### PR TITLE
Fix path to .ZAP_JVM.properties in zap.bat

### DIFF
--- a/src/zap.bat
+++ b/src/zap.bat
@@ -1,5 +1,5 @@
-if exist "%HOMEPATH\OWASP ZAP\.ZAP_JVM.properties" (
-	set /p jvmopts=< "%HOMEPATH\OWASP ZAP\.ZAP_JVM.properties"
+if exist "%HOMEPATH%\OWASP ZAP\.ZAP_JVM.properties" (
+	set /p jvmopts=< "%HOMEPATH%\OWASP ZAP\.ZAP_JVM.properties"
 ) else (
 	set jvmopts=-Xmx512m
 )


### PR DESCRIPTION
Hi!

I noticed that zap.bat wasn't picking up my .ZAP_JVM.properties file.
The added percent signs should fix the path.