### PR TITLE
Normalise script error handling and report the message of last error

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -294,6 +294,7 @@ ascan.progress.table.reqs		= Reqs
 ascan.progress.table.status		= Status
 ascan.progress.title            = {0} Scan Progress
 ascan.scripts.activescanner.title	= Script Active Scan Rules
+ascan.scripts.interface.active.error = The provided Active Rules script ({0}) does not implement the required interface.\nPlease refer to the provided templates for examples.
 ascan.scripts.type.active		= Active Rules
 ascan.scripts.type.active.desc	= Active Rules scripts run when you run the Active Scanner.\n\n\
 You must enable them before they will be used.
@@ -317,6 +318,7 @@ variant.options.rpc.odata.label     = OData ID/Filter
 variant.options.rpc.dwr.label       = Direct Web Remoting
 
 variant.options.rpc.custom.label    = Enable Script Input Vectors
+variant.scripts.interface.variant.error = The provided Script Input Vector script ({0}) does not implement the required interface.\nPlease refer to the provided templates for examples.
 variant.scripts.type.variant        = Script Input Vector
 variant.scripts.type.variant.desc   = Input Vector scripts run when you run the Active Scanner.\n\n\
 You must enable them before they will be used.
@@ -1603,6 +1605,7 @@ pscan.options.policy.rules.label		= Rules
 pscan.options.policy.thresholdTo.label	= Threshold To
 
 pscan.scripts.passivescanner.title	= Script Passive Scan Rules
+pscan.scripts.interface.passive.error = The provided Passive Rules script ({0}) does not implement the required interface.\nPlease refer to the provided templates for examples.
 pscan.scripts.type.passive			= Passive Rules
 pscan.scripts.type.passive.desc		= Passive Rules scripts run when the Passive Scanner runs.\n\n\
 You must enable them before they will be used.

--- a/src/org/parosproxy/paros/core/scanner/VariantCustom.java
+++ b/src/org/parosproxy/paros/core/scanner/VariantCustom.java
@@ -19,12 +19,11 @@
  */
 package org.parosproxy.paros.core.scanner;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
-import javax.script.ScriptException;
 import org.apache.commons.codec.binary.Base64;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
@@ -57,10 +56,15 @@ public class VariantCustom implements Variant {
             try {
                 this.script = extension.getInterface(wrapper, VariantScript.class);
 
-            } catch (ScriptException | IOException ex) {
-                this.extension.setError(wrapper, ex);
-                this.extension.setEnabled(wrapper, false);
-                this.script = null;
+                if (script == null) {
+                    extension.handleFailedScriptInterface(
+                            wrapper,
+                            Constant.messages.getString("variant.scripts.interface.variant.error", wrapper.getName()));
+                }
+            } catch (Exception ex) {
+                // Catch Exception instead of ScriptException and IOException because script engine implementations
+                // might throw other exceptions on script errors (e.g. jdk.nashorn.internal.runtime.ECMAException)
+                this.extension.handleScriptException(wrapper, ex);
             }
         }
     }
@@ -76,9 +80,10 @@ public class VariantCustom implements Variant {
                 script.parseParameters(this, msg);
             }
             
-        } catch (ScriptException se) {
-            extension.setError(wrapper, se);
-            extension.setEnabled(wrapper, false);
+        } catch (Exception e) {
+            // Catch Exception instead of ScriptException because script engine implementations might
+            // throw other exceptions on script errors (e.g. jdk.nashorn.internal.runtime.ECMAException)
+            extension.handleScriptException(wrapper, e);
         }
     }
 
@@ -206,9 +211,10 @@ public class VariantCustom implements Variant {
                 script.setParameter(this, msg, paramName, value, escaped);
             }
                         
-        } catch (ScriptException se) {
-            extension.setError(wrapper, se);
-            extension.setEnabled(wrapper, false);
+        } catch (Exception e) {
+            // Catch Exception instead of ScriptException because script engine implementations might
+            // throw other exceptions on script errors (e.g. jdk.nashorn.internal.runtime.ECMAException)
+            extension.handleScriptException(wrapper, e);
         }
         
         return value;

--- a/src/org/zaproxy/zap/extension/ascan/ScriptsActiveScanner.java
+++ b/src/org/zaproxy/zap/extension/ascan/ScriptsActiveScanner.java
@@ -19,7 +19,6 @@
 package org.zaproxy.zap.extension.ascan;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Iterator;
 import java.util.List;
 
