### PR TITLE
Change "params" API view to filter the results with the given site

### DIFF
--- a/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsAPI.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsAPI.java
@@ -2,7 +2,6 @@ package org.zaproxy.zap.extension.httpsessions;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -22,6 +21,7 @@ import org.zaproxy.zap.extension.api.ApiResponseElement;
 import org.zaproxy.zap.extension.api.ApiResponseList;
 import org.zaproxy.zap.extension.api.ApiResponseSet;
 import org.zaproxy.zap.extension.api.ApiView;
+import org.zaproxy.zap.utils.ApiUtils;
 import org.zaproxy.zap.utils.Pair;
 import org.zaproxy.zap.utils.XMLStringUtil;
 
@@ -142,7 +142,7 @@ public class HttpSessionsAPI extends ApiImplementor {
 		HttpSessionsSite site;
 		switch (name) {
 		case ACTION_CREATE_EMPTY_SESSION:
-			site = extension.getHttpSessionsSite(getAuthority(params.getString(ACTION_PARAM_SITE)), true);
+			site = extension.getHttpSessionsSite(ApiUtils.getAuthority(params.getString(ACTION_PARAM_SITE)), true);
 			if (site == null) {
 				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, ACTION_PARAM_SITE);
 			}
@@ -154,7 +154,7 @@ public class HttpSessionsAPI extends ApiImplementor {
 			}
 			return ApiResponseElement.OK;
 		case ACTION_REMOVE_SESSION:
-			site = extension.getHttpSessionsSite(getAuthority(params.getString(ACTION_PARAM_SITE)), false);
+			site = extension.getHttpSessionsSite(ApiUtils.getAuthority(params.getString(ACTION_PARAM_SITE)), false);
 			if (site == null) {
 				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, ACTION_PARAM_SITE);
 			}
@@ -165,7 +165,7 @@ public class HttpSessionsAPI extends ApiImplementor {
 			site.removeHttpSession(sessionRS);
 			return ApiResponseElement.OK;
 		case ACTION_SET_ACTIVE_SESSION:
-			site = extension.getHttpSessionsSite(getAuthority(params.getString(ACTION_PARAM_SITE)), false);
+			site = extension.getHttpSessionsSite(ApiUtils.getAuthority(params.getString(ACTION_PARAM_SITE)), false);
 			if (site == null) {
 				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, ACTION_PARAM_SITE);
 			}
@@ -179,22 +179,22 @@ public class HttpSessionsAPI extends ApiImplementor {
 			// At this point, the given name does not match any session name
 			throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, ACTION_PARAM_SESSION);
 		case ACTION_UNSET_ACTIVE_SESSION:
-			site = extension.getHttpSessionsSite(getAuthority(params.getString(ACTION_PARAM_SITE)), false);
+			site = extension.getHttpSessionsSite(ApiUtils.getAuthority(params.getString(ACTION_PARAM_SITE)), false);
 			if (site == null) {
 				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, ACTION_PARAM_SITE);
 			}
 			site.unsetActiveSession();
 			return ApiResponseElement.OK;
 		case ACTION_ADD_SESSION_TOKEN:
