### PR TITLE
Install dependencies of the add-on installed through the command line

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -514,8 +514,10 @@ cfu.check.zap.latest   = ZAP is on the latest version
 cfu.check.zap.newer    = There is a more recent version of OWASP ZAP:
 
 cfu.cmdline.addondown		= Add-on downloaded to: {0}
+cfu.cmdline.addondown.failed = Add-on download failed for: {0}
 cfu.cmdline.addoninst		= Add-on already installed: {0}
 cfu.cmdline.addonurl		= Downloading add-on from: {0}
+cfu.cmdline.addonurl.unintalls.required = Not installing add-on(s). The installation would require uninstall the following add-ons: {0}
 cfu.cmdline.install.help	= Install the specified add-on from the ZAP Marketplace
 cfu.cmdline.update.help		= Update all changed add-ons from the ZAP Marketplace
 cfu.cmdline.noaddon			= Failed to find add-on: {0}

--- a/src/org/zaproxy/zap/extension/autoupdate/AddOnDependencyChecker.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/AddOnDependencyChecker.java
@@ -347,6 +347,22 @@ class AddOnDependencyChecker {
     }
 
     /**
+     * Calculates the changes required to update the given add-on.
+     * <p>
+     * It might require updating, installing or uninstalling other add-ons depending on the dependencies of the affected
+     * add-ons.
+     *
+     * @param addOn the add-on that would be updated
+     * @return the resulting changes with the add-ons that need to be updated, installed or uninstalled
+     * @since TODO add version
+     */
+    public AddOnChangesResult calculateUpdateChanges(AddOn addOn) {
+        Set<AddOn> addOns = new HashSet<>();
+        addOns.add(addOn);
+        return calculateUpdateChanges(addOns);
+    }
+
+    /**
      * Calculates the changes required to update the given add-ons.
      * <p>
      * It might require updating, installing or uninstalling other add-ons depending on the dependencies of the affected


### PR DESCRIPTION
Change ExtensionAutoUpdate to install the dependencies of the add-on
being installed/updated through the command line, aborting the
installation if it's required to uninstall add-ons (for example, because
of incompatibilities in the dependencies of the add-on(s)).
Inform about all the add-ons being installed (downloaded) and possibly
updated (because of dependency requirements). Also inform, as error,
about failed downloads.
Add helper method AddOnDependencyChecker.calculateUpdateChanges(AddOn),
not requiring the callers to create a Set when just calculating the
update changes of a single add-on.