### PR TITLE
Change HttpSessionsSite to better handle expired cookies (max-age < 0)

### DIFF
--- a/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsSite.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsSite.java
@@ -386,8 +386,15 @@ public class HttpSessionsSite {
 		for (HttpCookie cookie : cookiesToSet) {
 			String lcCookieName = cookie.getName();
 			if (siteTokensSet.isSessionToken(lcCookieName)) {
-				Cookie ck = new Cookie(cookie.getDomain(),lcCookieName,cookie.getValue(),cookie.getPath(),(int) cookie.getMaxAge(),cookie.getSecure());				
-				tokenValues.put(lcCookieName, ck);
+				try {
+					// Use 0 if max-age less than -1, Cookie class does not accept negative (expired) max-age (-1 has special
+					// meaning).
+					long maxAge = cookie.getMaxAge() < -1 ? 0 : cookie.getMaxAge();
+					Cookie ck = new Cookie(cookie.getDomain(),lcCookieName,cookie.getValue(),cookie.getPath(),(int) maxAge,cookie.getSecure());				
+					tokenValues.put(lcCookieName, ck);
+				} catch (IllegalArgumentException e) {
+					log.warn("Failed to create cookie [" + cookie + "] for site [" + getSite() + "]: " + e.getMessage());
+				}
 			}
 		}
 


### PR DESCRIPTION
Change method HttpSessionsSite.processHttpResponseMessage(HttpMessage)
to use max-age as 0 (expired) when the cookie has a negative max-age
(rfc6265, 5.2.2), class Cookie does not accept negative max-age (note,
the check uses -1 instead of 0 because the former value has a special
meaning). Also, catch exception thrown by Cookie class to prevent other
cookie "errors" from being handled by other unrelated classes (like
HttpSender class).
Fix #2226 - ZAP should handle HttpSessionsSite's cookie errors more
gracefully