### PR TITLE
Quote variables JMEM and MEM in zap.sh script

### DIFF
--- a/src/zap.sh
+++ b/src/zap.sh
@@ -73,21 +73,21 @@ elif [ "$OS" = "FreeBSD" ]; then
   MEM=$(($(sysctl -n hw.physmem)/1024/1024))
 fi
 
-if [ ! -z $JMEM ]; then
+if [ ! -z "$JMEM" ]; then
   echo "Using jvm memory setting from $JVMPROPS"
-elif [ -z $MEM ]; then
+elif [ -z "$MEM" ]; then
   echo "Failed to obtain current memory, using jvm default memory settings"
 else
-  echo "Available memory: " $MEM "MB"
-  if [ $MEM -gt 1500 ]
+  echo "Available memory: $MEM MB"
+  if [ "$MEM" -gt 1500 ]
   then
     JMEM="-Xmx512m"
   else
-    if [ $MEM -gt 900 ]
+    if [ "$MEM" -gt 900 ]
     then
       JMEM="-Xmx256m"
     else
-      if [ $MEM -gt 512 ]
+      if [ "$MEM" -gt 512 ]
       then
         JMEM="-Xmx128m"
       fi


### PR DESCRIPTION
Quote the variables in if statements to avoid issues with the contents
of the variables (specially JMEM which might contain spaces, breaking
the script, if multiple JVM arguments are specified in the ZAP options).
Merge an echoed string which use MEM variable.
Fix suggested in #1934 (also related to #1877).