### PR TITLE
Change AbstractParam's clone method to clone its configuration

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -432,6 +432,7 @@
                 </fileset>
                 <fileset dir="${test.build}">
                     <include name="**/AbstractPluginUnitTest.class"/>
+                    <include name="**/AbstractParamUnitTest.class"/>
                 </fileset>
             </batchtest>
 		</junit>

--- a/src/org/parosproxy/paros/common/AbstractParam.java
+++ b/src/org/parosproxy/paros/common/AbstractParam.java
@@ -33,12 +33,11 @@ import java.util.Map.Entry;
 
 import org.apache.commons.configuration.ConfigurationUtils;
 import org.apache.commons.configuration.FileConfiguration;
-import org.apache.commons.configuration.XMLConfiguration;
 import org.apache.log4j.Logger;
 import org.zaproxy.zap.control.ControlOverrides;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public abstract class AbstractParam {
+public abstract class AbstractParam implements Cloneable {
 
     private static final Logger logger = Logger.getLogger(AbstractParam.class);
     
@@ -84,10 +83,8 @@ public abstract class AbstractParam {
     @Override
     public AbstractParam clone()  {
     	try {
-			AbstractParam clone = this.getClass().newInstance();
-			FileConfiguration fileConfig = new XMLConfiguration();
-			ConfigurationUtils.copy(this.getConfig(), fileConfig);
-			clone.load(fileConfig);
+			AbstractParam clone = (AbstractParam) super.clone();
+			clone.load((FileConfiguration) ConfigurationUtils.cloneConfiguration(config));
 			return clone;
         } catch (Exception e) {
             logger.error(e.getMessage(), e);

--- a/test/org/parosproxy/paros/common/AbstractParamUnitTest.java
+++ b/test/org/parosproxy/paros/common/AbstractParamUnitTest.java
@@ -1,0 +1,147 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.common;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.configuration.FileConfiguration;
+import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.junit.Test;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/**
+ * Unit test for {@link AbstractParam}.
+ */
+public class AbstractParamUnitTest {
+
+    private static final String VALUE_KEY = "config.value";
+    private static final String VALUE = "Value X";
+
+    private static final String VALUES_KEY = "config.values";
+    private static final String VALUES_VALUE_KEY = "value";
+    private static final List<String> VALUES;
+
+    static {
+        VALUES = new ArrayList<>(5);
+        VALUES.add("Value 1");
+        VALUES.add("Value 2");
+        VALUES.add("Value 3");
+        VALUES.add("Value 4");
+        VALUES.add("Value 5");
+    }
+
+    @Test
+    public void shouldNotHaveConfigByDefault() {
+        // Given / When
+        AbstractParam param = createTestAbstractParam();
+        // Then
+        assertThat(param.getConfig(), is(equalTo(null)));
+    }
+
+    @Test
+    public void shouldParseLoadedFileConfiguration() {
+        // Given
+        TestAbstractParam param = createTestAbstractParam();
+        FileConfiguration config = createTestConfig();
+        // When
+        param.load(config);
+        // Then
+        assertThat(param.getValue(), is(equalTo(VALUE)));
+        assertThat(param.getValues(), is(equalTo(VALUES)));
+    }
+
+    @Test
+    public void shouldBeCloneableByDefault() {
+        // Given
+        TestAbstractParam param = createTestAbstractParam();
+        // When
+        TestAbstractParam clone = param.clone();
+        // Then
+        assertThat(clone, is(not(equalTo(null))));
+        assertThat(clone.getValue(), is(equalTo(null)));
+        assertThat(clone.getValues(), is(equalTo(null)));
+    }
+
+    @Test
+    public void shouldHaveLoadedConfigsAfterCloning() {
+        // Given
+        TestAbstractParam param = createTestAbstractParam();
+        FileConfiguration config = createTestConfig();
+        param.load(config);
+        // When
+        TestAbstractParam clone = param.clone();
+        // Then
+        assertThat(clone, is(not(equalTo(null))));
+        assertThat(clone.getValue(), is(equalTo(VALUE)));
+        assertThat(clone.getValues(), is(equalTo(VALUES)));
+    }
+
+    private static TestAbstractParam createTestAbstractParam() {
+        return new TestAbstractParam();
+    }
+
+    private static class TestAbstractParam extends AbstractParam {
+
+        private String value;
+        private List<String> values;
+
+        @Override
+        protected void parse() {
+            if (getConfig() == null) {
+                return;
+            }
+
+            value = getConfig().getString(VALUE_KEY);
+            List<HierarchicalConfiguration> fields = ((HierarchicalConfiguration) getConfig()).configurationsAt(VALUES_KEY);
+            values = new ArrayList<>(fields.size());
+            for (HierarchicalConfiguration sub : fields) {
+                values.add(sub.getString(VALUES_VALUE_KEY));
+            }
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public List<String> getValues() {
+            return values;
+        }
+
+        @Override
+        public TestAbstractParam clone() {
+            return (TestAbstractParam) super.clone();
+        }
+    }
+
+    private static FileConfiguration createTestConfig() {
+        ZapXmlConfiguration config = new ZapXmlConfiguration();
+        config.setProperty(VALUE_KEY, VALUE);
+        for (int i = 0, size = VALUES.size(); i < size; ++i) {
+            config.setProperty(VALUES_KEY + "(" + i + ")." + VALUES_VALUE_KEY, VALUES.get(i));
+        }
+        return config;
+    }
+}


### PR DESCRIPTION
Change to clone the configuration instead of copying it because the
latter does not handle hierarchical configurations (the ones used by
ZAP) correctly, leading to missing options in the new configuration.
This was making the AJAX Spider lose click elements when the options
were being cloned.
Add tests to assert the expected behaviour.
Fix #2151 - AJAX Spider does not click all elements set in the options