### PR TITLE
Change SpiderUrlTask to not send an empty context name

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -19,7 +19,7 @@
 	<property name="zap.extensions.beta.dir" location="../../zap-extensions_beta/" />
 	<property name="zap.extensions.trunk.dir" location="../../zap-extensions/" />
 	<property name="zap.test.trunk.dir" location="../../zaproxy-test/" />
-	<property name="zap.java.api.version" value="9" />
+	<property name="zap.java.api.version" value="10" />
 	<property name="package" value="zaproxy" />
 
 	<!-- mac specific properties -->

--- a/src/org/zaproxy/clientapi/ant/SpiderUrlTask.java
+++ b/src/org/zaproxy/clientapi/ant/SpiderUrlTask.java
@@ -29,7 +29,7 @@ public class SpiderUrlTask extends ZapTask {
 	@Override
 	public void execute() throws BuildException {
 		try {
-			this.getClientApi().spider.scan(apikey, url, "", "", "");
+			this.getClientApi().spider.scan(apikey, url, "", "", null);
 			
 		} catch (Exception e) {
 			throw new BuildException(e);


### PR DESCRIPTION
ZAP (v2.4.3) spider "scan" API enpoint validates the context name even
if it's empty, leading to the scan to always fail with missing context
error.
Bump version of Java API client.
Related to #2108 - ZAP API clients should not send optional parameters
unless specified

--
Issue reported in OWASP ZAP User Group: https://groups.google.com/d/topic/zaproxy-users/1hzGyuJu-Fs/discussion