### PR TITLE
Fix ClassCastException in ClassLoaderUtil

### DIFF
--- a/src/org/zaproxy/zap/utils/ClassLoaderUtil.java
+++ b/src/org/zaproxy/zap/utils/ClassLoaderUtil.java
@@ -44,6 +44,9 @@ public class ClassLoaderUtil {
      * @throws IOException IOException
      */
     public static void addURL(URL u) throws IOException {
+        if (!(ClassLoader.getSystemClassLoader() instanceof URLClassLoader)) {
+            return;
+        }
 
         URLClassLoader sysLoader = (URLClassLoader) ClassLoader.getSystemClassLoader();
         URL[] urls = sysLoader.getURLs();


### PR DESCRIPTION
Change ClassLoaderUtil to not attempt to cast/use the default delegation
parent class loader as URLClassLoader if it's not one, otherwise it
would lead to a ClassCastException and ZAP would fail to start. ZAP does
not require the dynamic loading of the dependencies or other resources,
if they are already in the classpath (or set in the ClassLoader, which
is the case when the ClassCastException happened).