### PR TITLE
Load plugins' state when loading all plugins from a policy file

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/src/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -784,16 +784,23 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
     
     @Override
     public void saveTo(Configuration conf) {
-        setProperty(conf, "enabled", getProperty("enabled"));
+        setProperty(conf, "enabled", Boolean.toString(enabled));
         setProperty(conf, "level", getProperty("level"));
         setProperty(conf, "strength", getProperty("strength"));
     }
     
     @Override
     public void loadFrom(Configuration conf) {
-        setProperty("enabled", getProperty(conf, "enabled"));
         setProperty("level", getProperty(conf, "level"));
         setProperty("strength", getProperty(conf, "strength"));
+        String enabledProperty = getProperty(conf, "enabled");
+        if (enabledProperty != null) {
+            enabled = Boolean.parseBoolean(enabledProperty);
+        } else {
+            enabled = getAlertThreshold() != AlertThreshold.OFF;
+            enabledProperty = Boolean.toString(enabled);
+        }
+        setProperty("enabled", enabledProperty);
     }
 
     @Override

--- a/src/org/parosproxy/paros/core/scanner/PluginFactory.java
+++ b/src/org/parosproxy/paros/core/scanner/PluginFactory.java
@@ -298,6 +298,7 @@ public class PluginFactory {
                     Plugin plugin = getLoadedPlugins().get(i);
                     plugin.setConfig(config);
                     plugin.createParamIfNotExist();
+                    plugin.loadFrom(config);
                     if (!plugin.isVisible()) {
                         log.info("Plugin " + plugin.getName() + " not visible");
                         continue;


### PR DESCRIPTION
Change PluginFactory.loadAllPlugin(Configuration) to call the method
Plugin.loadFrom(Configuration) to make sure that the plugin's state is
loaded from the policy file.
Change AbstractPlugin.saveTo(Configuration) and loadFrom(Configuration)
to save/load the in-memory enabled state, otherwise the AbstractPlugin
would not save the (current) enabled state and/or would be kept enabled
even if it was disabled in the provided policy file.
Add tests to AbstractPluginUnitTest to assert the expected behaviour.
Fix #1971 - Active scanners' enabled state not correctly restored from
policy file