### PR TITLE
Suppress INFO log messages of some Crawljax classes by default

### DIFF
--- a/src/xml/log4j.properties
+++ b/src/xml/log4j.properties
@@ -18,3 +18,14 @@ log4j.logger.org.zaproxy.zap=INFO
 log4j.logger.org.apache.commons.httpclient=ERROR
 log4j.logger.org.parosproxy.paros.core.proxy.ProxyThread=ERROR
 log4j.logger.net.htmlparser.jericho=ERROR
+
+# Prevent Crawljax from logging too many, not so useful, INFO messages.
+# For example:
+# INFO  Crawler - New DOM is a new state! crawl depth is now 10
+# INFO  Crawler - Crawl depth is now 1
+# INFO  Crawler - Crawl depth is now 2
+# INFO  UnfiredCandidateActions - There are 64 states with unfired actions
+# INFO  StateMachine - State state106 added to the StateMachine.
+log4j.logger.com.crawljax.core.Crawler = WARN
+log4j.logger.com.crawljax.core.state.StateMachine = WARN
+log4j.logger.com.crawljax.core.UnfiredCandidateActions = WARN


### PR DESCRIPTION
Change file log4j.properties to only log messages with WARN level (and
up) for classes Crawler, StateMachine and UnfiredCandidateActions, as
the INFO log messages from those classes can easily fill the log file
with not so useful (for every day use) information, for example:
 INFO  StateMachine - State state1583 added to the StateMachine.
 INFO  Crawler - New DOM is a new state! crawl depth is now 4
 INFO  UnfiredCandidateActions - There are 3 states with unfired actions
 INFO  Crawler - Crawl depth is now 1
 INFO  Crawler - Crawl depth is now 2
 INFO  Crawler - Crawl depth is now 3
 INFO  StateMachine - CLONE State detected: state1584 and state1382 are
 the same.
 INFO  UnfiredCandidateActions - There are 3 states with unfired actions
 INFO  Crawler - Crawl depth is now 1
 INFO  Crawler - Crawl depth is now 2
 INFO  Crawler - Crawl depth is now 3
 INFO  Crawler - Crawl depth is now 4
 INFO  Crawler - Crawl depth is now 5
 INFO  Crawler - Crawl depth is now 6
 INFO  Crawler - Crawl depth is now 7
 INFO  Crawler - Crawl depth is now 8
 INFO  Crawler - Crawl depth is now 9
 INFO  StateMachine - State state1585 added to the StateMachine.