-			extension.addHttpSessionToken(getAuthority(params.getString(ACTION_PARAM_SITE)),
+			extension.addHttpSessionToken(ApiUtils.getAuthority(params.getString(ACTION_PARAM_SITE)),
 					params.getString(ACTION_PARAM_TOKEN_NAME));
 			return ApiResponseElement.OK;
 		case ACTION_REMOVE_SESSION_TOKEN:
-			extension.removeHttpSessionToken(getAuthority(params.getString(ACTION_PARAM_SITE)),
+			extension.removeHttpSessionToken(ApiUtils.getAuthority(params.getString(ACTION_PARAM_SITE)),
 					params.getString(ACTION_PARAM_TOKEN_NAME));
 			return ApiResponseElement.OK;
 		case ACTION_SET_SESSION_TOKEN:
-			site = extension.getHttpSessionsSite(getAuthority(params.getString(ACTION_PARAM_SITE)), false);
+			site = extension.getHttpSessionsSite(ApiUtils.getAuthority(params.getString(ACTION_PARAM_SITE)), false);
 			if (site == null) {
 				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, ACTION_PARAM_SITE);
 			}
@@ -202,13 +202,13 @@ public class HttpSessionsAPI extends ApiImplementor {
 			if (sessionSST == null) {
 				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, ACTION_PARAM_SESSION);
 			}
-			extension.addHttpSessionToken(getAuthority(params.getString(ACTION_PARAM_SITE)), 
+			extension.addHttpSessionToken(ApiUtils.getAuthority(params.getString(ACTION_PARAM_SITE)), 
 					params.getString(ACTION_PARAM_TOKEN_NAME));
 			sessionSST.setTokenValue(params.getString(ACTION_PARAM_TOKEN_NAME),
 					new Cookie(null /* domain */, params.getString(ACTION_PARAM_TOKEN_NAME), params.getString(ACTION_PARAM_TOKEN_VALUE)));
 			return ApiResponseElement.OK;
 		case ACTION_RENAME_SESSION:
-			site = extension.getHttpSessionsSite(getAuthority(params.getString(ACTION_PARAM_SITE)), false);
+			site = extension.getHttpSessionsSite(ApiUtils.getAuthority(params.getString(ACTION_PARAM_SITE)), false);
 			if (site == null) {
 				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, ACTION_PARAM_SITE);
 			}
@@ -233,7 +233,7 @@ public class HttpSessionsAPI extends ApiImplementor {
 		switch (name) {
 		case VIEW_SESSIONS:
 			// Get existing sessions
-			site = extension.getHttpSessionsSite(getAuthority(params.getString(ACTION_PARAM_SITE)), false);
+			site = extension.getHttpSessionsSite(ApiUtils.getAuthority(params.getString(ACTION_PARAM_SITE)), false);
 			if (site == null) {
 				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, ACTION_PARAM_SITE);
 			}
@@ -244,7 +244,7 @@ public class HttpSessionsAPI extends ApiImplementor {
 			if (vsName == null || vsName.isEmpty()) {
 				Set<HttpSession> sessions = site.getHttpSessions();
 				if (log.isDebugEnabled()) {
-					log.debug("API View for sessions for " + getAuthority(params.getString(VIEW_PARAM_SITE)) + ": " + site);
+					log.debug("API View for sessions for " + ApiUtils.getAuthority(params.getString(VIEW_PARAM_SITE)) + ": " + site);
 				}
 
 				// Build the response
@@ -265,12 +265,12 @@ public class HttpSessionsAPI extends ApiImplementor {
 
 		case VIEW_ACTIVE_SESSION:
 			// Get existing sessions
-			site = extension.getHttpSessionsSite(getAuthority(params.getString(ACTION_PARAM_SITE)), false);
+			site = extension.getHttpSessionsSite(ApiUtils.getAuthority(params.getString(ACTION_PARAM_SITE)), false);
 			if (site == null) {
 				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, ACTION_PARAM_SITE);
 			}
 			if (log.isDebugEnabled()) {
-				log.debug("API View for active session for " + getAuthority(params.getString(VIEW_PARAM_SITE)) + ": " + site);
+				log.debug("API View for active session for " + ApiUtils.getAuthority(params.getString(VIEW_PARAM_SITE)) + ": " + site);
 			}
 
 			if (site.getActiveSession() != null) {
@@ -279,7 +279,7 @@ public class HttpSessionsAPI extends ApiImplementor {
 				return new ApiResponseElement("active_session", "");
 			}
 		case VIEW_SESSION_TOKENS:
-			final String siteName = getAuthority(params.getString(ACTION_PARAM_SITE));
+			final String siteName = ApiUtils.getAuthority(params.getString(ACTION_PARAM_SITE));
 			// Check if the site exists
 			if (extension.getHttpSessionsSite(siteName, false) == null) {
 				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, ACTION_PARAM_SITE);
@@ -309,40 +309,6 @@ public class HttpSessionsAPI extends ApiImplementor {
 		sessionResult.addItem(new TokenValuesResponseSet(session.getTokenValuesUnmodifiableMap()));
 		sessionResult.addItem(new ApiResponseElement("messages_matched", Integer.toString(session.getMessagesMatched())));
 		return sessionResult;
-	}
-
-	/**
-	 * Returns the authority of the given {@code site} (i.e. the host [ ":" port ] ).
-	 * <p>
-	 * For example, the result of returning the authority from:
-	 * <blockquote><pre>http://example.com:8080/some/path?a=b#c</pre></blockquote> is:
-	 * <blockquote><pre>example.com:8080</pre></blockquote>
-	 * <p>
-	 * <strong>Note:</strong> The implementation is optimised to handle only HTTP and HTTPS schemes, the behaviour is undefined
-	 * for other schemes.
-	 * 
-	 * @param site the site whose authority will be extracted
-	 * @return the authority of the site
-	 */
-	static String getAuthority (String site) {
-		String authority = site;
-		boolean isSecure = false;
-		// Remove http(s)://
-		if (authority.toLowerCase(Locale.ROOT).startsWith("http://")) {
-			authority = authority.substring(7);
-		} else if (authority.toLowerCase(Locale.ROOT).startsWith("https://")) {
-			authority = authority.substring(8);
-			isSecure = true;
-		}
-		// Remove trailing chrs
-		int idx = authority.indexOf('/');
-		if (idx > 0) {
-			authority = authority.substring(0, idx);
-		}
-		if (isSecure && authority.indexOf(':') == -1) {
-			return authority + ":443";
-		}
-		return authority;
 	}
 
 	private static class TokenValuesResponseSet extends ApiResponseSet {

--- a/src/org/zaproxy/zap/extension/params/ExtensionParams.java
+++ b/src/org/zaproxy/zap/extension/params/ExtensionParams.java
@@ -453,6 +453,34 @@ public class ExtensionParams extends ExtensionAdaptor
 		}
 	}
 
+	/**
+	 * Tells whether or not the given {@code site} was already seen.
+	 *
+	 * @param site the site that will be checked
+	 * @return {@code true} if the given {@code site} was already seen, {@code false} otherwise.
+	 * @since TODO add version
+	 * @see #hasParameters(String)
+	 */
+	public boolean hasSite(String site) {
+		return siteParamsMap.containsKey(site);
+	}
+
+	/**
+	 * Tells whether or not the given {@code site} has parameters.
+	 *
+	 * @param site the site that will be checked
+	 * @return {@code true} if the given {@code site} has parameters, {@code false} if not, or was not yet seen.
+	 * @since TODO add version
+	 * @see #hasSite(String)
+	 */
+	public boolean hasParameters(String site) {
+		SiteParameters siteParameters = siteParamsMap.get(site);
+		if (siteParameters == null) {
+			return false;
+		}
+		return siteParameters.hasParams();
+	}
+
 	public SiteParameters getSiteParameters(String site) {
 		SiteParameters sps = this.siteParamsMap.get(site);
 		if (sps == null) {

--- a/src/org/zaproxy/zap/extension/params/SiteParameters.java
+++ b/src/org/zaproxy/zap/extension/params/SiteParameters.java
@@ -53,6 +53,16 @@ public class SiteParameters {
 		this.site = site;
 	}
 
+	/**
+	 * Tells whether or not this site has any parameters (cookies, query or form parameters).
+	 *
+	 * @return {@code true} if this site has parameters, {@code false} otherwise.
+	 * @since TODO add version
+	 */
+	public boolean hasParams() {
+		return !cookieParams.isEmpty() || !urlParams.isEmpty() || !formParams.isEmpty();
+	}
+
 	public HtmlParameterStats getParam(HtmlParameter.Type type, String name) {
 		switch (type) {
 		case cookie:

--- a/src/org/zaproxy/zap/utils/ApiUtils.java
+++ b/src/org/zaproxy/zap/utils/ApiUtils.java
@@ -21,6 +21,8 @@ package org.zaproxy.zap.utils;
 
 import net.sf.json.JSONObject;
 
+import java.util.Locale;
+
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiException.Type;
@@ -159,6 +161,46 @@ public final class ApiUtils {
 			throw new ApiException(ApiException.Type.DOES_NOT_EXIST, contextName);
 		}
 		return context;
+	}
+
+	/**
+	 * Returns the authority of the given {@code site} (i.e. host ":" port ).
+	 * <p>
+	 * For example, the result of returning the authority from:
+	 * <blockquote><pre>http://example.com:8080/some/path?a=b#c</pre></blockquote> is:
+	 * <blockquote><pre>example.com:8080</pre></blockquote>
+	 * <p>
+	 * If the provided site does not have a port, it's added the default of the used scheme.
+	 * <p>
+	 * <strong>Note:</strong> The implementation is optimised to handle only HTTP and HTTPS schemes, the behaviour is undefined
+	 * for other schemes.
+	 * 
+	 * @param site the site whose authority will be extracted
+	 * @return the authority of the site
+	 * @since TODO add version
+	 */
+	public static String getAuthority(String site) {
+		String authority = site;
+		boolean isSecure = false;
+		// Remove http(s)://
+		if (authority.toLowerCase(Locale.ROOT).startsWith("http://")) {
+			authority = authority.substring(7);
+		} else if (authority.toLowerCase(Locale.ROOT).startsWith("https://")) {
+			authority = authority.substring(8);
+			isSecure = true;
+		}
+		// Remove trailing chrs
+		int idx = authority.indexOf('/');
+		if (idx > 0) {
+			authority = authority.substring(0, idx);
+		}
+		if (!authority.isEmpty() && authority.indexOf(':') == -1) {
+			if (isSecure) {
+				return authority + ":443";
+			}
+			return authority + ":80";
+		}
+		return authority;
 	}
 
 	private ApiUtils() {

--- a/test/org/zaproxy/zap/utils/ApiUtilsUnitTest.java
+++ b/test/org/zaproxy/zap/utils/ApiUtilsUnitTest.java
@@ -3,7 +3,7 @@
  * 
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  * 
- * Copyright 2015 The ZAP Development Team
+ * Copyright 2016 The ZAP Development Team
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.httpsessions;
+package org.zaproxy.zap.utils;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -26,9 +26,9 @@ import static org.junit.Assert.assertThat;
 import org.junit.Test;
 
 /**
- * Unit test for {@link HttpSessionsAPI}.
+ * Unit test for {@link ApiUtils}.
  */
-public class HttpSessionsAPIUnitTest {
+public class ApiUtilsUnitTest {
 
     private static final String HOST = "example.com";
 
@@ -37,7 +37,7 @@ public class HttpSessionsAPIUnitTest {
         // Given
         String nullSite = null;
         // When
-        HttpSessionsAPI.getAuthority(nullSite);
+        ApiUtils.getAuthority(nullSite);
         // Then = NullPointerException
     }
 
@@ -46,7 +46,7 @@ public class HttpSessionsAPIUnitTest {
         // Given
         String emptySite = "";
         // When
-        String authority = HttpSessionsAPI.getAuthority(emptySite);
+        String authority = ApiUtils.getAuthority(emptySite);
         // Then
         assertThat(authority, is(equalTo(emptySite)));
     }
@@ -56,19 +56,19 @@ public class HttpSessionsAPIUnitTest {
         // Given
         String siteWithPort = HOST + ":8080";
         // When
-        String authority = HttpSessionsAPI.getAuthority(siteWithPort);
+        String authority = ApiUtils.getAuthority(siteWithPort);
         // Then
         assertThat(authority, is(equalTo(siteWithPort)));
     }
 
     @Test
-    public void shouldRemoveHttpSchemeWhenGettingAuthorityFromSite() {
+    public void shouldRemoveHttpSchemeAndAddDefaultPortWhenGettingAuthorityFromSite() {
         // Given
         String site = "http://" + HOST;
         // When
-        String authority = HttpSessionsAPI.getAuthority(site);
+        String authority = ApiUtils.getAuthority(site);
         // Then
-        assertThat(authority, is(equalTo(HOST)));
+        assertThat(authority, is(equalTo(HOST + ":80")));
     }
 
     @Test
@@ -76,7 +76,7 @@ public class HttpSessionsAPIUnitTest {
         // Given
         String site = "https://" + HOST + ":8443";
         // When
-        String authority = HttpSessionsAPI.getAuthority(site);
+        String authority = ApiUtils.getAuthority(site);
         // Then
         assertThat(authority, is(equalTo(HOST + ":8443")));
     }
@@ -86,7 +86,7 @@ public class HttpSessionsAPIUnitTest {
         // Given
         String site = "https://" + HOST;
         // When
-        String authority = HttpSessionsAPI.getAuthority(site);
+        String authority = ApiUtils.getAuthority(site);
         // Then
         assertThat(authority, is(equalTo(HOST + ":443")));
     }
@@ -96,9 +96,9 @@ public class HttpSessionsAPIUnitTest {
         // Given
         String site = HOST;
         // When
-        String authority = HttpSessionsAPI.getAuthority(site);
+        String authority = ApiUtils.getAuthority(site);
         // Then
-        assertThat(authority, is(equalTo(HOST)));
+        assertThat(authority, is(equalTo(HOST + ":80")));
     }
 
     @Test
@@ -106,8 +106,8 @@ public class HttpSessionsAPIUnitTest {
         // Given
         String site = HOST + "/path";
         // When
-        String authority = HttpSessionsAPI.getAuthority(site);
+        String authority = ApiUtils.getAuthority(site);
         // Then
-        assertThat(authority, is(equalTo(HOST)));
+        assertThat(authority, is(equalTo(HOST + ":80")));
     }
 }


### PR DESCRIPTION
Change class ParamsAPI to use the optional "site" parameter to filter
the results returned in the API response. Extract a method that creates
the API response to reduce code duplication, it's used for "all results"
and the filtered ones.
Change class ExtensionParams to allow to check if a site already exists
and if it has parameters, to allow the API to return an error if it
doesn't and to not create the (empty) response if it does not have any
parameters (also, change class SiteParameters to allow to check if it
has or not parameters).
Move the method HttpSessionsApi.getAuthority(String) to class ApiUtils,
it's now used by several classes (HttpSessionsApi and ParamsAPI) and
change it to return default port for HTTP scheme to not require the
callers to check and add the port. Also, move the tests to a new class,
ApitUtilsUnitTest, and update them to conform to new behaviour.

---
Issue reported in IRC channel.