### PR TITLE
Allow to active scan the HTTP headers of all requests

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -123,6 +123,8 @@ api.options.label.testingWarning	= <html>* The following options should only be 
 api.options.nokey.error		= You must supply an API key or explicitly disable it.
 ascan.activeActionPrefix = Active scanning: {0}
 ascan.api.action.scanAsUser = Active Scans from the perspective of a User, obtained using the given Context ID and User ID. See 'scan' action for more details.
+ascan.api.view.optionScanHeadersAllRequests = Tells whether or not the HTTP Headers of all requests should be scanned. Not just requests that send parameters, through the query or request body.
+ascan.api.action.setOptionScanHeadersAllRequests = Sets whether or not the HTTP Headers of all requests should be scanned. Not just requests that send parameters, through the query or request body.
 ascan.attack.icon.title		= Attack Mode queue
 ascan.attack.scan			= Attack Mode Scanner
 ascan.attack.prompt			= Rescan all of the nodes when scope changes?\n\
@@ -300,6 +302,8 @@ variant.options.injectable.label             = Injectable Targets:
 variant.options.injectable.querystring.label = URL Query String
 variant.options.injectable.postdata.label    = POST Data
 variant.options.injectable.headers.label     = HTTP Headers (could slow down testing)
+variant.options.injectable.headersAllRequests.label = All Requests
+variant.options.injectable.headersAllRequests.toolTip = <html>Allows to scan the HTTP Headers of all requests.<br>Not just requests that send parameters, through the query or request body.</html>
 variant.options.injectable.cookie.label      = Cookie Data (could slow down testing)
 variant.options.injectable.urlpath.label     = URL Path (could slow down testing)
 

--- a/src/org/parosproxy/paros/core/scanner/ScannerParam.java
+++ b/src/org/parosproxy/paros/core/scanner/ScannerParam.java
@@ -40,6 +40,7 @@
 // ZAP: 2015/03/04 Issue 1345: Added 'attack on start' option
 // ZAP: 2015/03/25 Issue 1573: Add option to inject plugin ID in header for all ascan requests
 // ZAP: 2015/10/01 Issue 1944:  Chart responses per second in ascan progress
+// ZAP: 2016/01/20 Issue 1959: Allow to active scan headers of all requests
 
 package org.parosproxy.paros.core.scanner;
 