@@ -99,7 +98,6 @@ public class ScriptsActiveScanner extends AbstractAppParamPlugin {
 			
 		for (Iterator<ScriptWrapper> it = scripts.iterator(); it.hasNext() && !isStop();) {
 			ScriptWrapper script = it.next();
-			StringWriter writer = new StringWriter();
 			try {
 				if (script.isEnabled()) {
 					// Note that 'old' scripts may not implement the scan() method, so just ignore them
@@ -113,9 +111,7 @@ public class ScriptsActiveScanner extends AbstractAppParamPlugin {
 				}
 				
 			} catch (Exception e) {
-				writer.append(e.toString());
-				extension.setError(script, e);
-				extension.setEnabled(script, false);
+				extension.handleScriptException(script, e);
 			}
 		}
 
@@ -133,7 +129,6 @@ public class ScriptsActiveScanner extends AbstractAppParamPlugin {
 			
 		for (Iterator<ScriptWrapper> it = scripts.iterator(); it.hasNext() && !isStop();) {
 			ScriptWrapper script = it.next();
-			StringWriter writer = new StringWriter();
 			try {
 				if (script.isEnabled()) {
 					ActiveScript s = extension.getInterface(script, ActiveScript.class);
@@ -144,16 +139,14 @@ public class ScriptsActiveScanner extends AbstractAppParamPlugin {
 						s.scan(this, msg, param, value);
 						
 					} else {
-						writer.append(Constant.messages.getString("scripts.interface.active.error"));
-						extension.setError(script, writer.toString());
-						extension.setEnabled(script, false);
+						extension.handleFailedScriptInterface(
+								script,
+								Constant.messages.getString("ascan.scripts.interface.active.error", script.getName()));
 					}
 				}
 				
 			} catch (Exception e) {
-				writer.append(e.toString());
-				extension.setError(script, e);
-				extension.setEnabled(script, false);
+				extension.handleScriptException(script, e);
 			}
 		}
 	}

--- a/src/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
+++ b/src/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.pscan.scanner;
 
-import java.io.StringWriter;
 import java.util.List;
 
 import net.htmlparser.jericho.Source;
@@ -83,7 +82,6 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
 			currentHRefId = id;
 			List<ScriptWrapper> scripts = extension.getScripts(ExtensionPassiveScan.SCRIPT_TYPE_PASSIVE);
 			for (ScriptWrapper script : scripts) {
-				StringWriter writer = new StringWriter();
 				try {
 					if (script.isEnabled()) {
 						PassiveScript s = extension.getInterface(script, PassiveScript.class);
@@ -92,16 +90,14 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
 							s.scan(this, msg, source);
 							
 						} else {
-							writer.append(Constant.messages.getString("scripts.interface.active.error"));
-							extension.setError(script, writer.toString());
-							extension.setEnabled(script, false);
+							extension.handleFailedScriptInterface(
+									script,
+									Constant.messages.getString("pscan.scripts.interface.passive.error", script.getName()));
 						}
 					}
 					
 				} catch (Exception e) {
-					writer.append(e.toString());
-					extension.setError(script, e);
-					extension.setEnabled(script, false);
+					extension.handleScriptException(script, e);
 				}
 			}
 		}

--- a/src/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/src/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -1068,6 +1068,24 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 	 * Handles exceptions thrown by scripts.
 	 * <p>
 	 * The given {@code exception} (if of type {@code ScriptException} the cause will be used instead) will be written to the
