### PR TITLE
Fix NPE when attempting to get an interface from a (Zest) script

### DIFF
--- a/src/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/src/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -1335,7 +1335,15 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 			Thread.currentThread().setContextClassLoader(previousContextClassLoader);
 		}
 		
-		return invokeScript(script).getInterface(class1);
+		if (script.isRunableStandalone()) {
+			return null;
+		}
+
+		Invocable invocable = invokeScript(script);
+		if (invocable != null) {
+			return invocable.getInterface(class1);
+		}
+		return null;
 
 	}
 


### PR DESCRIPTION
Change method ExtensionScript.getInterface(ScriptWrapper, Class<T>) to
check if the Invocable returned from the invoked script is not null
before attempting to get the interface, thus preventing the
NullPointerException. Also, change the method to not attempt to get an
interface from a stand alone script, as those scripts are not expected
to implement an interface (not directly at least).
The issue happened while attempting to get an (extended)
AuthenticationScript interface from a Zest authentication script (which
is also a stand alone script), because the Zest script does not directly
implement an interface (returning a null Invocable).