### PR TITLE
Convert options to not use extensions' names as XML element names

### DIFF
--- a/src/org/parosproxy/paros/Constant.java
+++ b/src/org/parosproxy/paros/Constant.java
@@ -60,6 +60,7 @@
 // ZAP: 2015/08/01 Remove code duplication in catch of exceptions, use installation directory in default config file
 // ZAP: 2015/11/11 Issue 2045: Dont copy old configs if -dir option used 
 // ZAP: 2015/11/26 Issue 2084: Warn users if they are probably using out of date versions
+// ZAP: 2016/02/17 Convert extensions' options to not use extensions' names as XML element names
 
 package org.parosproxy.paros;
 
@@ -118,9 +119,10 @@ public final class Constant {
     public static final String ALPHA_VERSION = "alpha";
     public static final String BETA_VERSION = "beta";
     
-    private static final long VERSION_TAG = 2004002;
+    private static final long VERSION_TAG = 2004003;
     
     // Old version numbers - for upgrade
+    private static final long V_2_4_3_TAG = 2004003;
     private static final long V_2_3_1_TAG = 2003001;
     private static final long V_2_2_0_TAG = 2002000;
     private static final long V_2_1_0_TAG = 2001000;
@@ -505,6 +507,9 @@ public final class Constant {
 	            	if (ver <= V_2_3_1_TAG) {
 	            		upgradeFrom2_3_1(config);
 	            	}
+                    if (ver <= V_2_4_3_TAG) {
+                        upgradeFrom2_4_3(config);
+                    }
 	            	log.info("Upgraded from " + ver);
             		
             		// Update the version
@@ -763,6 +768,28 @@ public final class Constant {
         // Remove old authentication options no longer used
         config.clearProperty("connection.confirmRemoveAuth");
         config.clearTree("options.auth");
+    }
+
+    private void upgradeFrom2_4_3(XMLConfiguration config) {
+        List<Object[]> oldData = new ArrayList<>();
+        // Convert extensions' options to not use extensions' names as XML element names
+        for (Iterator<String> it = config.getKeys("ext"); it.hasNext();) {
+            String key = it.next();
+
+            Object[] data = new Object[2];
+            data[0] = key.substring(4);
+            data[1] = config.getBoolean(key);
+            oldData.add(data);
+        }
+        config.clearTree("ext");
+
+        for (int i = 0, size = oldData.size(); i < size; ++i) {
+            String elementBaseKey = "extensions.extension(" + i + ").";
+            Object[] data = oldData.get(i);
+
+            config.setProperty(elementBaseKey + "name", data[0]);
+            config.setProperty(elementBaseKey + "enabled", data[1]);
+        }
     }
 
 	public static void setLocale (String loc) {

--- a/src/org/zaproxy/zap/extension/ext/ExtensionExtension.java
+++ b/src/org/zaproxy/zap/extension/ext/ExtensionExtension.java
@@ -56,6 +56,8 @@ public class ExtensionExtension extends ExtensionAdaptor implements CommandLineL
 	public void hook(ExtensionHook extensionHook) {
 	    super.hook(extensionHook);
 
+		extensionHook.addOptionsParamSet(new ExtensionParam());
+
 	    if (getView() != null) {
 	        extensionHook.getHookView().addOptionPanel(getOptionsExtensionPanel());
 	    }

--- a/src/org/zaproxy/zap/extension/ext/ExtensionParam.java
+++ b/src/org/zaproxy/zap/extension/ext/ExtensionParam.java
@@ -1,0 +1,139 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ext;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.configuration.ConversionException;
+import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.common.AbstractParam;
+
+/**
+ * Manages the extensions' configurations saved in the configuration file.
+ * <p>
+ * It allows to change, programmatically, the extensions' enabled state.
+ *
+ * @since TODO add version
+ */
+public class ExtensionParam extends AbstractParam {
+
+    private static final Logger LOGGER = Logger.getLogger(ExtensionParam.class);
+
+    /**
+     * The base configuration key for all extensions configurations.
+     */
+    private static final String EXTENSION_BASE_KEY = "extensions";
+
+    /**
+     * The configuration key used to clear saved options and save/load the extensions' name and state.
+     */
+    private static final String ALL_EXTENSIONS_KEY = EXTENSION_BASE_KEY + ".extension";
+
+    /**
+     * The configuration key used to save/load the name of an extension.
+     */
+    private static final String EXTENSION_NAME_KEY = "name";
+
+    /**
+     * The configuration key used to save/load the enabled state of an extension.
+     */
+    private static final String EXTENSION_ENABLED_KEY = "enabled";
+
+    /**
+     * The extensions' state, never {@code null}.
+     */
+    private List<ExtensionState> extensions = Collections.emptyList();
+
+    @Override
+    protected void parse() {
+        try {
+            List<HierarchicalConfiguration> fields = ((HierarchicalConfiguration) getConfig())
+                    .configurationsAt(ALL_EXTENSIONS_KEY);
+            extensions = new ArrayList<>(fields.size());
+            for (HierarchicalConfiguration sub : fields) {
+                String name = sub.getString(EXTENSION_NAME_KEY, "");
+                boolean enabled = sub.getBoolean(EXTENSION_ENABLED_KEY, true);
+                extensions.add(new ExtensionState(name, enabled));
+            }
+        } catch (ConversionException e) {
+            LOGGER.error("Error while loading extensions' state: " + e.getMessage(), e);
+            extensions = Collections.emptyList();
+        }
+    }
+
+    /**
+     * Gets the extensions' state (as saved in the configuration file).
+     *
+     * @return an unmodifiable list with the extensions' state, never {@code null}
+     */
+    List<ExtensionState> getExtensions() {
+        return Collections.unmodifiableList(extensions);
+    }
+
+    /**
+     * Sets the extensions' state, to be saved in the configuration file.
+     *
+     * @param extensionsState the extensions' state
+     */
+    void setExtensions(List<ExtensionState> extensionsState) {
+        if (extensionsState == null) {
+            throw new IllegalArgumentException("Parameter extensionsState must not be null.");
+        }
+
+        ((HierarchicalConfiguration) getConfig()).clearTree(ALL_EXTENSIONS_KEY);
+        for (int i = 0; i < extensionsState.size(); i++) {
+            ExtensionState elem = extensionsState.get(i);
+            // Don't persist if enabled, extensions are enabled by default.
+            if (!elem.isEnabled()) {
+                String elementBaseKey = ALL_EXTENSIONS_KEY + "(" + i + ").";
+                getConfig().setProperty(elementBaseKey + EXTENSION_NAME_KEY, elem.getName());
+                getConfig().setProperty(elementBaseKey + EXTENSION_ENABLED_KEY, Boolean.valueOf(elem.isEnabled()));
+            }
+        }
+        this.extensions = extensionsState;
+    }
+
+    /**
+     * An extension's state.
+     * <p>
+     * Contains the name of the extension and the enabled state.
+     */
+    static class ExtensionState {
+
+        private final String name;
+        private final boolean enabled;
+
+        public ExtensionState(String name, boolean enabled) {
+            this.name = name;
+            this.enabled = enabled;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+    }
+}

--- a/src/org/zaproxy/zap/extension/ext/OptionsExtensionPanel.java
+++ b/src/org/zaproxy/zap/extension/ext/OptionsExtensionPanel.java
@@ -24,7 +24,10 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -115,9 +118,19 @@ public class OptionsExtensionPanel extends AbstractParamPanel {
 	@Override
     public void initParam(Object obj) {
 	    OptionsParam optionsParam = (OptionsParam) obj;
+		ExtensionParam extParam = optionsParam.getParamSet(ExtensionParam.class);
+
+		Map<String, Boolean> extensionsState = new HashMap<>();
+		for (ExtensionParam.ExtensionState extEntry : extParam.getExtensions()) {
+			extensionsState.put(extEntry.getName(), extEntry.isEnabled());
+		}
 		List<Extension> exts = extensionModel.getExtensions();
 		for (Extension ext : exts) {
-            ext.setEnabled(optionsParam.getConfig().getBoolean("ext." + ext.getName(), true));
+			Boolean enabled = extensionsState.get(ext.getName());
+			if (enabled == null) {
+				enabled = Boolean.TRUE;
+			}
+			ext.setEnabled(enabled);
 		}
     }
 
@@ -131,10 +144,13 @@ public class OptionsExtensionPanel extends AbstractParamPanel {
     @Override
     public void saveParam(Object obj) throws Exception {
 	    OptionsParam optionsParam = (OptionsParam) obj;
-		List<Extension> exts = extensionModel.getExtensions();
-		for (Extension ext : exts) {
-            optionsParam.getConfig().setProperty("ext." + ext.getName(), ext.isEnabled());
+		ExtensionParam extParam = optionsParam.getParamSet(ExtensionParam.class);
+
+		List<ExtensionParam.ExtensionState> extensions = new ArrayList<>(extensionModel.getExtensions().size());
+		for (Extension ext : extensionModel.getExtensions()) {
+			extensions.add(new ExtensionParam.ExtensionState(ext.getName(), ext.isEnabled()));
 		}
+		extParam.setExtensions(extensions);
     }
 
 	/**


### PR DESCRIPTION
Prevent exceptions when the name of the extensions are not valid XML
element names.
Add class ExtensionParam that takes care to save/load the configurations
instead of doing that in the class OptionsExtensionPanel (now using the
former).
Change Constant class to convert to the new options when updating from
version 2.4.3.
Change class ExtensionExtension to install/register ExtensionParam.
The configurations now use specific elements, "name" and "enabled", to
save the name and enabled state of the extension, each one in its own
"extension" element (which are all under an "extensions" element).