### PR TITLE
Inform if the authentication script was not yet loaded when adding users

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -387,7 +387,8 @@ authentication.method.script.dialog.error.title				= Script loading error
 authentication.method.script.dialog.error.text.interface	= The provided Authentication script ({0}) does not implement the required interface. Please take a look at the provided templates for examples.
 authentication.method.script.dialog.error.text.loading		= An error has occurred while loading the selected Authentication script: {0}
 authentication.method.script.dialog.error.text.required		= You have not configured a value for the required field: {0} 
-authentication.method.script.dialog.error.text.notLoaded	= You need to load and configure an Authentication Script. 
+authentication.method.script.dialog.error.text.notLoaded	= You need to load an Authentication Script. 
+authentication.method.script.dialog.error.text.notLoadedNorConfigured = You need to load and configure an Authentication Script.
 
 authorization.panel.title									= Authorization
 authorization.panel.label.description 						= This panel allows you to configure how authorized/unauthorized requests are handled by your web application.

--- a/src/org/zaproxy/zap/authentication/AuthenticationMethod.java
+++ b/src/org/zaproxy/zap/authentication/AuthenticationMethod.java
@@ -69,10 +69,27 @@ public abstract class AuthenticationMethod {
 	protected abstract AuthenticationMethod duplicate();
 
 	/**
+	 * Validates that the creation of authentication credentials is possible, returning {@code true} if it is, {@code false}
+	 * otherwise.
+	 * <p>
+	 * If view is enabled the user should be informed that it's not possible to create authentication credentials.
+	 * <p>
+	 * Default implementation returns, always, {@code true}.
+	 * 
+	 * @return {@code true} if the creation of authentication credentials is possible, {@code false} otherwise
+	 * @see #createAuthenticationCredentials()
+	 * @since TODO add version
+	 */
+	public boolean validateCreationOfAuthenticationCredentials() {
+		return true;
+	}
+
+	/**
 	 * Creates a new, empty, Authentication Credentials object corresponding to this type of
 	 * Authentication method.
 	 * 
 	 * @return the authentication credentials
+	 * @see #validateCreationOfAuthenticationCredentials()
 	 */
 	public abstract AuthenticationCredentials createAuthenticationCredentials();
 

--- a/src/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
@@ -40,6 +40,7 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
+import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.authentication.GenericAuthenticationCredentials.GenericAuthenticationCredentialsOptionsPanel;
 import org.zaproxy.zap.extension.api.ApiDynamicActionImplementor;
@@ -176,6 +177,20 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
 		}
 
 		@Override
+		public boolean validateCreationOfAuthenticationCredentials() {
+			if (credentialsParamNames != null) {
+				return true;
+			}
+
+			if (View.isInitialised()) {
+				View.getSingleton().showMessageDialog(
+						Constant.messages.getString("authentication.method.script.dialog.error.text.notLoaded"));
+			}
+
+			return false;
+		}
+
+		@Override
 		public AuthenticationCredentials createAuthenticationCredentials() {
 			return new GenericAuthenticationCredentials(this.credentialsParamNames);
 		}
@@ -299,7 +314,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
 				this.scriptsComboBox.requestFocusInWindow();
 				throw new IllegalStateException(
 						Constant.messages
-								.getString("authentication.method.script.dialog.error.text.notLoaded"));
+								.getString("authentication.method.script.dialog.error.text.notLoadedNorConfigured"));
 			}
 			this.dynamicFieldsPanel.validateFields();
 		}

--- a/src/org/zaproxy/zap/extension/users/ContextUsersPanel.java
+++ b/src/org/zaproxy/zap/extension/users/ContextUsersPanel.java
@@ -114,6 +114,11 @@ public class ContextUsersPanel extends AbstractContextPropertiesPanel {
 
 		@Override
 		public User showAddDialogue() {
+			boolean valid = uiSharedContext.getAuthenticationMethod().validateCreationOfAuthenticationCredentials();
+			if (!valid) {
+				return null;
+			}
+
 			if (addDialog == null) {
 				addDialog = new DialogAddUser(View.getSingleton().getOptionsDialog(null), this.extension);
 				addDialog.pack();


### PR DESCRIPTION
Change AuthenticationMethod to allow to validate the creation of users
(i.e. AuthenticationCredentials).
Change ContextUsersPanel to validate the creation of users before
showing the dialogue to create them.
Change ScriptBasedAuthenticationMethodType to, when validating, inform
and prevent the creation of users if the script was not yet loaded.
Tweak resource messages to differentiate from script not yet loaded and
a script not yet loaded nor configured.
Fix #1951 - Exception when trying to add users before loading an
authentication script