### PR TITLE
Correct the parent ClassLoader used by class loader AddOnLoader

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnLoader.java
@@ -114,7 +114,7 @@ public class AddOnLoader extends URLClassLoader {
     private Map<String, AddOnClassLoader> addOnLoaders = new HashMap<>();
 
     public AddOnLoader(File[] dirs) {
-        super(new URL[0]);
+        super(new URL[0], AddOnLoader.class.getClassLoader());
         
         this.loadBlockList();
 


### PR DESCRIPTION
Change class AddOnLoader to use, always, as parent ClassLoader the class
loader used to load the class itself instead of defaulting to the
default delegation parent ClassLoader as the returned class loader might
not be the same that loaded the class, leading to fail to find and load
classes of ZAP.