### PR TITLE
Faster loading of persisted sessions

### DIFF
--- a/src/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
@@ -379,7 +379,7 @@ public class FormBasedAuthenticationMethodType extends AuthenticationMethodType 
 			values.put("methodName", API_METHOD_NAME);
 			values.put("loginUrl", loginRequestURL);
 			values.put("loginRequestData", this.loginRequestBody);
-			return new ApiResponseSet("method", values);
+			return new ApiResponseSet<String>("method", values);
 		}
 
 		@Override

--- a/src/org/zaproxy/zap/authentication/GenericAuthenticationCredentials.java
+++ b/src/org/zaproxy/zap/authentication/GenericAuthenticationCredentials.java
@@ -63,7 +63,7 @@ public class GenericAuthenticationCredentials implements AuthenticationCredentia
 	public ApiResponse getApiResponseRepresentation() {
 		Map<String, String> values = new HashMap<>(paramValues);
 		values.put("type", API_NAME);
-		return new ApiResponseSet("credentials", values);
+		return new ApiResponseSet<String>("credentials", values);
 	}
 
 	/**

--- a/src/org/zaproxy/zap/authentication/HttpAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/HttpAuthenticationMethodType.java
@@ -139,7 +139,7 @@ public class HttpAuthenticationMethodType extends AuthenticationMethodType {
 			values.put("host", this.hostname);
 			values.put("port", Integer.toString(this.port));
 			values.put("realm", this.realm);
-			return new ApiResponseSet("method", values);
+			return new ApiResponseSet<String>("method", values);
 		}
 
 	}

--- a/src/org/zaproxy/zap/authentication/ManualAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/ManualAuthenticationMethodType.java
@@ -215,7 +215,7 @@ public class ManualAuthenticationMethodType extends AuthenticationMethodType {
 			Map<String, String> values = new HashMap<>();
 			values.put("type", API_NAME);
 			values.put("sessionName", selectedSession != null ? selectedSession.getName() : "");
-			return new ApiResponseSet("credentials", values);
+			return new ApiResponseSet<String>("credentials", values);
 		}
 	}
 

--- a/src/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
@@ -268,7 +268,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
 			values.put("methodName", API_METHOD_NAME);
 			values.put("scriptName", script.getName());
 			values.putAll(paramValues);
-			return new ApiResponseSet("method", values);
+			return new ApiResponseSet<String>("method", values);
 		}
 
 	}

--- a/src/org/zaproxy/zap/authentication/UsernamePasswordAuthenticationCredentials.java
+++ b/src/org/zaproxy/zap/authentication/UsernamePasswordAuthenticationCredentials.java
@@ -178,7 +178,7 @@ class UsernamePasswordAuthenticationCredentials implements AuthenticationCredent
 		values.put("type", API_NAME);
 		values.put("username", username);
 		values.put("password", password);
-		return new ApiResponseSet("credentials", values);
+		return new ApiResponseSet<String>("credentials", values);
 	}
 
 	private static final String ACTION_SET_CREDENTIALS = "formBasedAuthenticationCredentials";

--- a/src/org/zaproxy/zap/extension/api/ApiDynamicActionImplementor.java
+++ b/src/org/zaproxy/zap/extension/api/ApiDynamicActionImplementor.java
@@ -47,11 +47,11 @@ public abstract class ApiDynamicActionImplementor extends ApiElement {
 		return configParams;
 	}
 
-	private static ApiResponseSet buildParamMap(String paramName, boolean mandatory) {
+	private static ApiResponseSet<String> buildParamMap(String paramName, boolean mandatory) {
 		Map<String, String> m = new HashMap<>();
 		m.put("name", paramName);
 		m.put("mandatory", mandatory ? "true" : "false");
-		return new ApiResponseSet("param", m);
+		return new ApiResponseSet<String>("param", m);
 	}
 
 }

--- a/src/org/zaproxy/zap/extension/api/ApiResponseConversionUtils.java
+++ b/src/org/zaproxy/zap/extension/api/ApiResponseConversionUtils.java
@@ -38,7 +38,7 @@ public class ApiResponseConversionUtils {
     private ApiResponseConversionUtils() {
     }
 
-    public static ApiResponseSet httpMessageToSet(int historyId, HttpMessage msg) {
+    public static ApiResponseSet<String> httpMessageToSet(int historyId, HttpMessage msg) {
         Map<String, String> map = new HashMap<>();
         map.put("id", String.valueOf(historyId));
         map.put("cookieParams", msg.getCookieParamsAsString());
@@ -67,7 +67,7 @@ public class ApiResponseConversionUtils {
             map.put("responseBody", msg.getResponseBody().toString());
         }
 
-        return new ApiResponseSet("message", map);
+        return new ApiResponseSet<String>("message", map);
     }
 
 }

--- a/src/org/zaproxy/zap/extension/api/ApiResponseSet.java
+++ b/src/org/zaproxy/zap/extension/api/ApiResponseSet.java
@@ -29,11 +29,11 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Text;
 import org.zaproxy.zap.utils.XMLStringUtil;
 
-public class ApiResponseSet extends ApiResponse {
+public class ApiResponseSet<T> extends ApiResponse {
 
-	private Map<String, ?> values = null;
+	private Map<String, T> values = null;
 
-	public ApiResponseSet(String name, Map<String, ?> values) {
+	public ApiResponseSet(String name, Map<String, T> values) {
 		super(name);
 		this.values = values;
 	}
@@ -44,7 +44,7 @@ public class ApiResponseSet extends ApiResponse {
 			return null;
 		}
 		JSONObject jo = new JSONObject();
-		for (Entry<String, ?> val : values.entrySet()) {
+		for (Entry<String, T> val : values.entrySet()) {
 			jo.put(val.getKey(), val.getValue());
 		}
 		return jo;
@@ -53,7 +53,8 @@ public class ApiResponseSet extends ApiResponse {
 	@Override
 	public void toXML(Document doc, Element parent) {
 		parent.setAttribute("type", "set");
-		for (Entry<String, ?> val : values.entrySet()) {
+
+		for (Entry<String, T> val : values.entrySet()) {
 			Element el = doc.createElement(val.getKey());
 			Text text;
 			if (val.getValue() instanceof String) {
@@ -71,7 +72,8 @@ public class ApiResponseSet extends ApiResponse {
 	public void toHTML(StringBuilder sb) {
 		sb.append("<h2>" + StringEscapeUtils.escapeHtml(this.getName()) + "</h2>\n");
 		sb.append("<table border=\"1\">\n");
-		for (Entry<String, ?> val : values.entrySet()) {
+
+		for (Entry<String, T> val : values.entrySet()) {
 			sb.append("<tr><td>\n");
 			sb.append(StringEscapeUtils.escapeHtml(val.getKey()));
 			sb.append("</td><td>\n");
@@ -94,7 +96,8 @@ public class ApiResponseSet extends ApiResponse {
 		sb.append("ApiResponseSet ");
 		sb.append(this.getName());
 		sb.append(" : [\n");
-		for (Entry<String, ?> val : values.entrySet()) {
+
+		for (Entry<String, T> val : values.entrySet()) {
 			for (int i = 0; i < indent + 1; i++) {
 				sb.append("\t");
 			}
@@ -113,7 +116,7 @@ public class ApiResponseSet extends ApiResponse {
 	/*
 	 * Package visible method for simplified unit testing
 	 */
