### PR TITLE
Fix NullPointerException during GUI initialisation

### DIFF
--- a/src/org/zaproxy/zap/view/ContextListTableModel.java
+++ b/src/org/zaproxy/zap/view/ContextListTableModel.java
@@ -20,6 +20,7 @@
 
 package org.zaproxy.zap.view;
 
+import java.util.Collections;
 import java.util.List;
 
 import javax.swing.table.AbstractTableModel;
@@ -35,7 +36,7 @@ public class ContextListTableModel extends AbstractTableModel {
 				Constant.messages.getString("context.list.table.name"),
 				Constant.messages.getString("context.list.table.inscope")};
     
-    private List<Object[]> values = null;
+    private List<Object[]> values = Collections.emptyList();
     
     //private static Logger log = Logger.getLogger(ContextListTableModel.class);
 


### PR DESCRIPTION
Change ContextListTableModel to initialise the instance variable
"values" with an empty list, preventing the EDT from failing to query
its number of rows.
Fix #2144 -Java.lang.NullPointerException in "AWT-EventQueue-0"