### PR TITLE
Reset the "Active Scan" and "Spider" dialogues on session change

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
+++ b/src/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
@@ -950,4 +950,14 @@ public class CustomScanDialog extends StandardFieldsDialog {
             return scanPolicy;
         }
     }
+
+    /**
+     * Resets the active scan dialogue to its default state.
+     * 
+     * @since TODO add version
+     */
+    void reset() {
+        target = null;
+        reset(true);
+    }
 }

--- a/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -510,6 +510,9 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
         
         if (View.isInitialised()) {
         	this.getActiveScanPanel().reset();
+            if (customScanDialog != null) {
+                customScanDialog.reset();
+            }
         }
     }
 

--- a/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
+++ b/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
@@ -196,6 +196,9 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
 		this.scanController.reset();
 		if (View.isInitialised()) {
 			this.getSpiderPanel().reset();
+			if (spiderDialog != null) {
+				spiderDialog.reset();
+			}
 		}
 	}
 

--- a/src/org/zaproxy/zap/extension/spider/SpiderDialog.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderDialog.java
@@ -392,4 +392,14 @@ public class SpiderDialog extends StandardFieldsDialog {
         
         return null;
     }
+
+    /**
+     * Resets the spider dialogue to its default state.
+     * 
+     * @since TODO add version
+     */
+    void reset() {
+        target = null;
+        reset(true);
+    }
 }


### PR DESCRIPTION
Change classes ExtensionActiveScan and ExtensionSpider to reset its scan
dialogues, CustomScanDialog and SpiderDialog, respectively, when the
session is about to change to prevent the use of old data/objects.

---
Steps to reproduce the issue:
1. Run ZAP;
2. Spider a target;
3. Open the "Active Scan" dialogue, select the "Starting Point" ("Select...") and start the scan (the scan can be stopped immediately after);
4. Create a new session;
5. Open the "Active scan" dialogue again, note that the "Starting Point" field has the previous selected URL, start the scan;
6. Check the log file, there should be some exceptions:
```
82172 [Thread-37] ERROR org.parosproxy.paros.core.scanner.HostProcess  - No history reference for id 107 type=2 GET:get(n,p[])
org.parosproxy.paros.network.HttpMalformedHeaderException: No history reference for id 107 type=2
	at org.parosproxy.paros.model.HistoryReference.getHttpMessage(Unknown Source)
	at org.parosproxy.paros.core.scanner.HostProcess.scanSingleNode(Unknown Source)
	at org.parosproxy.paros.core.scanner.HostProcess.traverse(Unknown Source)
	at org.parosproxy.paros.core.scanner.HostProcess.traverse(Unknown Source)
	at org.parosproxy.paros.core.scanner.HostProcess.traverse(Unknown Source)
	at org.parosproxy.paros.core.scanner.HostProcess.traverse(Unknown Source)
	at org.parosproxy.paros.core.scanner.HostProcess.traverse(Unknown Source)
	at org.parosproxy.paros.core.scanner.HostProcess.processPlugin(Unknown Source)
	at org.parosproxy.paros.core.scanner.HostProcess.run(Unknown Source)
	at java.lang.Thread.run(Thread.java:745)
```

Remarks:
The Spider dialogue should also be reset for consistency.

ZAP Version:
Versions >= 2.4.0