### PR TITLE
Do not always log exceptions as error when handling OTHER API requests

### DIFF
--- a/src/org/zaproxy/zap/extension/api/API.java
+++ b/src/org/zaproxy/zap/extension/api/API.java
@@ -565,7 +565,32 @@ public class API {
     private static void handleException(HttpMessage msg, Format format, String contentType, Exception cause) {
         String responseStatus = STATUS_INTERNAL_SERVER_ERROR;
         if (format == Format.OTHER) {
-            logger.error("API 'other' endpoint didn't handle exception:", cause);
+            boolean logError = true;
+            if (cause instanceof ApiException) {
+                switch (((ApiException) cause).getType()) {
+                case DISABLED:
+                    responseStatus = STATUS_BAD_REQUEST;
+                    logger.warn("ApiException while handling API request:", cause);
+                    logError = false;
+                    break;
+                case BAD_TYPE:
+                case NO_IMPLEMENTOR:
+                case BAD_API_KEY:
+                case MISSING_PARAMETER:
+                case BAD_ACTION:
+                case BAD_VIEW:
+                case BAD_OTHER:
+                    responseStatus = STATUS_BAD_REQUEST;
+                    logger.warn("API 'other' malformed request:", cause);
+                    logError = false;
+                    break;
+                default:
+                }
+            }
+
+            if (logError) {
+                logger.error("API 'other' endpoint didn't handle exception:", cause);
+            }
         } else {
             ApiException exception;
             if (cause instanceof ApiException) {


### PR DESCRIPTION
Some of the exceptions thrown during the handling of the API requests
might be thrown by the API class itself (for example, when validating
the API key or mandatory parameters), in those cases it should not be
logged an error nor it should be a "500 Internal Server Error" even if
the format is OTHER, it should be logged a warning and returned "400
Bad Request" (like the JSON and HTML formats).