### PR TITLE
Fixing issue #1875: added TYPE_SCANNER_TEMPORARY to ParosTableHistory and SqlTableHistory

### DIFF
--- a/src/org/parosproxy/paros/db/TableHistory.java
+++ b/src/org/parosproxy/paros/db/TableHistory.java
@@ -121,12 +121,14 @@ public interface TableHistory extends DatabaseListener {
 	/**
 	 * Deletes all records whose history type was marked as temporary (by calling {@code setHistoryTypeTemporary(int)}).
 	 * <p>
-	 * By default the only temporary history type is {@code HistoryReference#TYPE_TEMPORARY}.
+	 * By default the only temporary history types are {@code HistoryReference#TYPE_TEMPORARY} and
+	 * {@code HistoryReference#TYPE_SCANNER_TEMPORARY}.
 	 *
 	 * @throws DatabaseException if an error occurred while deleting the temporary history records
 	 * @see #setHistoryTypeAsTemporary(int)
 	 * @see #unsetHistoryTypeAsTemporary(int)
 	 * @see HistoryReference#TYPE_TEMPORARY
+	 * @see HistoryReference#TYPE_SCANNER_TEMPORARY
 	 */
 	void deleteTemporary() throws DatabaseException;
 

--- a/src/org/parosproxy/paros/db/paros/ParosTableHistory.java
+++ b/src/org/parosproxy/paros/db/paros/ParosTableHistory.java
@@ -92,13 +92,15 @@ public class ParosTableHistory extends ParosAbstractTable implements TableHistor
     /**
      * The {@code Set} of history types marked as temporary.
      * <p>
-     * By default the only temporary history type is {@code HistoryReference#TYPE_TEMPORARY}.
+     * By default the only temporary history types are {@code HistoryReference#TYPE_TEMPORARY} and
+     * {@code HistoryReference#TYPE_SCANNER_TEMPORARY}.
      * <p>
      * Iterations must be done in a {@code synchronized} block with {@code temporaryHistoryTypes}.
      * 
      * @since 2.4
      * @see #setHistoryTypeAsTemporary(int)
      * @see HistoryReference#TYPE_TEMPORARY
+     * @see HistoryReference#TYPE_SCANNER_TEMPORARY
      * @see Collections#synchronizedSet(Set)
      */
     private static Set<Integer> temporaryHistoryTypes = Collections.synchronizedSet(new HashSet<Integer>());
@@ -124,6 +126,7 @@ public class ParosTableHistory extends ParosAbstractTable implements TableHistor
 
     static {
         temporaryHistoryTypes.add(Integer.valueOf(HistoryReference.TYPE_TEMPORARY));
+        temporaryHistoryTypes.add(Integer.valueOf(HistoryReference.TYPE_SCANNER_TEMPORARY));
     }
 
     public ParosTableHistory() {
@@ -713,15 +716,18 @@ public class ParosTableHistory extends ParosAbstractTable implements TableHistor
     /**
      * Unsets the given {@code historyType} as temporary.
      * <p>
-     * Attempting to remove the default temporary history type ({@code HistoryReference#TYPE_TEMPORARY}) has no effect.
-     *
+     * Attempting to remove a default temporary history type (
+     * {@code HistoryReference#TYPE_TEMPORARY} or {@code HistoryReference#TYPE_SCANNER_TEMPORARY})
+     * has no effect.
+     * 
      * @since 2.4
      * @param historyType the history type that will be marked as temporary
      * @see #setHistoryTypeAsTemporary(int)
      * @see #deleteTemporary()
      */
     public static void unsetHistoryTypeAsTemporary(int historyType) {
-        if (HistoryReference.TYPE_TEMPORARY == historyType) {
+        if (HistoryReference.TYPE_TEMPORARY == historyType
+                || HistoryReference.TYPE_SCANNER_TEMPORARY == historyType) {
             return;
         }
         temporaryHistoryTypes.remove(Integer.valueOf(historyType));
@@ -730,12 +736,15 @@ public class ParosTableHistory extends ParosAbstractTable implements TableHistor
     /**
      * Deletes all records whose history type was marked as temporary (by calling {@code setHistoryTypeTemporary(int)}).
      * <p>
-     * By default the only temporary history type is {@code HistoryReference#TYPE_TEMPORARY}.
+     * By default the only temporary history types are {@code HistoryReference#TYPE_TEMPORARY} and
+     * {@code HistoryReference#TYPE_SCANNER_TEMPORARY}.
+     * </p>
      *
      * @throws DatabaseException if an error occurred while deleting the temporary history records
      * @see #setHistoryTypeAsTemporary(int)
      * @see #unsetHistoryTypeAsTemporary(int)
      * @see HistoryReference#TYPE_TEMPORARY
+     * @see HistoryReference#TYPE_SCANNER_TEMPORARY
      */
     @Override
     public void deleteTemporary() throws DatabaseException {

--- a/src/org/zaproxy/zap/db/sql/SqlTableHistory.java
+++ b/src/org/zaproxy/zap/db/sql/SqlTableHistory.java
@@ -68,13 +68,15 @@ public class SqlTableHistory extends SqlAbstractTable implements TableHistory {
     /**
      * The {@code Set} of history types marked as temporary.
      * <p>
-     * By default the only temporary history type is {@code HistoryReference#TYPE_TEMPORARY}.
+     * By default the only temporary history types are {@code HistoryReference#TYPE_TEMPORARY} and
+     * {@code HistoryReference#TYPE_SCANNER_TEMPORARY}.
      * <p>
      * Iterations must be done in a {@code synchronized} block with {@code temporaryHistoryTypes}.
      * 
      * @since 2.4
      * @see #setHistoryTypeAsTemporary(int)
      * @see HistoryReference#TYPE_TEMPORARY
+     * @see HistoryReference#TYPE_SCANNER_TEMPORARY
      * @see Collections#synchronizedSet(Set)
      */
     private static Set<Integer> temporaryHistoryTypes = Collections.synchronizedSet(new HashSet<Integer>());
@@ -621,7 +623,9 @@ public class SqlTableHistory extends SqlAbstractTable implements TableHistory {
     /**
      * Unsets the given {@code historyType} as temporary.
      * <p>
-     * Attempting to remove the default temporary history type ({@code HistoryReference#TYPE_TEMPORARY}) has no effect.
+     * Attempting to remove a default temporary history type (
+     * {@code HistoryReference#TYPE_TEMPORARY} or {@code HistoryReference#TYPE_SCANNER_TEMPORARY})
+     * has no effect.
      *
      * @since 2.4
      * @param historyType the history type that will be marked as temporary
@@ -629,7 +633,8 @@ public class SqlTableHistory extends SqlAbstractTable implements TableHistory {
      * @see #deleteTemporary()
      */
     public static void unsetHistoryTypeAsTemporary(int historyType) {
-        if (HistoryReference.TYPE_TEMPORARY == historyType) {
+        if (HistoryReference.TYPE_TEMPORARY == historyType
+                || HistoryReference.TYPE_SCANNER_TEMPORARY == historyType) {
             return;
         }
         temporaryHistoryTypes.remove(Integer.valueOf(historyType));


### PR DESCRIPTION
Added HistoryReference.TYPE_SCANNER_TEMPORARY to ParosTableHistory.java and SqlTableHistory.java.

*Still wondering if ```private static Set<Integer> temporaryHistoryTypes``` and the methods that modify it should be part of the class HistoryReference instead of duplicating code in ParosTableHistory and SqlTableHistory.*