-	Map<String, ?> getValues() {
+	Map<String, T> getValues() {
 		return values;
 	}
 

--- a/src/org/zaproxy/zap/extension/api/ContextAPI.java
+++ b/src/org/zaproxy/zap/extension/api/ContextAPI.java
@@ -341,7 +341,7 @@ public class ContextAPI extends ApiImplementor {
 		fields.put("postParameterParserClass", c.getPostParamParser().getClass().getCanonicalName());
 		fields.put("postParameterParserConfig", c.getPostParamParser().getConfig());
 		
-		return new ApiResponseSet("context", fields);
+		return new ApiResponseSet<String>("context", fields);
 	}
 	
 	/**

--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -1039,7 +1039,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 		}
 	}
 
-	private ApiResponseSet alertToSet(Alert alert) {
+	private ApiResponseSet<String> alertToSet(Alert alert) {
 		Map<String, String> map = new HashMap<>();
 		map.put("id", String.valueOf(alert.getAlertId()));
 		map.put("pluginId", String.valueOf(alert.getPluginId()));
@@ -1060,7 +1060,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 		if (alert.getHistoryRef() != null) {
 			map.put("messageId", String.valueOf(alert.getHistoryRef().getHistoryId()));
 		}
-		return new ApiResponseSet("alert", map);
+		return new ApiResponseSet<String>("alert", map);
 	}
 
 	private void processAlerts(String baseUrl, int start, int count, Processor<Alert> processor) throws ApiException {

--- a/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
@@ -600,7 +600,7 @@ public class ActiveScanAPI extends ApiImplementor {
 				map.put("id", Integer.toString(scan.getScanId()));
 				map.put("progress", Integer.toString(scan.getProgress()));
 				map.put("state", ((ActiveScan)scan).getState().name());
-				resultList.addItem(new ApiResponseSet("scan", map));
+				resultList.addItem(new ApiResponseSet<String>("scan", map));
 			}
 			result = resultList;
 			break;
@@ -703,7 +703,7 @@ public class ActiveScanAPI extends ApiImplementor {
 				map.put("attackStrength", attackStrength == null ? "" : String.valueOf(attackStrength));
 				map.put("alertThreshold", alertThreshold == null ? "" : String.valueOf(alertThreshold));
 				map.put("enabled", String.valueOf(isPolicyEnabled(policy, categoryId)));
-				resultList.addItem(new ApiResponseSet("policy", map));
+				resultList.addItem(new ApiResponseSet<String>("policy", map));
 			}
 
 			result = resultList;

--- a/src/org/zaproxy/zap/extension/authorization/BasicAuthorizationDetectionMethod.java
+++ b/src/org/zaproxy/zap/extension/authorization/BasicAuthorizationDetectionMethod.java
@@ -209,6 +209,6 @@ public class BasicAuthorizationDetectionMethod implements AuthorizationDetection
 		values.put(AuthorizationAPI.PARAM_STATUS_CODE, Integer.toString(this.statusCode));
 		values.put(AuthorizationAPI.PARAM_LOGICAL_OPERATOR, this.logicalOperator.name());
 		values.put(AuthorizationAPI.RESPONSE_TYPE, "basic");
-		return new ApiResponseSet(AuthorizationAPI.RESPONSE_TAG, values);
+		return new ApiResponseSet<String>(AuthorizationAPI.RESPONSE_TAG, values);
 	}
 }

--- a/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsAPI.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsAPI.java
@@ -311,7 +311,7 @@ public class HttpSessionsAPI extends ApiImplementor {
 		return sessionResult;
 	}
 
-	private static class TokenValuesResponseSet extends ApiResponseSet {
+	private static class TokenValuesResponseSet extends ApiResponseSet<Cookie> {
 
 		private final List<List<Pair<String, String>>> xmlTokenElements;
 

--- a/src/org/zaproxy/zap/extension/params/ParamsAPI.java
+++ b/src/org/zaproxy/zap/extension/params/ParamsAPI.java
@@ -93,7 +93,7 @@ public class ParamsAPI extends ApiImplementor {
 			map.put("name", param.getName());
 			map.put("type", param.getType().name());
 			map.put("timesUsed", String.valueOf(param.getTimesUsed()));
-			stats.addItem(new ApiResponseSet("Stats", map));
+			stats.addItem(new ApiResponseSet<String>("Stats", map));
 
 			ApiResponseList flags = new ApiResponseList("Flags");
 			for (String flag : param.getFlags()) {

--- a/src/org/zaproxy/zap/extension/pscan/PassiveScanAPI.java
+++ b/src/org/zaproxy/zap/extension/pscan/PassiveScanAPI.java
@@ -164,7 +164,7 @@ public class PassiveScanAPI extends ApiImplementor {
 				map.put("enabled", String.valueOf(scanner.isEnabled()));
 				map.put("alertThreshold", scanner.getLevel(true).name());
 				map.put("quality", scanner.getStatus().toString());
-				resultList.addItem(new ApiResponseSet("scanner", map));
+				resultList.addItem(new ApiResponseSet<String>("scanner", map));
 			}
 			
 			result = resultList;

--- a/src/org/zaproxy/zap/extension/script/ScriptAPI.java
+++ b/src/org/zaproxy/zap/extension/script/ScriptAPI.java
@@ -93,7 +93,7 @@ public class ScriptAPI extends ApiImplementor {
 					if (type.isEnableable()) {
 						map.put("enabled", Boolean.toString(script.isEnabled()));
 					}
-					result.addItem(new ApiResponseSet("Script", map));
+					result.addItem(new ApiResponseSet<String>("Script", map));
 				}
 			}
 			return result;

--- a/src/org/zaproxy/zap/extension/search/SearchAPI.java
+++ b/src/org/zaproxy/zap/extension/search/SearchAPI.java
@@ -181,7 +181,7 @@ public class SearchAPI extends ApiImplementor {
 						map.put("url", msg.getRequestHeader().getURI().toString());
 						map.put("code", String.valueOf(msg.getResponseHeader().getStatusCode()));
 						map.put("time", String.valueOf(msg.getTimeElapsedMillis()));
-						result.addItem(new ApiResponseSet(name, map));
+						result.addItem(new ApiResponseSet<String>(name, map));
 					}
 				};
 			}

--- a/src/org/zaproxy/zap/extension/spider/SpiderAPI.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderAPI.java
@@ -435,7 +435,7 @@ public class SpiderAPI extends ApiImplementor {
 					map.put("url", sr.getUri());
 					map.put("statusCode", Integer.toString(sr.getStatusCode()));
 					map.put("statusReason", sr.getStatusReason());
-					resultList.addItem(new ApiResponseSet("resource", map));
+					resultList.addItem(new ApiResponseSet<String>("resource", map));
 				}
 			}
 			resultUrls.addItem(resultList);
@@ -463,7 +463,7 @@ public class SpiderAPI extends ApiImplementor {
 				map.put("id", Integer.toString(spiderScan.getScanId()));
 				map.put("progress", Integer.toString(spiderScan.getProgress()));
 				map.put("state", spiderScan.getState());
-				resultList.addItem(new ApiResponseSet("scan", map));
+				resultList.addItem(new ApiResponseSet<String>("scan", map));
 			}
 			result = resultList;
 		} else {

--- a/src/org/zaproxy/zap/extension/stats/StatsAPI.java
+++ b/src/org/zaproxy/zap/extension/stats/StatsAPI.java
@@ -98,7 +98,7 @@ public class StatsAPI extends ApiImplementor {
 			for (Entry<String, Long> stat : memStats.getStats(this.getParam(params, PARAM_KEY_PREFIX, "")).entrySet()) {
 				map.put(stat.getKey(), stat.getValue().toString());
 			}
-			result = new ApiResponseSet(name, map);
+			result = new ApiResponseSet<String>(name, map);
 
 		} else if (VIEW_ALL_SITES_STATS.equals(name)) {
 			result = new ApiResponseList(name);
@@ -145,7 +145,7 @@ public class StatsAPI extends ApiImplementor {
 			for (Entry<String, Long> stat : this.stats.entrySet()) {
 				map.put(stat.getKey(), stat.getValue().toString());
 			}
-			this.addItem(new ApiResponseSet(site, map));
+			this.addItem(new ApiResponseSet<String>(site, map));
 		}
 		
 		@Override

--- a/src/org/zaproxy/zap/extension/users/UsersAPI.java
+++ b/src/org/zaproxy/zap/extension/users/UsersAPI.java
@@ -238,7 +238,7 @@ public class UsersAPI extends ApiImplementor {
 		fields.put("enabled", Boolean.toString(u.isEnabled()));
 		fields.put("credentials", u.getAuthenticationCredentials().getApiResponseRepresentation().toJSON()
 				.toString());
-		ApiResponseSet response = new ApiResponseSet("user", fields);
+		ApiResponseSet<String> response = new ApiResponseSet<String>("user", fields);
 		return response;
 	}
 

--- a/test/org/zaproxy/zap/extension/api/ApiResponseConversionUtilsUnitTest.java
+++ b/test/org/zaproxy/zap/extension/api/ApiResponseConversionUtilsUnitTest.java
@@ -48,16 +48,16 @@ public class ApiResponseConversionUtilsUnitTest {
 	
 	@Test
 	public void nameOfApiResponseShouldBeConstant() {
-		ApiResponseSet response = ApiResponseConversionUtils.httpMessageToSet(0, message);
+		ApiResponseSet<String> response = ApiResponseConversionUtils.httpMessageToSet(0, message);
 
 		assertThat(response.getName(), is("message"));
 	}
 
 	@Test
 	public void historyIdShouldBecomeIdOfApiResponse() {
-		ApiResponseSet response = ApiResponseConversionUtils.httpMessageToSet(42, message);
+		ApiResponseSet<String> response = ApiResponseConversionUtils.httpMessageToSet(42, message);
 
-		assertThat(response.getValues(), hasEntry("id", (Object)"42"));
+		assertThat(response.getValues(), hasEntry("id", "42"));
 	}
 
 	@Test
@@ -68,14 +68,13 @@ public class ApiResponseConversionUtilsUnitTest {
 		given(requestBody.toString()).willReturn("testRequestBody");
 		given(responseHeader.toString()).willReturn("testResponseHeader");
 		
-		ApiResponseSet response = ApiResponseConversionUtils.httpMessageToSet(0, message);
+		ApiResponseSet<String> response = ApiResponseConversionUtils.httpMessageToSet(0, message);
 		
-			
-		assertThat(response.getValues(), hasEntry("cookieParams", (Object)"testCookieParams"));
-		assertThat(response.getValues(), hasEntry("note", (Object)"testNote"));
-		assertThat(response.getValues(), hasEntry("requestHeader", (Object)requestHeader.toString()));
-		assertThat(response.getValues(), hasEntry("requestBody", (Object)requestBody.toString()));
-		assertThat(response.getValues(), hasEntry("responseHeader", (Object)responseHeader.toString()));
+		assertThat(response.getValues(), hasEntry("cookieParams", "testCookieParams"));
+		assertThat(response.getValues(), hasEntry("note", "testNote"));
+		assertThat(response.getValues(), hasEntry("requestHeader", requestHeader.toString()));
+		assertThat(response.getValues(), hasEntry("requestBody", requestBody.toString()));
+		assertThat(response.getValues(), hasEntry("responseHeader", responseHeader.toString()));
 	}
 
 	@Test
@@ -83,9 +82,9 @@ public class ApiResponseConversionUtilsUnitTest {
 		given(responseHeader.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn(HttpHeader.GZIP);
 		given(responseBody.getBytes()).willReturn(gzip(new byte[] {97, 98, 99}));
 
-		ApiResponseSet response = ApiResponseConversionUtils.httpMessageToSet(0, message);
+		ApiResponseSet<String> response = ApiResponseConversionUtils.httpMessageToSet(0, message);
 		
-		assertThat(response.getValues(), hasEntry("responseBody", (Object)"abc"));
+		assertThat(response.getValues(), hasEntry("responseBody", "abc"));
 	}
 
 	@Test
@@ -93,9 +92,9 @@ public class ApiResponseConversionUtilsUnitTest {
 		given(responseHeader.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn(HttpHeader.GZIP);
 		given(responseBody.getBytes()).willReturn(new byte[] {0,0,0});
 
-		ApiResponseSet response = ApiResponseConversionUtils.httpMessageToSet(0, message);
+		ApiResponseSet<String> response = ApiResponseConversionUtils.httpMessageToSet(0, message);
 		
-		assertThat(response.getValues(), hasEntry("responseBody", (Object)responseBody.toString()));
+		assertThat(response.getValues(), hasEntry("responseBody", responseBody.toString()));
 	}
 	
 	private byte[] gzip(byte[] raw) throws Exception {


### PR DESCRIPTION
Switched to ConcurrentSkipListSet as internal data structure in SiteNode
due to heavy load on contains method. Have not measured how this affects
other operations.
Changed how alerts are loaded from DB. Instead of fetching all IDs
and iteratively fetch one by one they are now loaded all at once.
Added a flag to addAlert to allow less notifyChange calls which causes redraw
