### PR TITLE
Disable 'clean completed scans' button when resetting the scanner panel

### DIFF
--- a/src/org/zaproxy/zap/view/ScanPanel2.java
+++ b/src/org/zaproxy/zap/view/ScanPanel2.java
@@ -545,6 +545,8 @@ public abstract class ScanPanel2<GS extends GenericScanner2, SC extends ScanCont
 		progressModel.removeAllElements();
 		progressSelect.addItem(selectScanEntry);
 		progressSelect.setSelectedIndex(0);
+
+		clearScansButton.setEnabled(false);
 	}
 
 	public void sessionScopeChanged(Session session) {


### PR DESCRIPTION
Change the method ScanPanel2.reset() to disable clearScansButton,
otherwise it would be kept enabled even if there were no scans present
in the panel (for example, after creating a new session).