### PR TITLE
Return the ID of the scanner when returning the Alert through the API

### DIFF
--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -953,6 +953,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 	private ApiResponseSet alertToSet(Alert alert) {
 		Map<String, String> map = new HashMap<>();
 		map.put("id", String.valueOf(alert.getAlertId()));
+		map.put("pluginId", String.valueOf(alert.getPluginId()));
 		map.put("alert", alert.getAlert());
 		map.put("description", alert.getDescription());
 		map.put("risk", Alert.MSG_RISK[alert.getRisk()]);


### PR DESCRIPTION
Allows to know which scanner raised the Alert (more information about
the scanner can be later obtained using the AScan/PScan API view
"scanners").