### PR TITLE
Allow to enable/disable database's recovery log (HSQLDB)

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -878,6 +878,8 @@ core.api.view.excludedFromProxy = Gets the regular expressions, applied to URLs,
 
 database.optionspanel.name = Database
 database.optionspanel.option.compact.label = Compact (on exit)
+database.optionspanel.option.recoveryLog.label = Recovery Log
+database.optionspanel.option.recoveryLog.tooltip = <html>Controls whether or not database's recovery log is enabled.<br>Improves the performance of the database when disabled but might lead to data loss if ZAP is exited abruptly.<br>Note: current session will be unaffected, changes take effect on new and opened sessions.</html>
 database.optionspanel.option.request.body.size.label = Maximum Request Body Size
 database.optionspanel.option.response.body.size.label = Maximum Response Body Size 
 

--- a/src/org/parosproxy/paros/db/paros/ParosDatabase.java
+++ b/src/org/parosproxy/paros/db/paros/ParosDatabase.java
@@ -34,6 +34,7 @@
 // ZAP: 2015/02/05 Issue 1524: New Persist Session dialog
 // ZAP: 2015/02/09 Issue 1525: Introduce a database interface layer to allow for alternative implementations
 // ZAP: 2015/04/02 Issue 1582: Low memory option
+// ZAP: 2016/02/10 Issue 1958: Allow to disable database (HSQLDB) log
 
 package org.parosproxy.paros.db.paros;
 
@@ -56,6 +57,7 @@ import org.parosproxy.paros.db.TableSession;
 import org.parosproxy.paros.db.TableSessionUrl;
 import org.parosproxy.paros.db.TableStructure;
 import org.parosproxy.paros.db.TableTag;
+import org.parosproxy.paros.extension.option.DatabaseParam;
 
 
 
