### PR TITLE
Log the exception when opening session file and internationalise message

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1286,6 +1286,7 @@ menu.file.newSession.error    = Error creating new session
 menu.file.newSession.mnemonic = n
 menu.file.openSession         = Open Session...
 menu.file.openSession.error   = Error opening a session
+menu.file.openSession.errorFile = Error opening session file.
 menu.file.openSession.mnemonic = o
 menu.file.persistSession      = Persist Session...
 menu.file.persistSession.error = Error persisting session

--- a/src/org/parosproxy/paros/control/MenuFileControl.java
+++ b/src/org/parosproxy/paros/control/MenuFileControl.java
@@ -41,6 +41,7 @@
 // ZAP: 2015/01/29 Issue 1489: Version number in window title
 // ZAP: 2015/02/05 Issue 1524: New Persist Session dialog
 // ZAP: 2015/04/02 Issue 321: Support multiple databases
+// ZAP: 2015/12/14 Log exception and internationalise error message
 
 package org.parosproxy.paros.control;
  
@@ -506,9 +507,9 @@ public class MenuFileControl implements SessionListener {
             setTitle();
             //view.getMainFrame().setTitle(file.getName().replaceAll(".session\\z","") + " - " + Constant.PROGRAM_NAME);
         } else {
-            view.showWarningDialog("Error opening session file");
+            view.showWarningDialog(Constant.messages.getString("menu.file.openSession.errorFile"));
             if (file != null) {
-                log.error("Error opening session file " + file.getAbsolutePath());
+                log.error("Error opening session file " + file.getAbsolutePath(), e);
             } else {
             	// File is null for table based sessions (ie non HSQLDB)
                 log.error(e.getMessage(), e);


### PR DESCRIPTION
Change method MenuFileControl.sessionOpened(File file, Exception) to log
the exception when failed to open the session from a file and to
internationalise GUI error message.

---
Issue reported in OWASP ZAP User Group: https://groups.google.com/d/topic/zaproxy-users/8TN8Yh-Vib8/discussion