### PR TITLE
Fix spider deadlock between spider thread(s) and thread stopping it

### DIFF
--- a/src/org/zaproxy/zap/view/ScanPanel2.java
+++ b/src/org/zaproxy/zap/view/ScanPanel2.java
@@ -482,19 +482,12 @@ public abstract class ScanPanel2<GS extends GenericScanner2, SC extends ScanCont
 	    if (EventQueue.isDispatchThread()) {
 	    	scanProgressEventHandler(id, host, progress, maximum);
 	    } else {
-	        try {
-	            EventQueue.invokeAndWait(new Runnable() {
-	                @Override
-	                public void run() {
-	                	scanProgressEventHandler(id, host, progress, maximum);
-	                }
-	            });
-	        } catch (InterruptedException e) {
-				log.info("Interrupt scan progress update on GUI.");
-			} 
-	        catch (Exception e) {
-	            log.error(e.getMessage(), e);
-	        }
+            EventQueue.invokeLater(new Runnable() {
+                @Override
+                public void run() {
+                	scanProgressEventHandler(id, host, progress, maximum);
+                }
+            });
 	    }
 	}
 


### PR DESCRIPTION
Change method ScanPanel2.scanProgress(...) to update the progress
asynchronously to not block the spider threads (and other scanner
threads).
Change Spider class to stop the threads more gracefully instead of
interrupting them (that is, consume the tasks in the queue without
executing them, parse resources). Do not count as tasks done the
notifications done after the spider has stopped since those tasks were
not really executed, also ignore any calls to complete after stopping.