### PR TITLE
Prevent the active scanner from reporting progress higher than 100%

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
@@ -627,6 +627,11 @@ public class ActiveScanAPI extends ApiImplementor {
 			        for (Plugin plugin : hp.getRunning()) {
 						ApiResponseList pList = new ApiResponseList("Plugin");
 						int pc = (int)(hp.getTestCurrentCount(plugin) * 100 / hp.getTestTotalCount());
+						// Make sure not return 100 (or more) if still running...
+						// That might happen if more nodes are being scanned that the ones enumerated at the beginning.
+						if (pc >= 100) {
+							pc = 99;
+						}
 						pList.addItem(new ApiResponseElement("name", XMLStringUtil.escapeControlChrs(plugin.getName())));
 						pList.addItem(new ApiResponseElement("id", Integer.toString(plugin.getId())));
 						pList.addItem(new ApiResponseElement("status", pc + "%"));

--- a/src/org/zaproxy/zap/extension/ascan/ScanProgressItem.java
+++ b/src/org/zaproxy/zap/extension/ascan/ScanProgressItem.java
@@ -98,18 +98,16 @@ public class ScanProgressItem {
 
     /**
      * Get back the percentage of completion.
-     * Currently this is a fake percentage which set 50%
-     * when the plugin begins and 100% when finished...
-     * Should be improved using HostProcess informations regarding
-     * the overall nodes that need to be scanned and the current
-     * executions done...
+     * 
      * @return the percentage value from 0 to 100
      */
     public int getProgressPercentage()  {
         // Implemented using node counts...
         if (isRunning()) {
-            return (int)((hProcess.getTestCurrentCount(plugin) * 100) / hProcess.getTestTotalCount());
-            
+            int progress = (hProcess.getTestCurrentCount(plugin) * 100) / hProcess.getTestTotalCount();
+            // Make sure not return 100 (or more) if still running...
+            // That might happen if more nodes are being scanned that the ones enumerated at the beginning.
+            return progress >= 100 ? 99 : progress;
         } else if (isCompleted()) {
             return 100;        
             


### PR DESCRIPTION
Change class HostProcess to:
 - Use the same function for both the actual scan of the nodes as
 well the calculation of the number of nodes that will be scanned, to
 ensure that the same logic is applied in both cases (currently it
 wasn't);
 - Log, with INFO level, the number of nodes that will be scanned;
 - In the event that more nodes are found while the active scan is in
 progress prevent the status of a given scanner to be higher than 99%
 when reached the known number of nodes and report 100% once completed.
 Also, to improve the reported progress of following scanners update
 the total number of nodes being scanned.

Change method ScanProgressItem.getProgressPercentage() and class
ActiveScanAPI to not return 100% (or more) when the scanner is still
running (for the former also remove outdated JavaDoc comment).

---
Issue reported in OWASP ZAP User Group: https://groups.google.com/d/topic/zaproxy-users/R5heEI0uJME/discussion