### PR TITLE
Fix: Evil NPE

### DIFF
--- a/src/org/zaproxy/zap/session/CookieBasedSessionManagementHelper.java
+++ b/src/org/zaproxy/zap/session/CookieBasedSessionManagementHelper.java
@@ -61,6 +61,12 @@ public class CookieBasedSessionManagementHelper {
 
 		// Make a copy of the session tokens set, as they will be modified
 		HttpSessionTokensSet tokensSet = session.getTokensNames();
+		
+		// If no tokens exists create dummy Object -> NPE
+		if (tokensSet == null) {
+			tokensSet = new HttpSessionTokensSet();
+		}
+		
 		Set<String> unsetSiteTokens = new LinkedHashSet<>(tokensSet.getTokensSet());
 
 		// Iterate through the cookies in the request


### PR DESCRIPTION
tokensSet is not checked for null

```
Traceback (most recent call last):
  File "<script>", line 77, in responseReceived
  File "<script>", line 133, in authenticate
  File "<script>", line 139, in resendMessageWithSession
	at org.zaproxy.zap.session.CookieBasedSessionManagementHelper.processMessageToMatchSession(CookieBasedSessionManagementHelper.java:64)

	at org.zaproxy.zap.session.CookieBasedSessionManagementHelper.processMessageToMatchSession(CookieBasedSessionManagementHelper.java:49)

	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)

	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)

	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)

	at java.lang.reflect.Method.invoke(Unknown Source)
```