### PR TITLE
Allow authentication scripts to provide logged in/out indicators

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -392,6 +392,7 @@ authentication.method.script.dialog.error.text.loading		= An error has occurred 
 authentication.method.script.dialog.error.text.required		= You have not configured a value for the required field: {0} 
 authentication.method.script.dialog.error.text.notLoaded	= You need to load an Authentication Script. 
 authentication.method.script.dialog.error.text.notLoadedNorConfigured = You need to load and configure an Authentication Script.
+authentication.method.script.dialog.loggedInOutIndicatorsInScript.toolTip = Defined in the Authentication script.
 
 authorization.panel.title									= Authorization
 authorization.panel.label.description 						= This panel allows you to configure how authorized/unauthorized requests are handled by your web application.

--- a/src/org/zaproxy/zap/authentication/AbstractAuthenticationMethodOptionsPanel.java
+++ b/src/org/zaproxy/zap/authentication/AbstractAuthenticationMethodOptionsPanel.java
@@ -60,9 +60,25 @@ public abstract class AbstractAuthenticationMethodOptionsPanel extends JPanel {
 	 * {@link #saveMethod()} was called).
 	 * 
 	 * @param method the method to be loaded/shown in the panel.
+	 * @throws UnsupportedAuthenticationMethodException if the {@code method} being bond is not supported
 	 */
 	public abstract void bindMethod(AuthenticationMethod method)
 			throws UnsupportedAuthenticationMethodException;
+
+	/**
+	 * Binds (loads) data from an existing Authentication method in the panel. After this method, to
+	 * {@link #getMethod()} should return the same object, eventually with some changes (if
+	 * {@link #saveMethod()} was called).
+	 * 
+	 * @param method the method to be loaded/shown in the panel.
+	 * @param indicatorsPanel the interface to manipulate the fields of the logged in/out indicators
+	 * @throws UnsupportedAuthenticationMethodException if the {@code method} being bond is not supported
+	 * @since TODO add version
+	 */
+	public void bindMethod(AuthenticationMethod method, AuthenticationIndicatorsPanel indicatorsPanel)
+			throws UnsupportedAuthenticationMethodException {
+		bindMethod(method);
+	}
 
 	/**
 	 * Gets the corresponding authentication method configured by this panel.

--- a/src/org/zaproxy/zap/authentication/AuthenticationIndicatorsPanel.java
+++ b/src/org/zaproxy/zap/authentication/AuthenticationIndicatorsPanel.java
@@ -1,0 +1,86 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.authentication;
+
+/**
+ * An interface that allows to manipulate the state (content, enabled and tool tip) of fields showing the logged in/out
+ * indicators.
+ * 
+ * @since TODO add version
+ */
+public interface AuthenticationIndicatorsPanel {
+
+    /**
+     * Gets the logged in indicator pattern.
+     * 
+     * @return the logged in indicator pattern
+     */
+    String getLoggedInIndicatorPattern();
+
+    /**
+     * Sets the logged in indicator pattern.
+     * 
+     * @param loggedInIndicatorPattern the new logged in indicator pattern
+     */
+    void setLoggedInIndicatorPattern(String loggedInIndicatorPattern);
+
+    /**
+     * Sets whether or not the field of the logged in indicator should be enabled.
+     *
+     * @param enabled {@code true} if the logged in indicator should be enabled, {@code false} otherwise
+     */
+    void setLoggedInIndicatorEnabled(boolean enabled);
+
+    /**
+     * Sets the tool tip of the logged in indicator.
+     *
+     * @param toolTip the tool tip of the logged in indicator, {@code null} to disable it
+     */
+    void setLoggedInIndicatorToolTip(String toolTip);
+
+    /**
+     * Gets the logged out indicator pattern.
+     * 
+     * @return the logged out indicator pattern
+     */
+    String getLoggedOutIndicatorPattern();
+
+    /**
+     * Sets the logged out indicator pattern.
+     * 
+     * @param loggedOutIndicatorPattern the new logged out indicator pattern
+     */
+    void setLoggedOutIndicatorPattern(String loggedOutIndicatorPattern);
+
+    /**
+     * Sets whether or not the field of the logged out indicator should be enabled.
+     *
+     * @param enabled {@code true} if the logged out indicator should be enabled, {@code false} otherwise
+     */
+    void setLoggedOutIndicatorEnabled(boolean enabled);
+
+    /**
+     * Sets the tool tip of the logged out indicator.
+     *
+     * @param toolTip the tool tip of the logged out indicator, {@code null} to disable it
+     */
+    void setLoggedOutIndicatorToolTip(String toolTip);
+
+}

--- a/src/org/zaproxy/zap/extension/authentication/ContextAuthenticationPanel.java
+++ b/src/org/zaproxy/zap/extension/authentication/ContextAuthenticationPanel.java
@@ -40,6 +40,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.model.Session;
 import org.zaproxy.zap.authentication.AbstractAuthenticationMethodOptionsPanel;
+import org.zaproxy.zap.authentication.AuthenticationIndicatorsPanel;
 import org.zaproxy.zap.authentication.AuthenticationMethod;
 import org.zaproxy.zap.authentication.AuthenticationMethodType;
 import org.zaproxy.zap.extension.users.ExtensionUserManagement;
@@ -96,6 +97,8 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
 
 	/** Hacked used to make sure a confirmation is not needed if changes where done during init. */
 	private boolean needsConfirm = true;
+
+	private AuthenticationIndicatorsPanel authenticationIndicatorsPanel;
 
 	/**
 	 * Instantiates a new context authentication configuration panel.
@@ -208,6 +211,7 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
 							authenticationMethodsComboBox.setSelectedItem(shownMethodType);
 							return;
 						}
+						resetLoggedInOutIndicators();
 
 						// Prepare the new authentication method
 						AuthenticationMethodType type = ((AuthenticationMethodType) e.getItem());
@@ -222,13 +226,20 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
 						// Show the configuration panel
 						changeMethodConfigPanel(type);
 						if (type.hasOptionsPanel()) {
-							shownConfigPanel.bindMethod(selectedAuthenticationMethod);
+							shownConfigPanel.bindMethod(selectedAuthenticationMethod, getAuthenticationIndicatorsPanel());
 						}
 					}
 				}
 			});
 		}
 		return authenticationMethodsComboBox;
+	}
+
+	private AuthenticationIndicatorsPanel getAuthenticationIndicatorsPanel() {
+		if (authenticationIndicatorsPanel == null) {
+			authenticationIndicatorsPanel = new AuthenticationIndicatorsPanelImpl();
+		}
+		return authenticationIndicatorsPanel;
 	}
 
 	/**
@@ -292,6 +303,8 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
 			log.debug("Initializing configuration panel for authentication method: "
 					+ selectedAuthenticationMethod + " for context " + uiSharedContext.getName());
 
+		resetLoggedInOutIndicators();
+
 		// If something was already configured, find the type and set the UI accordingly
 		if (selectedAuthenticationMethod != null) {
 			// Set logged in/out indicators
@@ -311,7 +324,7 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
 				if (shownMethodType.hasOptionsPanel()) {
 					log.debug("Binding authentication method to existing panel of proper type for context "
 							+ uiSharedContext.getName());
-					shownConfigPanel.bindMethod(selectedAuthenticationMethod);
+					shownConfigPanel.bindMethod(selectedAuthenticationMethod, getAuthenticationIndicatorsPanel());
 				}
 				return;
 			}
@@ -331,6 +344,19 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
 					break;
 				}
 		}
+	}
+
+	/**
+	 * Resets the tool tip and enables the fields of the logged in/out indicators.
+	 * 
+	 *  @see #getLoggedInIndicaterRegexField()
+	 *  @see #getLoggedOutIndicaterRegexField()
+	 */
+	private void resetLoggedInOutIndicators() {
+		getLoggedInIndicaterRegexField().setToolTipText(null);
+		getLoggedInIndicaterRegexField().setEnabled(true);
+		getLoggedOutIndicaterRegexField().setToolTipText(null);
+		getLoggedOutIndicaterRegexField().setEnabled(true);
 	}
 
 	@Override
@@ -379,4 +405,46 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
 		uiSharedContext.setAuthenticationMethod(selectedAuthenticationMethod);
 	}
 
+	private class AuthenticationIndicatorsPanelImpl implements AuthenticationIndicatorsPanel {
+
+		@Override
+		public String getLoggedInIndicatorPattern() {
+			return getLoggedInIndicaterRegexField().getText();
+		}
+
+		@Override
+		public void setLoggedInIndicatorPattern(String loggedInIndicatorPattern) {
+			getLoggedInIndicaterRegexField().setText(loggedInIndicatorPattern);
+		}
+
+		@Override
+		public void setLoggedInIndicatorEnabled(boolean enabled) {
+			getLoggedInIndicaterRegexField().setEnabled(enabled);
+		}
+
+		@Override
+		public void setLoggedInIndicatorToolTip(String toolTip) {
+			getLoggedInIndicaterRegexField().setToolTipText(toolTip);
+		}
+
+		@Override
+		public String getLoggedOutIndicatorPattern() {
+			return getLoggedOutIndicaterRegexField().getText();
+		}
+
+		@Override
+		public void setLoggedOutIndicatorPattern(String loggedOutIndicatorPattern) {
+			getLoggedOutIndicaterRegexField().setText(loggedOutIndicatorPattern);
+		}
+
+		@Override
+		public void setLoggedOutIndicatorEnabled(boolean enabled) {
+			getLoggedOutIndicaterRegexField().setEnabled(enabled);
+		}
+
+		@Override
+		public void setLoggedOutIndicatorToolTip(String toolTip) {
+			getLoggedOutIndicaterRegexField().setToolTipText(toolTip);
+		}
+	}
 }

