### PR TITLE
Fix NullPointerException on missing context's authentication script

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -385,6 +385,7 @@ authentication.method.script.type							= Authentication
 authentication.method.script.type.desc						= Authentication scripts run when you an authentication is needed.\n\nThe script must be properly configured in the Session Properties -> Authentication panel with a 'Script-based Authentication Method'
 authentication.method.script.field.label.scriptName			= Script:
 authentication.method.script.field.label.notLoaded			= <html><body><p>No script has been loaded yet. Select a Script in the box above and click the 'Load' button.</p></body></html>
+authentication.method.script.load.errorScriptNotFound		= Failed to find context''s Authentication script:\n{0}
 authentication.method.script.dialog.error.title				= Script loading error
 authentication.method.script.dialog.error.text.interface	= The provided Authentication script ({0}) does not implement the required interface. Please take a look at the provided templates for examples.
 authentication.method.script.dialog.error.text.loading		= An error has occurred while loading the selected Authentication script: {0}

--- a/src/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
@@ -171,7 +171,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
 		protected AuthenticationMethod duplicate() {
 			ScriptBasedAuthenticationMethod method = new ScriptBasedAuthenticationMethod();
 			method.script = script;
-			method.paramValues = new HashMap<String, String>(this.paramValues);
+			method.paramValues = this.paramValues != null ? new HashMap<String, String>(this.paramValues) : null;
 			method.credentialsParamNames = this.credentialsParamNames;
 			return method;
 		}
@@ -529,9 +529,13 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
 			if (script == null) {
 				log.error("Unable to find script while loading Script Based Authentication Method for name: "
 						+ scriptName);
-			} else {
-				log.info("Loaded script:" + script.getName());
+				if (View.isInitialised()) {
+					View.getSingleton().showMessageDialog(
+							Constant.messages.getString("authentication.method.script.load.errorScriptNotFound", scriptName));
+				}
+				return;
 			}
+			log.info("Loaded script:" + script.getName());
 			method.script = script;
 
 			// Check script interface and make sure we load the credentials parameter names


### PR DESCRIPTION
Change the method ScriptBasedAuthenticationMethodType.loadMethod
(ScriptBasedAuthenticationMethod, List<String>, List<String>) to not
continue loading the script if it was not found, preventing the
NullPointerException, also, if in GUI inform about the missing script.
Change the method ScriptBasedAuthenticationMethod.duplicate() to only
copy its parameters' values if those are non null (the parameters'
values are null, for example, if the script was not found or immediately
after instantiation).

---
Issue reported in OWASP ZAP User Group: https://groups.google.com/d/topic/zaproxy-users/8TN8Yh-Vib8/discussion