### PR TITLE
set / update default threshold and strength for a scan policy

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
@@ -40,7 +40,6 @@ import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.core.scanner.HostProcess;
 import org.parosproxy.paros.core.scanner.Plugin;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
-import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
@@ -372,8 +371,8 @@ public class ActiveScanAPI extends ApiImplementor {
 				}
 				policy = controller.getPolicyManager().getTemplatePolicy();
 				policy.setName(newPolicyName);
-				policy.setDefaultThreshold(getAlertThreshold(params));
-				policy.setDefaultStrength(getAttackStrength(params));
+				setAlertThreshold(policy, params);
+				setAttackStrength(policy, params);
 				controller.getPolicyManager().savePolicy(policy);
 				break;
 			case ACTION_REMOVE_SCAN_POLICY:
@@ -400,36 +399,32 @@ public class ActiveScanAPI extends ApiImplementor {
 		return ApiResponseElement.OK;
 	}
 
-	private AlertThreshold getAlertThreshold(JSONObject params) throws ApiException {
-		if (!isParamExists(params.getString(PARAM_ALERT_THRESHOLD))) {
-			return AlertThreshold.MEDIUM;
+	private void setAlertThreshold(ScanPolicy policy, JSONObject params) throws ApiException {
+		if (isParamExists(params, PARAM_ALERT_THRESHOLD)) {
+			policy.setDefaultThreshold(getAlertThresholdFromParamAlertThreshold(params));
 		}
-
-		return getAlertThresholdFromParamAlertThreshold(params);
 	}
 
-	private AttackStrength getAttackStrength(JSONObject params) throws ApiException {
-		if (!isParamExists(params.getString(PARAM_ATTACK_STRENGTH))) {
-			return AttackStrength.MEDIUM;
+	private void setAttackStrength(ScanPolicy policy, JSONObject params) throws ApiException {
+		if (isParamExists(params, PARAM_ATTACK_STRENGTH)) {
+			policy.setDefaultStrength(getAttackStrengthFromParamAttack(params));
 		}
-
-		return getAttackStrengthFromParamAttack(params);
 	}
 
 	private void changeAlertThreshold(ScanPolicy policy, JSONObject params) throws ApiException {
-		if (isParamExists(params.getString(PARAM_ALERT_THRESHOLD))) {
+		if (isParamExists(params, PARAM_ALERT_THRESHOLD)) {
 			policy.setDefaultThreshold(getAlertThresholdFromParamAlertThreshold(params));
 		}
 	}
 
 	private void changeAttackStrength(ScanPolicy policy, JSONObject params) throws ApiException {
-		if (isParamExists(params.getString(PARAM_ATTACK_STRENGTH))) {
+		if (isParamExists(params, PARAM_ATTACK_STRENGTH)) {
 			policy.setDefaultStrength(getAttackStrengthFromParamAttack(params));
 		}
 	}
 
-	private boolean isParamExists(String param) {
-		return StringUtils.isNotBlank(param);
+	private boolean isParamExists(JSONObject params, String key) {
+		return params.has(key) && StringUtils.isNotBlank(params.getString(key));
 	}
 
 	private static URI getTargetUrl(String url) throws ApiException {

--- a/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
@@ -33,7 +33,7 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Category;

--- a/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
@@ -95,6 +95,7 @@ public class ActiveScanAPI extends ApiImplementor {
 	private static final String ACTION_SET_SCANNER_ALERT_THRESHOLD = "setScannerAlertThreshold";
 	private static final String ACTION_ADD_SCAN_POLICY = "addScanPolicy";
 	private static final String ACTION_REMOVE_SCAN_POLICY = "removeScanPolicy";
+	private static final String ACTION_UPDATE_SCAN_POLICY = "updateScanPolicy";
 
 	private static final String VIEW_STATUS = "status";
 	private static final String VIEW_SCANS = "scans";
@@ -162,6 +163,8 @@ public class ActiveScanAPI extends ApiImplementor {
 		this.addApiAction(new ApiAction(ACTION_ADD_SCAN_POLICY, new String[] {PARAM_SCAN_POLICY_NAME},
 				new String[] {PARAM_ALERT_THRESHOLD, PARAM_ATTACK_STRENGTH}));
 		this.addApiAction(new ApiAction(ACTION_REMOVE_SCAN_POLICY, new String[] {PARAM_SCAN_POLICY_NAME}));
+		this.addApiAction(new ApiAction(ACTION_UPDATE_SCAN_POLICY, new String[] {PARAM_SCAN_POLICY_NAME},
+				new String[] {PARAM_ALERT_THRESHOLD, PARAM_ATTACK_STRENGTH}));
 
 		this.addApiView(new ApiView(VIEW_STATUS, null, new String[] { PARAM_SCAN_ID }));
 		this.addApiView(new ApiView(VIEW_SCAN_PROGRESS, null, new String[] { PARAM_SCAN_ID }));
@@ -382,6 +385,12 @@ public class ActiveScanAPI extends ApiImplementor {
 				}
 				controller.getPolicyManager().deletePolicy(policy.getName());
 				break;
+			case ACTION_UPDATE_SCAN_POLICY:
+				policy = getScanPolicyFromParams(params);
+				changeAlertThreshold(policy, params);
+				changeAttackStrength(policy, params);
+				controller.getPolicyManager().savePolicy(policy);
+				break;
 			default:
 				throw new ApiException(ApiException.Type.BAD_ACTION);
 			}
@@ -405,6 +414,18 @@ public class ActiveScanAPI extends ApiImplementor {
 		}
 
 		return getAttackStrengthFromParamAttack(params);
+	}
+
+	private void changeAlertThreshold(ScanPolicy policy, JSONObject params) throws ApiException {
+		if (isParamExists(params.getString(PARAM_ALERT_THRESHOLD))) {
+			policy.setDefaultThreshold(getAlertThresholdFromParamAlertThreshold(params));
+		}
+	}
+
+	private void changeAttackStrength(ScanPolicy policy, JSONObject params) throws ApiException {
+		if (isParamExists(params.getString(PARAM_ATTACK_STRENGTH))) {
+			policy.setDefaultStrength(getAttackStrengthFromParamAttack(params));
+		}
 	}
 
 	private boolean isParamExists(String param) {


### PR DESCRIPTION
main changes:
- AddScanPolicy API enhanced, 2 optional params added, so that user could set policy's default alert threshold and attack strength
- UpdateScanPolicy API added, so that user could modify the default alert threshold or attack strength for a given scan policy
