### PR TITLE
Use table model row when showing the modify dialogue on double click

### DIFF
--- a/src/org/zaproxy/zap/view/AbstractMultipleOptionsBaseTablePanel.java
+++ b/src/org/zaproxy/zap/view/AbstractMultipleOptionsBaseTablePanel.java
@@ -145,19 +145,20 @@ public abstract class AbstractMultipleOptionsBaseTablePanel<E> extends MultipleO
 			        if (me.getClickCount() == 2 && modifyButton != null && modifyButton.isEnabled()) {
 						JXTable table =(JXTable) me.getSource();
 				        Point p = me.getPoint();
-			        	modifyElement(table.rowAtPoint(p));
+				        int row = table.rowAtPoint(p);
+				        if (row >= 0) {
+				            modifyElement(getTable().convertRowIndexToModel(row));
+				        }
 			        }
 				}});
         }
     }
     
     private void modifyElement(int row) {
-    	if (row >= 0) {
-	        E e = showModifyDialogue(getMultipleOptionsModel().getElement(row));
-	        if (e != null) {
-	            getMultipleOptionsModel().modifyElement(row, e);
-	        }
-    	}
+        E e = showModifyDialogue(getMultipleOptionsModel().getElement(row));
+        if (e != null) {
+            getMultipleOptionsModel().modifyElement(row, e);
+        }
     }
     
     protected void selectionChanged(boolean entrySelected) {


### PR DESCRIPTION
Change AbstractMultipleOptionsBaseTablePanel to convert the table view
row index to model row index before showing the modify dialogue.
The view and model table row indices might differ when the columns of
the table are sorted, which could lead to a different entry being shown
than the one double clicked.
Move the if statement that guards against negative rows to MouseAdapter,
the check is now done (and required) before converting the row indices.