### PR TITLE
Fix issues with installation of passive and active scanners

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/PluginFactory.java
+++ b/src/org/parosproxy/paros/core/scanner/PluginFactory.java
@@ -39,6 +39,7 @@
 // ZAP: 2015/01/04 Issue 1486: Add-on components leak
 // ZAP: 2015/07/25 Do not log error if the duplicated scanner is (apparently) a newer/older version
 // ZAP: 2015/08/19 Issue 1785: Plugin enabled even if dependencies are not, "hangs" active scan
+// ZAP: 2015/11/02 Issue 1969: Issues with installation of scanners
 
 package org.parosproxy.paros.core.scanner;
 
@@ -90,11 +91,53 @@ public class PluginFactory {
     	return loadedPlugins;
     }
     
+    /**
+     * Tells whether or not the given {@code plugin} was already loaded.
+     *
+     * @param plugin the plugin that will be checked
+     * @return {@code true} if the plugin was already loaded, {@code false} otherwise
+     * @since TODO add version
+     */
+    public static boolean isPluginLoaded(AbstractPlugin plugin) {
+        if (loadedPlugins == null) {
+            return false;
+        }
+        return isPluginLoadedImpl(plugin);
+    }
+
+    private static boolean isPluginLoadedImpl(AbstractPlugin plugin) {
+        for (AbstractPlugin otherPlugin : getLoadedPlugins()) {
+            if (otherPlugin == plugin) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Adds the given loaded {@code plugin} to the {@code PluginFactory}. Loaded plugins, are used by the active scanner, if
+     * enabled.
+     * <p>
+     * Call to this method has not effect it the {@code plugin} was already added.
+     *
+     * @param plugin the plugin that should be loaded
+     * @since 2.4.0
+     * @see #isPluginLoaded(AbstractPlugin)
+     */
     public static void loadedPlugin(AbstractPlugin plugin) {
-    	getLoadedPlugins().add(plugin);
-        Collections.sort(loadedPlugins, riskComparator);
+        if (!isPluginLoadedImpl(plugin)) {
+            getLoadedPlugins().add(plugin);
+            Collections.sort(loadedPlugins, riskComparator);
+        }
     }
     
+    /**
+     * @deprecated (TODO add version) Use {@link #loadedPlugin(AbstractPlugin)} instead, the status of the scanner is not
+     *             properly set.
+     * @see AbstractPlugin#getStatus()
+     */
+    @Deprecated
+    @SuppressWarnings("javadoc")
     public static boolean loadedPlugin(String className) {
         try {
         	Class<?> c = ExtensionFactory.getAddOnLoader().loadClass(className);
@@ -107,9 +150,23 @@ public class PluginFactory {
     }
     
     public static void unloadedPlugin(AbstractPlugin plugin) {
-    	getLoadedPlugins().remove(plugin);
+        if (loadedPlugins == null) {
+            return;
+        }
+        for (Iterator<AbstractPlugin> it = getLoadedPlugins().iterator(); it.hasNext();) {
+            if (it.next() == plugin) {
+                it.remove();
+                return;
+            }
+        }
     }
     
+    /**
+     * @deprecated (TODO add version) Use {@link #unloadedPlugin(AbstractPlugin)} instead, which ensures that the exact scanner
+     *             instance is unloaded.
+     */
+    @Deprecated
+    @SuppressWarnings("javadoc")
     public static boolean unloadedPlugin(String className) {
         if (loadedPlugins == null) {
             return true;

--- a/src/org/zaproxy/zap/control/AddOn.java
+++ b/src/org/zaproxy/zap/control/AddOn.java
@@ -45,11 +45,13 @@ import org.jgrapht.graph.DefaultDirectedGraph;
 import org.jgrapht.graph.DefaultEdge;
 import org.jgrapht.traverse.TopologicalOrderIterator;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.AbstractPlugin;
 import org.parosproxy.paros.extension.Extension;
 import org.zaproxy.zap.Version;
 import org.zaproxy.zap.control.BaseZapAddOnXmlData.AddOnDep;
 import org.zaproxy.zap.control.BaseZapAddOnXmlData.Dependencies;
 import org.zaproxy.zap.control.BaseZapAddOnXmlData.ExtensionWithDeps;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 public class AddOn  {
 	public enum Status {unknown, example, alpha, beta, weekly, release}
@@ -145,7 +147,11 @@ public class AddOn  {
 	 */
 	private List<Extension> loadedExtensions;
 	private List<String> ascanrules = Collections.emptyList();
+	private List<AbstractPlugin> loadedAscanrules = Collections.emptyList();
+	private boolean loadedAscanRulesSet;
 	private List<String> pscanrules = Collections.emptyList();
+	private List<PluginPassiveScanner> loadedPscanrules = Collections.emptyList();
+	private boolean loadedPscanRulesSet;
 	private List<String> files = Collections.emptyList();
 	
 	private Dependencies dependencies;
@@ -533,8 +539,148 @@ public class AddOn  {
 		return ascanrules;
 	}
 	
+	/**
+	 * Gets the active scan rules of this add-on that were loaded.
+	 *
+	 * @return an unmodifiable {@code List} with the active scan rules of this add-on that were loaded, never {@code null}
+	 * @since TODO add version
+	 * @see #setLoadedAscanrules(List)
+	 */
+	public List<AbstractPlugin> getLoadedAscanrules() {
+		return loadedAscanrules;
+	}
+
+	/**
+	 * Sets the loaded active scan rules of the add-on, allowing to set the status of the active scan rules appropriately and to
+	 * keep track of the active scan rules loaded so that they can be removed during uninstallation.
+	 * <p>
+	 * <strong>Note:</strong> Helper method to be used (only) by/during (un)installation process and loading of the add-on.
+	 * Should be called when installing/loading the add-on, by setting the loaded active scan rules, and when uninstalling by
+	 * setting an empty list. The method {@code setLoadedAscanrulesSet(boolean)} should also be called.
+	 * 
+	 * @param ascanrules the active scan rules loaded, might be empty if none were actually loaded
+	 * @throws IllegalArgumentException if {@code ascanrules} is {@code null}.
+	 * @since TODO add version
+	 * @see #setLoadedAscanrulesSet(boolean)
+	 * @see AbstractPlugin#setStatus(Status)
+	 */
+	void setLoadedAscanrules(List<AbstractPlugin> ascanrules) {
+		if (ascanrules == null) {
+			throw new IllegalArgumentException("Parameter ascanrules must not be null.");
+		}
+
+		if (ascanrules.isEmpty()) {
+			loadedAscanrules = Collections.emptyList();
+			return;
+		}
+
+		for (AbstractPlugin ascanrule : ascanrules) {
+			ascanrule.setStatus(getStatus());
+		}
+		loadedAscanrules = Collections.unmodifiableList(new ArrayList<>(ascanrules));
+	}
+
+	/**
+	 * Tells whether or not the loaded active scan rules of the add-on, if any, were already set to the add-on.
+	 * <p>
+	 * <strong>Note:</strong> Helper method to be used (only) by/during (un)installation process and loading of the add-on.
+	 *
+	 * @return {@code true} if the loaded active scan rules were already set, {@code false} otherwise
+	 * @since TODO add version
+	 * @see #setLoadedAscanrules(List)
+	 * @see #setLoadedAscanrulesSet(boolean)
+	 */
+	boolean isLoadedAscanrulesSet() {
+		return loadedAscanRulesSet;
+	}
+
+	/**
+	 * Sets whether or not the loaded active scan rules, if any, where already set to the add-on.
+	 * <p>
+	 * <strong>Note:</strong> Helper method to be used (only) by/during (un)installation process and loading of the add-on. The
+	 * method should be called, with {@code true} during installation/loading and {@code false} during uninstallation, after
+	 * calling the method {@code setLoadedAscanrules(List)}.
+	 *
+	 * @param ascanrulesSet {@code true} if the loaded active scan rules were already set, {@code false} otherwise
+	 * @since TODO add version
+	 * @see #setLoadedAscanrules(List)
+	 */
+	void setLoadedAscanrulesSet(boolean ascanrulesSet) {
+		loadedAscanRulesSet = ascanrulesSet;
+	}
+
 	public List<String> getPscanrules() {
 		return pscanrules;
+	}
+
+	/**
+	 * Gets the passive scan rules of this add-on that were loaded.
+	 *
+	 * @return an unmodifiable {@code List} with the passive scan rules of this add-on that were loaded, never {@code null}
+	 * @since TODO add version
+	 * @see #setLoadedPscanrules(List)
+	 */
+	public List<PluginPassiveScanner> getLoadedPscanrules() {
+		return loadedPscanrules;
+	}
+
+	/**
+	 * Sets the loaded passive scan rules of the add-on, allowing to set the status of the passive scan rules appropriately and
+	 * keep track of the passive scan rules loaded so that they can be removed during uninstallation.
+	 * <p>
+	 * <strong>Note:</strong> Helper method to be used (only) by/during (un)installation process and loading of the add-on.
+	 * Should be called when installing/loading the add-on, by setting the loaded passive scan rules, and when uninstalling by
+	 * setting an empty list. The method {@code setLoadedPscanrulesSet(boolean)} should also be called.
+	 * 
+	 * @param pscanrules the passive scan rules loaded, might be empty if none were actually loaded
+	 * @throws IllegalArgumentException if {@code pscanrules} is {@code null}.
+	 * @since TODO add version
+	 * @see #setLoadedPscanrulesSet(boolean)
+	 * @see PluginPassiveScanner#setStatus(Status)
+	 */
+	void setLoadedPscanrules(List<PluginPassiveScanner> pscanrules) {
+		if (pscanrules == null) {
+			throw new IllegalArgumentException("Parameter pscanrules must not be null.");
+		}
+
+		if (pscanrules.isEmpty()) {
+			loadedPscanrules = Collections.emptyList();
+			return;
+		}
+
+		for (PluginPassiveScanner pscanrule : pscanrules) {
+			pscanrule.setStatus(getStatus());
+		}
+		loadedPscanrules = Collections.unmodifiableList(new ArrayList<>(pscanrules));
+	}
+
+	/**
+	 * Tells whether or not the loaded passive scan rules of the add-on, if any, were already set to the add-on.
+	 * <p>
+	 * <strong>Note:</strong> Helper method to be used (only) by/during (un)installation process and loading of the add-on.
+	 *
+	 * @return {@code true} if the loaded passive scan rules were already set, {@code false} otherwise
+	 * @since TODO add version
+	 * @see #setLoadedPscanrules(List)
+	 * @see #setLoadedPscanrulesSet(boolean)
+	 */
+	boolean isLoadedPscanrulesSet() {
+		return loadedPscanRulesSet;
+	}
+
+	/**
+	 * Sets whether or not the loaded passive scan rules, if any, where already set to the add-on.
+	 * <p>
+	 * <strong>Note:</strong> Helper method to be used (only) by/during (un)installation process and loading of the add-on. The
+	 * method should be called, with {@code true} during installation/loading and {@code false} during uninstallation, after
+	 * calling the method {@code setLoadedPscanrules(List)}.
+	 *
+	 * @param pscanrulesSet {@code true} if the loaded passive scan rules were already set, {@code false} otherwise
+	 * @since TODO add version
+	 * @see #setLoadedPscanrules(List)
+	 */
+	void setLoadedPscanrulesSet(boolean pscanrulesSet) {
+		loadedPscanRulesSet = pscanrulesSet;
 	}
 	
 	public List<String> getFiles() {

--- a/src/org/zaproxy/zap/control/AddOnLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnLoader.java
@@ -685,7 +685,9 @@ public class AddOnLoader extends URLClassLoader {
                     }
                     AddOnClassLoader extAddOnClassLoader = new AddOnClassLoader(addOnClassLoader, dependencies);
                     Extension ext = loadAddOnExtension(addOn, extReqs.getClassname(), extAddOnClassLoader);
-                    extensions.add(ext);
+                    if (ext != null) {
+                        extensions.add(ext);
+                    }
                 } else if (logger.isDebugEnabled()) {
                     logger.debug("Can't run extension '" + extReqs.getClassname() + "' of add-on '" + addOn.getName()
                             + "' because of missing requirements: " + AddOnRunIssuesUtils.getRunningIssues(extReqs));
@@ -711,79 +713,54 @@ public class AddOnLoader extends URLClassLoader {
     }
 
     private static Extension loadAddOnExtension(AddOn addOn, String classname, AddOnClassLoader addOnClassLoader) {
-        Class<?> cls;
-        try {
-            cls = addOnClassLoader.loadClass(classname);
-        } catch (ClassNotFoundException e) {
-            logger.error("Declared extension was not found: " + classname, e);
-            return null;
-        }
-
-        if (Modifier.isAbstract(cls.getModifiers()) || Modifier.isInterface(cls.getModifiers())) {
-            logger.error("Declared \"extension\" is abstract or an interface: " + classname);
-            return null;
-        }
-
-        if (!Extension.class.isAssignableFrom(cls)) {
-            logger.error("Declared \"extension\" is not of type Extension: " + classname);
-            return null;
-        }
-
-        try {
-            @SuppressWarnings("unchecked")
-            Constructor<Extension> c = (Constructor<Extension>) cls.getConstructor();
-            Extension extension = c.newInstance();
+        Extension extension = AddOnLoaderUtils
+                .loadAndInstantiateClass(addOnClassLoader, classname, Extension.class, "extension");
+        if (extension != null) {
             addOn.addLoadedExtension(extension);
-            return extension;
-        } catch (Exception e) {
-            logger.debug(e.getMessage());
         }
-        return null;
+        return extension;
     }
 
-	@SuppressWarnings("unchecked")
+	/**
+	 * Gets the active scan rules of all the loaded add-ons.
+	 * <p>
+	 * The discovery of active scan rules is done by resorting to {@code ZapAddOn.xml} file bundled in the add-ons.
+	 *
+	 * @return an unmodifiable {@code List} with all the active scan rules, never {@code null}
+	 * @since 2.4.0
+	 * @see AbstractPlugin
+	 */
 	public List<AbstractPlugin> getActiveScanRules () {
-		List<AbstractPlugin> list = new ArrayList<AbstractPlugin>();
+		ArrayList<AbstractPlugin> list = new ArrayList<>();
 		for (AddOn addOn : getAddOnCollection().getAddOns()) {
-			if (addOn.getAscanrules() != null) {
-				for (String extName : addOn.getAscanrules()) {
-					try {
-						Class<?> cls = this.addOnLoaders.get(addOn.getId()).loadClass(extName);
-	                    Constructor<?> c = (Constructor<?>) cls.getConstructor();
-	                    AbstractPlugin plugin = ((Constructor<AbstractPlugin>)c).newInstance();
-	                    plugin.setStatus(addOn.getStatus());
-	                    list.add(plugin);
-					} catch (Exception e) {
-		            	logger.debug(e.getMessage());
-					}
-				}
+			AddOnClassLoader addOnClassLoader = this.addOnLoaders.get(addOn.getId());
+			if (addOnClassLoader != null) {
+				list.addAll(AddOnLoaderUtils.getActiveScanRules(addOn, addOnClassLoader));
 			}
         }
-		
-		return list;
+		list.trimToSize();
+		return Collections.unmodifiableList(list);
 	}
 
-
-	@SuppressWarnings("unchecked")
+	/**
+	 * Gets the passive scan rules of all the loaded add-ons.
+	 * <p>
+	 * The discovery of passive scan rules is done by resorting to {@code ZapAddOn.xml} file bundled in the add-ons.
+	 *
+	 * @return an unmodifiable {@code List} with all the passive scan rules, never {@code null}
+	 * @since 2.4.0
+	 * @see PluginPassiveScanner
+	 */
 	public List<PluginPassiveScanner> getPassiveScanRules() {
-		List<PluginPassiveScanner> list = new ArrayList<PluginPassiveScanner>();
+		ArrayList<PluginPassiveScanner> list = new ArrayList<>();
 		for (AddOn addOn : getAddOnCollection().getAddOns()) {
-			if (addOn.getPscanrules() != null) {
-				for (String extName : addOn.getPscanrules()) {
-					try {
-						Class<?> cls = this.addOnLoaders.get(addOn.getId()).loadClass(extName);
-	                    Constructor<?> c = (Constructor<?>) cls.getConstructor();
-						PluginPassiveScanner plugin = ((Constructor<PluginPassiveScanner>)c).newInstance();
-	                    plugin.setStatus(addOn.getStatus());
-	                    list.add(plugin);
-					} catch (Exception e) {
-		            	logger.debug(e.getMessage());
-					}
-				}
+			AddOnClassLoader addOnClassLoader = this.addOnLoaders.get(addOn.getId());
+			if (addOnClassLoader != null) {
+				list.addAll(AddOnLoaderUtils.getPassiveScanRules(addOn, addOnClassLoader));
 			}
         }
-		
-		return list;
+		list.trimToSize();
+		return Collections.unmodifiableList(list);
 	}
 
 	public <T> List<T> getImplementors (String packageName, Class<T> classType) {

--- a/src/org/zaproxy/zap/control/AddOnLoaderUtils.java
+++ b/src/org/zaproxy/zap/control/AddOnLoaderUtils.java
@@ -1,0 +1,230 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2015 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.control;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.core.scanner.AbstractPlugin;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+/**
+ * A class with utility methods to help with add-on loading and (un)installation.
+ *
+ * @since TODO add version
+ */
+final class AddOnLoaderUtils {
+
+    private static final Logger LOGGER = Logger.getLogger(AddOnLoaderUtils.class);
+
+    private AddOnLoaderUtils() {
+    }
+
+    /**
+     * Loads, using the given {@code addOnClassLoader}, and creates an instance with the given {@code classname} of the
+     * (expected) given {@code clazz}. The {@code type} is used in error log messages, to indicate the expected type being
+     * loaded.
+     *
+     * @param <T> the type of the class that will be instantiated
+     * @param addOnClassLoader the class loader of the add-on that contains the classes
+     * @param classname the binary name of the class that will be loaded
+     * @param clazz the type of the instance that will be created using the class loaded
+     * @param type the expected type being loaded (for example, "extension", "ascanrule"...)
+     * @return an instance of the given {@code clazz}, or {@code null} if an error occurred (for example, not being of the
+     *         expected type)
+     * @throws IllegalArgumentException if any of the parameters is {@code null}.
+     */
+    public static <T> T loadAndInstantiateClass(
+            AddOnClassLoader addOnClassLoader,
+            String classname,
+            Class<T> clazz,
+            String type) {
+        validateNotNull(addOnClassLoader, "addOnClassLoader");
+        validateNotNull(classname, "classname");
+        validateNotNull(clazz, "clazz");
+        validateNotNull(type, "type");
+
+        return loadAndInstantiateClassImpl(addOnClassLoader, classname, clazz, type);
+    }
+
+    /**
+     * Loads, using the given {@code addOnClassLoader}, and creates an instance with the given {@code classname} of the
+     * (expected) given {@code clazz}. The {@code type} is used in error log messages, to indicate the expected type being
+     * loaded.
+     * <p>
+     * <strong>Note:</strong> Internal method that does not validate that the parameters are not {@code null}.
+     *
+     * @param <T> the type of the class that will be instantiated
+     * @param addOnClassLoader the class loader of the add-on that contains the classes, must not be {@code null}
+     * @param classname the binary name of the class that will be loaded, must not be {@code null}
+     * @param clazz the type of the instance that will be created using the class loaded, must not be {@code null}
+     * @param type the expected type being loaded (for example, "extension", "ascanrule"...), must not be {@code null}
+     * @return an instance of the given {@code clazz}, or {@code null} if an error occurred (for example, not being of the
+     *         expected type)
+     */
+    private static <T> T loadAndInstantiateClassImpl(
+            AddOnClassLoader addOnClassLoader,
+            String classname,
+            Class<T> clazz,
+            String type) {
+        Class<?> cls;
+        try {
+            cls = addOnClassLoader.loadClass(classname);
+        } catch (ClassNotFoundException e) {
+            LOGGER.error("Declared \"" + type + "\" was not found: " + classname, e);
+            return null;
+        }
+
+        if (Modifier.isAbstract(cls.getModifiers()) || Modifier.isInterface(cls.getModifiers())) {
+            LOGGER.error("Declared \"" + type + "\" is abstract or an interface: " + classname);
+            return null;
+        }
+
+        if (!clazz.isAssignableFrom(cls)) {
+            LOGGER.error("Declared \"" + type + "\" is not of type \"" + clazz.getName() + "\": " + classname);
+            return null;
+        }
+
+        try {
+            @SuppressWarnings("unchecked")
+            Constructor<T> c = (Constructor<T>) cls.getConstructor();
+            T instance = c.newInstance();
+            return instance;
+        } catch (Exception e) {
+            LOGGER.debug(e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Loads, using the given {@code addOnClassLoader}, and creates instances with the given {@code classnames} of the
+     * (expected) given {@code clazz}. The {@code type} is used in error log messages, to indicate the expected type being
+     * loaded. Any classname that leads to an error (for example, not being of the expected type or if it was not found) it will
+     * be ignored (after logging the error).
+     *
+     * @param <T> the type of the class that will be instantiated
+     * @param addOnClassLoader the class loader of the add-on that contains the classes
+     * @param classnames the binary names of the classes that will be loaded
+     * @param clazz the type of the instance that will be created using the classes loaded
+     * @param type the expected type being loaded (for example, "extension", "ascanrule"...)
+     * @return an unmodifiable {@code List} with the instances of the given {@code clazz}
+     * @throws IllegalArgumentException if any of the parameters is {@code null}.
+     * @see #loadAndInstantiateClass(AddOnClassLoader, String, Class, String)
+     */
+    public static <T> List<T> loadDeclaredClasses(
+            AddOnClassLoader addOnClassLoader,
+            List<String> classnames,
+            Class<T> clazz,
+            String type) {
+        validateNotNull(addOnClassLoader, "addOnClassLoader");
+        validateNotNull(classnames, "classnames");
+        validateNotNull(clazz, "clazz");
+        validateNotNull(type, "type");
+
+        if (classnames.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        ArrayList<T> instances = new ArrayList<>(classnames.size());
+        for (String classname : classnames) {
+            T instance = loadAndInstantiateClassImpl(addOnClassLoader, classname, clazz, type);
+            if (instance != null) {
+                instances.add(instance);
+            }
+        }
+        instances.trimToSize();
+        return Collections.unmodifiableList(instances);
+    }
+
+    /**
+     * Gets the active scan rules of the given {@code addOn}. The active scan rules are first loaded, if they weren't already.
+     *
+     * @param addOn the add-on whose active scan rules will be returned
+     * @param addOnClassLoader the {@code AddOnClassLoader} of the given {@code addOn}
+     * @return an unmodifiable {@code List} with the active scan rules, never {@code null}
+     * @throws IllegalArgumentException if any of the parameters is {@code null}.
+     */
+    public static List<AbstractPlugin> getActiveScanRules(AddOn addOn, AddOnClassLoader addOnClassLoader) {
+        validateNotNull(addOn, "addOn");
+        validateNotNull(addOnClassLoader, "addOnClassLoader");
+
+        synchronized (addOn) {
+            if (addOn.isLoadedAscanrulesSet()) {
+                return addOn.getLoadedAscanrules();
+            }
+
+            List<AbstractPlugin> ascanrules = loadDeclaredClasses(
+                    addOnClassLoader,
+                    addOn.getAscanrules(),
+                    AbstractPlugin.class,
+                    "ascanrule");
+            addOn.setLoadedAscanrules(ascanrules);
+            addOn.setLoadedAscanrulesSet(true);
+            return Collections.unmodifiableList(ascanrules);
+        }
+    }
+
+    /**
+     * Gets the passive scan rules of the given {@code addOn}. The passive scan rules are first loaded, if they weren't already.
+     *
+     * @param addOn the add-on whose passive scan rules will be returned
+     * @param addOnClassLoader the {@code AddOnClassLoader} of the given {@code addOn}
+     * @return an unmodifiable {@code List} with the passive scan rules, never {@code null}
+     * @throws IllegalArgumentException if any of the parameters is {@code null}.
+     */
+    public static List<PluginPassiveScanner> getPassiveScanRules(AddOn addOn, AddOnClassLoader addOnClassLoader) {
+        validateNotNull(addOn, "addOn");
+        validateNotNull(addOnClassLoader, "addOnClassLoader");
+
+        synchronized (addOn) {
+            if (addOn.isLoadedPscanrulesSet()) {
+                return addOn.getLoadedPscanrules();
+            }
+
+            List<PluginPassiveScanner> pscanrules = loadDeclaredClasses(
+                    addOnClassLoader,
+                    addOn.getPscanrules(),
+                    PluginPassiveScanner.class,
+                    "pscanrule");
+            addOn.setLoadedPscanrules(pscanrules);
+            addOn.setLoadedPscanrulesSet(true);
+            return Collections.unmodifiableList(pscanrules);
+        }
+    }
+
+    /**
+     * Helper method that validates that the given {@code object} is not {@code null}, throwing an
+     * {@code IllegalArgumentException} if it is.
+     *
+     * @param object the object that will be validated that it's not {@code null}
+     * @param name the name used in the exception message
+     * @throws IllegalArgumentException if the given {@code object} is {@code null}.
+     */
+    private static void validateNotNull(Object object, String name) {
+        if (object == null) {
+            throw new IllegalArgumentException("Parameter " + name + " must not be null.");
+        }
+    }
+
+}

--- a/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -117,6 +117,13 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
         getPassiveScannerList().setAutoTagScanners(getPassiveScanParam().getAutoTagScanners());
     }
 
+    /**
+     * @deprecated (TODO add version) Use {@link #addPluginPassiveScanner(PluginPassiveScanner)} instead, the status of the
+     *             scanner is not properly set.
+     * @see PluginPassiveScanner#getStatus()
+     */
+    @Deprecated
+    @SuppressWarnings("javadoc")
     public boolean addPassiveScanner(String className) {
         try {
             Class<?> c = ExtensionFactory.getAddOnLoader().loadClass(className);


### PR DESCRIPTION
Fix issues with installation of passive and active scanners

Change to load and set the quality of the passive and active scanners
during installation of the add-on, preventing the quality from being
"Unknown". The loading/instantiation of the scanners is now done by the
same code (refactored to new class AddOnLoaderUtils, also refactored the
code that loads/instantiates a class, or classes, from an add-on). The
methods previously used during the installation, ExtensionPassiveScan.
addPassiveScanner(String) and PluginFactory.loadedPlugin(String), are
now deprecated as the quality is not correctly set. The method
PluginFactory.unloadedPlugin(String) is also deprecated, no longer used
by core code (the active scanners are now removed using the loaded
instances).
Change to load the active scanners just once by checking that the
scanners were not already loaded/added. The active scanners were being
added twice because the method PluginFactory.loadedPlugin(String) called
the method that initialised the list of scanners which was being
initialised with the add-ons already loaded, which included the add-on
being installed. The PluginFactory now checks if a scanner is already
loaded by reference and when removing, to make sure that's checking and
removing the exact instance (added). Previously it was using the equals
of the default implementation (AbstractPlugin) which checked the
equality by using the ID of the scanner, which would lead to unexpected
results when different scanners have (wrongly) the same ID (as it could
remove the other scanner).
The AddOn now keeps references to the scanners loaded, which is used to
prevent loading the scanners more than once and are used during the
uninstallation of the add-on.
Fix #1969 - Issues with installation of scanners