+	 * the writer(s) associated with the given {@code script}, moreover it will be disabled and flagged that has an error.
+	 *
+	 * @param script the script that resulted in an exception, must not be {@code null}
+	 * @param exception the exception thrown , must not be {@code null}
+	 * @since TODO add version
+	 * @see #setEnabled(ScriptWrapper, boolean)
+	 * @see #setError(ScriptWrapper, Exception)
+	 * @see #handleFailedScriptInterface(ScriptWrapper, String)
+	 * @see ScriptException
+	 */
+	public void handleScriptException(ScriptWrapper script, Exception exception) {
+		handleScriptException(script, getWriters(script), exception);
+	}
+	
+	/**
+	 * Handles exceptions thrown by scripts.
+	 * <p>
+	 * The given {@code exception} (if of type {@code ScriptException} the cause will be used instead) will be written to the
 	 * given {@code writer} and the given {@code script} will be disabled and flagged that has an error.
 	 *
 	 * @param script the script that resulted in an exception, must not be {@code null}
@@ -1131,19 +1149,42 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 	/**
 	 * Handles a failed attempt to convert a script into an interface.
 	 * <p>
+	 * The given {@code errorMessage} will be written to the writer(s) associated with the given {@code script}, moreover it
+	 * will be disabled and flagged that has an error.
+	 *
+	 * @param script the script that resulted in an exception, must not be {@code null}
+	 * @param errorMessage the message that will be written to the writer(s)
+	 * @since TODO add version
+	 * @see #setEnabled(ScriptWrapper, boolean)
+	 * @see #setError(ScriptWrapper, Exception)
+	 * @see #handleScriptException(ScriptWrapper, Exception)
+	 */
+	public void handleFailedScriptInterface(ScriptWrapper script, String errorMessage) {
+		handleFailedScriptInterface(script, getWriters(script), errorMessage);
+	}
+
+	/**
+	 * Handles a failed attempt to convert a script into an interface.
+	 * <p>
 	 * The given {@code errorMessage} will be written to the given {@code writer} and the given {@code script} will be disabled
 	 * and flagged that has an error.
 	 *
 	 * @param script the script that failed to be converted to an interface, must not be {@code null}
 	 * @param writer the writer associated with the script, must not be {@code null}
 	 * @param errorMessage the message that will be written to the given {@code writer}
-	 * @throws IOException if an error occurred while writing the {@code errorMessage}
 	 * @see #setError(ScriptWrapper, String)
 	 * @see #setEnabled(ScriptWrapper, boolean)
 	 */
-	private void handleFailedScriptInterface(ScriptWrapper script, Writer writer, String errorMessage) throws IOException {
-		writer.append(errorMessage);
-		this.setError(script, writer.toString());
+	private void handleFailedScriptInterface(ScriptWrapper script, Writer writer, String errorMessage) {
+		try {
+			writer.append(errorMessage);
+		} catch (IOException e) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Failed to append script error message because of an exception:", e);
+			}
+			logger.warn("Failed to append error message: " + errorMessage);
+		}
+		this.setError(script, errorMessage);
 		this.setEnabled(script, false);
 	}
 
@@ -1227,6 +1268,10 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 	}
 
 	public void setEnabled(ScriptWrapper script, boolean enabled) {
+		if (!script.getType().isEnableable()) {
+			return;
+		}
+
 		if (enabled && script.getEngine() == null) {
 			return;
 		}
@@ -1239,6 +1284,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 
 	public void setError(ScriptWrapper script, String details) {
 		script.setError(true);
+		script.setLastErrorDetails(details);
 		script.setLastOutput(details);
 		
 		this.getTreeModel().nodeStructureChanged(script);
@@ -1253,18 +1299,8 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 	}
 
 	public void setError(ScriptWrapper script, Exception e) {
-		script.setError(true);
 		script.setLastException(e);
-		
-		this.getTreeModel().nodeStructureChanged(script);
-		
-		for (ScriptEventListener listener : this.listeners) {
-			try {
-				listener.scriptError(script);
-			} catch (Exception e1) {
-				logger.error(e.getMessage(), e);
-			}
-		}
+		setError(script, e.getMessage());
 	}
 	
 	public void addListener(ScriptEventListener listener) {


### PR DESCRIPTION
Change class ExtensionScript to:
 - Expose/add the methods that handle script errors,
 handleScriptException(ScriptWrapper, Exception), and failure to
 implement an interface, handleFailedScriptInterface(ScriptWrapper,
 String), so that the error handling can be normalised throughout the
 code;
 - Ignore scripts that can't be enabled/disabled in the method
 setEnabled(ScriptWrapper script, boolean);
 - Reduce code duplication in setError(ScriptWrapper, Exception), by
 calling the method setError(ScriptWrapper, String) and change the
 latter to set the details of last error to the script (by calling
 ScriptWrapper.setLastErrorDetails(String)).

Change classes ScriptsActiveScanner, ScriptsPassiveScanner and
VariantCustom to call the exposed error handling methods, replace the
messages used for the errors with core resource messages (the former
messages were being read from an add-on, "Script Console", which might
not be installed leading to MissingResourceException, though caught
there was no indication that it happened) and to caught Exception
instead of ScriptException and IOException (preventing script engine's
exceptions from breaking other functionalities, for example, in case of
errors in "Script Input Vector" scripts it would prevent the active
scanners from being run).

Change ScriptBasedAuthenticationMethodType to use the exposed methods
and to not use the same try-catch block for the calls of the script
interface instantiation and the actual calls to the interface, for better
readability and differentiation of script error handling.

Other "core" scripts (for example, "HTTP Sender") were already using the
internal error handling methods from ExtensionScript, so no other
changes are required to normalise the handling of errors.