### PR TITLE
Tidy up of scanners IDs (add, restore, fix duplicates and deprecate)

### DIFF
--- a/src/doc/alerts.xml
+++ b/src/doc/alerts.xml
@@ -44,14 +44,18 @@ This list the alerts
 6		Directory/Path traversal
 7		Remote File Inclusion
 
+41	Source Code Disclosure - Git 
+42	Source Code Disclosure - SVN
+43	Source Code Disclosure - File Inclusion
+
 10000	Password Autocomplete in browser (Depreciated)
-10001	Secure page browser cache
+10001	Secure page browser cache (Deprecated)
 
 10010	Cookie set without HttpOnly flag
 10011	Cookie set without secure flag
 10012	Password Autocomplete in browser
-10013	Weak HTTP authentication over an unsecured connection
-10014	Cross Site Request Forgery
+10013	Weak HTTP authentication over an unsecured connection (Deprecated)
+10014	Cross Site Request Forgery (Deprecated)
 10015	Incomplete or no cache-control and pragma HTTPHeader set
 10016   Web Browser XSS Protection Not Enabled
 10017	Cross-domain JavaScript source file inclusion
@@ -59,7 +63,7 @@ This list the alerts
 10019	Content-Type header missing
 10020	X-Frame-Options header not set
 10021	X-Content-Type-Options header missing
-10022	Information disclosure - database error messages
+10022	Information disclosure - database error messages (Deprecated)
 10023	Information disclosure - debug error messages
 10024	Information disclosure - sensitive informations in URL
 10025	Information disclosure - sensitive informations on HTTP Referrer header
@@ -86,11 +90,22 @@ This list the alerts
 10046	Insecure Component
 10047	HTTPS Content Available via HTTP
 10048	ShellShock
-10049   Image Location Scanner - passive scanner finding
-10050   TestUserAgent
+10049   Cacheability and Retrievability Content
+10050   Retrieved from Cache
+10051   Relative Path Confusion
+10094   Base64 Disclosure
+10095   Backup File Disclosure
+10096   Timestamp Disclosure
+10097   Hash Disclosure
+10098   Cross-Domain Misconfiguration
+10099   Source Code Disclosure
 
 10101	Insufficient Authentication
 10102	Insufficient Authorization
+
+10103   Image Location Scanner - passive scanner finding
+10104   TestUserAgent
+10105   Weak Authentication Method
 
 20000	Cold Fusion default file (Depreciated)
 20001	Lotus Domino default files (Depreciated)
@@ -100,6 +115,7 @@ This list the alerts
 20005	BEA WebLogic example files (Depreciated)
 20006	IBM WebSphere default files (Depreciated)
 20010	URL Redirector Abuse
+20012	Anti CSRF Tokens Scanner
 20014	HTTP Parameter Pollution
 20015   Heartbleed OpenSSL Vulnerability
 20016	Cross-Domain Requests Permitted
@@ -111,19 +127,19 @@ This list the alerts
 30002  Check for proper format string handling in back end c code.
 30003  Check for proper integer handling in back end c code.
 
-40000	Cross site scripting
-40001	Cross site scripting in SCRIPT section 
-40002	Cross site scripting without brackets
+40000	Cross site scripting (Deprecated)
+40001	Cross site scripting in SCRIPT section (Deprecated)
+40002	Cross site scripting without brackets (Deprecated)
 40003	CRLF injection
-40004	SQL Injection Fingerprinting
-40005	SQL Injection
-40006	MS SQL Injection Enumeration
-40007	Oracle SQL Injection Enumeration
+40004	SQL Injection Fingerprinting (Deprecated)
+40005	SQL Injection (Deprecated)
+40006	MS SQL Injection Enumeration (Deprecated)
+40007	Oracle SQL Injection Enumeration (Deprecated)
 40008	Parameter tampering
 40009	Server side include
-40010	Cross site scripting in TAG
-40011	Cross Site Scripting in TAG Attribute
-40012	CSRF Token missing
+40010	Cross site scripting in TAG (Deprecated)
+40011	Cross Site Scripting in TAG Attribute (Deprecated)
+40012	Cross Site Scripting (Reflected)
 40013	Session Fixation
 40014	Persistent XSS (Attack)
 40015	LDAP Injection
@@ -136,7 +152,8 @@ This list the alerts
 40022	SQL Injection Postgresql
 40023	Username Enumeration
 40024	SQL Injection SQLite
-40025	Cross site scripting (DOM)
+40025	Proxy Disclosure
+40026	Cross site scripting (DOM)
 
 50000	Active Scan scripts
 50001	Passive Scan scripts
@@ -147,6 +164,8 @@ This list the alerts
 60100	Example simple active rule 
 60101	Example file active rule 
 
+90001	Insecure JSF ViewState
+90011	Charset Mismatch
 90018	SQL Injection SQLMap
 90019	Code Injection
 90020	Command Injection
@@ -160,6 +179,7 @@ This list the alerts
 90028	Insecure HTTP Method
 90029   SOAP XML Injection
 90030   WSDL File Detection
+90033   Loosely Scoped Cookie
 
 To be developed:
 .	Check session cookie for secured


### PR DESCRIPTION
Add:
 - 41, Source Code Disclosure - Git
 - 42, Source Code Disclosure - SVN
 - 43, Source Code Disclosure - File Inclusion
 - 10094, Base64 Disclosure
 - 10095, Backup File Disclosure
 - 10096, Timestamp Disclosure
 - 10097, Hash Disclosure
 - 10098, Cross-Domain Misconfiguration
 - 10099, Source Code Disclosure
 - 20012, Anti CSRF Tokens Scanner
 - 90001, Insecure JSF ViewState
 - 90011, Charset Mismatch
 - 90033, Loosely Scoped Cookie

Restore:
 - 10049, Cacheability and Retrievability Content
 - 10050, Retrieved from Cache
 - 10051, Relative Path Confusion
 - 40025, Proxy Disclosure

The IDs were "lost" in another branch (the changes were not applied nor
merged to the main branch), @5520bcaff2c532bfad894fa1ca764f18b37867b1.

Fix duplicates (some caused by the lost IDs):
 - 10049 -> 10103, Image Location Scanner
 - 10050 -> 10104, TestUserAgent
 - 40017 -> 10105, Weak Authentication Method
 - 40025 -> 40026, Cross site scripting (DOM)

Deprecate (scanners no longer exist):
 - 10001, Secure page browser cache
 - 10013, Weak HTTP authentication over an unsecured connection
 - 10014, Cross Site Request Forgery
 - 10022, Information disclosure - database error messages
 - 40000, Cross site scripting
 - 40001, Cross site scripting in SCRIPT section
 - 40002, Cross site scripting without brackets
 - 40004, SQL Injection Fingerprinting
 - 40005, SQL Injection
 - 40006, MS SQL Injection Enumeration
 - 40007, Oracle SQL Injection Enumeration
 - 40010, Cross site scripting in TAG
 - 40011, Cross Site Scripting in TAG Attribute

Change name of 40012 to "Cross Site Scripting (Reflected)", the previous
name "CSRF Token missing" was from a scanner with same ID (which no
longer exist).