### PR TITLE
Notify listeners that the script was changed when changing enabled state

### DIFF
--- a/src/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/src/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -1206,6 +1206,17 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 			this.getTreeModel().nodeStructureChanged(node.getParent());
 		}
 		
+		notifyScriptChanged(script);
+	}
+
+	/**
+	 * Notifies the {@code ScriptEventListener}s that the given {@code script} was changed.
+	 *
+	 * @param script the script that was changed, must not be {@code null}
+	 * @see #listeners
+	 * @see ScriptEventListener#scriptChanged(ScriptWrapper)
+	 */
+	private void notifyScriptChanged(ScriptWrapper script) {
 		for (ScriptEventListener listener : this.listeners) {
 			try {
 				listener.scriptChanged(script);
@@ -1222,6 +1233,8 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 
 		script.setEnabled(enabled);
 		this.getTreeModel().nodeStructureChanged(script);
+
+		notifyScriptChanged(script);
 	}
 
 	public void setError(ScriptWrapper script, String details) {


### PR DESCRIPTION
Change ExtensionScript.setEnabled(ScriptWrapper) to notify the script
listeners (ScriptEventListener) that the script was changed.
The script (ScriptWrapper) is marked as changed when it's enabled or
disabled, but the script listeners were not notified of the change, for
example, causing the UI to not be immediately updated to reflect the
change by enabling the save button.
Fix #1939 - Scripts - Save Button Enablement Issue