### PR TITLE
Change CustomScanDialog to not cache ScanPolicy, once closed

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/PolicyManager.java
+++ b/src/org/zaproxy/zap/extension/ascan/PolicyManager.java
@@ -106,7 +106,14 @@ public class PolicyManager {
     	}
 	}
 	
-	private boolean policyExists(String name) {
+	/**
+	 * Tells whether or not a scan policy with the given {@code name} exists.
+	 *
+	 * @param name the name of the scan policy
+	 * @return {@code true} if the scan policy exists, {@code false} otherwise
+	 * @since TODO add version
+	 */
+	public static boolean policyExists(String name) {
 		return (new File(Constant.getPoliciesDir(), name + POLICY_EXTENSION)).exists();
 		
 	}


### PR DESCRIPTION
Change CustomScanDialog to stop referencing the ScanPolicy created for
the dialogue once the dialogue is closed (or hidden).
The dialogue now just caches the name of the selected policy, obtaining
the ScanPolicy when the dialogue is (re)initialised.
Change PolicyManager class to expose the method that allows to check if
a policy exists (policyExists(String)), to handle the cases when the
policy is removed/renamed.
Fix #1960 - Active Scan dialogue might use outdated scan policy