### PR TITLE
Install new versions of the add-ons after downloading with -addonupdate

### DIFF
--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -984,7 +984,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 	            return;
 			}
 		}
-		logger.debug("Installing new addon " + ao.getId() + " v" + ao.getFileVersion());
+		logger.info("Installing new addon " + ao.getId() + " v" + ao.getFileVersion());
 		if (View.isInitialised()) {
 			// Report info to the Output tab
 			View.getSingleton().getOutputPanel().append(
@@ -1526,13 +1526,8 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
         	options.setCheckAddonUpdates(true);
         	options.setInstallAddonUpdates(true);
 			checkForAddOnUpdates(aoc, options);
-			while (downloadManager.getCurrentDownloadCount() > 0) {
-    			try {
-					Thread.sleep(200);
-				} catch (InterruptedException e) {
-					// Ignore
-				}
-			}
+
+			waitAndInstallDownloads();
     		CommandLine.info(Constant.messages.getString("cfu.cmdline.updated"));
         }
         if (arguments[ARG_CFU_INSTALL_ALL_IDX].isEnabled()) {
@@ -1588,26 +1583,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
                 
                 processAddOnChanges(null, allResults);
 
-                while (downloadManager.getCurrentDownloadCount() > 0) {
-                    try {
-                        Thread.sleep(200);
-                    } catch (InterruptedException e) {
-                        // Ignore
-                    }
-                }
-
-                for (Downloader download : downloadManager.getProgress()) {
-                    if (download.isValidated()) {
-                        CommandLine.info(MessageFormat.format(
-                                Constant.messages.getString("cfu.cmdline.addondown"),
-                                download.getTargetFile().getAbsolutePath()));
-                    } else {
-                        CommandLine.error(MessageFormat.format(
-                                Constant.messages.getString("cfu.cmdline.addondown.failed"),
-                                download.getTargetFile().getName()));
-                    }
-                }
-                installNewExtensions();
+                waitAndInstallDownloads();
         	}
         }
         if (arguments[ARG_CFU_INSTALL_IDX].isEnabled()) {
@@ -1660,31 +1636,34 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 
                     processAddOnChanges(null, result);
 
-                    while (downloadManager.getCurrentDownloadCount() > 0) {
-                        try {
-                            Thread.sleep(200);
-                        } catch (InterruptedException e) {
-                            // Ignore
-                        }
-                    }
-
-                    for (Downloader download : downloadManager.getProgress()) {
-                        if (download.isValidated()) {
-                            CommandLine.info(MessageFormat.format(
-                                    Constant.messages.getString("cfu.cmdline.addondown"),
-                                    download.getTargetFile().getAbsolutePath()));
-                        } else {
-                            CommandLine.error(MessageFormat.format(
-                                    Constant.messages.getString("cfu.cmdline.addondown.failed"),
-                                    download.getTargetFile().getName()));
-                        }
-                    }
-                    installNewExtensions();
+                    waitAndInstallDownloads();
             	}
             }
         }
 	}
 	
+	private void waitAndInstallDownloads() {
+		while (downloadManager.getCurrentDownloadCount() > 0) {
+			try {
+				Thread.sleep(200);
+			} catch (InterruptedException e) {
+				// Ignore
+			}
+		}
+		for (Downloader download : downloadManager.getProgress()) {
+			if (download.isValidated()) {
+				CommandLine.info(MessageFormat.format(
+						Constant.messages.getString("cfu.cmdline.addondown"),
+						download.getTargetFile().getAbsolutePath()));
+			} else {
+				CommandLine.error(MessageFormat.format(
+						Constant.messages.getString("cfu.cmdline.addondown.failed"),
+						download.getTargetFile().getName()));
+			}
+		}
+		installNewExtensions();
+	}
+
 	@Override
 	public boolean handleFile(File file) {
 		// Not supported


### PR DESCRIPTION
Change ExtensionAutoUpdate to call the method installNewExtensions()
after downloading the new versions of the add-ons, so that the add-ons
are effectively updated.
Extract a method that waits for the downloads to finish and install
them, as that's done by all ExtensionAutoUpdate command line arguments.
Log as INFO when an add-on is being installed (so that by default that
information is logged).