### PR TITLE
Do not attempt to add a script with missing type, when loading ZAP

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1599,6 +1599,9 @@ script.cmdline.noext				= Script does not have an extension: {0}
 script.cmdline.noengine				= Script Engine not found for extension: {0}
 
 script.desc							= Script integration
+script.info.scriptsNotAdded.message = It was not possible to add the following scripts because of errors:
+script.info.scriptsNotAdded.table.column.scriptName = Script Name
+script.info.scriptsNotAdded.table.column.scriptEngine = Script Engine
 script.interface.httpsender.error   = No script interface found for HttpSender script
 script.interface.proxy.error		= No script interface found for Proxy scripts
 script.interface.targeted.error		= No script interface found for Targeted scripts


### PR DESCRIPTION
Change ExtensionScript#postInit() to only (attempt to) add the scripts,
loaded from the configuration file, if the type is not missing and log,
with WARN level, otherwise.
Change to also catch the exception thrown if unable to add the script,
in case the script configuration is not correct (for example, user tries
to add a script with duplicated name through the command line args).
The user will also be informed, through a dialogue, which of the scripts
were not loaded.
Fix #1949 - Script with missing type prevents scripts and templates from
being loaded