### PR TITLE
Use ZAP's classes to load ZAP resources

### DIFF
--- a/src/org/zaproxy/zap/view/ContextsTreeCellRenderer.java
+++ b/src/org/zaproxy/zap/view/ContextsTreeCellRenderer.java
@@ -34,10 +34,10 @@ import org.zaproxy.zap.utils.DisplayUtils;
  */
 public class ContextsTreeCellRenderer extends DefaultTreeCellRenderer {
 	
-	private static final ImageIcon ROOT_ICON = new ImageIcon(DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/applications-blue.png"));
-	private static final ImageIcon CONTEXT_IN_SCOPE_ICON = new ImageIcon(DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/application-blue-target.png"));
-	private static final ImageIcon CONTEXT_ICON = new ImageIcon(DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/application-blue.png"));
-	private static final ImageIcon ALL_IN_SCOPE_ICON = new ImageIcon(DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/target.png"));
+	private static final ImageIcon ROOT_ICON = new ImageIcon(ContextsTreeCellRenderer.class.getResource("/resource/icon/fugue/applications-blue.png"));
+	private static final ImageIcon CONTEXT_IN_SCOPE_ICON = new ImageIcon(ContextsTreeCellRenderer.class.getResource("/resource/icon/fugue/application-blue-target.png"));
+	private static final ImageIcon CONTEXT_ICON = new ImageIcon(ContextsTreeCellRenderer.class.getResource("/resource/icon/fugue/application-blue.png"));
+	private static final ImageIcon ALL_IN_SCOPE_ICON = new ImageIcon(ContextsTreeCellRenderer.class.getResource("/resource/icon/fugue/target.png"));
 
 	private static final long serialVersionUID = -4278691012245035225L;
 

--- a/src/org/zaproxy/zap/view/SiteMapTreeCellRenderer.java
+++ b/src/org/zaproxy/zap/view/SiteMapTreeCellRenderer.java
@@ -41,17 +41,17 @@ import org.zaproxy.zap.utils.DisplayUtils;
  */
 public class SiteMapTreeCellRenderer extends DefaultTreeCellRenderer {
 	
-	private static final ImageIcon ROOT_ICON = new ImageIcon(DefaultTreeCellRenderer.class.getResource("/resource/icon/16/094.png"));
-	private static final ImageIcon LEAF_IN_SCOPE_ICON = new ImageIcon(DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/document-target.png"));
-	private static final ImageIcon LEAF_ICON = new ImageIcon(DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/document.png"));
-	private static final ImageIcon FOLDER_OPEN_IN_SCOPE_ICON = new ImageIcon(DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/folder-horizontal-open-target.png"));
-	private static final ImageIcon FOLDER_OPEN_ICON = new ImageIcon(DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/folder-horizontal-open.png"));
-	private static final ImageIcon FOLDER_CLOSED_IN_SCOPE_ICON = new ImageIcon(DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/folder-horizontal-target.png"));
-	private static final ImageIcon FOLDER_CLOSED_ICON = new ImageIcon(DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/folder-horizontal.png"));
-	private static final ImageIcon DATA_DRIVEN_ICON = new ImageIcon(DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/database.png"));
-	private static final ImageIcon DATA_DRIVEN_IN_SCOPE_ICON = new ImageIcon(DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/database-target.png"));
+	private static final ImageIcon ROOT_ICON = new ImageIcon(SiteMapTreeCellRenderer.class.getResource("/resource/icon/16/094.png"));
+	private static final ImageIcon LEAF_IN_SCOPE_ICON = new ImageIcon(SiteMapTreeCellRenderer.class.getResource("/resource/icon/fugue/document-target.png"));
+	private static final ImageIcon LEAF_ICON = new ImageIcon(SiteMapTreeCellRenderer.class.getResource("/resource/icon/fugue/document.png"));
+	private static final ImageIcon FOLDER_OPEN_IN_SCOPE_ICON = new ImageIcon(SiteMapTreeCellRenderer.class.getResource("/resource/icon/fugue/folder-horizontal-open-target.png"));
+	private static final ImageIcon FOLDER_OPEN_ICON = new ImageIcon(SiteMapTreeCellRenderer.class.getResource("/resource/icon/fugue/folder-horizontal-open.png"));
+	private static final ImageIcon FOLDER_CLOSED_IN_SCOPE_ICON = new ImageIcon(SiteMapTreeCellRenderer.class.getResource("/resource/icon/fugue/folder-horizontal-target.png"));
+	private static final ImageIcon FOLDER_CLOSED_ICON = new ImageIcon(SiteMapTreeCellRenderer.class.getResource("/resource/icon/fugue/folder-horizontal.png"));
+	private static final ImageIcon DATA_DRIVEN_ICON = new ImageIcon(SiteMapTreeCellRenderer.class.getResource("/resource/icon/fugue/database.png"));
+	private static final ImageIcon DATA_DRIVEN_IN_SCOPE_ICON = new ImageIcon(SiteMapTreeCellRenderer.class.getResource("/resource/icon/fugue/database-target.png"));
 
-	private static final ImageIcon LOCK_OVERLAY_ICON = new ImageIcon(DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/lock-overlay.png"));
+	private static final ImageIcon LOCK_OVERLAY_ICON = new ImageIcon(SiteMapTreeCellRenderer.class.getResource("/resource/icon/fugue/lock-overlay.png"));
 
 	private static final long serialVersionUID = -4278691012245035225L;
 


### PR DESCRIPTION
Change classes ContextsTreeCellRenderer and SiteMapTreeCellRenderer
to use the classes themselves to load the resources instead of the
class DefaultTreeCellRenderer, the latter class might not always have
access to the resources, failing to find them and leading to a
NullPointerException.