### PR TITLE
Create default policy in "weekly" and "stable" Docker images

### DIFF
--- a/build/docker/Dockerfile-stable
+++ b/build/docker/Dockerfile-stable
@@ -49,6 +49,17 @@ ENV HOME /home/zap/
 
 # Create some useful policies
 RUN mkdir -p /home/zap/.ZAP/policies
+
+ENV zappolicy /home/zap/.ZAP/policies/Default Policy.policy
+RUN echo "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" > ${zappolicy}
+RUN echo "<configuration>"      >> ${zappolicy}
+RUN echo "<policy>Default Policy</policy>"  >> ${zappolicy}
+RUN echo "<scanner>"            >> ${zappolicy}
+RUN echo "<level>MEDIUM</level>"    >> ${zappolicy}
+RUN echo "<strength>MEDIUM</strength>"    >> ${zappolicy}
+RUN echo "</scanner>"           >> ${zappolicy}
+RUN echo "</configuration>"         >> ${zappolicy}
+
 ENV zappolicy /home/zap/.ZAP/policies/St-High-Th-Med.policy
 RUN echo "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" > ${zappolicy}
 RUN echo "<configuration>" 		>> ${zappolicy}

--- a/build/docker/Dockerfile-weekly
+++ b/build/docker/Dockerfile-weekly
@@ -41,6 +41,16 @@ ENV HOME /home/zap/
 
 RUN mkdir -p /home/zap/.ZAP_D/policies
 
+ENV zappolicy /home/zap/.ZAP_D/policies/Default Policy.policy
+RUN echo "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" > ${zappolicy}
+RUN echo "<configuration>"      >> ${zappolicy}
+RUN echo "<policy>Default Policy</policy>"  >> ${zappolicy}
+RUN echo "<scanner>"            >> ${zappolicy}
+RUN echo "<level>MEDIUM</level>"    >> ${zappolicy}
+RUN echo "<strength>MEDIUM</strength>"    >> ${zappolicy}
+RUN echo "</scanner>"           >> ${zappolicy}
+RUN echo "</configuration>"         >> ${zappolicy}
+
 # Create some useful policies
 ENV zappolicy /home/zap/.ZAP_D/policies/St-High-Th-Med.policy
 RUN echo "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" > ${zappolicy}


### PR DESCRIPTION
When initialising ZAP does not create the "Default Policy" if at least
one policy was already created, the case with the docker images which
already have custom policies (e.g. St-High-Th-Med.policy,
St-Low-Th-Med.policy...).
The default policy is needed/used for ZAP scan tests.