@@ -85,6 +86,14 @@ public class ScannerParam extends AbstractParam {
     private static final String TARGET_INJECTABLE = ACTIVE_SCAN_BASE_KEY + ".injectable";
     private static final String TARGET_ENABLED_RPC = ACTIVE_SCAN_BASE_KEY + ".enabledRPC";
 
+    /**
+     * Configuration key to write/read the {@code scanHeadersAllRequests} flag.
+     * 
+     * @since TODO add version
+     * @see #scanHeadersAllRequests
+     */
+    private static final String SCAN_HEADERS_ALL_REQUESTS = ACTIVE_SCAN_BASE_KEY + ".scanHeadersAllRequests";
+
     // ZAP: Configuration constants
     public static final int TARGET_QUERYSTRING = 1;
     public static final int TARGET_POSTDATA = 1 << 1;
@@ -126,6 +135,19 @@ public class ScannerParam extends AbstractParam {
     // ZAP: Variants Configuration
     private int targetParamsInjectable = TARGET_INJECTABLE_DEFAULT;
     private int targetParamsEnabledRPC = TARGET_ENABLED_RPC_DEFAULT;
+
+    /**
+     * Flag that indicates if the HTTP Headers of all requests should be scanned, not just requests that send parameters,
+     * through the query or request body.
+     * <p>
+     * Default value is {@code false}.
+     * 
+     * @since TODO add version
+     * @see #SCAN_HEADERS_ALL_REQUESTS
+     * @see #isScanHeadersAllRequests()
+     * @see #setScanHeadersAllRequests(boolean)
+     */
+    private boolean scanHeadersAllRequests;
 
     // ZAP: Excluded Parameters
     private final List<ScannerParamFilter> excludedParams = new ArrayList<>();
@@ -223,6 +245,11 @@ public class ScannerParam extends AbstractParam {
 
         try {
             this.maxChartTimeInMins = getConfig().getInt(MAX_CHART_TIME_IN_MINS, DEFAULT_MAX_CHART_TIME_IN_MINS);
+        } catch (Exception e) {
+        }
+
+        try {
+            this.scanHeadersAllRequests = getConfig().getBoolean(SCAN_HEADERS_ALL_REQUESTS, false);
         } catch (Exception e) {
         }
 
@@ -545,5 +572,34 @@ public class ScannerParam extends AbstractParam {
 		this.maxChartTimeInMins = maxChartTimeInMins;
         getConfig().setProperty(MAX_CHART_TIME_IN_MINS, this.maxChartTimeInMins);
 	}
+
+    /**
+     * Tells whether or not the HTTP Headers of all requests should be scanned, not just requests that send parameters, through
+     * the query or request body.
+     *
+     * @return {@code true} if the HTTP Headers of all requests should be scanned, {@code false} otherwise
+     * @since TODO add version
+     * @see #setScanHeadersAllRequests(boolean)
+     */
+    public boolean isScanHeadersAllRequests() {
+        return scanHeadersAllRequests;
+    }
+
+    /**
+     * Sets whether or not the HTTP Headers of all requests should be scanned, not just requests that send parameters, through
+     * the query or request body.
+     *
+     * @param scanAllRequests {@code true} if the HTTP Headers of all requests should be scanned, {@code false} otherwise
+     * @since TODO add version
+     * @see #isScanHeadersAllRequests()
+     */
+    public void setScanHeadersAllRequests(boolean scanAllRequests) {
+        if (scanAllRequests == scanHeadersAllRequests) {
+            return;
+        }
+
+        this.scanHeadersAllRequests = scanAllRequests;
+        getConfig().setProperty(SCAN_HEADERS_ALL_REQUESTS, Boolean.valueOf(this.scanHeadersAllRequests));
+    }
 
 }

--- a/src/org/zaproxy/zap/extension/ascan/OptionsVariantPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/OptionsVariantPanel.java
@@ -23,6 +23,8 @@ import java.awt.CardLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
@@ -55,6 +57,7 @@ public class OptionsVariantPanel extends AbstractParamPanel {
     private JCheckBox chkInjectableUrlPath = null;
     private JCheckBox chkInjectablePostData = null;
     private JCheckBox chkInjectableHeaders = null;
+    private JCheckBox chkInjectableHeadersAllRequests;
     private JCheckBox chkInjectableCookie = null;
     
     // Checkbox for RPC to be enabled definitions
@@ -115,8 +118,11 @@ public class OptionsVariantPanel extends AbstractParamPanel {
                     this.getChkInjectableHeaders(),
                     LayoutHelper.getGBC(0, 4, 1, 1.0D, 0, GridBagConstraints.HORIZONTAL, new Insets(2, 8, 2, 2)));
             panelInjectable.add(
+                    this.getChkInjectableHeadersAllRequests(),
+                    LayoutHelper.getGBC(0, 5, 1, 1.0D, 0, GridBagConstraints.HORIZONTAL, new Insets(2, 32, 2, 2)));
+            panelInjectable.add(
                     this.getChkInjectableCookie(),
-                    LayoutHelper.getGBC(0, 5, 1, 1.0D, 0, GridBagConstraints.HORIZONTAL, new Insets(2, 8, 2, 2)));
+                    LayoutHelper.getGBC(0, 6, 1, 1.0D, 0, GridBagConstraints.HORIZONTAL, new Insets(2, 8, 2, 2)));
             
             panelVariant.add(
                     new JLabel(Constant.messages.getString("variant.options.injectable.label")),
@@ -200,6 +206,7 @@ public class OptionsVariantPanel extends AbstractParamPanel {
         this.getChkInjectableUrlPath().setSelected((targets & ScannerParam.TARGET_URLPATH) != 0);
         this.getChkInjectablePostData().setSelected((targets & ScannerParam.TARGET_POSTDATA) != 0);
         this.getChkInjectableHeaders().setSelected((targets & ScannerParam.TARGET_HTTPHEADERS) != 0);
+        this.getChkInjectableHeadersAllRequests().setSelected(param.isScanHeadersAllRequests());
         this.getChkInjectableCookie().setSelected((targets & ScannerParam.TARGET_COOKIE) != 0);
 
         int rpcEnabled = param.getTargetParamsEnabledRPC();
@@ -262,6 +269,8 @@ public class OptionsVariantPanel extends AbstractParamPanel {
             targets |= ScannerParam.TARGET_HTTPHEADERS;
         }
         
+        param.setScanHeadersAllRequests(getChkInjectableHeadersAllRequests().isSelected());
+
         if (this.getChkInjectableCookie().isSelected()) {
             targets |= ScannerParam.TARGET_COOKIE;
         }
@@ -313,6 +322,7 @@ public class OptionsVariantPanel extends AbstractParamPanel {
         this.getChkInjectableUrlPath().setEnabled(enabled);
         this.getChkInjectablePostData().setEnabled(enabled);
         this.getChkInjectableHeaders().setEnabled(enabled);
+        this.getChkInjectableHeadersAllRequests().setEnabled(enabled && getChkInjectableHeaders().isSelected());
         this.getChkInjectableCookie().setEnabled(enabled);
          
         this.getChkRPCMultipart().setEnabled(enabled);
@@ -373,8 +383,27 @@ public class OptionsVariantPanel extends AbstractParamPanel {
         if (chkInjectableHeaders == null) {
             chkInjectableHeaders = new JCheckBox();
             chkInjectableHeaders.setText(Constant.messages.getString("variant.options.injectable.headers.label"));
+            chkInjectableHeaders.addItemListener(new ItemListener() {
+
+                @Override
+                public void itemStateChanged(ItemEvent e) {
+                    getChkInjectableHeadersAllRequests().setEnabled(e.getStateChange() == ItemEvent.SELECTED);
+
+                }
+            });
         }
         return chkInjectableHeaders;
+    }
+
+    private JCheckBox getChkInjectableHeadersAllRequests() {
+        if (chkInjectableHeadersAllRequests == null) {
+            chkInjectableHeadersAllRequests = new JCheckBox();
+            chkInjectableHeadersAllRequests
+                    .setText(Constant.messages.getString("variant.options.injectable.headersAllRequests.label"));
+            chkInjectableHeadersAllRequests
+                    .setToolTipText(Constant.messages.getString("variant.options.injectable.headersAllRequests.toolTip"));
+        }
+        return chkInjectableHeadersAllRequests;
     }
 
     private JCheckBox getChkInjectableCookie() {


### PR DESCRIPTION
Change classes ScannerParam and OptionsVariantPanel to allow to specify
if the HTTP headers of all requests should be scanned, programmatically
and through the GUI, respectively.
Change class VariantHeader to use the new option from ScannerParam
allowing to scan (or not) the HTTP headers of all requests.
Fix #1959 - Allow to active scan headers of all requests