### PR TITLE
deprecate use of alert vs name in Alert

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/Alert.java
+++ b/src/org/parosproxy/paros/core/scanner/Alert.java
@@ -40,6 +40,7 @@
 // ZAP: 2015/02/09 Issue 1525: Introduce a database interface layer to allow for alternative implementations
 // ZAP: 2015/08/24 Issue 1849: Option to merge related issues in reports
 // ZAP: 2015/11/16 Issue 1555: Rework inclusion of HTML tags in reports 
+// ZAP: 2016/02/26 Deprecate alert as an element of Alert in favour of name
 
 package org.parosproxy.paros.core.scanner;
 
@@ -95,7 +96,7 @@ public class Alert implements Comparable<Object>  {
 	
 	private int		alertId = -1;	// ZAP: Changed default alertId
 	private int		pluginId = 0;
-	private String 	alert = "";
+	private String name = "";
 	private int risk = RISK_INFO;
 	/**
 	 * @deprecated
@@ -131,10 +132,10 @@ public class Alert implements Comparable<Object>  {
 		
 	}
 	
-	public Alert(int pluginId, int risk, int confidence, String alert) {
+	public Alert(int pluginId, int risk, int confidence, String name) {
 		this(pluginId);
 		setRiskConfidence(risk, confidence);
-		setAlert(alert);
+		setName(name);
 	}
 
 	public Alert(RecordAlert recordAlert) {
@@ -185,13 +186,23 @@ public class Alert implements Comparable<Object>  {
 		this.risk = risk;
 		this.confidence = confidence;
 	}
-	
+	/**
+	 * @deprecated (TODO add version) Replaced by {@link #setName}.
+	 * Use of alert has been deprecated in favour of using name.
+	 */
+	@Deprecated
 	public void setAlert(String alert) {
-	    if (alert == null) return;
-	    // ZAP: Changed to not create a new String.
-	    this.alert = alert;
+	    setName(alert);
 	}
-	
+	/**
+	 * Sets the name of the alert to name
+	 * @param name the name to set for the alert
+	 * @since TODO add version
+	 */
+	public void setName(String name) {
+	    if (name == null) return;
+	    this.name = name;
+	}
 	
 	/**
 	 * @deprecated (2.2.0) Replaced by
@@ -304,7 +315,7 @@ public class Alert implements Comparable<Object>  {
 			return 1;
 		}
 		
-		int result = alert.compareToIgnoreCase(alert2.alert);
+		int result = name.compareToIgnoreCase(alert2.name);
 		if (result != 0) {
 			return result;
 		}
@@ -333,7 +344,7 @@ public class Alert implements Comparable<Object>  {
 		Alert item = null;
 		if (obj instanceof Alert) {
 			item = (Alert) obj;
-			if ((pluginId == item.pluginId) && alert.equals(item.alert) && uri.equalsIgnoreCase(item.uri)
+			if ((pluginId == item.pluginId) && name.equals(item.name) && uri.equalsIgnoreCase(item.uri)
 				&& param.equalsIgnoreCase(item.param) && otherInfo.equalsIgnoreCase(item.otherInfo)) {
 				return true;
 			}
@@ -347,7 +358,7 @@ public class Alert implements Comparable<Object>  {
 	public Alert newInstance() {
 		Alert item = new Alert(this.pluginId);
 		item.setRiskConfidence(this.risk, this.confidence);
-		item.setAlert(this.alert);
+		item.setName(this.name);
 		item.setDetail(this.description, this.uri, this.param, this.attack, this.otherInfo, this.solution, this.reference, this.historyRef);
 		return item;
 	}
@@ -356,7 +367,8 @@ public class Alert implements Comparable<Object>  {
 		StringBuilder sb = new StringBuilder(150); // ZAP: Changed the type to StringBuilder.
 		sb.append("<alertitem>\r\n");
 		sb.append("  <pluginid>").append(pluginId).append("</pluginid>\r\n");
-		sb.append("  <alert>").append(replaceEntity(alert)).append("</alert>\r\n");
+		sb.append("  <alert>").append(replaceEntity(name)).append("</alert>\r\n"); //Deprecated in TODO add version, maintain for compatibility with custom code
+		sb.append("  <name>").append(replaceEntity(name)).append("</name>\r\n");
 		sb.append("  <riskcode>").append(risk).append("</riskcode>\r\n");
 		sb.append("  <confidence>").append(confidence).append("</confidence>\r\n");
 		sb.append("  <riskdesc>").append(replaceEntity(MSG_RISK[risk] + " (" + MSG_CONFIDENCE[confidence] + ")")).append("</riskdesc>\r\n");
@@ -392,12 +404,21 @@ public class Alert implements Comparable<Object>  {
 	public String paragraph(String text) {
 		return "<p>" + text.replaceAll("\\r\\n","</p><p>").replaceAll("\\n","</p><p>") + "</p>";
 	}
-    
-    /**
-     * @return Returns the alert.
-     */
+	/**
+	 * @deprecated (TODO add version) Replaced by {@link #getName}.
+	 * Use of alert has been deprecated in favour of using name.
+	 * @return Returns the alert.
+	 */
+	@Deprecated
     public String getAlert() {
-        return alert;
+        return name;
+    }
+	/**
+	 * @return Returns the name of the alert.
+	 * @since TODO add version
+	 */
+    public String getName() {
+        return name;
     }
     /**
      * @return Returns the description.

--- a/src/org/zaproxy/zap/extension/alert/AlertTreeModel.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertTreeModel.java
@@ -44,7 +44,7 @@ class AlertTreeModel extends DefaultTreeModel {
     }
     
     private String getRiskString (Alert alert) {
-		return "<html><img src=\"" + alert.getIconUrl() + "\">&nbsp;" + alert.getAlert() + "<html>";
+		return "<html><img src=\"" + alert.getIconUrl() + "\">&nbsp;" + alert.getName() + "<html>";
     }
     
     void addPath(final Alert alert) {

--- a/src/org/zaproxy/zap/extension/alert/AlertViewPanel.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertViewPanel.java
@@ -400,8 +400,8 @@ public class AlertViewPanel extends AbstractPanel {
 		alertUrl.setText(alert.getUri());
 		
 		if (editable) {
-			nameListModel.addElement(alert.getAlert());
-			alertEditName.setSelectedItem(alert.getAlert());
+			nameListModel.addElement(alert.getName());
+			alertEditName.setSelectedItem(alert.getName());
 			alertEditRisk.setSelectedItem(Alert.MSG_RISK[alert.getRisk()]);
 			alertEditConfidence.setSelectedItem(Alert.MSG_CONFIDENCE[alert.getConfidence()]);
 			alertEditParam.setSelectedItem(alert.getParam());
@@ -413,7 +413,7 @@ public class AlertViewPanel extends AbstractPanel {
 			alertEditWascId.setValue(alert.getWascId());
 			
 		} else {
-			alertName.setText(alert.getAlert());
+			alertName.setText(alert.getName());
 	
 			alertRisk.setText(Alert.MSG_RISK[alert.getRisk()]);
 	    	if (alert.getConfidence() == Alert.CONFIDENCE_FALSE_POSITIVE) {
@@ -526,7 +526,7 @@ public class AlertViewPanel extends AbstractPanel {
 		if (! editable && originalAlert != null) {
 			Alert alert = originalAlert.newInstance();
 			alert.setAlertId(originalAlert.getAlertId());
-			alert.setAlert((String)alertEditName.getSelectedItem());
+			alert.setName((String)alertEditName.getSelectedItem());
 			alert.setParam((String)alertEditParam.getSelectedItem());
 			alert.setRiskConfidence(alertEditRisk.getSelectedIndex(), 
 					alertEditConfidence.getSelectedIndex());

--- a/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -134,7 +134,7 @@ public class ExtensionAlert extends ExtensionAdaptor implements SessionChangedLi
 
     public void alertFound(Alert alert, HistoryReference ref) {
         try {
-            logger.debug("alertFound " + alert.getAlert() + " " + alert.getUri());
+            logger.debug("alertFound " + alert.getName() + " " + alert.getUri());
             if (ref == null) {
                 ref = alert.getHistoryRef();
             }
@@ -294,7 +294,7 @@ public class ExtensionAlert extends ExtensionAdaptor implements SessionChangedLi
             scanId = recordScan.getScanId();
         }
         RecordAlert recordAlert = tableAlert.write(
-                scanId, alert.getPluginId(), alert.getAlert(), alert.getRisk(), alert.getConfidence(),
+                scanId, alert.getPluginId(), alert.getName(), alert.getRisk(), alert.getConfidence(),
                 alert.getDescription(), alert.getUri(), alert.getParam(), alert.getAttack(),
                 alert.getOtherInfo(), alert.getSolution(), alert.getReference(),
                 alert.getEvidence(), alert.getCweId(), alert.getWascId(),
@@ -305,7 +305,7 @@ public class ExtensionAlert extends ExtensionAdaptor implements SessionChangedLi
     }
 
     public void updateAlert(Alert alert) throws HttpMalformedHeaderException, DatabaseException {
-        logger.debug("updateAlert " + alert.getAlert() + " " + alert.getUri());
+        logger.debug("updateAlert " + alert.getName() + " " + alert.getUri());
         updateAlertInDB(alert);
         if (alert.getHistoryRef() != null) {
             this.siteNodeChanged(alert.getHistoryRef().getSiteNode());
@@ -315,14 +315,14 @@ public class ExtensionAlert extends ExtensionAdaptor implements SessionChangedLi
     private void updateAlertInDB(Alert alert) throws HttpMalformedHeaderException, DatabaseException {
 
         TableAlert tableAlert = getModel().getDb().getTableAlert();
-        tableAlert.update(alert.getAlertId(), alert.getAlert(), alert.getRisk(),
+        tableAlert.update(alert.getAlertId(), alert.getName(), alert.getRisk(),
                 alert.getConfidence(), alert.getDescription(), alert.getUri(),
                 alert.getParam(), alert.getAttack(), alert.getOtherInfo(), alert.getSolution(), alert.getReference(), 
                 alert.getEvidence(), alert.getCweId(), alert.getWascId(), alert.getSourceHistoryId());
     }
 
     public void displayAlert(Alert alert) {
-        logger.debug("displayAlert " + alert.getAlert() + " " + alert.getUri());
+        logger.debug("displayAlert " + alert.getName() + " " + alert.getUri());
         this.alertPanel.getAlertViewPanel().displayAlert(alert);
     }
 
@@ -452,7 +452,7 @@ public class ExtensionAlert extends ExtensionAdaptor implements SessionChangedLi
     }
 
     public void deleteAlert(Alert alert) {
-        logger.debug("deleteAlert " + alert.getAlert() + " " + alert.getUri());
+        logger.debug("deleteAlert " + alert.getName() + " " + alert.getUri());
 
         try {
             getModel().getDb().getTableAlert().deleteAlert(alert.getAlertId());

--- a/src/org/zaproxy/zap/extension/alert/PopupMenuShowAlerts.java
+++ b/src/org/zaproxy/zap/extension/alert/PopupMenuShowAlerts.java
@@ -68,7 +68,7 @@ public class PopupMenuShowAlerts extends PopupMenuHistoryReferenceContainer {
 			if (hrefURI != null && ! alert.getUri().equals(hrefURI.toString())) {
 				continue;
 			}
-			final PopupMenuShowAlert menuItem = new PopupMenuShowAlert(alert.getAlert(), alert);
+			final PopupMenuShowAlert menuItem = new PopupMenuShowAlert(alert.getName(), alert);
 			menuItem.setIcon(new ImageIcon(alert.getIconUrl()));
 			
 			alertList.add(menuItem);

--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -974,7 +974,8 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 		Map<String, String> map = new HashMap<>();
 		map.put("id", String.valueOf(alert.getAlertId()));
 		map.put("pluginId", String.valueOf(alert.getPluginId()));
-		map.put("alert", alert.getAlert());
+		map.put("alert", alert.getName()); //Deprecated in TODO add version, maintain for compatibility with custom code
+		map.put("name", alert.getName());
 		map.put("description", alert.getDescription());
 		map.put("risk", Alert.MSG_RISK[alert.getRisk()]);
 		map.put("confidence", Alert.MSG_CONFIDENCE[alert.getConfidence()]);

--- a/src/xml/report.html.xsl
+++ b/src/xml/report.html.xsl
@@ -70,11 +70,11 @@
   <xsl:template match="alertitem">
 <p></p>
 <table width="100%" border="0">
-<xsl:apply-templates select="text()|alert|desc|uri|param|attack|evidence|instances|count|otherinfo|solution|reference|cweid|wascid|p|br|wbr|ul|li"/>
+<xsl:apply-templates select="text()|name|desc|uri|param|attack|evidence|instances|count|otherinfo|solution|reference|cweid|wascid|p|br|wbr|ul|li"/>
 </table>
   </xsl:template>
 
-  <xsl:template match="alert[following-sibling::riskcode='3']">
+  <xsl:template match="name[following-sibling::riskcode='3']">
   <tr bgcolor="red" height="24">	
     <td width="20%" valign="top"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
     <a name="high"/>
@@ -86,7 +86,7 @@
   </tr>
   </xsl:template>
 
-  <xsl:template match="alert[following-sibling::riskcode='2']">
+  <xsl:template match="name[following-sibling::riskcode='2']">
   <!-- ZAP: Changed the medium colour to orange -->
   <tr bgcolor="orange" height="24">	
     <td width="20%" valign="top"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
@@ -99,7 +99,7 @@
   </tr>
 
   </xsl:template>
-  <xsl:template match="alert[following-sibling::riskcode='1']">
+  <xsl:template match="name[following-sibling::riskcode='1']">
   <!-- ZAP: Changed the low colour to yellow -->
   <tr bgcolor="yellow" height="24">
     <a name="low"/>
@@ -112,7 +112,7 @@
   </tr>
   </xsl:template>
   
-  <xsl:template match="alert[following-sibling::riskcode='0']">
+  <xsl:template match="name[following-sibling::riskcode='0']">
   <tr bgcolor="blue" height="24">	
     <td width="20%" valign="top"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
     <a name="info"/>


### PR DESCRIPTION
Make the name of an alert be a name field (vs.
alert within alert), which is more developer and user friendly. Ensure
web API components updated, and xsl for reporting purposes. Fixes
zaproxy/zaproxy#1341