### PR TITLE
Change SpiderAPI to ignore empty context names when handling scan action

### DIFF
--- a/src/org/zaproxy/zap/extension/spider/SpiderAPI.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderAPI.java
@@ -166,7 +166,10 @@ public class SpiderAPI extends ApiImplementor {
 				}
 			}
 			if (params.containsKey(PARAM_CONTEXT_NAME)) {
-				context = ApiUtils.getContextByName(params, PARAM_CONTEXT_NAME);
+				String contextName = params.getString(PARAM_CONTEXT_NAME);
+				if (!contextName.isEmpty()) {
+					context = ApiUtils.getContextByName(contextName);
+				}
 			}
 			int scanId = scanURL(url, null, maxChildren, this.getParam(params, PARAM_RECURSE, true), context);
 			return new ApiResponseElement(name, Integer.toString(scanId));


### PR DESCRIPTION
Change the method SpiderAPI.handleApiAction(String, JSONObject) to
ignore empty context names when handling the "scan" action since ZAP API
clients might always send the context's name parameter even if it was
not specified (for example, the ZAP API UI or older versions of Java ZAP
API client), leading to the "scan" action to always fail with missing
context error.
Related to #2108 - ZAP API clients should not send optional parameters
unless specified