### PR TITLE
Remove unnecessary null checks related to HTTP message headers/bodies

### DIFF
--- a/src/org/parosproxy/paros/network/HttpSender.java
+++ b/src/org/parosproxy/paros/network/HttpSender.java
@@ -458,7 +458,7 @@ public class HttpSender {
 		// If there's a 'Requesting User', make sure the response corresponds to an authenticated
 		// session and, if not, attempt a reauthentication and try again
 		if (initiator != AUTHENTICATION_INITIATOR && forceUser != null
-				&& msg.getResponseBody() != null && !msg.getRequestHeader().isImage()
+				&& !msg.getRequestHeader().isImage()
 				&& !forceUser.isAuthenticated(msg)) {
 			log.debug("First try to send authenticated message failed for " + msg.getRequestHeader().getURI()
 					+ ". Authenticating and trying again...");

--- a/src/org/zaproxy/zap/extension/history/PopupMenuExportURLs.java
+++ b/src/org/zaproxy/zap/extension/history/PopupMenuExportURLs.java
@@ -130,8 +130,7 @@ public class PopupMenuExportURLs extends ExtensionPopupMenuItem {
          				node.getHistoryReference().getHistoryType() == HistoryReference.TYPE_SPIDER)) {
         		
         	 	HttpMessage msg = node.getHistoryReference().getHttpMessage();
-    			if (msg != null && msg.getRequestHeader() != null &&
-        			msg.getRequestHeader().getURI() != null) {
+    			if (msg != null && msg.getRequestHeader().getURI() != null) {
 
             		writer.write(msg.getRequestHeader().getMethod());
             		writer.write("\t");

--- a/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/all/response/HttpResponseAllPanelSyntaxHighlightTextView.java
+++ b/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/all/response/HttpResponseAllPanelSyntaxHighlightTextView.java
@@ -167,7 +167,7 @@ public class HttpResponseAllPanelSyntaxHighlightTextView extends HttpPanelSyntax
 		@Override
 		protected String detectSyntax(HttpMessage httpMessage) {
 			String syntax = null;
-			if (httpMessage != null && httpMessage.getResponseHeader() != null) {
+			if (httpMessage != null) {
 				String contentType = httpMessage.getResponseHeader().getHeader(HttpHeader.CONTENT_TYPE);
 				if(contentType != null && !contentType.isEmpty()) {
 					contentType = contentType.toLowerCase(Locale.ENGLISH);

--- a/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/split/request/HttpRequestBodyPanelSyntaxHighlightTextView.java
+++ b/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/split/request/HttpRequestBodyPanelSyntaxHighlightTextView.java
@@ -169,7 +169,7 @@ public class HttpRequestBodyPanelSyntaxHighlightTextView extends HttpPanelSyntax
 		@Override
 		protected String detectSyntax(HttpMessage httpMessage) {
 			String syntax = null;
-			if (httpMessage != null && httpMessage.getRequestHeader() != null) {
+			if (httpMessage != null) {
 				String contentType = httpMessage.getRequestHeader().getHeader(HttpHeader.CONTENT_TYPE);
 				if(contentType != null && !contentType.isEmpty()) {
 					contentType = contentType.toLowerCase(Locale.ENGLISH);

--- a/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/split/response/HttpResponseBodyPanelSyntaxHighlightTextView.java
+++ b/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/split/response/HttpResponseBodyPanelSyntaxHighlightTextView.java
@@ -88,7 +88,7 @@ public class HttpResponseBodyPanelSyntaxHighlightTextView extends HttpPanelSynta
 		@Override
 		protected String detectSyntax(HttpMessage httpMessage) {
 			String syntax = null;
-			if (httpMessage != null && httpMessage.getResponseHeader() != null) {
+			if (httpMessage != null) {
 				String contentType = httpMessage.getResponseHeader().getHeader(HttpHeader.CONTENT_TYPE);
 				if(contentType != null && !contentType.isEmpty()) {
 					contentType = contentType.toLowerCase(Locale.ENGLISH);

--- a/src/org/zaproxy/zap/spider/parser/SpiderHtmlFormParser.java
+++ b/src/org/zaproxy/zap/spider/parser/SpiderHtmlFormParser.java
@@ -375,7 +375,6 @@ public class SpiderHtmlFormParser extends SpiderParser {
 	@Override
 	public boolean canParseResource(HttpMessage message, String path, boolean wasAlreadyConsumed) {
 		// Fallback parser - if it's a HTML message which has not already been processed		
-		return !wasAlreadyConsumed && message.getResponseHeader() != null
-				&& message.getResponseHeader().isHtml();
+		return !wasAlreadyConsumed && message.getResponseHeader().isHtml();
 	}
 }

--- a/src/org/zaproxy/zap/spider/parser/SpiderHtmlParser.java
+++ b/src/org/zaproxy/zap/spider/parser/SpiderHtmlParser.java
@@ -196,8 +196,7 @@ public class SpiderHtmlParser extends SpiderParser {
 	@Override
 	public boolean canParseResource(HttpMessage message, String path, boolean wasAlreadyConsumed) {
 		// Fallback parser - if it's a HTML message which has not already been processed
-		return !wasAlreadyConsumed && message.getResponseHeader() != null
-				&& message.getResponseHeader().isHtml();
+		return !wasAlreadyConsumed && message.getResponseHeader().isHtml();
 	}
 
 }

--- a/src/org/zaproxy/zap/spider/parser/SpiderODataAtomParser.java
+++ b/src/org/zaproxy/zap/spider/parser/SpiderODataAtomParser.java
@@ -78,8 +78,7 @@ public class SpiderODataAtomParser extends SpiderParser {
 	@Override
 	public boolean canParseResource(HttpMessage message, String path, boolean wasAlreadyParsed) {
 		// Fallback parser - if it's an XML message which has not already been processed
-		return !wasAlreadyParsed && message.getResponseHeader() != null
-				&& message.getResponseHeader().isXml();
+		return !wasAlreadyParsed && message.getResponseHeader().isXml();
 	}
 
 }

--- a/src/org/zaproxy/zap/spider/parser/SpiderRedirectParser.java
+++ b/src/org/zaproxy/zap/spider/parser/SpiderRedirectParser.java
@@ -49,7 +49,6 @@ public class SpiderRedirectParser extends SpiderParser {
 
 	@Override
 	public boolean canParseResource(HttpMessage message, String path, boolean wasAlreadyParsed) {
-		return message.getResponseHeader() != null
-				&& HttpStatusCode.isRedirection(message.getResponseHeader().getStatusCode());
+		return HttpStatusCode.isRedirection(message.getResponseHeader().getStatusCode());
 	}
 }

--- a/src/org/zaproxy/zap/spider/parser/SpiderTextParser.java
+++ b/src/org/zaproxy/zap/spider/parser/SpiderTextParser.java
@@ -39,12 +39,10 @@ public class SpiderTextParser extends SpiderParser {
 		log.debug("Parsing a non-HTML text resource.");
 
 		// Use a simple pattern matcher to find urls
-		if (message.getResponseBody() != null) {
-			Matcher matcher = patternURL.matcher(message.getResponseBody().toString());
-			while (matcher.find()) {
-				String s = matcher.group(1);
-				processURL(message, depth, s, "");
-			}
+		Matcher matcher = patternURL.matcher(message.getResponseBody().toString());
+		while (matcher.find()) {
+			String s = matcher.group(1);
+			processURL(message, depth, s, "");
 		}
 
 		return false;
@@ -53,8 +51,7 @@ public class SpiderTextParser extends SpiderParser {
 	@Override
 	public boolean canParseResource(HttpMessage message, String path, boolean wasAlreadyConsumed) {
 		// Fall-back parser - if it's a text, non-HTML response which has not already been processed
-		return !wasAlreadyConsumed && message.getResponseHeader() != null
-				&& message.getResponseHeader().isText() && !message.getResponseHeader().isHtml();
+		return !wasAlreadyConsumed && message.getResponseHeader().isText() && !message.getResponseHeader().isHtml();
 	}
 
 }


### PR DESCRIPTION
Class HttpMessage no longer returns null request/response's header and
body.
Changes done in commit bcfb6ff0d111d215190ffc104be8c7c9305fe233 guarantee that the headers/bodies are
never null (though, wrongly, it didn't remove the no longer necessary null
checks).