### PR TITLE
Allow to spider a context through the ZAP API

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1733,7 +1733,7 @@ sites.spider.popup         = Spider...
 sites.showinsites.popup    = Show in Sites tab
 
 spider.activeActionPrefix = Spidering: {0}
-spider.api.action.scan = Runs the spider against the given URL. Optionally, the 'maxChildren' parameter can be set to limit the number of children scanned, and the 'recurse' parameter can be used to prevent the spider from seeding recursively.
+spider.api.action.scan = Runs the spider against the given URL. Optionally, the 'maxChildren' parameter can be set to limit the number of children scanned, the 'recurse' parameter can be used to prevent the spider from seeding recursively and the parameter 'contextName' can be used to constrain the scan to a Context.
 spider.api.action.scanAsUser = Runs the spider from the perspective of a User, obtained using the given Context ID and User ID. See 'scan' action for more details.
 spider.api.view.optionSendRefererHeader = Sets whether or not the 'Referer' header should be sent while spidering
 spider.custom.button.reset	= Reset

--- a/src/org/zaproxy/zap/extension/api/ContextAPI.java
+++ b/src/org/zaproxy/zap/extension/api/ContextAPI.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.extension.authorization.AuthorizationDetectionMethod;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
+import org.zaproxy.zap.utils.ApiUtils;
 
 public class ContextAPI extends ApiImplementor {
 
@@ -293,15 +294,7 @@ public class ContextAPI extends ApiImplementor {
      * @see JSONObject#getString(String)
      */
     private Context getContext(JSONObject params) throws ApiException {
-        return getContext(params.getString(CONTEXT_NAME));
-    }
-
-    private Context getContext(String contextName) throws ApiException {
-        Context context = Model.getSingleton().getSession().getContext(contextName);
-        if (context == null) {
-            throw new ApiException(ApiException.Type.DOES_NOT_EXIST, contextName);
-        }
-        return context;
+        return ApiUtils.getContextByName(params, CONTEXT_NAME);
     }
 
     /**

--- a/src/org/zaproxy/zap/utils/ApiUtils.java
+++ b/src/org/zaproxy/zap/utils/ApiUtils.java
@@ -126,6 +126,41 @@ public final class ApiUtils {
 		return context;
 	}
 
+	/**
+	 * Returns the {@code Context} with the given name. The context's name is obtained from the given {@code parameters}, whose
+	 * name is the value of {@code parameterName}.
+	 * <p>
+	 * The parameter must exist, that is, it should be a mandatory parameter, otherwise a runtime exception is thrown.
+	 *
+	 * @param parameters the parameters that contain the context's name
+	 * @param parameterName the name of the parameter used to obtain the context's name
+	 * @return the {@code Context} with the given name
+	 * @throws ApiException If the context with the given name does not exist
+	 * @since TODO add version
+	 * @see #getContextByName(String)
+	 * @see JSONObject#getString(String)
+	 */
+	public static Context getContextByName(JSONObject parameters, String parameterName) throws ApiException {
+		return getContextByName(parameters.getString(parameterName));
+	}
+
+	/**
+	 * Returns the {@code Context} with the given name.
+	 *
+	 * @param contextName the name of the context
+	 * @return the {@code Context} with the given name
+	 * @throws ApiException If the context with the given name does not exist
+	 * @since TODO add version
+	 * @see #getContextByName(JSONObject, String)
+	 */
+	public static Context getContextByName(String contextName) throws ApiException {
+		Context context = Model.getSingleton().getSession().getContext(contextName);
+		if (context == null) {
+			throw new ApiException(ApiException.Type.DOES_NOT_EXIST, contextName);
+		}
+		return context;
+	}
+
 	private ApiUtils() {
 		// Utility class
 	}


### PR DESCRIPTION
Change the action "scan" of SpiderAPI to allow to specify the name of
the context used in the spider process.
Add methods to ApiUtils that allows to obtain the context from the API
parameters and by just using the context name (which throws an
ApiException if it doesn't exist).
Change ContextAPI to use the new method from ApiUtils.
Fix #1953 - Allow to spider a context through the ZAP API