### PR TITLE
Add ZAP CLI to Docker images

### DIFF
--- a/build/docker/Dockerfile-stable
+++ b/build/docker/Dockerfile-stable
@@ -8,6 +8,7 @@ RUN mkdir /zap
 RUN gem install zapr
 RUN apt-get --assume-yes install python-pip
 RUN pip install python-owasp-zap-v2.4
+RUN pip install zapcli
 WORKDIR /zap
 RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions-2.4.xml | xmlstarlet sel -t -v //url |grep -i linux | wget --content-disposition -i - -O - | tar zxv 
 
@@ -23,9 +24,12 @@ run echo "zap.sh" >> /home/zap/.xinitrc
 RUN chmod a+x /home/zap/.xinitrc
 RUN chown -R zap /home/zap/
 RUN chmod -R u+rw /home/zap/
+RUN chown -R zap /zap/
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64/
 ENV PATH $JAVA_HOME/bin:/zap/ZAP_2.4.2/:$PATH
 ENV ZAP_PATH /zap/ZAP_2.4.2/zap.sh
+# Default port for use with zapcli
+ENV ZAP_PORT 8080
 ENV HOME /home/zap/
 
 # For noVNC support. Currently broken. Please fix.

--- a/build/docker/Dockerfile-weekly
+++ b/build/docker/Dockerfile-weekly
@@ -8,6 +8,7 @@ RUN mkdir /zap
 RUN gem install zapr
 RUN apt-get --assume-yes install python-pip
 RUN pip install python-owasp-zap-v2.4
+RUN pip install zapcli
 WORKDIR /zap
 RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions-dev.xml | xmlstarlet sel -t -v //url |grep -i weekly | wget --content-disposition -i - 
 RUN unzip *.zip && rm *.zip
@@ -23,9 +24,12 @@ run echo "zap.sh" >> /home/zap/.xinitrc
 RUN chmod a+x /home/zap/.xinitrc
 RUN chown -R zap /home/zap/
 RUN chmod -R u+rw /home/zap/
+RUN chown -R zap /zap/
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64/
 ENV PATH $JAVA_HOME/bin:/zap/weekly/:$PATH
 ENV ZAP_PATH /zap/weekly/zap.sh
+# Default port for use with zapcli
+ENV ZAP_PORT 8080
 ENV HOME /home/zap/
 
 


### PR DESCRIPTION
Add [ZAP CLI](https://github.com/Grunny/zap-cli) to Docker images. ZAP CLI can be used to run quick, targeted
scans with ZAP from within the container. It can be used with the API key
disabled or a custom API key, so that it can be used with the current
version of ZAP in the container which helps address https://github.com/zaproxy/zaproxy/issues/1880.

/cc @psiinon