### PR TITLE
Save the Context after configuring the authentication through the APIs

### DIFF
--- a/src/org/zaproxy/zap/authentication/UsernamePasswordAuthenticationCredentials.java
+++ b/src/org/zaproxy/zap/authentication/UsernamePasswordAuthenticationCredentials.java
@@ -34,6 +34,16 @@ class UsernamePasswordAuthenticationCredentials implements AuthenticationCredent
 
 	private static final String API_NAME = "UsernamePasswordAuthenticationCredentials";
 
+	/**
+	 * String used to represent encoded null credentials, that is, when {@code username} is {@code null}.
+	 * <p>
+	 * It's a null character Base64 encoded, which will never be equal to encoding of defined {@code username}/{@code password}.
+	 * 
+	 * @see #encode(String)
+	 * @see #decode(String)
+	 */
+	private static final String NULL_CREDENTIALS = "AA==";
+
 	private static String FIELD_SEPARATOR = "~";
 	private String username;
 	private String password;
@@ -75,6 +85,10 @@ class UsernamePasswordAuthenticationCredentials implements AuthenticationCredent
 	@Override
 	public String encode(String parentStringSeparator) {
 		assert (!FIELD_SEPARATOR.equals(parentStringSeparator));
+		if (username == null) {
+			return NULL_CREDENTIALS;
+		}
+
 		StringBuilder out = new StringBuilder();
 		out.append(Base64.encodeBase64String(username.getBytes())).append(FIELD_SEPARATOR);
 		out.append(Base64.encodeBase64String(password.getBytes())).append(FIELD_SEPARATOR);
@@ -83,6 +97,12 @@ class UsernamePasswordAuthenticationCredentials implements AuthenticationCredent
 
 	@Override
 	public void decode(String encodedCredentials) {
+		if (NULL_CREDENTIALS.equals(encodedCredentials)) {
+			username = null;
+			password = null;
+			return;
+		}
+
 		String[] pieces = encodedCredentials.split(FIELD_SEPARATOR);
 		this.username = new String(Base64.decodeBase64(pieces[0]));
 		if (pieces.length > 1)

--- a/src/org/zaproxy/zap/extension/authentication/AuthenticationAPI.java
+++ b/src/org/zaproxy/zap/extension/authentication/AuthenticationAPI.java
@@ -141,19 +141,24 @@ public class AuthenticationAPI extends ApiImplementor {
 	public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
 		log.debug("handleApiAction " + name + " " + params.toString());
 
+		Context context;
 		switch (name) {
 		case ACTION_SET_LOGGED_IN_INDICATOR:
 			String loggedInIndicator = params.getString(PARAM_LOGGED_IN_INDICATOR);
 			if (loggedInIndicator == null || loggedInIndicator.isEmpty())
 				throw new ApiException(Type.MISSING_PARAMETER, PARAM_LOGGED_IN_INDICATOR);
-			getContext(params).getAuthenticationMethod().setLoggedInIndicatorPattern(loggedInIndicator);
+			context = getContext(params);
+			context.getAuthenticationMethod().setLoggedInIndicatorPattern(loggedInIndicator);
+			context.save();
 			return ApiResponseElement.OK;
 
 		case ACTION_SET_LOGGED_OUT_INDICATOR:
 			String loggedOutIndicator = params.getString(PARAM_LOGGED_OUT_INDICATOR);
 			if (loggedOutIndicator == null || loggedOutIndicator.isEmpty())
 				throw new ApiException(Type.MISSING_PARAMETER, PARAM_LOGGED_OUT_INDICATOR);
-			getContext(params).getAuthenticationMethod().setLoggedOutIndicatorPattern(loggedOutIndicator);
+			context = getContext(params);
+			context.getAuthenticationMethod().setLoggedOutIndicatorPattern(loggedOutIndicator);
+			context.save();
 			return ApiResponseElement.OK;
 
 		case ACTION_SET_METHOD:
@@ -163,9 +168,11 @@ public class AuthenticationAPI extends ApiImplementor {
 				actionParams = API.getParams(params.getString(PARAM_METHOD_CONFIG_PARAMS));
 			else
 				actionParams = new JSONObject();
-			actionParams.put(PARAM_CONTEXT_ID, getContextId(params));
+			context = getContext(params);
+			actionParams.put(PARAM_CONTEXT_ID, context.getIndex());
 			// Run the method
 			getSetMethodActionImplementor(params).handleAction(actionParams);
+			context.save();
 			return ApiResponseElement.OK;
 		default:
 			throw new ApiException(Type.BAD_ACTION);

--- a/src/org/zaproxy/zap/extension/forceduser/ForcedUserAPI.java
+++ b/src/org/zaproxy/zap/extension/forceduser/ForcedUserAPI.java
@@ -102,6 +102,7 @@ public class ForcedUserAPI extends ApiImplementor {
 			} catch (IllegalStateException ex) {
 				throw new ApiException(Type.USER_NOT_FOUND);
 			}
+			context.save();
 			return ApiResponseElement.OK;
 		case ACTION_SET_FORCED_USER_MODE_ENABLED:
 			if (!params.containsKey(PARAM_MODE_ENABLED))

--- a/src/org/zaproxy/zap/extension/sessions/SessionManagementAPI.java
+++ b/src/org/zaproxy/zap/extension/sessions/SessionManagementAPI.java
@@ -128,9 +128,11 @@ public class SessionManagementAPI extends ApiImplementor {
 				actionParams = API.getParams(params.getString(PARAM_METHOD_CONFIG_PARAMS));
 			else
 				actionParams = new JSONObject();
-			actionParams.put(PARAM_CONTEXT_ID, getContextId(params));
+			Context context = getContext(params);
+			actionParams.put(PARAM_CONTEXT_ID, context.getIndex());
 			// Run the method
 			getSetMethodActionImplementor(params).handleAction(actionParams);
+			context.save();
 			return ApiResponseElement.OK;
 		default:
 			throw new ApiException(Type.BAD_ACTION);

--- a/src/org/zaproxy/zap/extension/users/UsersAPI.java
+++ b/src/org/zaproxy/zap/extension/users/UsersAPI.java
@@ -171,14 +171,16 @@ public class UsersAPI extends ApiImplementor {
 			user.setAuthenticationCredentials(context.getAuthenticationMethod()
 					.createAuthenticationCredentials());
 			extension.getContextUserAuthManager(context.getIndex()).addUser(user);
+			context.save();
 			return new ApiResponseElement(PARAM_USER_ID, String.valueOf(user.getId()));
 		case ACTION_REMOVE_USER:
-			int contextId = ApiUtils.getIntParam(params, PARAM_CONTEXT_ID);
+			context = ApiUtils.getContextByParamId(params, PARAM_CONTEXT_ID);
 			int userId = ApiUtils.getIntParam(params, PARAM_USER_ID);
-			boolean deleted = extension.getContextUserAuthManager(contextId).removeUserById(userId);
-			if (deleted)
+			boolean deleted = extension.getContextUserAuthManager(context.getIndex()).removeUserById(userId);
+			if (deleted) {
+				context.save();
 				return ApiResponseElement.OK;
-			else
+			} else
 				return ApiResponseElement.FAIL;
 		case ACTION_SET_ENABLED:
 			boolean enabled = false;
@@ -187,13 +189,17 @@ public class UsersAPI extends ApiImplementor {
 			} catch (JSONException e) {
 				throw new ApiException(Type.ILLEGAL_PARAMETER, PARAM_ENABLED + " - should be boolean");
 			}
-			getUser(params).setEnabled(enabled);
+			user = getUser(params);
+			user.setEnabled(enabled);
+			user.getContext().save();
 			return ApiResponseElement.OK;
 		case ACTION_SET_NAME:
 			String nameSN = params.getString(PARAM_USER_NAME);
 			if (nameSN == null || nameSN.isEmpty())
 				throw new ApiException(Type.MISSING_PARAMETER, PARAM_USER_NAME);
-			getUser(params).setName(nameSN);
+			user = getUser(params);
+			user.setName(nameSN);
+			user.getContext().save();
 			return ApiResponseElement.OK;
 		case ACTION_SET_AUTH_CREDENTIALS:
 			// Prepare the params
@@ -209,6 +215,7 @@ public class UsersAPI extends ApiImplementor {
 			ApiDynamicActionImplementor a = loadedAuthenticationMethodActions.get(context
 					.getAuthenticationMethod().getType().getUniqueIdentifier());
 			a.handleAction(actionParams);
+			context.save();
 			return ApiResponseElement.OK;
 
 		default:


### PR DESCRIPTION
Change AuthenticationAPI, ForcedUserAPI, SessionManagementAPI and
UsersAPI to call the method Context.save() after doing the changes
to save the authentication configurations of the context.
Change UsernamePasswordAuthenticationCredentials to cope with null
username and password when persisting the data (happens when no valid
authentication credentials were yet set to a user).
Fix #2052 - Authentication changes done through the API not saved to
session