### PR TITLE
Keep "All Requests" option enabled state in sync with "HTTP Headers"

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/OptionsVariantPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/OptionsVariantPanel.java
@@ -207,6 +207,7 @@ public class OptionsVariantPanel extends AbstractParamPanel {
         this.getChkInjectablePostData().setSelected((targets & ScannerParam.TARGET_POSTDATA) != 0);
         this.getChkInjectableHeaders().setSelected((targets & ScannerParam.TARGET_HTTPHEADERS) != 0);
         this.getChkInjectableHeadersAllRequests().setSelected(param.isScanHeadersAllRequests());
+        this.getChkInjectableHeadersAllRequests().setEnabled(getChkInjectableHeaders().isSelected());
         this.getChkInjectableCookie().setSelected((targets & ScannerParam.TARGET_COOKIE) != 0);
 
         int rpcEnabled = param.getTargetParamsEnabledRPC();


### PR DESCRIPTION
Change method OptionsVariantPanel.initParam(ScannerParam) to add missing
initialisation of the enabled state of "All Requests" option, to keep it
disabled when the option "HTTP Headers" is not selected and enabled when
it is.