### PR TITLE
spider: fallback to parse HTML comments as plain text if no URL found

### DIFF
--- a/test/org/zaproxy/zap/spider/parser/SpiderHtmlParserUnitTest.java
+++ b/test/org/zaproxy/zap/spider/parser/SpiderHtmlParserUnitTest.java
@@ -1,0 +1,510 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.spider.parser;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.log4j.Logger;
+import org.apache.log4j.varia.NullAppender;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.spider.SpiderParam;
+
+import net.htmlparser.jericho.Source;
+
+/**
+ * Unit test for {@link SpiderHtmlParser}.
+ */
+public class SpiderHtmlParserUnitTest extends SpiderParserTestUtils {
+
+    private static final String ROOT_PATH = "/";
+    private static final int BASE_DEPTH = 0;
+
+    private static final Path BASE_DIR_HTML_FILES = Paths.get("test/resources/org/zaproxy/zap/spider/parser");
+
+    @BeforeClass
+    public static void suppressLogging() {
+        Logger.getRootLogger().addAppender(new NullAppender());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToCreateParserWithUndefinedSpiderOptions() {
+        // Given
+        SpiderParam undefinedSpiderOptions = null;
+        // When
+        new SpiderHtmlParser(undefinedSpiderOptions);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldFailToEvaluateAnUndefinedMessage() {
+        // Given
+        HttpMessage undefinedMessage = null;
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        // When
+        htmlParser.canParseResource(undefinedMessage, ROOT_PATH, false);
+        // Then = NullPointerException
+    }
+
+    @Test
+    public void shouldNotParseMessageIfAlreadyParsed() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        boolean parsed = false;
+        // When
+        boolean canParse = htmlParser.canParseResource(new HttpMessage(), ROOT_PATH, parsed);
+        // Then
+        assertThat(canParse, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldParseHtmlResponse() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        HttpMessage messageHtmlResponse = createMessageWith("NoURLsSpiderHtmlParser.html");
+        boolean parsed = false;
+        // When
+        boolean canParse = htmlParser.canParseResource(messageHtmlResponse, ROOT_PATH, parsed);
+        // Then
+        assertThat(canParse, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldParseHtmlResponseEvenIfProvidedPathIsNull() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        HttpMessage messageHtmlResponse = createMessageWith("NoURLsSpiderHtmlParser.html");
+        boolean parsed = false;
+        // When
+        boolean canParse = htmlParser.canParseResource(messageHtmlResponse, null, parsed);
+        // Then
+        assertThat(canParse, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldNotParseHtmlResponseIfAlreadyParsed() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        HttpMessage messageHtmlResponse = createMessageWith("NoURLsSpiderHtmlParser.html");
+        boolean parsed = true;
+        // When
+        boolean canParse = htmlParser.canParseResource(messageHtmlResponse, ROOT_PATH, parsed);
+        // Then
+        assertThat(canParse, is(equalTo(false)));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldFailToParseAnUndefinedMessage() {
+        // Given
+        HttpMessage undefinedMessage = null;
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        Source source = createSource(createMessageWith("NoURLsSpiderHtmlParser.html"));
+        // When
+        htmlParser.parseResource(undefinedMessage, source, BASE_DEPTH);
+        // Then = NullPointerException
+    }
+
+    @Test
+    public void shouldParseMessageEvenWithoutSource() {
+        // Given
+        Source source = null;
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        HttpMessage messageHtmlResponse = createMessageWith("NoURLsSpiderHtmlParser.html");
+        // When
+        htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then = No exception
+    }
+
+    @Test
+    public void shouldNeverConsiderCompletelyParsed() {
+        // Given
+        Source source = null;
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        HttpMessage messageHtmlResponse = createMessageWith("NoURLsSpiderHtmlParser.html");
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldFindUrlsInAElements() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("AElementsSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(7)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "http://a.example.com/base/scheme",
+                        "http://a.example.com:8000/b",
+                        "https://a.example.com/c?a=b",
+                        "http://example.com/sample/a/relative",
+                        "http://example.com/sample/",
+                        "http://example.com/a/absolute",
+                        "ftp://a.example.com/"));
+    }
+
+    @Test
+    public void shouldUseMessageUriIfNoBaseElement() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("NoBaseWithAElementSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(listener.getUrlsFound(), contains("http://example.com/relative/no/base"));
+    }
+
+    @Test
+    public void shouldIgnoreBaseAndUseMessageUriIfBaseElementDoesNotHaveHref() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("BaseWithoutHrefAElementSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(listener.getUrlsFound(), contains("http://example.com/relative/no/base"));
+    }
+
+    @Test
+    public void shouldIgnoreBaseAndUseMessageUriIfBaseElementHaveEmptyHref() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("BaseWithEmptyHrefAElementSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(listener.getUrlsFound(), contains("http://example.com/relative/no/base"));
+    }
+
+    @Test
+    public void shouldFindUrlsInAreaElements() throws Exception {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("AreaElementsSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(7)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "http://area.example.com/base/scheme",
+                        "http://area.example.com:8000/b",
+                        "https://area.example.com/c?a=b",
+                        "http://example.com/sample/area/relative",
+                        "http://example.com/sample/",
+                        "http://example.com/area/absolute",
+                        "ftp://area.example.com/"));
+    }
+
+    @Test
+    public void shouldFindUrlsInFrameElements() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("FrameElementsSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(7)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "http://frame.example.com/base/scheme",
+                        "http://frame.example.com:8000/b",
+                        "https://frame.example.com/c?a=b",
+                        "http://example.com/sample/frame/relative",
+                        "http://example.com/sample/",
+                        "http://example.com/frame/absolute",
+                        "ftp://frame.example.com/"));
+    }
+
+    @Test
+    public void shouldFindUrlsInIFrameElements() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("IFrameElementsSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(7)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "http://iframe.example.com/base/scheme",
+                        "http://iframe.example.com:8000/b",
+                        "https://iframe.example.com/c?a=b",
+                        "http://example.com/sample/iframe/relative",
+                        "http://example.com/sample/",
+                        "http://example.com/iframe/absolute",
+                        "ftp://iframe.example.com/"));
+    }
+
+    @Test
+    public void shouldFindUrlsInLinkElements() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("LinkElementsSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(7)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "http://link.example.com/base/scheme",
+                        "http://link.example.com:8000/b",
+                        "https://link.example.com/c?a=b",
+                        "http://example.com/sample/link/relative",
+                        "http://example.com/sample/",
+                        "http://example.com/link/absolute",
+                        "ftp://link.example.com/"));
+    }
+
+    @Test
+    public void shouldFindUrlsInScriptElements() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("ScriptElementsSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(7)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "http://script.example.com/base/scheme",
+                        "http://script.example.com:8000/b",
+                        "https://script.example.com/c?a=b",
+                        "http://example.com/sample/script/relative",
+                        "http://example.com/sample/",
+                        "http://example.com/script/absolute",
+                        "ftp://script.example.com/"));
+    }
+
+    @Test
+    public void shouldFindUrlsInImgElements() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("ImgElementsSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(7)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "http://img.example.com/base/scheme",
+                        "http://img.example.com:8000/b",
+                        "https://img.example.com/c?a=b",
+                        "http://example.com/sample/img/relative",
+                        "http://example.com/sample/",
+                        "http://example.com/img/absolute",
+                        "ftp://img.example.com/"));
+    }
+
+    @Test
+    public void shouldFindUrlsInMetaElements() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("MetaElementsSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(10)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "http://meta.example.com:8443/refresh/base/scheme",
+                        "https://meta.example.com/refresh",
+                        "http://example.com/sample/meta/refresh/relative",
+                        "http://example.com/meta/refresh/absolute",
+                        "ftp://meta.example.com/refresh",
+                        "http://meta.example.com:8080/location/base/scheme",
+                        "https://meta.example.com/location",
+                        "http://example.com/sample/meta/location/relative",
+                        "http://example.com/meta/location/absolute",
+                        "ftp://meta.example.com/location"));
+    }
+
+    @Test
+    public void shouldFindUrlsInCommentsWithElements() {
+        // AKA shouldNotFindPlainUrlsInCommentsWithElements
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("CommentWithElementsSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(9)));
+        System.err.println(listener.getUrlsFound());
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "http://a.example.com/",
+                        "http://area.example.com/",
+                        "http://frame.example.com/",
+                        "http://iframe.example.com/",
+                        "http://img.example.com/",
+                        "http://link.example.com/",
+                        "http://meta.example.com/refresh/",
+                        "http://meta.example.com/location/",
+                        "http://script.example.com/"));
+    }
+
+    @Test
+    public void shouldNotFindUrlsInCommentsWithElementsIfNotEnabledToParseComments() {
+        // Given
+        SpiderParam spiderOptions = createSpiderParamWithConfig();
+        spiderOptions.setParseComments(false);
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(spiderOptions);
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("CommentWithElementsSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(0)));
+        assertThat(listener.getUrlsFound(), is(empty()));
+    }
+
+    @Test
+    public void shouldFindUrlsInCommentsWithoutElements() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("CommentWithoutElementsSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(7)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "http://plaincomment.example.com/",
+                        "http://plaincomment.example.com/z.php?x=y",
+                        "http://plaincomment.example.com/c.pl?x=y",
+                        "https://plaincomment.example.com/d.asp?x=y",
+                        "https://plaincomment.example.com/e/e1/e2.html?x=y",
+                        "http://plaincomment.example.com/variant1",
+                        "http://plaincomment.example.com/variant2"));
+    }
+
+    @Test
+    public void shouldNotFindUrlsInCommentsWithoutElementsIfNotEnabledToParseComments() {
+        // Given
+        SpiderParam spiderOptions = createSpiderParamWithConfig();
+        spiderOptions.setParseComments(false);
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(spiderOptions);
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("CommentWithoutElementsSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(0)));
+        assertThat(listener.getUrlsFound(), is(empty()));
+    }
+
+    private static HttpMessage createMessageWith(String filename) {
+        HttpMessage message = new HttpMessage();
+        try {
+            String fileContents = readFile(BASE_DIR_HTML_FILES.resolve(filename));
+            message.setRequestHeader("GET / HTTP/1.1\r\nHost: example.com\r\n");
+            message.setResponseHeader(
+                    "HTTP/1.1 200 OK\r\n" + "Content-Type: text/html; charset=UTF-8\r\n" + "Content-Length: "
+                            + fileContents.length());
+            message.setResponseBody(fileContents);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return message;
+    }
+}

--- a/test/org/zaproxy/zap/spider/parser/SpiderParserTestUtils.java
+++ b/test/org/zaproxy/zap/spider/parser/SpiderParserTestUtils.java
@@ -1,0 +1,224 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.spider.parser;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.spider.SpiderParam;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+import net.htmlparser.jericho.Source;
+
+/**
+ * Class with helper/utility methods to help testing classes involving {@code SpiderParser} implementations.
+ *
+ * @see org.zaproxy.zap.spider.parser.SpiderParser
+ */
+public class SpiderParserTestUtils {
+
+    protected static Source createSource(HttpMessage messageHtmlResponse) {
+        return new Source(messageHtmlResponse.getResponseBody().toString());
+    }
+
+    protected static SpiderParam createSpiderParamWithConfig() {
+        SpiderParam spiderParam = new SpiderParam();
+        spiderParam.load(new ZapXmlConfiguration());
+        return spiderParam;
+    }
+
+    protected static String readFile(Path file) throws IOException {
+        StringBuilder strBuilder = new StringBuilder();
+        for (String line : Files.readAllLines(file, StandardCharsets.UTF_8)) {
+            strBuilder.append(line).append('\n');
+        }
+        return strBuilder.toString();
+    }
+
+    public static TestSpiderParserListener createTestSpiderParserListener() {
+        return new TestSpiderParserListener();
+    }
+
+    public static class TestSpiderParserListener implements SpiderParserListener {
+
+        private final List<SpiderResource> resources;
+        private final List<String> urls;
+
+        private TestSpiderParserListener() {
+            resources = new ArrayList<>();
+            urls = new ArrayList<>();
+        }
+
+        public int getNumberOfUrlsFound() {
+            return resources.size();
+        }
+
+        public List<String> getUrlsFound() {
+            return urls;
+        }
+
+        @Override
+        public void resourceURIFound(HttpMessage responseMessage, int depth, String uri) {
+            urls.add(uri);
+            resources.add(SpiderResource.createUriResource(responseMessage, depth, uri));
+        }
+
+        @Override
+        public void resourceURIFound(HttpMessage responseMessage, int depth, String uri, boolean shouldIgnore) {
+            urls.add(uri);
+            resources.add(SpiderResource.createUriResource(responseMessage, depth, uri, shouldIgnore));
+        }
+
+        @Override
+        public void resourcePostURIFound(HttpMessage responseMessage, int depth, String uri, String requestBody) {
+            urls.add(uri);
+            resources.add(SpiderResource.createPostResource(responseMessage, depth, uri, requestBody));
+        }
+
+        public boolean isResourceFound() {
+            return false;
+        }
+    }
+
+    public static class SpiderResource {
+
+        private final HttpMessage message;
+        private final int depth;
+        private final String uri;
+
+        private final boolean shouldIgnore;
+
+        private final String requestBody;
+
+        private SpiderResource(HttpMessage message, int depth, String uri) {
+            this.message = message;
+            this.depth = depth;
+            this.uri = uri;
+            this.requestBody = null;
+            this.shouldIgnore = false;
+        }
+
+        private SpiderResource(HttpMessage message, int depth, String uri, boolean shouldIgnore) {
+            this.message = message;
+            this.depth = depth;
+            this.uri = uri;
+            this.requestBody = null;
+            this.shouldIgnore = shouldIgnore;
+        }
+
+        private SpiderResource(HttpMessage message, int depth, String uri, String requestBody) {
+            this.message = message;
+            this.depth = depth;
+            this.uri = uri;
+            this.requestBody = requestBody;
+            this.shouldIgnore = false;
+        }
+
+        public HttpMessage getMessage() {
+            return message;
+        }
+
+        public int getDepth() {
+            return depth;
+        }
+
+        public String getUri() {
+            return uri;
+        }
+
+        public boolean isShouldIgnore() {
+            return shouldIgnore;
+        }
+
+        public String getRequestBody() {
+            return requestBody;
+        }
+
+        public static SpiderResource createUriResource(HttpMessage message, int depth, String uri) {
+            return new SpiderResource(message, depth, uri);
+        }
+
+        public static SpiderResource createUriResource(HttpMessage message, int depth, String uri, boolean shouldIgnore) {
+            return new SpiderResource(message, depth, uri, shouldIgnore);
+        }
+
+        public static SpiderResource createPostResource(HttpMessage message, int depth, String uri, String requestBody) {
+            return new SpiderResource(message, depth, uri, requestBody);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = 31 + depth;
+            result = 31 * result + ((message == null) ? 0 : message.hashCode());
+            result = 31 * result + ((requestBody == null) ? 0 : requestBody.hashCode());
+            result = 31 * result + (shouldIgnore ? 1231 : 1237);
+            result = 31 * result + ((uri == null) ? 0 : uri.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            SpiderResource other = (SpiderResource) obj;
+            if (depth != other.depth) {
+                return false;
+            }
+            if (message == null) {
+                if (other.message != null) {
+                    return false;
+                }
+            } else if (message != other.message) {
+                return false;
+            }
+            if (requestBody == null) {
+                if (other.requestBody != null) {
+                    return false;
+                }
+            } else if (!requestBody.equals(other.requestBody)) {
+                return false;
+            }
+            if (shouldIgnore != other.shouldIgnore) {
+                return false;
+            }
+            if (uri == null) {
+                if (other.uri != null) {
+                    return false;
+                }
+            } else if (!uri.equals(other.uri)) {
+                return false;
+            }
+            return true;
+        }
+
+    }
+}

--- a/test/resources/org/zaproxy/zap/spider/parser/AElementsSpiderHtmlParser.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/AElementsSpiderHtmlParser.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://example.com/sample/">
+<meta charset="UTF-8">
+<title>A Elements - Spider HTML Parser</title>
+</head>
+<body>
+
+<a href="//a.example.com/base/scheme">sub-domain using base scheme</a><br />
+<a href="http://a.example.com:8000/b">sub-domain (http)</a><br />
+<a href="https://a.example.com/c?a=b#fragment">sub-domain (https)</a><br />
+<a href="a/relative">relative</a><br />
+<a href="">relative (same page)</a><br />
+<a href="/a/absolute">absolute</a><br />
+<a href="ftp://a.example.com/">ftp</a><br />
+
+Ignored:<br />
+<a>no href</a><br />
+<a href="mailto:a@example.com">mailto:</a><br />
+<a href="javascript:hello();">javascript:</a><br />
+<a href="scheme://a.example.com/invalid">scheme:</a>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/AreaElementsSpiderHtmlParser.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/AreaElementsSpiderHtmlParser.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://example.com/sample/">
+<meta charset="UTF-8">
+<title>Area Elements - Spider HTML Parser</title>
+</head>
+<body>
+<map>
+<area href="//area.example.com/base/scheme" />
+<area href="http://area.example.com:8000/b" />
+<area href="https://area.example.com/c?a=b#fragment" />
+<area href="area/relative" />
+<area href="" />
+<area href="/area/absolute" />
+<area href="ftp://area.example.com/" />
+</map>
+
+<!--  Ignored: -->
+<map>
+<area />
+<area href="mailto:area@example.com" />
+<area href="javascript:hello();" />
+<area href="scheme://area.example.com/invalid" />
+</map>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/BaseWithEmptyHrefAElementSpiderHtmlParser.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/BaseWithEmptyHrefAElementSpiderHtmlParser.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="">
+<meta charset="UTF-8">
+<title>Base Element With Empty href - Spider HTML Parser</title>
+</head>
+<body>
+
+<a href="relative/no/base">relative no base</a>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/BaseWithoutHrefAElementSpiderHtmlParser.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/BaseWithoutHrefAElementSpiderHtmlParser.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base>
+<meta charset="UTF-8">
+<title>Base Element Without href - Spider HTML Parser</title>
+</head>
+<body>
+
+<a href="relative/no/base">relative no base</a>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/CommentWithElementsSpiderHtmlParser.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/CommentWithElementsSpiderHtmlParser.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://example.com/sample/">
+<meta charset="UTF-8">
+<title>HTML Comments With Elements - Spider HTML Parser</title>
+</head>
+<body>
+
+<!--
+<a href="http://a.example.com/">sub-domain using base scheme</a><br />
+-->
+<!--
+<map>
+<area href="http://area.example.com/" />
+</map>
+-->
+<!--
+<frameset>
+<frame src="http://frame.example.com/" />
+</frameset>
+-->
+<!--
+<iframe src="http://iframe.example.com/"></iframe>
+-->
+<!--
+<img src="http://img.example.com/">
+-->
+<!--
+<link href="http://link.example.com/">
+-->
+<!--
+<meta http-equiv="refresh" content="0;URL=//meta.example.com/refresh/">
+-->
+<!--
+<meta http-equiv="location" content="url=//meta.example.com/location/">
+-->
+<!--
+<script src="http://script.example.com/"></script>
+-->
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/CommentWithoutElementsSpiderHtmlParser.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/CommentWithoutElementsSpiderHtmlParser.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://example.com/sample/">
+<meta charset="UTF-8">
+<title>HTML Comments Without Elements - Spider HTML Parser</title>
+</head>
+<body>
+
+<!-- Following valid HTTP URLs in HTML comments:
+ - //plaincomment.example.com some text not part of URL
+ - "//plaincomment.example.com/z.php?x=y" more text not part of URL
+ - 'http://plaincomment.example.com/c.pl?x=y' even more text not part of URL
+ - <https://plaincomment.example.com/d.asp?x=y> ...
+ - https://plaincomment.example.com/e/e1/e2.html?x=y#stop fragment should be ignored
+-->
+
+<!-- Following are also valid but just starting from "//" HTTP URLs in HTML comments:
+ - ://plaincomment.example.com/variant1
+ - ftp://plaincomment.example.com/variant2
+ -->
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/FrameElementsSpiderHtmlParser.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/FrameElementsSpiderHtmlParser.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://example.com/sample/">
+<meta charset="UTF-8">
+<title>Frame Elements - Spider HTML Parser</title>
+</head>
+<body>
+<frameset>
+<frame src="//frame.example.com/base/scheme" />
+<frame src="http://frame.example.com:8000/b" />
+<frame src="https://frame.example.com/c?a=b#fragment" />
+<frame src="frame/relative" />
+<frame src="" />
+<frame src="/frame/absolute" />
+<frame src="ftp://frame.example.com/" />
+</frameset>
+
+<!--  Ignored: -->
+<frameset>
+<frame />
+<frame src="mailto:frame@example.com" />
+<frame src="javascript:hello();" />
+<frame src="scheme://frame.example.com/invalid" />
+</frameset>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/IFrameElementsSpiderHtmlParser.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/IFrameElementsSpiderHtmlParser.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://example.com/sample/">
+<meta charset="UTF-8">
+<title>IFrame Elements - Spider HTML Parser</title>
+</head>
+<body>
+<iframe src="//iframe.example.com/base/scheme"></iframe>
+<iframe src="http://iframe.example.com:8000/b"></iframe>
+<iframe src="https://iframe.example.com/c?a=b#fragment"></iframe>
+<iframe src="iframe/relative"></iframe>
+<iframe src=""></iframe>
+<iframe src="/iframe/absolute"></iframe>
+<iframe src="ftp://iframe.example.com/"></iframe>
+
+<!--  Ignored: -->
+<iframe></iframe>
+<iframe src="mailto:iframe@example.com"></iframe>
+<iframe src="javascript:hello();"></iframe>
+<iframe src="scheme://iframe.example.com/invalid"></iframe>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/ImgElementsSpiderHtmlParser.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/ImgElementsSpiderHtmlParser.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://example.com/sample/">
+<meta charset="UTF-8">
+<title>Img Elements - Spider HTML Parser</title>
+</head>
+<body>
+
+<img src="//img.example.com/base/scheme">
+<img src="http://img.example.com:8000/b">
+<img src="https://img.example.com/c?a=b#fragment">
+<img src="img/relative">
+<img src="">
+<img src="/img/absolute">
+<img src="ftp://img.example.com/">
+
+<!--  Ignored: -->
+<img>
+<img src="mailto:img@example.com">
+<img src="javascript:hello();">
+<img src="scheme://img.example.com/invalid">
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/LinkElementsSpiderHtmlParser.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/LinkElementsSpiderHtmlParser.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://example.com/sample/">
+<meta charset="UTF-8">
+<title>Link Elements - Spider HTML Parser</title>
+
+<link href="//link.example.com/base/scheme">
+<link href="http://link.example.com:8000/b">
+<link href="https://link.example.com/c?a=b#fragment">
+<link href="link/relative">
+<link href="">
+<link href="/link/absolute">
+<link href="ftp://link.example.com/">
+
+<!--  Ignored: -->
+<link>
+<link href="mailto:link@example.com">
+<link href="javascript:hello();">
+<link href="scheme://link.example.com/invalid">
+
+</head>
+<body>
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/MetaElementsSpiderHtmlParser.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/MetaElementsSpiderHtmlParser.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://example.com/sample/">
+<meta charset="UTF-8">
+<title>Meta Elements - Spider HTML Parser</title>
+
+<meta http-equiv="refresh" content="0;URL=//meta.example.com:8443/refresh/base/scheme">
+<meta http-equiv="refresh" content="0;URL=https://meta.example.com/refresh">
+<meta http-equiv="refresh" content="0;URL=meta/refresh/relative">
+<meta http-equiv="refresh" content="0;URL=/meta/refresh/absolute">
+<meta http-equiv="refresh" content="0;URL=ftp://meta.example.com/refresh">
+
+<meta http-equiv="location" content="url=//meta.example.com:8080/location/base/scheme">
+<meta http-equiv="location" content="url=https://meta.example.com/location">
+<meta http-equiv="location" content="url=meta/location/relative">
+<meta http-equiv="location" content="url=/meta/location/absolute">
+<meta http-equiv="location" content="url=ftp://meta.example.com/location">
+
+<!-- Ignored: -->
+<meta http-equiv="refresh" content="0;URL=scheme://meta.example.com/refresh/ignored">
+<meta http-equiv="refresh" content="0;URL=">
+<meta http-equiv="refresh" content="">
+<meta http-equiv="refresh">
+
+<meta http-equiv="location" content="url=scheme://meta.example.com/location/ignored">
+<meta http-equiv="location" content="url=">
+<meta http-equiv="location" content="">
+<meta http-equiv="location">
+
+<meta http-equiv="ignored" content="0;URL=http://meta.example.com/ignored/1">
+<meta http-equiv="ignored" content="url=http://meta.example.com/ignored/2">
+
+</head>
+<body>
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/NoBaseWithAElementSpiderHtmlParser.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/NoBaseWithAElementSpiderHtmlParser.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>No Base Element - Spider HTML Parser</title>
+</head>
+<body>
+
+<a href="relative/no/base">relative no base</a>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/NoURLsSpiderHtmlParser.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/NoURLsSpiderHtmlParser.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>No Elements - No URLs - Spider HTML Parser</title>
+</head>
+<body>
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/ScriptElementsSpiderHtmlParser.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/ScriptElementsSpiderHtmlParser.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://example.com/sample/">
+<meta charset="UTF-8">
+<title>Script Elements - Spider HTML Parser</title>
+
+<script src="//script.example.com/base/scheme"></script>
+<script src="http://script.example.com:8000/b"></script>
+<script src="https://script.example.com/c?a=b#fragment"></script>
+<script src="script/relative"></script>
+<script src=""></script>
+<script src="/script/absolute"></script>
+<script src="ftp://script.example.com/"></script>
+
+<!--  Ignored: -->
+<script></script>
+<script src="mailto:script@example.com"></script>
+<script src="javascript:hello();"></script>
+<script src="scheme://script.example.com/invalid"></script>
+
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
Change class SpiderHtmlParser to try to find URLs in HTML comments if
the comment, parsed as HTML, does not have any, allowing to find URLs
in "plain" comments.
With the change it finds URLs with schemes HTTP and HTTPS and with no
explicit scheme ("//example.com/") all with (possibly) path and query
components. For example, WIVET test case 8_1b6e1
("http://example.com/innerpages/8_1b6e1.php") would be found while test
case 8_2b6f1 ("/innerpages/8_2b6f1.php") would not. The latter is not
included as it might lead to too many false positives.
Add tests to assert the expected behaviour of SpiderHtmlParser.
Other minor changes were done to "normalise" the behaviour/expectations
of class SpiderHtmlParser:
 - Throw an exception when creating an instance with null SpiderParam,
 it's required to check if HTML comments should be parsed;
 - Expect always a message when parsing (letting a NullPointerException
 be thrown if not);
 - Require the HTML base element to have a non empty value to be used;
 - Document in canParseResource(...) that a message is expected (that
 is, a NullPointerException is thrown if not provided).