### PR TITLE
Allow add-ons to specify which classes can be loaded by its classloader

### DIFF
--- a/src/org/zaproxy/zap/control/AddOn.java
+++ b/src/org/zaproxy/zap/control/AddOn.java
@@ -153,6 +153,8 @@ public class AddOn  {
 	private List<PluginPassiveScanner> loadedPscanrules = Collections.emptyList();
 	private boolean loadedPscanRulesSet;
 	private List<String> files = Collections.emptyList();
+
+	private AddOnClassnames addOnClassnames = AddOnClassnames.ALL_ALLOWED;
 	
 	private Dependencies dependencies;
 
@@ -239,6 +241,8 @@ public class AddOn  {
 						this.extensionsWithDeps = zapAddOnXml.getExtensionsWithDeps();
 						this.files = zapAddOnXml.getFiles();
 						this.pscanrules = zapAddOnXml.getPscanrules();
+
+						this.addOnClassnames = zapAddOnXml.getAddOnClassnames();
 
 						hasZapAddOnEntry = true;
 					}
@@ -421,6 +425,16 @@ public class AddOn  {
 		}
 		return hasZapAddOnEntry;
 	}
+
+	/**
+	 * Gets the classnames that can be loaded for the add-on.
+	 * 
+	 * @return the classnames that can be loaded
+	 * @since TODO add version
+	 */
+	public AddOnClassnames getAddOnClassnames() {
+		return addOnClassnames;
+	}
 	
 	public List<String> getExtensions() {
 		return extensions;
@@ -442,6 +456,27 @@ public class AddOn  {
 			extensionClassnames.add(extension.getClassname());
 		}
 		return extensionClassnames;
+	}
+
+	/**
+	 * Returns the classnames that can be loaded for the given {@code Extension} (with dependencies).
+	 * 
+	 * @param classname the classname of the extension
+	 * @return the classnames that can be loaded
+	 * @since TODO add version
+	 * @see #hasExtensionsWithDeps()
+	 */
+	public AddOnClassnames getExtensionAddOnClassnames(String classname) {
+		if (extensionsWithDeps.isEmpty() || classname == null || classname.isEmpty()) {
+			return AddOnClassnames.ALL_ALLOWED;
+		}
+
+		for (ExtensionWithDeps extension : extensionsWithDeps) {
+			if (classname.equals(extension.getClassname())) {
+				return extension.getAddOnClassnames();
+			}
+		}
+		return AddOnClassnames.ALL_ALLOWED;
 	}
 
 	/**

--- a/src/org/zaproxy/zap/control/AddOnClassnames.java
+++ b/src/org/zaproxy/zap/control/AddOnClassnames.java
@@ -1,0 +1,71 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2015 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.control;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A class that allows to query if a classname can be loaded.
+ * <p>
+ * The classnames can be allowed or restricted.
+ * 
+ * @since TODO add version
+ */
+final class AddOnClassnames {
+
+    public static final AddOnClassnames ALL_ALLOWED = new AddOnClassnames(
+            Collections.<String> emptyList(),
+            Collections.<String> emptyList());
+
+    private final List<String> allowedClassnames;
+    private final List<String> restrictedClassnames;
+
+    public AddOnClassnames(List<String> allowedClassnames, List<String> restrictedClassnames) {
+        if (allowedClassnames == null) {
+            throw new IllegalArgumentException("Parameter allowedClassnames must not be null.");
+        }
+        if (restrictedClassnames == null) {
+            throw new IllegalArgumentException("Parameter restrictedClassnames must not be null.");
+        }
+
+        this.allowedClassnames = allowedClassnames;
+        this.restrictedClassnames = restrictedClassnames;
+    }
+
+    public boolean isAllowed(String classname) {
+        if (!restrictedClassnames.isEmpty()) {
+            for (String restrictedClassname : restrictedClassnames) {
+                if (classname.startsWith(restrictedClassname)) {
+                    return false;
+                }
+            }
+        }
+        if (!allowedClassnames.isEmpty()) {
+            for (String allowedClassname : allowedClassnames) {
+                if (classname.startsWith(allowedClassname)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/org/zaproxy/zap/control/AddOnLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnLoader.java
@@ -249,7 +249,7 @@ public class AddOnLoader extends URLClassLoader {
 
             List<String> idsAddOnDependencies = ao.getIdsAddOnDependencies();
             if (idsAddOnDependencies.isEmpty()) {
-                addOnClassLoader = new AddOnClassLoader(ao.getFile().toURI().toURL(), this);
+                addOnClassLoader = new AddOnClassLoader(ao.getFile().toURI().toURL(), this, ao.getAddOnClassnames());
                 this.addOnLoaders.put(ao.getId(), addOnClassLoader);
                 return addOnClassLoader;
             }
@@ -263,7 +263,7 @@ public class AddOnLoader extends URLClassLoader {
                 dependencies.add(addOnClassLoader);
             }
 
-            addOnClassLoader = new AddOnClassLoader(ao.getFile().toURI().toURL(), this, dependencies);
+            addOnClassLoader = new AddOnClassLoader(ao.getFile().toURI().toURL(), this, dependencies, ao.getAddOnClassnames());
             this.addOnLoaders.put(ao.getId(), addOnClassLoader);
             return addOnClassLoader;
         } catch (MalformedURLException e) {
@@ -436,7 +436,10 @@ public class AddOnLoader extends URLClassLoader {
                         for (AddOn addOnDep : extReqs.getDependencies()) {
                             dependencies.add(addOnLoaders.get(addOnDep.getId()));
                         }
-                        AddOnClassLoader extAddOnClassLoader = new AddOnClassLoader(entry.getValue(), dependencies);
+                        AddOnClassLoader extAddOnClassLoader = new AddOnClassLoader(
+                                entry.getValue(),
+                                dependencies,
+                                runningAddOn.getExtensionAddOnClassnames(extClassName));
                         Extension ext = loadAddOnExtension(runningAddOn, extReqs.getClassname(), extAddOnClassLoader);
                         AddOnInstaller.installAddOnExtension(runningAddOn, ext);
                         runnableAddOns.get(runningAddOn).add(extReqs.getClassname());
@@ -683,7 +686,10 @@ public class AddOnLoader extends URLClassLoader {
                     for (AddOn addOnDep : extReqs.getDependencies()) {
                         dependencies.add(addOnLoaders.get(addOnDep.getId()));
                     }
-                    AddOnClassLoader extAddOnClassLoader = new AddOnClassLoader(addOnClassLoader, dependencies);
+                    AddOnClassLoader extAddOnClassLoader = new AddOnClassLoader(
+                            addOnClassLoader,
+                            dependencies,
+                            addOn.getExtensionAddOnClassnames(extReqs.getClassname()));
                     Extension ext = loadAddOnExtension(addOn, extReqs.getClassname(), extAddOnClassLoader);
                     if (ext != null) {
                         extensions.add(ext);

--- a/src/org/zaproxy/zap/control/BaseZapAddOnXmlData.java
+++ b/src/org/zaproxy/zap/control/BaseZapAddOnXmlData.java
@@ -113,6 +113,10 @@ public abstract class BaseZapAddOnXmlData {
     private static final String EXTENSIONS_V1_ALL_ELEMENTS = "extensions/" + EXTENSION_ELEMENT + "[@v='1']";
     private static final String EXTENSION_CLASS_NAME = "classname";
     private static final String EXTENSION_DEPENDENCIES = DEPENDENCIES_ELEMENT + "/" + DEPENDENCIES_ADDONS_ALL_ELEMENTS;
+    private static final String CLASSNAMES_ALLOWED_ELEMENT = "allowed";
+    private static final String CLASSNAMES_ALLOWED_ALL_ELEMENTS = "classnames/" + CLASSNAMES_ALLOWED_ELEMENT;
+    private static final String CLASSNAMES_RESTRICTED_ELEMENT = "restricted";
+    private static final String CLASSNAMES_RESTRICTED_ALL_ELEMENTS = "classnames/" + CLASSNAMES_RESTRICTED_ELEMENT;
 
     private String name;
     private int packageVersion;
@@ -123,6 +127,8 @@ public abstract class BaseZapAddOnXmlData {
     private String changes;
 
     private Dependencies dependencies;
+
+    private AddOnClassnames addOnClassnames;
 
     private String notBeforeVersion;
     private String notFromVersion;
@@ -179,6 +185,8 @@ public abstract class BaseZapAddOnXmlData {
         extensions = getStrings(zapAddOnXml, EXTENSIONS_ALL_ELEMENTS, EXTENSION_ELEMENT);
         extensionsWithDeps = readExtensionsWithDeps(zapAddOnXml);
 
+        addOnClassnames = readAddOnClassnames(zapAddOnXml);
+
         readAdditionalData(zapAddOnXml);
     }
 
@@ -229,6 +237,10 @@ public abstract class BaseZapAddOnXmlData {
 
     public Dependencies getDependencies() {
         return dependencies;
+    }
+    
+    public AddOnClassnames getAddOnClassnames() {
+        return addOnClassnames;
     }
 
     public String getNotBeforeVersion() {
@@ -335,10 +347,20 @@ public abstract class BaseZapAddOnXmlData {
             }
 
             List<AddOnDep> addOnDeps = readAddOnDependencies(fields);
-            extensionsWithDeps.add(new ExtensionWithDeps(classname, addOnDeps));
+            AddOnClassnames classnames = readAddOnClassnames(extensionNode);
+            extensionsWithDeps.add(new ExtensionWithDeps(classname, addOnDeps, classnames));
         }
 
         return extensionsWithDeps;
+    }
+
+    private AddOnClassnames readAddOnClassnames(HierarchicalConfiguration node) {
+        List<String> allowed = getStrings(node, CLASSNAMES_ALLOWED_ALL_ELEMENTS, CLASSNAMES_ALLOWED_ELEMENT);
+        List<String> restricted = getStrings(node, CLASSNAMES_RESTRICTED_ALL_ELEMENTS, CLASSNAMES_RESTRICTED_ELEMENT);
+        if (allowed.isEmpty() && restricted.isEmpty()) {
+            return AddOnClassnames.ALL_ALLOWED;
+        }
+        return new AddOnClassnames(allowed, restricted);
     }
 
     private void malformedFile(String reason) {
@@ -412,10 +434,12 @@ public abstract class BaseZapAddOnXmlData {
 
         private final String classname;
         private final List<AddOnDep> addOnDependencies;
+        private final AddOnClassnames addOnClassnames;
 
-        public ExtensionWithDeps(String classname, List<AddOnDep> addOnDependencies) {
+        public ExtensionWithDeps(String classname, List<AddOnDep> addOnDependencies, AddOnClassnames addOnClassnames) {
             this.classname = classname;
             this.addOnDependencies = addOnDependencies;
+            this.addOnClassnames = addOnClassnames;
         }
 
         public String getClassname() {
@@ -424,6 +448,10 @@ public abstract class BaseZapAddOnXmlData {
 
         public List<AddOnDep> getDependencies() {
             return addOnDependencies;
+        }
+
+        public AddOnClassnames getAddOnClassnames() {
+            return addOnClassnames;
         }
     }
 }


### PR DESCRIPTION
The change allows the add-ons to specify (through its ZapAddOn.xml file)
which classnames are allowed or restricted for the whole add-on and for
its extensions, when loading classes from the add-on.
The change allows add-ons to better compartmentalise its extensions,
for when they depend on other add-ons, preventing the load of the same
classes (from the add-on itself) more than once (which leads to
misleading issues since the classes are the same, but have different
class loaders).