### PR TITLE
Include correct redirection messages in the HAR/list returned by the API

### DIFF
--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -467,7 +467,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 
 					sender.sendAndReceive(tempReq);
 					persistMessage(tempReq);
-					processor.process(request);
+					processor.process(tempReq);
 				}
 			}
 		} finally {


### PR DESCRIPTION
Use the correct variable ("tempReq" instead of "request") when adding
the redirection messages to the HAR/list, in the method
CoreAPI.sendRequest(HttpMessage, boolean, Processor<HttpMessage>).
Fix #1973 - Returned HAR/list does not contain correct redirection
messages