@@ -79,6 +81,8 @@ public class ParosDatabase implements Database {
 
 	// ZAP: Added type arguments.
 	private Vector<DatabaseListener> listenerList = new Vector<>();
+
+	private DatabaseParam databaseOptions;
 
 	public ParosDatabase() {
 	    tableHistory = new ParosTableHistory();
@@ -180,7 +184,7 @@ public class ParosDatabase implements Database {
 	public void open(String path) throws ClassNotFoundException, Exception {
 	    // ZAP: Added log statement.
 		log.debug("open " + path);
-	    setDatabaseServer(new ParosDatabaseServer(path));
+	    setDatabaseServer(new ParosDatabaseServer(path, databaseOptions));
 	    notifyListenerDatabaseOpen();
 	}
 	
@@ -346,4 +350,17 @@ public class ParosDatabase implements Database {
 		return Database.DB_TYPE_HSQLDB;
 	}
 
+	/**
+	 * Sets the object that holds the database options.
+	 *
+	 * @param databaseOptions the object that holds the database options, must not be {@code null}
+	 * @throws IllegalArgumentException if the given parameter is {@code null}.
+	 * @since TODO add version
+	 */
+	public void setDatabaseParam(DatabaseParam databaseOptions) {
+		if (databaseOptions == null) {
+			throw new IllegalArgumentException("Parameter databaseOptions must not be null.");
+		}
+		this.databaseOptions = databaseOptions;
+	}
 }

--- a/src/org/parosproxy/paros/extension/option/DatabaseParam.java
+++ b/src/org/parosproxy/paros/extension/option/DatabaseParam.java
@@ -29,6 +29,7 @@ import org.parosproxy.paros.common.AbstractParam;
  * <li>Compact - allows the database to be compacted on exit.</li>
  * <li>Request Body Size - the size of the request body in the 'History' database table.</li>
  * <li>Response Body Size - the size of the response body in the 'History' database table.</li>
+ * <li>Recovery Log - if the recovery log should be enabled (HSQLDB option only).</li>
  * </ul>
  * </p>
  */
@@ -71,6 +72,11 @@ public class DatabaseParam extends AbstractParam {
     private static final String PARAM_NEW_SESSION_PROMPT = PARAM_BASE_KEY + ".newsessionprompt";
 
     /**
+     * The configuration key for database's recovery log option.
+     */
+    private static final String PARAM_RECOVERY_LOG_ENABLED = PARAM_BASE_KEY + ".recoverylog";
+
+    /**
      * The compact option, whether the database should be compacted on exit.
      * Default is {@code false}.
      * 
@@ -102,6 +108,15 @@ public class DatabaseParam extends AbstractParam {
     private int newSessionOption;
     
     private boolean newSessionPrompt;
+
+    /**
+     * Flag used to indicate whether or not database's recovery log is enabled.
+     * <p>
+     * Default is {@code true}.
+     * 
+     * @see #isRecoveryLogEnabled()
+     */
+    private boolean recoveryLogEnabled;
     
     public DatabaseParam() {
         super();
@@ -111,6 +126,7 @@ public class DatabaseParam extends AbstractParam {
 		responsebodysize = 16777216;
 		newSessionOption = NEW_SESSION_NOT_SPECIFIED;
 		newSessionPrompt = true;
+		recoveryLogEnabled = true;
     }
 
     /**
@@ -121,6 +137,7 @@ public class DatabaseParam extends AbstractParam {
      * <li>Compact - allows the database to be compacted on exit.</li>
      * <li>Request Body Size - the size of the request body in the 'History' database table.</li>
      * <li>Response Body Size - the size of the response body in the 'History' database table.</li>
+     * <li>Recovery Log - if the recovery log should be enabled (HSQLDB option only).</li>
      * </ul>
      * </p>
      */
@@ -131,6 +148,7 @@ public class DatabaseParam extends AbstractParam {
         responsebodysize = getConfig().getInt(PARAM_RESPONSE_BODY_SIZE, responsebodysize);
 		newSessionOption = getConfig().getInt(PARAM_NEW_SESSION_OPTION, newSessionOption);
 		newSessionPrompt = getConfig().getBoolean(PARAM_NEW_SESSION_PROMPT, newSessionPrompt);
+		recoveryLogEnabled = getConfig().getBoolean(PARAM_RECOVERY_LOG_ENABLED, recoveryLogEnabled);
     }
 
     /**
@@ -220,6 +238,29 @@ public class DatabaseParam extends AbstractParam {
 	public void setNewSessionPrompt(boolean newSessionPrompt) {
 		this.newSessionPrompt = newSessionPrompt;
 		getConfig().setProperty(PARAM_NEW_SESSION_PROMPT, newSessionPrompt);
+	}
+
+	/**
+	 * Tells whether or not database's recovery log is enabled.
+	 * 
+	 * @return {@code true} if database's recovery log is enabled, {@code false} otherwise
+	 * @see #setRecoveryLogEnabled(boolean)
+	 * @version TODO add version
+	 */
+	public boolean isRecoveryLogEnabled() {
+		return recoveryLogEnabled;
+	}
+
+	/**
+	 * Sets whether or not database's recovery log is enabled.
+	 * 
+	 * @param enabled {@code true} if database's recovery log should be enabled, {@code false} otherwise
+	 * @see #isRecoveryLogEnabled()
+	 * @version TODO add version
+	 */
+	public void setRecoveryLogEnabled(boolean enabled) {
+		this.recoveryLogEnabled = enabled;
+		getConfig().setProperty(PARAM_RECOVERY_LOG_ENABLED, Boolean.valueOf(recoveryLogEnabled));
 	}
 
 }

--- a/src/org/parosproxy/paros/extension/option/OptionsDatabasePanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsDatabasePanel.java
@@ -44,6 +44,7 @@ import org.zaproxy.zap.view.LayoutHelper;
  * <li>Compact - allows the database to be compacted on exit.</li>
  * <li>Request Body Size - the size of the request body in the 'History' database table.</li>
  * <li>Response Body Size - the size of the response body in the 'History' database table.</li>
+ * <li>Recovery Log - if the recovery log should be enabled (HSQLDB option only).</li>
  * </ul>
  * </p>
  * 
@@ -73,6 +74,19 @@ public class OptionsDatabasePanel extends AbstractParamPanel {
      */
     private static final String RESPONSE_BODY_SIZE_DATABASE_LABEL = Constant.messages.getString("database.optionspanel.option.response.body.size.label");
 
+    /**
+     * The label for the recovery log option.
+     * 
+     * @see #getCheckRecoveryLog()
+     */
+    private static final String RECOVERY_LOG_LABEL = Constant.messages.getString("database.optionspanel.option.recoveryLog.label");
+
+    /**
+     * The tool tip for the recovery log option.
+     * 
+     * @see #getCheckRecoveryLog()
+     */
+    private static final String RECOVERY_LOG_TOOL_TIP = Constant.messages.getString("database.optionspanel.option.recoveryLog.tooltip");
     
 	/**
 	 * The check box used to select/deselect the compact option.
@@ -93,6 +107,11 @@ public class OptionsDatabasePanel extends AbstractParamPanel {
 	
 	private JComboBox<String> comboNewSessionOption = null;
 
+	/**
+	 * The check box used to enabled/disable database's recovery log option.
+	 */
+	private JCheckBox checkBoxRecoveryLog = null;
+
     public OptionsDatabasePanel() {
         super();
         setName(NAME);
@@ -101,7 +120,7 @@ public class OptionsDatabasePanel extends AbstractParamPanel {
         
         java.awt.GridBagConstraints gridBagConstraintsLabelRequestBodySize = new GridBagConstraints();
         gridBagConstraintsLabelRequestBodySize.gridx = 0;
-        gridBagConstraintsLabelRequestBodySize.gridy = 1;
+        gridBagConstraintsLabelRequestBodySize.gridy = 2;
         gridBagConstraintsLabelRequestBodySize.insets = new java.awt.Insets(2,2,2,2);
         gridBagConstraintsLabelRequestBodySize.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraintsLabelRequestBodySize.fill = java.awt.GridBagConstraints.HORIZONTAL;
@@ -109,7 +128,7 @@ public class OptionsDatabasePanel extends AbstractParamPanel {
         
         java.awt.GridBagConstraints gridBagConstraintsRequestBodySize = new GridBagConstraints();
         gridBagConstraintsRequestBodySize.gridx = 1;
-        gridBagConstraintsRequestBodySize.gridy = 1;
+        gridBagConstraintsRequestBodySize.gridy = 2;
         gridBagConstraintsRequestBodySize.weightx = 0.5D;
         gridBagConstraintsRequestBodySize.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraintsRequestBodySize.insets = new java.awt.Insets(2,2,2,2);
@@ -118,7 +137,7 @@ public class OptionsDatabasePanel extends AbstractParamPanel {
 
         java.awt.GridBagConstraints gridBagConstraintsLabelResponseBodySize = new GridBagConstraints();
         gridBagConstraintsLabelResponseBodySize.gridx = 0;
-        gridBagConstraintsLabelResponseBodySize.gridy = 2;
+        gridBagConstraintsLabelResponseBodySize.gridy = 3;
         gridBagConstraintsLabelResponseBodySize.insets = new java.awt.Insets(2,2,2,2);
         gridBagConstraintsLabelResponseBodySize.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraintsLabelResponseBodySize.fill = java.awt.GridBagConstraints.HORIZONTAL;
@@ -126,7 +145,7 @@ public class OptionsDatabasePanel extends AbstractParamPanel {
         
         java.awt.GridBagConstraints gridBagConstraintsResponseBodySize = new GridBagConstraints();
         gridBagConstraintsResponseBodySize.gridx = 1;
-        gridBagConstraintsResponseBodySize.gridy = 2;
+        gridBagConstraintsResponseBodySize.gridy = 3;
         gridBagConstraintsResponseBodySize.weightx = 0.5D;
         gridBagConstraintsResponseBodySize.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraintsResponseBodySize.insets = new java.awt.Insets(2,2,2,2);
@@ -149,14 +168,15 @@ public class OptionsDatabasePanel extends AbstractParamPanel {
         gbc.insets = new java.awt.Insets(2,2,2,2);
         gbc.anchor = GridBagConstraints.WEST;
         panel.add(getCheckBoxCompactDatabase(), gbc);
+        panel.add(getCheckRecoveryLog(), LayoutHelper.getGBC(0, 1, 1, 1.0D, new Insets(2,2,2,2)));
         panel.add(jLabelRequestBodySize, gridBagConstraintsLabelRequestBodySize);
         panel.add(getRequestBodySize(), gridBagConstraintsRequestBodySize);
         panel.add(jLabelResponseBodySize, gridBagConstraintsLabelResponseBodySize);
         panel.add(getResponseBodySize(), gridBagConstraintsResponseBodySize);
-        panel.add(getCheckBoxNewSessionPrompt(), LayoutHelper.getGBC(0, 3, 2, 1.0D, new Insets(2,2,2,2)));
+        panel.add(getCheckBoxNewSessionPrompt(), LayoutHelper.getGBC(0, 4, 2, 1.0D, new Insets(2,2,2,2)));
         panel.add(new JLabel(Constant.messages.getString("database.optionspanel.option.newsessionopt.label")), 
-        		LayoutHelper.getGBC(0, 4, 1, 0.5D, new Insets(2,2,2,2)));
-        panel.add(comboNewSessionOption(), LayoutHelper.getGBC(1, 4, 1, 1.0D, new Insets(2,2,2,2)));
+        		LayoutHelper.getGBC(0, 5, 1, 0.5D, new Insets(2,2,2,2)));
+        panel.add(comboNewSessionOption(), LayoutHelper.getGBC(1, 5, 1, 1.0D, new Insets(2,2,2,2)));
         add(panel);
     }
     
@@ -167,6 +187,14 @@ public class OptionsDatabasePanel extends AbstractParamPanel {
         return checkBoxCompactDatabase;
     }
     
+    private JCheckBox getCheckRecoveryLog() {
+        if (checkBoxRecoveryLog == null) {
+            checkBoxRecoveryLog = new JCheckBox(RECOVERY_LOG_LABEL);
+            checkBoxRecoveryLog.setToolTipText(RECOVERY_LOG_TOOL_TIP);
+        }
+        return checkBoxRecoveryLog;
+    }
+
     private ZapSizeNumberSpinner getRequestBodySize() {
         if (spinnerRequestBodySize == null) {
         	spinnerRequestBodySize = new ZapSizeNumberSpinner(16777216);
@@ -211,6 +239,7 @@ public class OptionsDatabasePanel extends AbstractParamPanel {
         spinnerResponseBodySize.setValue(param.getResponseBodySize());
     	checkBoxNewSessionPrompt.setSelected(param.isNewSessionPrompt());
     	comboNewSessionOption.setSelectedIndex(param.getNewSessionOption());
+    	checkBoxRecoveryLog.setSelected(param.isRecoveryLogEnabled());
     }
 
     @Override
@@ -227,6 +256,7 @@ public class OptionsDatabasePanel extends AbstractParamPanel {
         param.setResponseBodySize(spinnerResponseBodySize.getValue());
         param.setNewSessionPrompt(checkBoxNewSessionPrompt.isSelected());
         param.setNewSessionOption(comboNewSessionOption.getSelectedIndex());
+        param.setRecoveryLogEnabled(checkBoxRecoveryLog.isSelected());
     }
     
     @Override

--- a/src/org/parosproxy/paros/model/Model.java
+++ b/src/org/parosproxy/paros/model/Model.java
@@ -35,6 +35,7 @@
 // ZAP: 2014/07/15 Issue 1265: Context import and export
 // ZAP: 2015/02/09 Issue 1525: Introduce a database interface layer to allow for alternative implementations
 // ZAP: 2015/04/02 Issue 321: Support multiple databases
+// ZAP: 2016/02/10 Issue 1958: Allow to disable database (HSQLDB) log
 
 package org.parosproxy.paros.model;
 
@@ -176,11 +177,15 @@ public class Model {
 	}
 
 	public void init(ControlOverrides overrides) throws SAXException, IOException, Exception {
+		getOptionsParam().load(Constant.getInstance().FILE_CONFIG, overrides);
+
 		if (overrides.isExperimentalDb()) {
 			logger.info("Using experimental database :/");
 			db = DbSQL.getSingleton().initDatabase();
 		} else {
-			db = new ParosDatabase();
+			ParosDatabase parosDb = new ParosDatabase();
+			parosDb.setDatabaseParam(getOptionsParam().getDatabaseParam());
+			db = parosDb;
 		}
 
 		createAndOpenUntitledDb();
@@ -188,7 +193,6 @@ public class Model {
 		HistoryReference.setTableHistory(getDb().getTableHistory());
 		HistoryReference.setTableTag(getDb().getTableTag());
 		HistoryReference.setTableAlert(getDb().getTableAlert());
-		getOptionsParam().load(Constant.getInstance().FILE_CONFIG, overrides);
 	}
 
 	public static Model getSingleton() {


### PR DESCRIPTION
Add option to "Database" options panel to allow to enable/disable
database's recovery log, by changing the class OptionsDatabasePanel.
Change class DatabaseParam to load/persist the new option from the
configuration file.
Change class ParosDatabase to allow to set the database options so that
they can be checked and applied (in this case the option recovery log)
by ParosDatabaseServer when connecting to new or existing databases.
Change class ParosDatabaseServer to enable/disable recovery log
depending on the state of the new option.
Change method Model.init(ControlOverrides) to load the configuration
file before creating the databases so that the databases can use the
configurations and also change it to set the database configurations to
ParosDatabase instance (HSQLDB implementation).
Fix #1958 - Allow to disable database (HSQLDB) log