--- a/src/scripts/templates/authentication/Authentication default template.js
+++ b/src/scripts/templates/authentication/Authentication default template.js
@@ -58,3 +58,15 @@ function getOptionalParamsNames(){
 function getCredentialsParamsNames(){
 	return ["username", "password"];
 }
+
+// This optional function is called during the script loading to obtain the logged in indicator.
+// NOTE: although optional this function must be implemented along with the function getLoggedOutIndicator().
+//function getLoggedInIndicator() {
+//	return "LoggedInIndicator";
+//}
+
+// This optional function is called during the script loading to obtain the logged out indicator.
+// NOTE: although optional this function must be implemented along with the function getLoggedInIndicator().
+//function getLoggedOutIndicator() {
+//	return "LoggedOutIndicator";
+//}


### PR DESCRIPTION
Change AbstractAuthenticationMethodOptionsPanel to allow authentication
implementations to control the logged in/out indicators through an
interface, AuthenticationIndicatorsPanel, which allows to set the logged
in/out indicators, enabled/disable the fields and set its tool tip.
The interface is implemented internally by ContextAuthenticationPanel
and provided to the authentication method implementations when bond,
loaded into the view.
Add an interface, AuthenticationScriptV2, that allows the Authentication
script implementations to provide the logged in/out indicators through
getters (getLoggedInIndicator() and  getLoggedOutIndicator()).
Change ScriptBasedAuthenticationMethodType to check if the
authentication scripts implement the new interface, in which case it
loads the indicators, otherwise it does nothing (new), and keeps the old
behaviour. When bond to the view it disables the fields of the logged
in/out indicators, as those are already being provided by the script
(it also shows a tool tip indicating that).
Update the default authentication template script with example functions
on how the new interface is expected to be implemented.
Fix #2068 - LoggedIn and LoggedOut indicators inside authentication
scripts