### PR TITLE
add-marketplace-sorting

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -625,6 +625,7 @@ cfu.status.beta        = Beta
 cfu.status.example     = Example
 cfu.status.release     = Release
 cfu.status.weekly      = Weekly
+cfu.status.unknown     = Unknown
 cfu.tab.installed		= Installed
 cfu.tab.browse			= Marketplace
 cfu.table.header.author = Author

--- a/src/org/zaproxy/zap/extension/autoupdate/AddOnsTableModel.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/AddOnsTableModel.java
@@ -63,6 +63,10 @@ public abstract class AddOnsTableModel extends AbstractTableModel {
 
     private AddOnSearcher addOnSeacher;
 
+	/**
+	 * @deprecated (TODO add version) Replaced by {@link #AddOnsTableModel(AddOnCollection, int)}. It will be removed in a future release.
+	 */
+    @Deprecated
     public AddOnsTableModel(Comparator<AddOnWrapper> comparator, AddOnCollection addOnCollection, int progressColumn) {
         super();
 
@@ -73,6 +77,16 @@ public abstract class AddOnsTableModel extends AbstractTableModel {
         this.addOnCollection = addOnCollection;
     }
 
+    public AddOnsTableModel(AddOnCollection addOnCollection, int progressColumn) {
+        super();
+
+        this.comparator = null;
+        this.wrappers = new ArrayList<>();
+        this.progressColumn = progressColumn;
+
+        this.addOnCollection = addOnCollection;
+    }
+    
     public void setAddOnCollection(AddOnCollection addOnCollection) {
         this.addOnCollection = addOnCollection;
     }
@@ -109,13 +123,18 @@ public abstract class AddOnsTableModel extends AbstractTableModel {
     protected void addAddOnWrapper(AddOn addOn, AddOnWrapper.Status status) {
         AddOnWrapper aow = createAddOnWrapper(addOn, status);
         int idx = 0;
-        for (; idx < getAddOnWrappers().size(); idx++) {
-            if (comparator.compare(aow, getAddOnWrappers().get(idx)) < 0) {
-                break;
-            }
+    	if (comparator != null) {
+    		for (; idx < getAddOnWrappers().size(); idx++) {
+        		if (comparator.compare(aow, getAddOnWrappers().get(idx)) < 0) {
+        			break;
+        		}
+                getAddOnWrappers().add(idx, aow);
+        	}
+        } else {
+        	idx = getAddOnWrappers().size();
+        	getAddOnWrappers().add(aow);
         }
 
-        getAddOnWrappers().add(idx, aow);
         fireTableRowsInserted(idx, idx);
 
         refreshEntries();

--- a/src/org/zaproxy/zap/extension/autoupdate/InstalledAddOnsTableModel.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/InstalledAddOnsTableModel.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.extension.autoupdate;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -47,18 +46,10 @@ public class InstalledAddOnsTableModel extends AddOnsTableModel {
     
 	private static final int COLUMN_COUNT = COLUMN_NAMES.length;
 
-    private static final Comparator<AddOnWrapper> COMPARATOR = new Comparator<AddOnWrapper>() {
-
-        @Override
-        public int compare(AddOnWrapper ao1, AddOnWrapper ao2) {
-            return ao1.getAddOn().getName().toLowerCase().compareTo(ao2.getAddOn().getName().toLowerCase());
-        };
-    };
-
     private AddOnCollection availableAddOns;
 
     public InstalledAddOnsTableModel(AddOnCollection installedAddOns) {
-        super(COMPARATOR, installedAddOns, 3);
+        super(installedAddOns, 3);
 
         for (AddOn addOn : installedAddOns.getAddOns()) {
             addAddOnWrapper(addOn, null);

--- a/src/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
@@ -28,6 +28,7 @@ import java.awt.HeadlessException;
 import java.io.File;
 import java.net.URL;
 import java.text.MessageFormat;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -41,6 +42,8 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
+import javax.swing.RowSorter;
+import javax.swing.SortOrder;
 import javax.swing.border.TitledBorder;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
@@ -355,7 +358,6 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
 	private JXTable getInstalledAddOnsTable () {
 		if (installedAddOnsTable == null) {
 			installedAddOnsTable = new JXTable();
-			installedAddOnsTable.setSortable(false);
 			installedAddOnsModel.addTableModelListener(new TableModelListener() {
 				@Override
 				public void tableChanged(TableModelEvent e) {
@@ -366,17 +368,21 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
 				}});
 
 			installedAddOnsTable.setModel(installedAddOnsModel);
-			installedAddOnsTable.getColumnModel().getColumn(0).setPreferredWidth(200);
-			installedAddOnsTable.getColumnModel().getColumn(1).setPreferredWidth(400);
-			installedAddOnsTable.getColumnModel().getColumn(2).setPreferredWidth(60);
-			installedAddOnsTable.getColumnModel().getColumn(3).setPreferredWidth(40);
-			
-			installedAddOnsTable.getColumnModel().getColumn(0).setMaxWidth(20);
-			installedAddOnsTable.getColumnModel().getColumn(1).setPreferredWidth(200);
-			installedAddOnsTable.getColumnModel().getColumn(2).setPreferredWidth(400);
-			installedAddOnsTable.getColumnModel().getColumn(3).setPreferredWidth(60);
+			installedAddOnsTable.getColumnModel().getColumn(0).setMaxWidth(20);//icon
+			installedAddOnsTable.getColumnExt(0).setSortable(false);//icon doesn't need to be sortable
+			installedAddOnsTable.getColumnModel().getColumn(1).setPreferredWidth(200);//name
+			installedAddOnsTable.getColumnModel().getColumn(2).setPreferredWidth(400);//description
+			installedAddOnsTable.getColumnExt(2).setSortable(false);//description doesn't need to be sortable
+			installedAddOnsTable.getColumnModel().getColumn(3).setPreferredWidth(60);//update
+			installedAddOnsTable.getColumnExt(3).setSortable(false);//update doesn't need to be sortable
 			installedAddOnsTable.getColumnModel().getColumn(4).setPreferredWidth(40);
-
+			installedAddOnsTable.getColumnExt(4).setSortable(false);//checkbox doesn't need to be sortable
+          
+            //Default sort by name (column 1)
+            List<RowSorter.SortKey> sortKeys = new ArrayList<RowSorter.SortKey>(1);
+            sortKeys.add(new RowSorter.SortKey(1, SortOrder.ASCENDING));
+            installedAddOnsTable.getRowSorter().setSortKeys(sortKeys);
+			
 			DefaultAddOnToolTipHighlighter toolTipHighlighter = new DefaultAddOnToolTipHighlighter(
 					AddOnsTableModel.COLUMN_ADD_ON_WRAPPER);
 			for (int i = 1; i < installedAddOnsTable.getColumnCount(); i++) {
@@ -404,7 +410,6 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
 	private JXTable getUninstalledAddOnsTable () {
 		if (uninstalledAddOnsTable == null) {
 			uninstalledAddOnsTable = new JXTable();
-			uninstalledAddOnsTable.setSortable(false);
 
 			uninstalledAddOnsModel.addTableModelListener(new TableModelListener() {
 				@Override
@@ -417,7 +422,8 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
 				public void valueChanged(ListSelectionEvent e) {
 					getAddOnInfoButton().setEnabled(false);
 					if (DesktopUtils.canOpenUrlInBrowser() && getUninstalledAddOnsTable ().getSelectedRowCount() == 1) {
-						AddOnWrapper ao = uninstalledAddOnsModel.getAddOnWrapper(getUninstalledAddOnsTable ().getSelectedRow());
+						//convertRowIndexToModel in-case they sorted
+						AddOnWrapper ao = uninstalledAddOnsModel.getAddOnWrapper(getUninstalledAddOnsTable().convertRowIndexToModel(getUninstalledAddOnsTable().getSelectedRow()));
 						if (ao != null && ao.getAddOn().getInfo() != null) {
 							getAddOnInfoButton().setEnabled(true);
 						}
@@ -425,13 +431,24 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
 				}});
 			
 			uninstalledAddOnsTable.setModel(uninstalledAddOnsModel);
-			uninstalledAddOnsTable.getColumnModel().getColumn(0).setMaxWidth(20);
-			uninstalledAddOnsTable.getColumnModel().getColumn(1).setPreferredWidth(50);
-			uninstalledAddOnsTable.getColumnModel().getColumn(2).setPreferredWidth(150);
-			uninstalledAddOnsTable.getColumnModel().getColumn(3).setPreferredWidth(300);
-			uninstalledAddOnsTable.getColumnModel().getColumn(4).setPreferredWidth(60);
-			uninstalledAddOnsTable.getColumnModel().getColumn(5).setPreferredWidth(40);
 
+			uninstalledAddOnsTable.getColumnModel().getColumn(0).setMaxWidth(20);//Icon
+			uninstalledAddOnsTable.getColumnExt(0).setSortable(false); //Icon doesn't need sorting
+			uninstalledAddOnsTable.getColumnModel().getColumn(1).setPreferredWidth(50);//Status
+			uninstalledAddOnsTable.getColumnModel().getColumn(2).setPreferredWidth(150);//Name
+			uninstalledAddOnsTable.getColumnModel().getColumn(3).setPreferredWidth(300);//Description
+			uninstalledAddOnsTable.getColumnExt(3).setSortable(false);//Description doesn't need sorting
+			uninstalledAddOnsTable.getColumnModel().getColumn(4).setPreferredWidth(60);//Update (version number)
+			uninstalledAddOnsTable.getColumnExt(4).setSortable(false);//Update doesn't need sorting
+			uninstalledAddOnsTable.getColumnModel().getColumn(5).setPreferredWidth(40);//Checkbox
+			uninstalledAddOnsTable.getColumnExt(5).setSortable(false);//Checkbox doesn't need sorting
+         
+            //Default sort by status (column 1) descending (Release, Beta, Alpha), and name (column 2) ascending 
+            List<RowSorter.SortKey> sortKeys = new ArrayList<RowSorter.SortKey>(2);
+            sortKeys.add(new RowSorter.SortKey(1, SortOrder.DESCENDING));
+            sortKeys.add(new RowSorter.SortKey(2, SortOrder.ASCENDING));
+            uninstalledAddOnsTable.getRowSorter().setSortKeys(sortKeys);
+                        
 			DefaultAddOnToolTipHighlighter toolTipHighlighter = new DefaultAddOnToolTipHighlighter(
 					UninstalledAddOnsTableModel.COLUMN_ADD_ON_WRAPPER);
 			for (int i = 1; i < uninstalledAddOnsTable.getColumnCount(); i++) {
@@ -912,8 +929,9 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
 			addOnInfoButton.addActionListener(new java.awt.event.ActionListener() { 
 				@Override
 				public void actionPerformed(java.awt.event.ActionEvent e) {
-					if (getUninstalledAddOnsTable ().getSelectedRow() >= 0) {
-						AddOnWrapper ao = uninstalledAddOnsModel.getAddOnWrapper(getUninstalledAddOnsTable ().getSelectedRow());
+					if (getUninstalledAddOnsTable().getSelectedRow() >= 0) {
+						//convertRowIndexToModel in-case they sorted
+						AddOnWrapper ao = uninstalledAddOnsModel.getAddOnWrapper(getUninstalledAddOnsTable().convertRowIndexToModel(getUninstalledAddOnsTable().getSelectedRow()));
 						if (ao != null && ao.getAddOn().getInfo() != null) {
 							DesktopUtils.openUrlInBrowser(ao.getAddOn().getInfo().toString());
 						}

--- a/src/org/zaproxy/zap/extension/autoupdate/UninstalledAddOnsTableModel.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/UninstalledAddOnsTableModel.java
@@ -19,14 +19,15 @@
  */
 package org.zaproxy.zap.extension.autoupdate;
 
-import java.util.Comparator;
 import java.util.List;
 
 import javax.swing.Icon;
 
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.control.AddOnCollection;
+import org.zaproxy.zap.view.StatusUI;
 
 
 public class UninstalledAddOnsTableModel extends AddOnsTableModel {
@@ -43,23 +44,11 @@ public class UninstalledAddOnsTableModel extends AddOnsTableModel {
     
 	private static final int COLUMN_COUNT = COLUMN_NAMES.length;
 
-    private static final Comparator<AddOnWrapper> COMPARATOR = new Comparator<AddOnWrapper>() {
-
-        @Override
-        public int compare(AddOnWrapper ao1, AddOnWrapper ao2) {
-            if (!ao1.getAddOn().getStatus().equals(ao2.getAddOn().getStatus())) {
-                // Reverse order - we want the most stable ones first
-                return ao2.getAddOn().getStatus().compareTo(ao1.getAddOn().getStatus());
-            }
-            return ao1.getAddOn().getName().toLowerCase().compareTo(ao2.getAddOn().getName().toLowerCase());
-        };
-    };
-    
     /**
      * 
      */
     public UninstalledAddOnsTableModel(AddOnCollection installedAddOns) {
-        super(COMPARATOR, installedAddOns, 4);
+        super(installedAddOns, 4);
     }
 
     @Override
@@ -79,9 +68,11 @@ public class UninstalledAddOnsTableModel extends AddOnsTableModel {
 
     @Override
     public Class<?> getColumnClass(int columnIndex) {
-        if (columnIndex == 0) {
+        if (columnIndex == 0) {//Icon
             return Icon.class;
-        } else if (columnIndex == 5) {
+        } else if (columnIndex == 1) {//Status (Quality)
+        	return StatusUI.class;
+        } else if (columnIndex == 5) {//update
             return Boolean.class;
         }
         return String.class;
@@ -95,7 +86,7 @@ public class UninstalledAddOnsTableModel extends AddOnsTableModel {
         case 0:
             return Boolean.valueOf(getAddOnWrapper(rowIndex).hasRunningIssues());
         case 1:
-            return Constant.messages.getString("cfu.status." + getAddOnWrapper(rowIndex).getAddOn().getStatus().toString());
+        	return View.getSingleton().getStatusUI(getAddOnWrapper(rowIndex).getAddOn().getStatus());
         case 2:
             return getAddOnWrapper(rowIndex).getAddOn().getName();
         case 3:

--- a/src/org/zaproxy/zap/view/StatusUI.java
+++ b/src/org/zaproxy/zap/view/StatusUI.java
@@ -1,0 +1,66 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.view;
+
+import org.zaproxy.zap.control.AddOn;
+
+/**
+ * A utility class for handling various UI elements related to status/quality
+ * related to extensions and extension components
+ * @since TODO add version
+ */
+public class StatusUI implements Comparable<StatusUI> {
+
+        private final AddOn.Status status;
+        private final String stringRepresentation;
+/**
+ * 
+ * @param status the AddOn.Status for which the StatusUI should be created
+ * @param stringRepresentation the internationalized status string that corresponds 
+ * to the AddOn.Status for which the StatusUI is being constructed.
+ * If either parameter is null then "unknown" status will be assumed. 
+ */
+        public StatusUI(AddOn.Status status, String stringRepresentation) {
+            if (status == null) {
+        		this.status = AddOn.Status.unknown;
+	        } else {
+	        	this.status = status;
+	        }
+            
+            if (stringRepresentation == null || stringRepresentation.isEmpty()) {
+            	this.stringRepresentation = status.toString();
+            } else {
+            	this.stringRepresentation = stringRepresentation;
+            }
+        }
+        
+        @Override
+        public int compareTo(StatusUI o) {
+            if (o == null) {
+                return 1;
+            }
+            return status.compareTo(o.status);
+        }
+
+        @Override
+        public String toString() {
+            return stringRepresentation;
+        }
+    }


### PR DESCRIPTION
Setup auto row sorter for installed and uninstalled addons tables in the
marketplace dialog. This is most handy in the uninstalled section if you
want to change to name sorting (vs. the default quality-name), or if (in
either table) you want the list reversed.

Add StatusUI component to be leveraged elsewhere for status/quality 
info. View now initializes a map (AddOn.Status, StatusUI), and exposes 
a getStatusUI method.