### PR TITLE
Change Spider to log the seeds with DEBUG level and keep them unique

### DIFF
--- a/src/org/zaproxy/zap/spider/Spider.java
+++ b/src/org/zaproxy/zap/spider/Spider.java
@@ -18,7 +18,7 @@
 package org.zaproxy.zap.spider;
 
 import java.net.CookieManager;
-import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -90,7 +90,7 @@ public class Spider {
 	private DefaultFetchFilter defaultFetchFilter;
 	
 	/** The seed list. */
-	private List<URI> seedList;
+	private LinkedHashSet<URI> seedList;
 	
 	/** The extension. */
 	private ExtensionSpider extension;
@@ -147,7 +147,7 @@ public class Spider {
 		this.model = model;
 		this.controller = new SpiderController(this, extension.getCustomParsers());
 		this.listeners = new LinkedList<>();
-		this.seedList = new ArrayList<>();
+		this.seedList = new LinkedHashSet<>();
 		this.cookieManager = new CookieManager();
 		this.scanContext = scanContext;
 		this.extension = extension;
@@ -451,8 +451,8 @@ public class Spider {
 
 		// Add the seeds
 		for (URI uri : seedList) {
-			if (log.isInfoEnabled()) {
-				log.info("Adding seed for spider: " + uri);
+			if (log.isDebugEnabled()) {
+				log.debug("Adding seed for spider: " + uri);
 			}
 			controller.addSeed(uri, HttpRequestHeader.GET);
 		}


### PR DESCRIPTION
Change Spider class to use a LinkedHashSet to keep the seeds, to avoid
repetitions while keeping the same iteration order as the ArrayList. The
seeds are repeated when they are added by the built-in parsers, per seed
added, for example:
 Adding seed for spider: http://example.com/
(following seeds added by built-in parsers)
 Adding seed for spider: http://example.com/robots.txt
 Adding seed for spider: http://example.com/sitemap.xml
 Adding seed for spider: http://example.com/.svn/entries
 Adding seed for spider: http://example.com/.svn/wc.db
 Adding seed for spider: http://example.com/.git/index

Change the log level, of the seeds added, from INFO to DEBUG as it logs
too much messages when spidering a target more than once (since
previously visited pages are added as seed, plus seeds added by built-in
parsers).