### PR TITLE
Fix typo in PhpAPIGenerator, to use a property defined in class Zapv2

### DIFF
--- a/php/api/zapv2/src/Zap/Acsrf.php
+++ b/php/api/zapv2/src/Zap/Acsrf.php
@@ -57,7 +57,7 @@ class Acsrf {
 	 * Generate a form for testing lack of anti CSRF tokens - typically invoked via ZAP
 	 */
 	public function genForm($hrefid, $apikey='') {
-		return $this->zap->requestother($this->zap->baseother . 'acsrf/other/genForm/', array('hrefId' => $hrefid, 'apikey' => $apikey));
+		return $this->zap->requestother($this->zap->base_other . 'acsrf/other/genForm/', array('hrefId' => $hrefid, 'apikey' => $apikey));
 	}
 
 }

--- a/php/api/zapv2/src/Zap/AjaxSpider.php
+++ b/php/api/zapv2/src/Zap/AjaxSpider.php
@@ -42,8 +42,15 @@ class AjaxSpider {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public function results($start='', $count='') {
-		return $this->zap->request($this->zap->base . 'ajaxSpider/view/results/', array('start' => $start, 'count' => $count))->{'results'};
+	public function results($start=NULL, $count=NULL) {
+		$params = array();
+		if ($start !== NULL) {
+			$params['start'] = $start;
+		}
+		if ($count !== NULL) {
+			$params['count'] = $count;
+		}
+		return $this->zap->request($this->zap->base . 'ajaxSpider/view/results/', $params)->{'results'};
 	}
 
 	/**
@@ -56,8 +63,110 @@ class AjaxSpider {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public function scan($url, $inscope='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'ajaxSpider/action/scan/', array('url' => $url, 'inScope' => $inscope, 'apikey' => $apikey));
+	public function optionBrowserId() {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/view/optionBrowserId/')->{'BrowserId'};
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function optionConfigVersionKey() {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/view/optionConfigVersionKey/')->{'ConfigVersionKey'};
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function optionCurrentVersion() {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/view/optionCurrentVersion/')->{'CurrentVersion'};
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function optionElems() {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/view/optionElems/')->{'Elems'};
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function optionElemsNames() {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/view/optionElemsNames/')->{'ElemsNames'};
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function optionEventWait() {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/view/optionEventWait/')->{'EventWait'};
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function optionMaxCrawlDepth() {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/view/optionMaxCrawlDepth/')->{'MaxCrawlDepth'};
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function optionMaxCrawlStates() {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/view/optionMaxCrawlStates/')->{'MaxCrawlStates'};
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function optionMaxDuration() {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/view/optionMaxDuration/')->{'MaxDuration'};
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function optionNumberOfBrowsers() {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/view/optionNumberOfBrowsers/')->{'NumberOfBrowsers'};
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function optionReloadWait() {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/view/optionReloadWait/')->{'ReloadWait'};
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function optionClickDefaultElems() {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/view/optionClickDefaultElems/')->{'ClickDefaultElems'};
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function optionClickElemsOnce() {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/view/optionClickElemsOnce/')->{'ClickElemsOnce'};
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function optionRandomInputs() {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/view/optionRandomInputs/')->{'RandomInputs'};
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function scan($url, $inscope=NULL, $apikey='') {
+		$params = array('url' => $url, 'apikey' => $apikey);
+		if ($inscope !== NULL) {
+			$params['inScope'] = $inscope;
+		}
+		return $this->zap->request($this->zap->base . 'ajaxSpider/action/scan/', $params);
 	}
 
 	/**
@@ -65,6 +174,76 @@ class AjaxSpider {
 	 */
 	public function stop($apikey='') {
 		return $this->zap->request($this->zap->base . 'ajaxSpider/action/stop/', array('apikey' => $apikey));
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function setOptionBrowserId($string, $apikey='') {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/action/setOptionBrowserId/', array('String' => $string, 'apikey' => $apikey));
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function setOptionClickDefaultElems($boolean, $apikey='') {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/action/setOptionClickDefaultElems/', array('Boolean' => $boolean, 'apikey' => $apikey));
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function setOptionClickElemsOnce($boolean, $apikey='') {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/action/setOptionClickElemsOnce/', array('Boolean' => $boolean, 'apikey' => $apikey));
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function setOptionEventWait($integer, $apikey='') {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/action/setOptionEventWait/', array('Integer' => $integer, 'apikey' => $apikey));
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function setOptionMaxCrawlDepth($integer, $apikey='') {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/action/setOptionMaxCrawlDepth/', array('Integer' => $integer, 'apikey' => $apikey));
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function setOptionMaxCrawlStates($integer, $apikey='') {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/action/setOptionMaxCrawlStates/', array('Integer' => $integer, 'apikey' => $apikey));
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function setOptionMaxDuration($integer, $apikey='') {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/action/setOptionMaxDuration/', array('Integer' => $integer, 'apikey' => $apikey));
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function setOptionNumberOfBrowsers($integer, $apikey='') {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/action/setOptionNumberOfBrowsers/', array('Integer' => $integer, 'apikey' => $apikey));
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function setOptionRandomInputs($boolean, $apikey='') {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/action/setOptionRandomInputs/', array('Boolean' => $boolean, 'apikey' => $apikey));
+	}
+
+	/**
+	 * This component is optional and therefore the API will only work if it is installed
+	 */
+	public function setOptionReloadWait($integer, $apikey='') {
+		return $this->zap->request($this->zap->base . 'ajaxSpider/action/setOptionReloadWait/', array('Integer' => $integer, 'apikey' => $apikey));
 	}
 
 }

--- a/php/api/zapv2/src/Zap/Ascan.php
+++ b/php/api/zapv2/src/Zap/Ascan.php
@@ -32,12 +32,20 @@ class Ascan {
 		$this->zap = $zap;
 	}
 
-	public function status($scanid='') {
-		return $this->zap->request($this->zap->base . 'ascan/view/status/', array('scanId' => $scanid))->{'status'};
+	public function status($scanid=NULL) {
+		$params = array();
+		if ($scanid !== NULL) {
+			$params['scanId'] = $scanid;
+		}
+		return $this->zap->request($this->zap->base . 'ascan/view/status/', $params)->{'status'};
 	}
 
-	public function scanProgress($scanid='') {
-		return $this->zap->request($this->zap->base . 'ascan/view/scanProgress/', array('scanId' => $scanid))->{'scanProgress'};
+	public function scanProgress($scanid=NULL) {
+		$params = array();
+		if ($scanid !== NULL) {
+			$params['scanId'] = $scanid;
+		}
+		return $this->zap->request($this->zap->base . 'ascan/view/scanProgress/', $params)->{'scanProgress'};
 	}
 
 	public function messagesIds($scanid) {
@@ -60,12 +68,26 @@ class Ascan {
 		return $this->zap->request($this->zap->base . 'ascan/view/excludedFromScan/')->{'excludedFromScan'};
 	}
 
-	public function scanners($scanpolicyname='', $policyid='') {
-		return $this->zap->request($this->zap->base . 'ascan/view/scanners/', array('scanPolicyName' => $scanpolicyname, 'policyId' => $policyid))->{'scanners'};
+	public function scanners($scanpolicyname=NULL, $policyid=NULL) {
+		$params = array();
+		if ($scanpolicyname !== NULL) {
+			$params['scanPolicyName'] = $scanpolicyname;
+		}
+		if ($policyid !== NULL) {
+			$params['policyId'] = $policyid;
+		}
+		return $this->zap->request($this->zap->base . 'ascan/view/scanners/', $params)->{'scanners'};
 	}
 
-	public function policies($scanpolicyname='', $policyid='') {
-		return $this->zap->request($this->zap->base . 'ascan/view/policies/', array('scanPolicyName' => $scanpolicyname, 'policyId' => $policyid))->{'policies'};
+	public function policies($scanpolicyname=NULL, $policyid=NULL) {
+		$params = array();
+		if ($scanpolicyname !== NULL) {
+			$params['scanPolicyName'] = $scanpolicyname;
+		}
+		if ($policyid !== NULL) {
+			$params['policyId'] = $policyid;
+		}
+		return $this->zap->request($this->zap->base . 'ascan/view/policies/', $params)->{'policies'};
 	}
 
 	public function attackModeQueue() {
@@ -144,15 +166,44 @@ class Ascan {
 		return $this->zap->request($this->zap->base . 'ascan/view/optionShowAdvancedDialog/')->{'ShowAdvancedDialog'};
 	}
 
-	public function scan($url, $recurse='', $inscopeonly='', $scanpolicyname='', $method='', $postdata='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'ascan/action/scan/', array('url' => $url, 'recurse' => $recurse, 'inScopeOnly' => $inscopeonly, 'scanPolicyName' => $scanpolicyname, 'method' => $method, 'postData' => $postdata, 'apikey' => $apikey));
+	public function scan($url, $recurse=NULL, $inscopeonly=NULL, $scanpolicyname=NULL, $method=NULL, $postdata=NULL, $apikey='') {
+		$params = array('url' => $url, 'apikey' => $apikey);
+		if ($recurse !== NULL) {
+			$params['recurse'] = $recurse;
+		}
+		if ($inscopeonly !== NULL) {
+			$params['inScopeOnly'] = $inscopeonly;
+		}
+		if ($scanpolicyname !== NULL) {
+			$params['scanPolicyName'] = $scanpolicyname;
+		}
+		if ($method !== NULL) {
+			$params['method'] = $method;
+		}
+		if ($postdata !== NULL) {
+			$params['postData'] = $postdata;
+		}
+		return $this->zap->request($this->zap->base . 'ascan/action/scan/', $params);
 	}
 
 	/**
 	 * Active Scans from the perspective of a User, obtained using the given Context ID and User ID. See 'scan' action for more details.
 	 */
-	public function scanAsUser($url, $contextid, $userid, $recurse='', $scanpolicyname='', $method='', $postdata='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'ascan/action/scanAsUser/', array('url' => $url, 'contextId' => $contextid, 'userId' => $userid, 'recurse' => $recurse, 'scanPolicyName' => $scanpolicyname, 'method' => $method, 'postData' => $postdata, 'apikey' => $apikey));
+	public function scanAsUser($url, $contextid, $userid, $recurse=NULL, $scanpolicyname=NULL, $method=NULL, $postdata=NULL, $apikey='') {
+		$params = array('url' => $url, 'contextId' => $contextid, 'userId' => $userid, 'apikey' => $apikey);
+		if ($recurse !== NULL) {
+			$params['recurse'] = $recurse;
+		}
+		if ($scanpolicyname !== NULL) {
+			$params['scanPolicyName'] = $scanpolicyname;
+		}
+		if ($method !== NULL) {
+			$params['method'] = $method;
+		}
+		if ($postdata !== NULL) {
+			$params['postData'] = $postdata;
+		}
+		return $this->zap->request($this->zap->base . 'ascan/action/scanAsUser/', $params);
 	}
 
 	public function pause($scanid, $apikey='') {
@@ -195,12 +246,20 @@ class Ascan {
 		return $this->zap->request($this->zap->base . 'ascan/action/excludeFromScan/', array('regex' => $regex, 'apikey' => $apikey));
 	}
 
-	public function enableAllScanners($scanpolicyname='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'ascan/action/enableAllScanners/', array('scanPolicyName' => $scanpolicyname, 'apikey' => $apikey));
+	public function enableAllScanners($scanpolicyname=NULL, $apikey='') {
+		$params = array('apikey' => $apikey);
+		if ($scanpolicyname !== NULL) {
+			$params['scanPolicyName'] = $scanpolicyname;
+		}
+		return $this->zap->request($this->zap->base . 'ascan/action/enableAllScanners/', $params);
 	}
 
-	public function disableAllScanners($scanpolicyname='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'ascan/action/disableAllScanners/', array('scanPolicyName' => $scanpolicyname, 'apikey' => $apikey));
+	public function disableAllScanners($scanpolicyname=NULL, $apikey='') {
+		$params = array('apikey' => $apikey);
+		if ($scanpolicyname !== NULL) {
+			$params['scanPolicyName'] = $scanpolicyname;
+		}
+		return $this->zap->request($this->zap->base . 'ascan/action/disableAllScanners/', $params);
 	}
 
 	public function enableScanners($ids, $apikey='') {
@@ -215,20 +274,36 @@ class Ascan {
 		return $this->zap->request($this->zap->base . 'ascan/action/setEnabledPolicies/', array('ids' => $ids, 'apikey' => $apikey));
 	}
 
-	public function setPolicyAttackStrength($id, $attackstrength, $scanpolicyname='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'ascan/action/setPolicyAttackStrength/', array('id' => $id, 'attackStrength' => $attackstrength, 'scanPolicyName' => $scanpolicyname, 'apikey' => $apikey));
+	public function setPolicyAttackStrength($id, $attackstrength, $scanpolicyname=NULL, $apikey='') {
+		$params = array('id' => $id, 'attackStrength' => $attackstrength, 'apikey' => $apikey);
+		if ($scanpolicyname !== NULL) {
+			$params['scanPolicyName'] = $scanpolicyname;
+		}
+		return $this->zap->request($this->zap->base . 'ascan/action/setPolicyAttackStrength/', $params);
 	}
 
-	public function setPolicyAlertThreshold($id, $alertthreshold, $scanpolicyname='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'ascan/action/setPolicyAlertThreshold/', array('id' => $id, 'alertThreshold' => $alertthreshold, 'scanPolicyName' => $scanpolicyname, 'apikey' => $apikey));
+	public function setPolicyAlertThreshold($id, $alertthreshold, $scanpolicyname=NULL, $apikey='') {
+		$params = array('id' => $id, 'alertThreshold' => $alertthreshold, 'apikey' => $apikey);
+		if ($scanpolicyname !== NULL) {
+			$params['scanPolicyName'] = $scanpolicyname;
+		}
+		return $this->zap->request($this->zap->base . 'ascan/action/setPolicyAlertThreshold/', $params);
 	}
 
-	public function setScannerAttackStrength($id, $attackstrength, $scanpolicyname='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'ascan/action/setScannerAttackStrength/', array('id' => $id, 'attackStrength' => $attackstrength, 'scanPolicyName' => $scanpolicyname, 'apikey' => $apikey));
+	public function setScannerAttackStrength($id, $attackstrength, $scanpolicyname=NULL, $apikey='') {
+		$params = array('id' => $id, 'attackStrength' => $attackstrength, 'apikey' => $apikey);
+		if ($scanpolicyname !== NULL) {
+			$params['scanPolicyName'] = $scanpolicyname;
+		}
+		return $this->zap->request($this->zap->base . 'ascan/action/setScannerAttackStrength/', $params);
 	}
 
-	public function setScannerAlertThreshold($id, $alertthreshold, $scanpolicyname='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'ascan/action/setScannerAlertThreshold/', array('id' => $id, 'alertThreshold' => $alertthreshold, 'scanPolicyName' => $scanpolicyname, 'apikey' => $apikey));
+	public function setScannerAlertThreshold($id, $alertthreshold, $scanpolicyname=NULL, $apikey='') {
+		$params = array('id' => $id, 'alertThreshold' => $alertthreshold, 'apikey' => $apikey);
+		if ($scanpolicyname !== NULL) {
+			$params['scanPolicyName'] = $scanpolicyname;
+		}
+		return $this->zap->request($this->zap->base . 'ascan/action/setScannerAlertThreshold/', $params);
 	}
 
 	public function addScanPolicy($scanpolicyname, $apikey='') {

--- a/php/api/zapv2/src/Zap/Authentication.php
+++ b/php/api/zapv2/src/Zap/Authentication.php
@@ -52,8 +52,12 @@ class Authentication {
 		return $this->zap->request($this->zap->base . 'authentication/view/getLoggedOutIndicator/', array('contextId' => $contextid))->{'getLoggedOutIndicator'};
 	}
 
-	public function setAuthenticationMethod($contextid, $authmethodname, $authmethodconfigparams='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'authentication/action/setAuthenticationMethod/', array('contextId' => $contextid, 'authMethodName' => $authmethodname, 'authMethodConfigParams' => $authmethodconfigparams, 'apikey' => $apikey));
+	public function setAuthenticationMethod($contextid, $authmethodname, $authmethodconfigparams=NULL, $apikey='') {
+		$params = array('contextId' => $contextid, 'authMethodName' => $authmethodname, 'apikey' => $apikey);
+		if ($authmethodconfigparams !== NULL) {
+			$params['authMethodConfigParams'] = $authmethodconfigparams;
+		}
+		return $this->zap->request($this->zap->base . 'authentication/action/setAuthenticationMethod/', $params);
 	}
 
 	public function setLoggedInIndicator($contextid, $loggedinindicatorregex, $apikey='') {

--- a/php/api/zapv2/src/Zap/Core.php
+++ b/php/api/zapv2/src/Zap/Core.php
@@ -42,15 +42,29 @@ class Core {
 	/**
 	 * Gets the alerts raised by ZAP, optionally filtering by URL and paginating with 'start' position and 'count' of alerts
 	 */
-	public function alerts($baseurl='', $start='', $count='') {
-		return $this->zap->request($this->zap->base . 'core/view/alerts/', array('baseurl' => $baseurl, 'start' => $start, 'count' => $count))->{'alerts'};
+	public function alerts($baseurl=NULL, $start=NULL, $count=NULL) {
+		$params = array();
+		if ($baseurl !== NULL) {
+			$params['baseurl'] = $baseurl;
+		}
+		if ($start !== NULL) {
+			$params['start'] = $start;
+		}
+		if ($count !== NULL) {
+			$params['count'] = $count;
+		}
+		return $this->zap->request($this->zap->base . 'core/view/alerts/', $params)->{'alerts'};
 	}
 
 	/**
 	 * Gets the number of alerts, optionally filtering by URL
 	 */
-	public function numberOfAlerts($baseurl='') {
-		return $this->zap->request($this->zap->base . 'core/view/numberOfAlerts/', array('baseurl' => $baseurl))->{'numberOfAlerts'};
+	public function numberOfAlerts($baseurl=NULL) {
+		$params = array();
+		if ($baseurl !== NULL) {
+			$params['baseurl'] = $baseurl;
+		}
+		return $this->zap->request($this->zap->base . 'core/view/numberOfAlerts/', $params)->{'numberOfAlerts'};
 	}
 
 	/**
@@ -84,15 +98,29 @@ class Core {
 	/**
 	 * Gets the HTTP messages sent by ZAP, request and response, optionally filtered by URL and paginated with 'start' position and 'count' of messages
 	 */
-	public function messages($baseurl='', $start='', $count='') {
-		return $this->zap->request($this->zap->base . 'core/view/messages/', array('baseurl' => $baseurl, 'start' => $start, 'count' => $count))->{'messages'};
+	public function messages($baseurl=NULL, $start=NULL, $count=NULL) {
+		$params = array();
+		if ($baseurl !== NULL) {
+			$params['baseurl'] = $baseurl;
+		}
+		if ($start !== NULL) {
+			$params['start'] = $start;
+		}
+		if ($count !== NULL) {
+			$params['count'] = $count;
+		}
+		return $this->zap->request($this->zap->base . 'core/view/messages/', $params)->{'messages'};
 	}
 
 	/**
 	 * Gets the number of messages, optionally filtering by URL
 	 */
-	public function numberOfMessages($baseurl='') {
-		return $this->zap->request($this->zap->base . 'core/view/numberOfMessages/', array('baseurl' => $baseurl))->{'numberOfMessages'};
+	public function numberOfMessages($baseurl=NULL) {
+		$params = array();
+		if ($baseurl !== NULL) {
+			$params['baseurl'] = $baseurl;
+		}
+		return $this->zap->request($this->zap->base . 'core/view/numberOfMessages/', $params)->{'numberOfMessages'};
 	}
 
 	/**
@@ -113,8 +141,12 @@ class Core {
 		return $this->zap->request($this->zap->base . 'core/view/homeDirectory/')->{'homeDirectory'};
 	}
 
-	public function stats($keyprefix='') {
-		return $this->zap->request($this->zap->base . 'core/view/stats/', array('keyPrefix' => $keyprefix))->{'stats'};
+	public function stats($keyprefix=NULL) {
+		$params = array();
+		if ($keyprefix !== NULL) {
+			$params['keyPrefix'] = $keyprefix;
+		}
+		return $this->zap->request($this->zap->base . 'core/view/stats/', $params)->{'stats'};
 	}
 
 	public function optionDefaultUserAgent() {
@@ -191,8 +223,15 @@ class Core {
 	/**
 	 * Creates a new session, optionally overwriting existing files. If a relative path is specified it will be resolved against the "session" directory in ZAP "home" dir.
 	 */
-	public function newSession($name='', $overwrite='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'core/action/newSession/', array('name' => $name, 'overwrite' => $overwrite, 'apikey' => $apikey));
+	public function newSession($name=NULL, $overwrite=NULL, $apikey='') {
+		$params = array('apikey' => $apikey);
+		if ($name !== NULL) {
+			$params['name'] = $name;
+		}
+		if ($overwrite !== NULL) {
+			$params['overwrite'] = $overwrite;
+		}
+		return $this->zap->request($this->zap->base . 'core/action/newSession/', $params);
 	}
 
 	/**
@@ -205,8 +244,12 @@ class Core {
 	/**
 	 * Saves the session with the name supplied, optionally overwriting existing files. If a relative path is specified it will be resolved against the "session" directory in ZAP "home" dir.
 	 */
-	public function saveSession($name, $overwrite='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'core/action/saveSession/', array('name' => $name, 'overwrite' => $overwrite, 'apikey' => $apikey));
+	public function saveSession($name, $overwrite=NULL, $apikey='') {
+		$params = array('name' => $name, 'apikey' => $apikey);
+		if ($overwrite !== NULL) {
+			$params['overwrite'] = $overwrite;
+		}
+		return $this->zap->request($this->zap->base . 'core/action/saveSession/', $params);
 	}
 
 	public function snapshotSession($apikey='') {
@@ -232,8 +275,12 @@ class Core {
 	/**
 	 * Sends the HTTP request, optionally following redirections. Returns the request sent and response received and followed redirections, if any.
 	 */
-	public function sendRequest($request, $followredirects='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'core/action/sendRequest/', array('request' => $request, 'followRedirects' => $followredirects, 'apikey' => $apikey));
+	public function sendRequest($request, $followredirects=NULL, $apikey='') {
+		$params = array('request' => $request, 'apikey' => $apikey);
+		if ($followredirects !== NULL) {
+			$params['followRedirects'] = $followredirects;
+		}
+		return $this->zap->request($this->zap->base . 'core/action/sendRequest/', $params);
 	}
 
 	public function deleteAllAlerts($apikey='') {
@@ -301,50 +348,64 @@ class Core {
 	}
 
 	public function proxypac($apikey='') {
-		return $this->zap->requestother($this->zap->baseother . 'core/other/proxy.pac/', array('apikey' => $apikey));
+		return $this->zap->requestother($this->zap->base_other . 'core/other/proxy.pac/', array('apikey' => $apikey));
 	}
 
 	public function rootcert($apikey='') {
-		return $this->zap->requestother($this->zap->baseother . 'core/other/rootcert/', array('apikey' => $apikey));
+		return $this->zap->requestother($this->zap->base_other . 'core/other/rootcert/', array('apikey' => $apikey));
 	}
 
 	public function setproxy($proxy, $apikey='') {
-		return $this->zap->requestother($this->zap->baseother . 'core/other/setproxy/', array('proxy' => $proxy, 'apikey' => $apikey));
+		return $this->zap->requestother($this->zap->base_other . 'core/other/setproxy/', array('proxy' => $proxy, 'apikey' => $apikey));
 	}
 
 	/**
 	 * Generates a report in XML format
 	 */
 	public function xmlreport($apikey='') {
-		return $this->zap->requestother($this->zap->baseother . 'core/other/xmlreport/', array('apikey' => $apikey));
+		return $this->zap->requestother($this->zap->base_other . 'core/other/xmlreport/', array('apikey' => $apikey));
 	}
 
 	/**
 	 * Generates a report in HTML format
 	 */
 	public function htmlreport($apikey='') {
-		return $this->zap->requestother($this->zap->baseother . 'core/other/htmlreport/', array('apikey' => $apikey));
+		return $this->zap->requestother($this->zap->base_other . 'core/other/htmlreport/', array('apikey' => $apikey));
 	}
 
 	/**
 	 * Gets the message with the given ID in HAR format
 	 */
 	public function messageHar($id, $apikey='') {
-		return $this->zap->requestother($this->zap->baseother . 'core/other/messageHar/', array('id' => $id, 'apikey' => $apikey));
+		return $this->zap->requestother($this->zap->base_other . 'core/other/messageHar/', array('id' => $id, 'apikey' => $apikey));
 	}
 
 	/**
 	 * Gets the HTTP messages sent through/by ZAP, in HAR format, optionally filtered by URL and paginated with 'start' position and 'count' of messages
 	 */
-	public function messagesHar($baseurl='', $start='', $count='', $apikey='') {
-		return $this->zap->requestother($this->zap->baseother . 'core/other/messagesHar/', array('baseurl' => $baseurl, 'start' => $start, 'count' => $count, 'apikey' => $apikey));
+	public function messagesHar($baseurl=NULL, $start=NULL, $count=NULL, $apikey='') {
+		$params = array('apikey' => $apikey);
+		if ($baseurl !== NULL) {
+			$params['baseurl'] = $baseurl;
+		}
+		if ($start !== NULL) {
+			$params['start'] = $start;
+		}
+		if ($count !== NULL) {
+			$params['count'] = $count;
+		}
+		return $this->zap->requestother($this->zap->base_other . 'core/other/messagesHar/', $params);
 	}
 
 	/**
 	 * Sends the first HAR request entry, optionally following redirections. Returns, in HAR format, the request sent and response received and followed redirections, if any.
 	 */
-	public function sendHarRequest($request, $followredirects='', $apikey='') {
-		return $this->zap->requestother($this->zap->baseother . 'core/other/sendHarRequest/', array('request' => $request, 'followRedirects' => $followredirects, 'apikey' => $apikey));
+	public function sendHarRequest($request, $followredirects=NULL, $apikey='') {
+		$params = array('request' => $request, 'apikey' => $apikey);
+		if ($followredirects !== NULL) {
+			$params['followRedirects'] = $followredirects;
+		}
+		return $this->zap->requestother($this->zap->base_other . 'core/other/sendHarRequest/', $params);
 	}
 
 }

--- a/php/api/zapv2/src/Zap/HttpSessions.php
+++ b/php/api/zapv2/src/Zap/HttpSessions.php
@@ -35,8 +35,12 @@ class HttpSessions {
 	/**
 	 * Gets the sessions of the given site. Optionally returning just the session with the given name.
 	 */
-	public function sessions($site, $session='') {
-		return $this->zap->request($this->zap->base . 'httpSessions/view/sessions/', array('site' => $site, 'session' => $session))->{'sessions'};
+	public function sessions($site, $session=NULL) {
+		$params = array('site' => $site);
+		if ($session !== NULL) {
+			$params['session'] = $session;
+		}
+		return $this->zap->request($this->zap->base . 'httpSessions/view/sessions/', $params)->{'sessions'};
 	}
 
 	/**
@@ -56,8 +60,12 @@ class HttpSessions {
 	/**
 	 * Creates an empty session for the given site. Optionally with the given name.
 	 */
-	public function createEmptySession($site, $session='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'httpSessions/action/createEmptySession/', array('site' => $site, 'session' => $session, 'apikey' => $apikey));
+	public function createEmptySession($site, $session=NULL, $apikey='') {
+		$params = array('site' => $site, 'apikey' => $apikey);
+		if ($session !== NULL) {
+			$params['session'] = $session;
+		}
+		return $this->zap->request($this->zap->base . 'httpSessions/action/createEmptySession/', $params);
 	}
 
 	/**

--- a/php/api/zapv2/src/Zap/ImportLogFiles.php
+++ b/php/api/zapv2/src/Zap/ImportLogFiles.php
@@ -56,15 +56,19 @@ class ImportLogFiles {
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
-	public function PostModSecurityAuditEvent($auditeventstring='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'importLogFiles/action/PostModSecurityAuditEvent/', array('AuditEventString' => $auditeventstring, 'apikey' => $apikey));
+	public function PostModSecurityAuditEvent($auditeventstring=NULL, $apikey='') {
+		$params = array('apikey' => $apikey);
+		if ($auditeventstring !== NULL) {
+			$params['AuditEventString'] = $auditeventstring;
+		}
+		return $this->zap->request($this->zap->base . 'importLogFiles/action/PostModSecurityAuditEvent/', $params);
 	}
 
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
 	public function OtherPostModSecurityAuditEvent($auditeventstring, $apikey='') {
-		return $this->zap->requestother($this->zap->baseother . 'importLogFiles/other/OtherPostModSecurityAuditEvent/', array('AuditEventString' => $auditeventstring, 'apikey' => $apikey));
+		return $this->zap->requestother($this->zap->base_other . 'importLogFiles/other/OtherPostModSecurityAuditEvent/', array('AuditEventString' => $auditeventstring, 'apikey' => $apikey));
 	}
 
 }

--- a/php/api/zapv2/src/Zap/Params.php
+++ b/php/api/zapv2/src/Zap/Params.php
@@ -35,8 +35,12 @@ class Params {
 	/**
 	 * Shows the parameters for the specified site, or for all sites if the site is not specified
 	 */
-	public function params($site='') {
-		return $this->zap->request($this->zap->base . 'params/view/params/', array('site' => $site))->{'params'};
+	public function params($site=NULL) {
+		$params = array();
+		if ($site !== NULL) {
+			$params['site'] = $site;
+		}
+		return $this->zap->request($this->zap->base . 'params/view/params/', $params)->{'params'};
 	}
 
 }

--- a/php/api/zapv2/src/Zap/Pnh.php
+++ b/php/api/zapv2/src/Zap/Pnh.php
@@ -64,28 +64,28 @@ class Pnh {
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
 	public function pnh($apikey='') {
-		return $this->zap->requestother($this->zap->baseother . 'pnh/other/pnh/', array('apikey' => $apikey));
+		return $this->zap->requestother($this->zap->base_other . 'pnh/other/pnh/', array('apikey' => $apikey));
 	}
 
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
 	public function manifest($apikey='') {
-		return $this->zap->requestother($this->zap->baseother . 'pnh/other/manifest/', array('apikey' => $apikey));
+		return $this->zap->requestother($this->zap->base_other . 'pnh/other/manifest/', array('apikey' => $apikey));
 	}
 
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
 	public function service($apikey='') {
-		return $this->zap->requestother($this->zap->baseother . 'pnh/other/service/', array('apikey' => $apikey));
+		return $this->zap->requestother($this->zap->base_other . 'pnh/other/service/', array('apikey' => $apikey));
 	}
 
 	/**
 	 * This component is optional and therefore the API will only work if it is installed
 	 */
 	public function fx_pnhxpi($apikey='') {
-		return $this->zap->requestother($this->zap->baseother . 'pnh/other/fx_pnh.xpi/', array('apikey' => $apikey));
+		return $this->zap->requestother($this->zap->base_other . 'pnh/other/fx_pnh.xpi/', array('apikey' => $apikey));
 	}
 
 }

--- a/php/api/zapv2/src/Zap/Script.php
+++ b/php/api/zapv2/src/Zap/Script.php
@@ -63,8 +63,12 @@ class Script {
 	/**
 	 * Loads a script into ZAP from the given local file, with the given name, type and engine, optionally with a description
 	 */
-	public function load($scriptname, $scripttype, $scriptengine, $filename, $scriptdescription='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'script/action/load/', array('scriptName' => $scriptname, 'scriptType' => $scripttype, 'scriptEngine' => $scriptengine, 'fileName' => $filename, 'scriptDescription' => $scriptdescription, 'apikey' => $apikey));
+	public function load($scriptname, $scripttype, $scriptengine, $filename, $scriptdescription=NULL, $apikey='') {
+		$params = array('scriptName' => $scriptname, 'scriptType' => $scripttype, 'scriptEngine' => $scriptengine, 'fileName' => $filename, 'apikey' => $apikey);
+		if ($scriptdescription !== NULL) {
+			$params['scriptDescription'] = $scriptdescription;
+		}
+		return $this->zap->request($this->zap->base . 'script/action/load/', $params);
 	}
 
 	/**

--- a/php/api/zapv2/src/Zap/Search.php
+++ b/php/api/zapv2/src/Zap/Search.php
@@ -32,52 +32,172 @@ class Search {
 		$this->zap = $zap;
 	}
 
-	public function urlsByUrlRegex($regex, $baseurl='', $start='', $count='') {
-		return $this->zap->request($this->zap->base . 'search/view/urlsByUrlRegex/', array('regex' => $regex, 'baseurl' => $baseurl, 'start' => $start, 'count' => $count))->{'urlsByUrlRegex'};
+	public function urlsByUrlRegex($regex, $baseurl=NULL, $start=NULL, $count=NULL) {
+		$params = array('regex' => $regex);
+		if ($baseurl !== NULL) {
+			$params['baseurl'] = $baseurl;
+		}
+		if ($start !== NULL) {
+			$params['start'] = $start;
+		}
+		if ($count !== NULL) {
+			$params['count'] = $count;
+		}
+		return $this->zap->request($this->zap->base . 'search/view/urlsByUrlRegex/', $params)->{'urlsByUrlRegex'};
 	}
 
-	public function urlsByRequestRegex($regex, $baseurl='', $start='', $count='') {
-		return $this->zap->request($this->zap->base . 'search/view/urlsByRequestRegex/', array('regex' => $regex, 'baseurl' => $baseurl, 'start' => $start, 'count' => $count))->{'urlsByRequestRegex'};
+	public function urlsByRequestRegex($regex, $baseurl=NULL, $start=NULL, $count=NULL) {
+		$params = array('regex' => $regex);
+		if ($baseurl !== NULL) {
+			$params['baseurl'] = $baseurl;
+		}
+		if ($start !== NULL) {
+			$params['start'] = $start;
+		}
+		if ($count !== NULL) {
+			$params['count'] = $count;
+		}
+		return $this->zap->request($this->zap->base . 'search/view/urlsByRequestRegex/', $params)->{'urlsByRequestRegex'};
 	}
 
-	public function urlsByResponseRegex($regex, $baseurl='', $start='', $count='') {
-		return $this->zap->request($this->zap->base . 'search/view/urlsByResponseRegex/', array('regex' => $regex, 'baseurl' => $baseurl, 'start' => $start, 'count' => $count))->{'urlsByResponseRegex'};
+	public function urlsByResponseRegex($regex, $baseurl=NULL, $start=NULL, $count=NULL) {
+		$params = array('regex' => $regex);
+		if ($baseurl !== NULL) {
+			$params['baseurl'] = $baseurl;
+		}
+		if ($start !== NULL) {
+			$params['start'] = $start;
+		}
+		if ($count !== NULL) {
+			$params['count'] = $count;
+		}
+		return $this->zap->request($this->zap->base . 'search/view/urlsByResponseRegex/', $params)->{'urlsByResponseRegex'};
 	}
 
-	public function urlsByHeaderRegex($regex, $baseurl='', $start='', $count='') {
-		return $this->zap->request($this->zap->base . 'search/view/urlsByHeaderRegex/', array('regex' => $regex, 'baseurl' => $baseurl, 'start' => $start, 'count' => $count))->{'urlsByHeaderRegex'};
+	public function urlsByHeaderRegex($regex, $baseurl=NULL, $start=NULL, $count=NULL) {
+		$params = array('regex' => $regex);
+		if ($baseurl !== NULL) {
+			$params['baseurl'] = $baseurl;
+		}
+		if ($start !== NULL) {
+			$params['start'] = $start;
+		}
+		if ($count !== NULL) {
+			$params['count'] = $count;
+		}
+		return $this->zap->request($this->zap->base . 'search/view/urlsByHeaderRegex/', $params)->{'urlsByHeaderRegex'};
 	}
 
-	public function messagesByUrlRegex($regex, $baseurl='', $start='', $count='') {
-		return $this->zap->request($this->zap->base . 'search/view/messagesByUrlRegex/', array('regex' => $regex, 'baseurl' => $baseurl, 'start' => $start, 'count' => $count))->{'messagesByUrlRegex'};
+	public function messagesByUrlRegex($regex, $baseurl=NULL, $start=NULL, $count=NULL) {
+		$params = array('regex' => $regex);
+		if ($baseurl !== NULL) {
+			$params['baseurl'] = $baseurl;
+		}
+		if ($start !== NULL) {
+			$params['start'] = $start;
+		}
+		if ($count !== NULL) {
+			$params['count'] = $count;
+		}
+		return $this->zap->request($this->zap->base . 'search/view/messagesByUrlRegex/', $params)->{'messagesByUrlRegex'};
 	}
 
-	public function messagesByRequestRegex($regex, $baseurl='', $start='', $count='') {
-		return $this->zap->request($this->zap->base . 'search/view/messagesByRequestRegex/', array('regex' => $regex, 'baseurl' => $baseurl, 'start' => $start, 'count' => $count))->{'messagesByRequestRegex'};
+	public function messagesByRequestRegex($regex, $baseurl=NULL, $start=NULL, $count=NULL) {
+		$params = array('regex' => $regex);
+		if ($baseurl !== NULL) {
+			$params['baseurl'] = $baseurl;
+		}
+		if ($start !== NULL) {
+			$params['start'] = $start;
+		}
+		if ($count !== NULL) {
+			$params['count'] = $count;
+		}
+		return $this->zap->request($this->zap->base . 'search/view/messagesByRequestRegex/', $params)->{'messagesByRequestRegex'};
 	}
 
-	public function messagesByResponseRegex($regex, $baseurl='', $start='', $count='') {
-		return $this->zap->request($this->zap->base . 'search/view/messagesByResponseRegex/', array('regex' => $regex, 'baseurl' => $baseurl, 'start' => $start, 'count' => $count))->{'messagesByResponseRegex'};
+	public function messagesByResponseRegex($regex, $baseurl=NULL, $start=NULL, $count=NULL) {
+		$params = array('regex' => $regex);
+		if ($baseurl !== NULL) {
+			$params['baseurl'] = $baseurl;
+		}
+		if ($start !== NULL) {
+			$params['start'] = $start;
+		}
+		if ($count !== NULL) {
+			$params['count'] = $count;
+		}
+		return $this->zap->request($this->zap->base . 'search/view/messagesByResponseRegex/', $params)->{'messagesByResponseRegex'};
 	}
 
-	public function messagesByHeaderRegex($regex, $baseurl='', $start='', $count='') {
-		return $this->zap->request($this->zap->base . 'search/view/messagesByHeaderRegex/', array('regex' => $regex, 'baseurl' => $baseurl, 'start' => $start, 'count' => $count))->{'messagesByHeaderRegex'};
+	public function messagesByHeaderRegex($regex, $baseurl=NULL, $start=NULL, $count=NULL) {
+		$params = array('regex' => $regex);
+		if ($baseurl !== NULL) {
+			$params['baseurl'] = $baseurl;
+		}
+		if ($start !== NULL) {
+			$params['start'] = $start;
+		}
+		if ($count !== NULL) {
+			$params['count'] = $count;
+		}
+		return $this->zap->request($this->zap->base . 'search/view/messagesByHeaderRegex/', $params)->{'messagesByHeaderRegex'};
 	}
 
-	public function harByUrlRegex($regex, $baseurl='', $start='', $count='', $apikey='') {
-		return $this->zap->requestother($this->zap->baseother . 'search/other/harByUrlRegex/', array('regex' => $regex, 'baseurl' => $baseurl, 'start' => $start, 'count' => $count, 'apikey' => $apikey));
+	public function harByUrlRegex($regex, $baseurl=NULL, $start=NULL, $count=NULL, $apikey='') {
+		$params = array('regex' => $regex, 'apikey' => $apikey);
+		if ($baseurl !== NULL) {
+			$params['baseurl'] = $baseurl;
+		}
+		if ($start !== NULL) {
+			$params['start'] = $start;
+		}
+		if ($count !== NULL) {
+			$params['count'] = $count;
+		}
+		return $this->zap->requestother($this->zap->base_other . 'search/other/harByUrlRegex/', $params);
 	}
 
-	public function harByRequestRegex($regex, $baseurl='', $start='', $count='', $apikey='') {
-		return $this->zap->requestother($this->zap->baseother . 'search/other/harByRequestRegex/', array('regex' => $regex, 'baseurl' => $baseurl, 'start' => $start, 'count' => $count, 'apikey' => $apikey));
+	public function harByRequestRegex($regex, $baseurl=NULL, $start=NULL, $count=NULL, $apikey='') {
+		$params = array('regex' => $regex, 'apikey' => $apikey);
+		if ($baseurl !== NULL) {
+			$params['baseurl'] = $baseurl;
+		}
+		if ($start !== NULL) {
+			$params['start'] = $start;
+		}
+		if ($count !== NULL) {
+			$params['count'] = $count;
+		}
+		return $this->zap->requestother($this->zap->base_other . 'search/other/harByRequestRegex/', $params);
 	}
 
-	public function harByResponseRegex($regex, $baseurl='', $start='', $count='', $apikey='') {
-		return $this->zap->requestother($this->zap->baseother . 'search/other/harByResponseRegex/', array('regex' => $regex, 'baseurl' => $baseurl, 'start' => $start, 'count' => $count, 'apikey' => $apikey));
+	public function harByResponseRegex($regex, $baseurl=NULL, $start=NULL, $count=NULL, $apikey='') {
+		$params = array('regex' => $regex, 'apikey' => $apikey);
+		if ($baseurl !== NULL) {
+			$params['baseurl'] = $baseurl;
+		}
+		if ($start !== NULL) {
+			$params['start'] = $start;
+		}
+		if ($count !== NULL) {
+			$params['count'] = $count;
+		}
+		return $this->zap->requestother($this->zap->base_other . 'search/other/harByResponseRegex/', $params);
 	}
 
-	public function harByHeaderRegex($regex, $baseurl='', $start='', $count='', $apikey='') {
-		return $this->zap->requestother($this->zap->baseother . 'search/other/harByHeaderRegex/', array('regex' => $regex, 'baseurl' => $baseurl, 'start' => $start, 'count' => $count, 'apikey' => $apikey));
+	public function harByHeaderRegex($regex, $baseurl=NULL, $start=NULL, $count=NULL, $apikey='') {
+		$params = array('regex' => $regex, 'apikey' => $apikey);
+		if ($baseurl !== NULL) {
+			$params['baseurl'] = $baseurl;
+		}
+		if ($start !== NULL) {
+			$params['start'] = $start;
+		}
+		if ($count !== NULL) {
+			$params['count'] = $count;
+		}
+		return $this->zap->requestother($this->zap->base_other . 'search/other/harByHeaderRegex/', $params);
 	}
 
 }

--- a/php/api/zapv2/src/Zap/SessionManagement.php
+++ b/php/api/zapv2/src/Zap/SessionManagement.php
@@ -44,8 +44,12 @@ class SessionManagement {
 		return $this->zap->request($this->zap->base . 'sessionManagement/view/getSessionManagementMethod/', array('contextId' => $contextid))->{'getSessionManagementMethod'};
 	}
 
-	public function setSessionManagementMethod($contextid, $methodname, $methodconfigparams='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'sessionManagement/action/setSessionManagementMethod/', array('contextId' => $contextid, 'methodName' => $methodname, 'methodConfigParams' => $methodconfigparams, 'apikey' => $apikey));
+	public function setSessionManagementMethod($contextid, $methodname, $methodconfigparams=NULL, $apikey='') {
+		$params = array('contextId' => $contextid, 'methodName' => $methodname, 'apikey' => $apikey);
+		if ($methodconfigparams !== NULL) {
+			$params['methodConfigParams'] = $methodconfigparams;
+		}
+		return $this->zap->request($this->zap->base . 'sessionManagement/action/setSessionManagementMethod/', $params);
 	}
 
 }

--- a/php/api/zapv2/src/Zap/Spider.php
+++ b/php/api/zapv2/src/Zap/Spider.php
@@ -32,12 +32,20 @@ class Spider {
 		$this->zap = $zap;
 	}
 
-	public function status($scanid='') {
-		return $this->zap->request($this->zap->base . 'spider/view/status/', array('scanId' => $scanid))->{'status'};
+	public function status($scanid=NULL) {
+		$params = array();
+		if ($scanid !== NULL) {
+			$params['scanId'] = $scanid;
+		}
+		return $this->zap->request($this->zap->base . 'spider/view/status/', $params)->{'status'};
 	}
 
-	public function results($scanid='') {
-		return $this->zap->request($this->zap->base . 'spider/view/results/', array('scanId' => $scanid))->{'results'};
+	public function results($scanid=NULL) {
+		$params = array();
+		if ($scanid !== NULL) {
+			$params['scanId'] = $scanid;
+		}
+		return $this->zap->request($this->zap->base . 'spider/view/results/', $params)->{'results'};
 	}
 
 	public function fullResults($scanid) {
@@ -142,15 +150,32 @@ class Spider {
 	/**
 	 * Runs the spider against the given URL. Optionally, the 'maxChildren' parameter can be set to limit the number of children scanned, the 'recurse' parameter can be used to prevent the spider from seeding recursively and the parameter 'contextName' can be used to constrain the scan to a Context.
 	 */
-	public function scan($url, $maxchildren='', $recurse='', $contextname='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'spider/action/scan/', array('url' => $url, 'maxChildren' => $maxchildren, 'recurse' => $recurse, 'contextName' => $contextname, 'apikey' => $apikey));
+	public function scan($url, $maxchildren=NULL, $recurse=NULL, $contextname=NULL, $apikey='') {
+		$params = array('url' => $url, 'apikey' => $apikey);
+		if ($maxchildren !== NULL) {
+			$params['maxChildren'] = $maxchildren;
+		}
+		if ($recurse !== NULL) {
+			$params['recurse'] = $recurse;
+		}
+		if ($contextname !== NULL) {
+			$params['contextName'] = $contextname;
+		}
+		return $this->zap->request($this->zap->base . 'spider/action/scan/', $params);
 	}
 
 	/**
 	 * Runs the spider from the perspective of a User, obtained using the given Context ID and User ID. See 'scan' action for more details.
 	 */
-	public function scanAsUser($url, $contextid, $userid, $maxchildren='', $recurse='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'spider/action/scanAsUser/', array('url' => $url, 'contextId' => $contextid, 'userId' => $userid, 'maxChildren' => $maxchildren, 'recurse' => $recurse, 'apikey' => $apikey));
+	public function scanAsUser($url, $contextid, $userid, $maxchildren=NULL, $recurse=NULL, $apikey='') {
+		$params = array('url' => $url, 'contextId' => $contextid, 'userId' => $userid, 'apikey' => $apikey);
+		if ($maxchildren !== NULL) {
+			$params['maxChildren'] = $maxchildren;
+		}
+		if ($recurse !== NULL) {
+			$params['recurse'] = $recurse;
+		}
+		return $this->zap->request($this->zap->base . 'spider/action/scanAsUser/', $params);
 	}
 
 	public function pause($scanid, $apikey='') {
@@ -161,8 +186,12 @@ class Spider {
 		return $this->zap->request($this->zap->base . 'spider/action/resume/', array('scanId' => $scanid, 'apikey' => $apikey));
 	}
 
-	public function stop($scanid='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'spider/action/stop/', array('scanId' => $scanid, 'apikey' => $apikey));
+	public function stop($scanid=NULL, $apikey='') {
+		$params = array('apikey' => $apikey);
+		if ($scanid !== NULL) {
+			$params['scanId'] = $scanid;
+		}
+		return $this->zap->request($this->zap->base . 'spider/action/stop/', $params);
 	}
 
 	public function removeScan($scanid, $apikey='') {

--- a/php/api/zapv2/src/Zap/Users.php
+++ b/php/api/zapv2/src/Zap/Users.php
@@ -32,12 +32,23 @@ class Users {
 		$this->zap = $zap;
 	}
 
-	public function usersList($contextid='') {
-		return $this->zap->request($this->zap->base . 'users/view/usersList/', array('contextId' => $contextid))->{'usersList'};
+	public function usersList($contextid=NULL) {
+		$params = array();
+		if ($contextid !== NULL) {
+			$params['contextId'] = $contextid;
+		}
+		return $this->zap->request($this->zap->base . 'users/view/usersList/', $params)->{'usersList'};
 	}
 
-	public function getUserById($contextid='', $userid='') {
-		return $this->zap->request($this->zap->base . 'users/view/getUserById/', array('contextId' => $contextid, 'userId' => $userid))->{'getUserById'};
+	public function getUserById($contextid=NULL, $userid=NULL) {
+		$params = array();
+		if ($contextid !== NULL) {
+			$params['contextId'] = $contextid;
+		}
+		if ($userid !== NULL) {
+			$params['userId'] = $userid;
+		}
+		return $this->zap->request($this->zap->base . 'users/view/getUserById/', $params)->{'getUserById'};
 	}
 
 	public function getAuthenticationCredentialsConfigParams($contextid) {
@@ -64,8 +75,12 @@ class Users {
 		return $this->zap->request($this->zap->base . 'users/action/setUserName/', array('contextId' => $contextid, 'userId' => $userid, 'name' => $name, 'apikey' => $apikey));
 	}
 
-	public function setAuthenticationCredentials($contextid, $userid, $authcredentialsconfigparams='', $apikey='') {
-		return $this->zap->request($this->zap->base . 'users/action/setAuthenticationCredentials/', array('contextId' => $contextid, 'userId' => $userid, 'authCredentialsConfigParams' => $authcredentialsconfigparams, 'apikey' => $apikey));
+	public function setAuthenticationCredentials($contextid, $userid, $authcredentialsconfigparams=NULL, $apikey='') {
+		$params = array('contextId' => $contextid, 'userId' => $userid, 'apikey' => $apikey);
+		if ($authcredentialsconfigparams !== NULL) {
+			$params['authCredentialsConfigParams'] = $authcredentialsconfigparams;
+		}
+		return $this->zap->request($this->zap->base . 'users/action/setAuthenticationCredentials/', $params);
 	}
 
 }

--- a/src/org/zaproxy/zap/extension/api/PhpAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/PhpAPIGenerator.java
@@ -196,7 +196,7 @@ public class PhpAPIGenerator {
 		String baseUrl = "base";
 		if (type.equals("other")) {
 			method += "other";
-			baseUrl += "other";
+			baseUrl += "_other";
 		}
 
 		out.write("\t\treturn $this->zap->" + method + "($this->zap->" + baseUrl + " . '" +


### PR DESCRIPTION
Correct the name of a Zapv2 property ("base_other") used by the
generated API classes when calling OTHER endpoints.
Regenerate the PHP API client to fix the typo (and to not send the
parameters that were not specified, #2108).
Reported in #2168 - Problem with API on new ZAP 2.4.3