### PR TITLE
Disallow Spider scans when ZAP is in Safe (or Protected) mode

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1779,7 +1779,9 @@ spider.custom.popup			= Spider...
 spider.custom.title			= Spider
 spider.custom.tab.adv		= Advanced
 spider.custom.tab.scope		= Scope
+spider.custom.notSafe.error = Spider scans are not allowed in 'Safe' mode.
 spider.custom.nostart.error	= You must select a valid starting point\nincluding the protocol e.g. https://www.example.com
+spider.custom.targetNotInScope.error = The following target is not allowed in 'Protected' mode:\n{0}
 
 spider.desc                     = Spider used for automatically finding URIs on a site
 spider.label.inScope            = URI found during crawl:

--- a/src/org/zaproxy/zap/extension/spider/SpiderDialog.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderDialog.java
@@ -352,22 +352,42 @@ public class SpiderDialog extends StandardFieldsDialog {
 
     @Override
     public String validateFields() {
+        if (Control.Mode.safe == Control.getSingleton().getMode()) {
+            // The dialogue shouldn't be shown when in safe mode but if it is warn.
+            return Constant.messages.getString("spider.custom.notSafe.error");
+        }
+
     	if (this.isEmptyField(FIELD_START)) {
             return Constant.messages.getString("spider.custom.nostart.error");
     	}
 		if (!getStringValue(FIELD_START).equals(getTargetText(target))) {
+			String url = this.getStringValue(FIELD_START);
 			try {
 				// Need both constructors as they catch slightly different issues ;)
-				String url = this.getStringValue(FIELD_START);
 				new URI(url, true);
 				new URL(url);
 			} catch (Exception e) {
                 return Constant.messages.getString("spider.custom.nostart.error");
 			}
+
+            if (Control.getSingleton().getMode() == Control.Mode.protect) {
+                if (!extension.isTargetUriInScope(url)) {
+                    return Constant.messages.getString("spider.custom.targetNotInScope.error", url);
+                }
+            }
 		}
 
-    	if (this.target != null && !this.target.isValid()) {
-            return Constant.messages.getString("spider.custom.nostart.error");
+    	if (this.target != null) {
+            if (!this.target.isValid()) {
+                return Constant.messages.getString("spider.custom.nostart.error");
+            }
+
+            if (Control.getSingleton().getMode() == Control.Mode.protect) {
+                String uri = extension.getTargetUriOutOfScope(target);
+                if (uri != null) {
+                    return Constant.messages.getString("spider.custom.targetNotInScope.error", uri);
+                }
+            }
         }
         
         return null;


### PR DESCRIPTION
Change method ExtensionSpider.sessionModeChanged(Mode) to disable the
"Spider.." menu when the mode is changed to Safe (and enable otherwise),
it would allow to start the scans even in "Safe" mode. Also, change to
not start the scans if the mode is "Safe" or if the target is not in
scope when in "Protected" mode.
Change SpiderDialog to inform and do not start the scan when in Safe or
Protected mode, if the target is not in scope.