### PR TITLE
Catch Exception when calling AuthenticationScript.authenticate(...)

### DIFF
--- a/src/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
@@ -206,7 +206,9 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
 				script = getScriptsExtension().getInterface(this.script, AuthenticationScript.class);
 				msg = script.authenticate(new AuthenticationHelper(getHttpSender(), sessionManagementMethod,
 						user), this.paramValues, cred);
-			} catch (ScriptException | IOException e) {
+			} catch (Exception e) {
+				// Catch Exception instead of ScriptException and IOException because script engine implementations
+				// might throw other exceptions on script errors (e.g. jdk.nashorn.internal.runtime.ECMAException)
 				log.error("An error occurred while trying to authenticate using the Authentication Script: "
 						+ this.script.getName(), e);
 				getScriptsExtension().setError(this.script, e);


### PR DESCRIPTION
Change ScriptBasedAuthenticationMethod to catch Exception when calling
AuthenticationScript.authenticate(...), to cover all exceptions thrown
by script engine implementations (which throw exceptions of unexpected
type, e.g. jdk.nashorn.internal.runtime.ECMAException instead of
javax.script.ScriptException).
Fix #1950 - Connection closed without response, with an Authentication
script with errors