### PR TITLE
Fix NullPointerException in VariantCookie implementation

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/NameValuePair.java
+++ b/src/org/parosproxy/paros/core/scanner/NameValuePair.java
@@ -21,7 +21,7 @@
 // ZAP: 2013/07/02 Changed API to public because future extensible Variant model
 // ZAP: 2014/01/06 Issue 965: Support 'single page' apps and 'non standard' parameter separators
 // ZAP: 2014/02/08 Used the same constants used in ScanParam Target settings
-//
+// ZAP: 2016/02/22 Add hashCode, equals and toString methods. Remove redundant instance variable initialisations.
 package org.parosproxy.paros.core.scanner;
 
 public class NameValuePair {
@@ -34,10 +34,10 @@ public class NameValuePair {
     public static final int TYPE_POST_DATA = ScannerParam.TARGET_POSTDATA;
     public static final int TYPE_UNDEFINED = -1;
     
-    private int targetType = 0;
-    private String name = null;
-    private String value = null;
-    private int position = 0;
+    private final int targetType;
+    private String name;
+    private String value;
+    private int position;
 
     /**
      * @param name
@@ -100,5 +100,66 @@ public class NameValuePair {
      */
     public void setPosition(int position) {
         this.position = position;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + position;
+        result = prime * result + targetType;
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        NameValuePair other = (NameValuePair) obj;
+        if (name == null) {
+            if (other.name != null) {
+                return false;
+            }
+        } else if (!name.equals(other.name)) {
+            return false;
+        }
+        if (position != other.position) {
+            return false;
+        }
+        if (targetType != other.targetType) {
+            return false;
+        }
+        if (value == null) {
+            if (other.value != null) {
+                return false;
+            }
+        } else if (!value.equals(other.value)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder strBuilder = new StringBuilder(75);
+        strBuilder.append("[Position=").append(position);
+        strBuilder.append(", Type=").append(targetType);
+        if (name != null) {
+            strBuilder.append(", Name=").append(name);
+        }
+        if (value != null) {
+            strBuilder.append(", Value=").append(value);
+        }
+        strBuilder.append(']');
+        return strBuilder.toString();
     }
 }

--- a/src/org/parosproxy/paros/core/scanner/VariantCookie.java
+++ b/src/org/parosproxy/paros/core/scanner/VariantCookie.java
@@ -20,59 +20,89 @@
 
 package org.parosproxy.paros.core.scanner;
 
-import java.net.HttpCookie;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Set;
-import org.parosproxy.paros.network.HtmlParameter;
+import java.util.Vector;
+
+import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 
 /**
- *
+ * A {@code Variant} for Cookie headers, allowing to attack the names and values of the cookies.
+ * 
  * @author andy
+ * @see Variant
  */
 public class VariantCookie implements Variant {
 
-    private final List<NameValuePair> params = new ArrayList<>();
+    private List<NameValuePair> params = Collections.emptyList();
 
     /**
-     * 
-     * @param msg 
+     * @throws IllegalArgumentException if {@code message} is {@code null}.
      */
     @Override
-    public void setMessage(HttpMessage msg) {
-        Set<HtmlParameter> cp = msg.getRequestHeader().getCookieParams();
-        int idx = 0;
-        
-        for (HtmlParameter param : cp) {
-            // ZAP: the parameter could be encoded so decode it
-            params.add(new NameValuePair(NameValuePair.TYPE_COOKIE, param.getName(), getUnescapedValue(param.getValue()), idx++));
+    public void setMessage(HttpMessage message) {
+        if (message == null) {
+            throw new IllegalArgumentException("Parameter message must not be null.");
+        }
+
+        Vector<String> cookieLines = message.getRequestHeader().getHeaders(HttpHeader.COOKIE);
+        if (cookieLines == null) {
+            params = Collections.emptyList();
+            return;
+        }
+
+        ArrayList<NameValuePair> extractedParameters = new ArrayList<>();
+        for (String cookieLine : cookieLines) {
+            if (cookieLine.trim().isEmpty()) {
+                continue;
+            }
+
+            String[] cookieArray = cookieLine.split("; ?");
+            for (String cookie : cookieArray) {
+                String[] nameValuePair = cookie.split("=", 2);
+                String name = nameValuePair[0];
+                String value = null;
+                if (nameValuePair.length == 2) {
+                    value = getUnescapedValue(nameValuePair[1]);
+                }
+                extractedParameters.add(new NameValuePair(NameValuePair.TYPE_COOKIE, name, value, extractedParameters.size()));
+            }
+        }
+
+        if (extractedParameters.isEmpty()) {
+            params = Collections.emptyList();
+        } else {
+            extractedParameters.trimToSize();
+            params = Collections.unmodifiableList(extractedParameters);
         }
     }
 
     /**
-     * Encode the parameter
-     * @param value the value that need to be encoded
-     * @return the Encoded value
+     * Encodes the given {@code value}.
+     * 
+     * @param value the value that needs to be encoded, must not be {@code null}.
+     * @return the encoded value
      */
-    private String getEscapedValue(String value) {
-        return (value != null) ? 
-                AbstractPlugin.getURLEncode(value) : "";
+    private static String getEscapedValue(String value) {
+        return AbstractPlugin.getURLEncode(value);
     }
     
     /**
-     * Decode the parameter
-     * @param value
-     * @return 
+     * Decodes the given {@code value}.
+     * 
+     * @param value the value that needs to be decoded, must not be {@code null}.
+     * @return the decoded value
      */
     private String getUnescapedValue(String value) {
-        //return value;
-        return (value != null) ? AbstractPlugin.getURLDecode(value) : "";
+        return AbstractPlugin.getURLDecode(value);
     }
     
     /**
+     * Gets the list of parameters (that is, cookies) extracted from the request header of the message.
      * 
-     * @return 
+     * @return an unmodifiable {@code List} containing the extracted parameters, never {@code null}.
      */
     @Override
     public List<NameValuePair> getParamList() {
@@ -115,21 +145,54 @@ public class VariantCookie implements Variant {
      * @return 
      */
     private String setParameter(HttpMessage msg, NameValuePair originalPair, String name, String value, boolean escaped) {        
-        List<HttpCookie> cookies = new ArrayList<>();
-        String encodedValue = (escaped) ? value : getEscapedValue(value);
-        NameValuePair param;
-        
+        String escapedValue = value == null ? null : escaped ? value : getEscapedValue(value);
+        StringBuilder cookieString = new StringBuilder();
         for (int idx = 0; idx < params.size(); idx++) {
-            param = params.get(idx);
+            String cookieName = null;
+            String cookieValue = null;
             if (idx == originalPair.getPosition()) {
-                cookies.add(new HttpCookie(name, encodedValue));
-                
+                if (!(name == null && escapedValue == null)) {
+                    cookieName = name;
+                    if (escapedValue != null) {
+                        cookieValue = escapedValue;
+                    }
+                }
             } else {
-                cookies.add(new HttpCookie(param.getName(), getEscapedValue(param.getValue())));
+                NameValuePair param = params.get(idx);
+                cookieName = param.getName();
+                cookieValue = param.getValue();
+                if (cookieValue != null) {
+                    cookieValue = getEscapedValue(cookieValue);
+                }
+            }
+
+            if (cookieString.length() != 0 && !(cookieName == null && cookieValue == null)) {
+                cookieString.append("; ");
+            }
+
+            if (cookieName != null) {
+                cookieString.append(cookieName);
+            }
+
+            if (cookieValue != null) {
+                cookieString.append('=');
+                cookieString.append(cookieValue);
             }
         }
-        
-        msg.getRequestHeader().setCookies(cookies);
-        return name + "=" + encodedValue;
+
+        msg.getRequestHeader().setHeader(HttpHeader.COOKIE, null);
+        if (cookieString.length() != 0) {
+            msg.getRequestHeader().setHeader(HttpHeader.COOKIE, cookieString.toString());
+        }
+
+        if (escapedValue == null) {
+            return name;
+        }
+
+        if (name == null) {
+            return "=" + escapedValue;
+        }
+
+        return name + "=" + escapedValue;
     }    
 }

--- a/test/org/parosproxy/paros/core/scanner/NameValuePairUnitTest.java
+++ b/test/org/parosproxy/paros/core/scanner/NameValuePairUnitTest.java
@@ -1,0 +1,265 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.core.scanner;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit test for {@link NameValuePair}.
+ */
+public class NameValuePairUnitTest {
+
+    private static final String NAME = "name";
+    private static final String VALUE = "value";
+
+    @Test
+    public void shouldCreateNameValuePair() {
+        // Given / When
+        NameValuePair nameValuePair = new NameValuePair(1, NAME, VALUE, 2);
+        // Then
+        assertThat(nameValuePair.getName(), is(equalTo(NAME)));
+        assertThat(nameValuePair.getValue(), is(equalTo(VALUE)));
+        assertThat(nameValuePair.getType(), is(equalTo(1)));
+        assertThat(nameValuePair.getPosition(), is(equalTo(2)));
+    }
+
+    @Test
+    public void shouldCreateNameValuePairWithNegativeTypeAndPosition() {
+        // Given / When
+        NameValuePair nameValuePair = new NameValuePair(-1, NAME, VALUE, -2);
+        // Then
+        assertThat(nameValuePair.getType(), is(equalTo(-1)));
+        assertThat(nameValuePair.getPosition(), is(equalTo(-2)));
+    }
+
+    @Test
+    public void shouldCreateNameValuePairWithNullNameAndValue() {
+        // Given / When
+        NameValuePair nameValuePair = new NameValuePair(1, null, null, 2);
+        // Then
+        assertThat(nameValuePair.getName(), is(nullValue()));
+        assertThat(nameValuePair.getValue(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldSetName() {
+        // Given
+        NameValuePair nameValuePair = new NameValuePair(1, NAME, VALUE, 2);
+        String name = "AnotherName";
+        // When
+        nameValuePair.setName(name);
+        // Then
+        assertThat(nameValuePair.getName(), is(equalTo(name)));
+    }
+
+    @Test
+    public void shouldSetValue() {
+        // Given
+        NameValuePair nameValuePair = new NameValuePair(1, NAME, VALUE, 2);
+        String value = "AnotherValue";
+        // When
+        nameValuePair.setValue(value);
+        // Then
+        assertThat(nameValuePair.getValue(), is(equalTo(value)));
+    }
+
+    @Test
+    public void shouldSetPosition() {
+        // Given
+        NameValuePair nameValuePair = new NameValuePair(1, NAME, VALUE, 2);
+        int position = 10;
+        // When
+        nameValuePair.setPosition(position);
+        // Then
+        assertThat(nameValuePair.getPosition(), is(equalTo(position)));
+    }
+
+    @Test
+    public void shouldProduceConsistentHashCodes() {
+        // Given
+        NameValuePair[] nameValuePairs = {
+                new NameValuePair(1, NAME, VALUE, 2),
+                new NameValuePair(3, NAME, null, 4),
+                new NameValuePair(5, null, VALUE, 6),
+                new NameValuePair(-341, null, null, -950) };
+        int[] expectedHashCodes = { 1834755624, 1722784887, 112902163, 0 };
+        for (int i = 0; i < nameValuePairs.length; i++) {
+            // When / Then
+            assertThat(nameValuePairs[i].hashCode(), is(equalTo(expectedHashCodes[i])));
+        }
+    }
+
+    @Test
+    public void shouldBeEqualToItself() {
+        // Given
+        NameValuePair nameValuePair = new NameValuePair(1, NAME, VALUE, 2);
+        // When
+        boolean equals = nameValuePair.equals(nameValuePair);
+        // Then
+        assertThat(equals, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldBeEqualToDifferentNameValuePairWithSameContents() {
+        // Given
+        NameValuePair nameValuePair = new NameValuePair(1, NAME, VALUE, 2);
+        NameValuePair otherEqualNameValuePair = new NameValuePair(1, NAME, VALUE, 2);
+        // When
+        boolean equals = nameValuePair.equals(otherEqualNameValuePair);
+        // Then
+        assertThat(equals, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldBeEqualToDifferentNameValuePairWithNullNames() {
+        // Given
+        NameValuePair nameValuePair = new NameValuePair(1, null, VALUE, 2);
+        NameValuePair otherEqualNameValuePair = new NameValuePair(1, null, VALUE, 2);
+        // When
+        boolean equals = nameValuePair.equals(otherEqualNameValuePair);
+        // Then
+        assertThat(equals, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldBeEqualToDifferentNameValuePairWithNullValues() {
+        // Given
+        NameValuePair nameValuePair = new NameValuePair(1, NAME, null, 2);
+        NameValuePair otherEqualNameValuePair = new NameValuePair(1, NAME, null, 2);
+        // When
+        boolean equals = nameValuePair.equals(otherEqualNameValuePair);
+        // Then
+        assertThat(equals, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldNotBeEqualToNull() {
+        // Given
+        NameValuePair nameValuePair = new NameValuePair(1, NAME, VALUE, 2);
+        // When
+        boolean equals = nameValuePair.equals(null);
+        // Then
+        assertThat(equals, is(false));
+    }
+
+    @Test
+    public void shouldNotBeEqualToNameValuePairWithJustDifferentName() {
+        // Given
+        NameValuePair nameValuePair = new NameValuePair(1, NAME, VALUE, 2);
+        NameValuePair otherNameValuePair = new NameValuePair(1, "OtherName", VALUE, 2);
+        // When
+        boolean equals = nameValuePair.equals(otherNameValuePair);
+        // Then
+        assertThat(equals, is(false));
+    }
+
+    @Test
+    public void shouldNotBeEqualToNameValuePairWithJustDifferentNullName() {
+        // Given
+        NameValuePair nameValuePair = new NameValuePair(1, null, VALUE, 2);
+        NameValuePair otherNameValuePair = new NameValuePair(1, NAME, VALUE, 2);
+        // When
+        boolean equals = nameValuePair.equals(otherNameValuePair);
+        // Then
+        assertThat(equals, is(false));
+    }
+
+    @Test
+    public void shouldNotBeEqualToNameValuePairWithJustDifferentValue() {
+        // Given
+        NameValuePair nameValuePair = new NameValuePair(1, NAME, VALUE, 2);
+        NameValuePair otherNameValuePair = new NameValuePair(1, NAME, "OtherValue", 2);
+        // When
+        boolean equals = nameValuePair.equals(otherNameValuePair);
+        // Then
+        assertThat(equals, is(false));
+    }
+
+    @Test
+    public void shouldNotBeEqualToNameValuePairWithJustDifferentNullValue() {
+        // Given
+        NameValuePair nameValuePair = new NameValuePair(1, NAME, null, 2);
+        NameValuePair otherNameValuePair = new NameValuePair(1, NAME, VALUE, 2);
+        // When
+        boolean equals = nameValuePair.equals(otherNameValuePair);
+        // Then
+        assertThat(equals, is(false));
+    }
+
+    @Test
+    public void shouldNotBeEqualToNameValuePairWithJustDifferentType() {
+        // Given
+        NameValuePair nameValuePair = new NameValuePair(1, NAME, VALUE, 2);
+        NameValuePair otherNameValuePair = new NameValuePair(8, NAME, VALUE, 2);
+        // When
+        boolean equals = nameValuePair.equals(otherNameValuePair);
+        // Then
+        assertThat(equals, is(false));
+    }
+
+    @Test
+    public void shouldNotBeEqualToNameValuePairWithJustDifferentPosition() {
+        // Given
+        NameValuePair nameValuePair = new NameValuePair(1, NAME, VALUE, 2);
+        NameValuePair otherNameValuePair = new NameValuePair(1, NAME, VALUE, 5);
+        // When
+        boolean equals = nameValuePair.equals(otherNameValuePair);
+        // Then
+        assertThat(equals, is(false));
+    }
+
+    @Test
+    public void shouldNotBeEqualToExtendedNameValuePair() {
+        // Given
+        NameValuePair nameValuePair = new NameValuePair(1, NAME, VALUE, 2);
+        NameValuePair otherNameValuePair = new NameValuePair(1, NAME, VALUE, 2) {
+            // Anonymous NameValuePair
+        };
+        // When
+        boolean equals = nameValuePair.equals(otherNameValuePair);
+        // Then
+        assertThat(equals, is(false));
+    }
+
+    @Test
+    public void shouldProduceConsistentStringRepresentations() {
+        // Given
+        NameValuePair[] nameValuePairs = {
+                new NameValuePair(1, NAME, VALUE, 2),
+                new NameValuePair(3, NAME, null, 4),
+                new NameValuePair(5, null, VALUE, 6),
+                new NameValuePair(7, null, null, 8) };
+        String[] expectedStringRepresentations = {
+                "[Position=2, Type=1, Name=" + NAME + ", Value=" + VALUE + "]",
+                "[Position=4, Type=3, Name=" + NAME + "]",
+                "[Position=6, Type=5, Value=" + VALUE + "]",
+                "[Position=8, Type=7]" };
+        for (int i = 0; i < nameValuePairs.length; i++) {
+            // When / Then
+            assertThat(nameValuePairs[i].toString(), is(equalTo(expectedStringRepresentations[i])));
+        }
+    }
+
+}

--- a/test/org/parosproxy/paros/core/scanner/VariantCookieUnitTest.java
+++ b/test/org/parosproxy/paros/core/scanner/VariantCookieUnitTest.java
@@ -1,0 +1,468 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.core.scanner;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+import java.util.Vector;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+
+/**
+ * Unit test for {@link VariantCookie}.
+ */
+public class VariantCookieUnitTest {
+
+    @Test
+    public void shouldHaveParametersListEmptyByDefault() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        // When
+        List<NameValuePair> parameters = variantCookie.getParamList();
+        // Then
+        assertThat(parameters, is(empty()));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldNotAllowToModifyReturnedParametersList() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        // When
+        variantCookie.getParamList().add(cookie("Name", "Value", 0));
+        // Then = UnsupportedOperationException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToExtractParametersFromUndefinedMessage() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage undefinedMessage = null;
+        // When
+        variantCookie.setMessage(undefinedMessage);
+        // Then = IllegalArgumentException
+    }
+
+    @Test
+    public void shouldNotExtractAnyParameterIfThereAreNoCookieHeaders() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage messageWithCookies = createMessageWithoutCookies();
+        // When
+        variantCookie.setMessage(messageWithCookies);
+        // Then
+        assertThat(variantCookie.getParamList(), is(empty()));
+    }
+
+    @Test
+    public void shouldNotExtractAnyParameterIfTheCookieHeadersDontHaveCoookies() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage messageWithCookies = createMessageWithCookies("", "");
+        // When
+        variantCookie.setMessage(messageWithCookies);
+        // Then
+        assertThat(variantCookie.getParamList(), is(empty()));
+    }
+
+    @Test
+    public void shouldExtractParametersFromWellformedCookieHeader() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage messageWithCookies = createMessageWithCookies("a=b; c=\"d\"; e=f");
+        // When
+        variantCookie.setMessage(messageWithCookies);
+        // Then
+        assertThat(variantCookie.getParamList().size(), is(equalTo(3)));
+        assertThat(variantCookie.getParamList(), contains(cookie("a", "b", 0), cookie("c", "\"d\"", 1), cookie("e", "f", 2)));
+    }
+
+    @Test
+    public void shouldExtractParametersFromWellformedCookieHeaders() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage messageWithCookies = createMessageWithCookies("a=b; c=d; e=f", "g=h; i=j; k=l");
+        // When
+        variantCookie.setMessage(messageWithCookies);
+        // Then
+        assertThat(variantCookie.getParamList().size(), is(equalTo(6)));
+        assertThat(variantCookie.getParamList(), contains(
+                cookie("a", "b", 0),
+                cookie("c", "d", 1),
+                cookie("e", "f", 2),
+                cookie("g", "h", 3),
+                cookie("i", "j", 4),
+                cookie("k", "l", 5)));
+    }
+
+    @Test
+    public void shouldExtractParametersFromMalformedCookieHeader() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage messageWithCookies = createMessageWithCookies("a=; =d;e;g=\"h; i=j\"");
+        // When
+        variantCookie.setMessage(messageWithCookies);
+        // Then
+        assertThat(variantCookie.getParamList().size(), is(equalTo(5)));
+        assertThat(variantCookie.getParamList(), contains(
+                cookie("a", "", 0),
+                cookie("", "d", 1),
+                cookie("e", null, 2),
+                cookie("g", "\"h", 3),
+                cookie("i", "j\"", 4)));
+    }
+
+    @Test
+    public void shouldExtractParametersFromMalformedCookieHeaders() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage messageWithCookies = createMessageWithCookies("a=;=d; e", "g; =j;l=", "n=\"", "=\"");
+        // When
+        variantCookie.setMessage(messageWithCookies);
+        // Then
+        assertThat(variantCookie.getParamList().size(), is(equalTo(8)));
+        assertThat(
+                variantCookie.getParamList(),
+                contains(
+                        cookie("a", "", 0),
+                        cookie("", "d", 1),
+                        cookie("e", null, 2),
+                        cookie("g", null, 3),
+                        cookie("", "j", 4),
+                        cookie("l", "", 5),
+                        cookie("n", "\"", 6),
+                        cookie("", "\"", 7)));
+    }
+
+    @Test
+    public void shouldDecodeValueFromExtractedParameters() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage messageWithCookies = createMessageWithCookies("a=b; c=d; e=%26%27%28%29%2A", "=%27");
+        // When
+        variantCookie.setMessage(messageWithCookies);
+        // Then
+        assertThat(variantCookie.getParamList().size(), is(equalTo(4)));
+        assertThat(
+                variantCookie.getParamList(),
+                contains(cookie("a", "b", 0), cookie("c", "d", 1), cookie("e", "&'()*", 2), cookie("", "'", 3)));
+    }
+
+    @Test
+    public void shouldNotDecodeNameFromExtractedParameters() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage messageWithCookies = createMessageWithCookies("%29=b; c=d; e=f", "%26");
+        // When
+        variantCookie.setMessage(messageWithCookies);
+        // Then
+        assertThat(variantCookie.getParamList().size(), is(equalTo(4)));
+        assertThat(
+                variantCookie.getParamList(),
+                contains(cookie("%29", "b", 0), cookie("c", "d", 1), cookie("e", "f", 2), cookie("%26", null, 3)));
+    }
+
+    @Test
+    public void shouldNotAccumulateExtractedParameters() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage messageWithCookies = createMessageWithCookies("a=b; c=d; e=f");
+        HttpMessage otherMessageWithCookies = createMessageWithCookies("g=h; i=j; k=l");
+        // When
+        variantCookie.setMessage(messageWithCookies);
+        variantCookie.setMessage(otherMessageWithCookies);
+        // Then
+        assertThat(variantCookie.getParamList().size(), is(equalTo(3)));
+        assertThat(variantCookie.getParamList(), contains(cookie("g", "h", 0), cookie("i", "j", 1), cookie("k", "l", 2)));
+    }
+
+    @Test
+    public void shouldInjectCookieModificationOnWellformedHeader() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage message = createMessageWithCookies("a=b; c=d; e=f");
+        variantCookie.setMessage(message);
+        // When
+        String injectedCookie = variantCookie.setParameter(message, cookie("a", "b", 0), "y", "z");
+        // Then
+        assertThat(injectedCookie, is(equalTo("y=z")));
+        assertThat(message, containsCookieHeader("y=z; c=d; e=f"));
+    }
+
+    @Test
+    public void shouldInjectCookieModificationOnMalformedHeader() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage message = createMessageWithCookies("a; =b; =d; e=;");
+        variantCookie.setMessage(message);
+        // When
+        String injectedCookie = variantCookie.setParameter(message, cookie("b", null, 1), "y", "z");
+        // Then
+        assertThat(injectedCookie, is(equalTo("y=z")));
+        assertThat(message, containsCookieHeader("a; y=z; =d; e="));
+    }
+
+    @Test
+    public void shouldInjectUnescapedCookieValueModification() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage message = createMessageWithCookies("a=b; c=d; e=f");
+        variantCookie.setMessage(message);
+        // When
+        String injectedCookie = variantCookie.setParameter(message, cookie("a", "b", 0), "y", "&'()");
+        // Then
+        assertThat(injectedCookie, is(equalTo("y=%26%27%28%29")));
+        assertThat(message, containsCookieHeader("y=%26%27%28%29; c=d; e=f"));
+    }
+
+    @Test
+    public void shouldInjectEscapedCookieValueModification() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage message = createMessageWithCookies("a=b; c=d; e=f");
+        variantCookie.setMessage(message);
+        // When
+        String injectedCookie = variantCookie.setEscapedParameter(message, cookie("a", "b", 0), "y", "%26%27%28%29");
+        // Then
+        assertThat(injectedCookie, is(equalTo("y=%26%27%28%29")));
+        assertThat(message, containsCookieHeader("y=%26%27%28%29; c=d; e=f"));
+    }
+
+    @Test
+    public void shouldIgnorePreviouslyInjectCookieModifications() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage message = createMessageWithCookies("a=b; c=d; e=f");
+        variantCookie.setMessage(message);
+        // When
+        String previouslyInjectedCookie = variantCookie.setParameter(message, cookie("a", "b", 0), "y", "z");
+        String injectedCookie = variantCookie.setParameter(message, cookie("e", "f", 2), "i", "j");
+        // Then
+        assertThat(previouslyInjectedCookie, is(equalTo("y=z")));
+        assertThat(injectedCookie, is(equalTo("i=j")));
+        assertThat(message, containsCookieHeader("a=b; c=d; i=j"));
+    }
+
+    @Test
+    public void shouldMergeCookieHeadersWhenInjectingCookieModifications() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage message = createMessageWithCookies("a=b", "c=d", "e=f");
+        variantCookie.setMessage(message);
+        // When
+        String injectedCookie = variantCookie.setParameter(message, cookie("c", "d", 1), "y", "z");
+        // Then
+        assertThat(injectedCookie, is(equalTo("y=z")));
+        assertThat(message, containsCookieHeader("a=b; y=z; e=f"));
+    }
+
+    @Test
+    public void shouldIgnoreNameOfCookieAndUsePositionWhenInjectingCookieModifications() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage message = createMessageWithCookies("a=b; c=d");
+        variantCookie.setMessage(message);
+        // When
+        String injectedCookie = variantCookie.setParameter(message, cookie("DifferentName", "d", 1), "y", "z");
+        // Then
+        assertThat(injectedCookie, is(equalTo("y=z")));
+        assertThat(message, containsCookieHeader("a=b; y=z"));
+    }
+
+    @Test
+    public void shouldIgnoreValueOfOriginalCookieAndUsePositionWhenInjectingCookieModifications() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage message = createMessageWithCookies("a=b; c=d");
+        variantCookie.setMessage(message);
+        // When
+        String injectedCookie = variantCookie.setParameter(message, cookie("c", "DifferentValue", 1), "y", "z");
+        // Then
+        assertThat(injectedCookie, is(equalTo("y=z")));
+        assertThat(message, containsCookieHeader("a=b; y=z"));
+    }
+
+    @Test
+    public void shouldNotInjectCookieModificationsIfPositionOfCookieDoesNotExist() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage message = createMessageWithCookies("a=b; c=d");
+        variantCookie.setMessage(message);
+        // When
+        variantCookie.setParameter(message, cookie("c", "d", 3), "y", "z");
+        // Then
+        assertThat(message, containsCookieHeader("a=b; c=d"));
+    }
+
+    @Test
+    public void shouldRemoveCookieNameIfNameNotInjected() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage message = createMessageWithCookies("a=b; c=d; e=f");
+        variantCookie.setMessage(message);
+        // When
+        String injectedCookie = variantCookie.setParameter(message, cookie("e", "f", 2), null, "z");
+        // Then
+        assertThat(injectedCookie, is(equalTo("=z")));
+        assertThat(message, containsCookieHeader("a=b; c=d; =z"));
+    }
+
+    @Test
+    public void shouldRemoveCookieValueIfValueNotInjected() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage message = createMessageWithCookies("a=b; c=d; e=f");
+        variantCookie.setMessage(message);
+        // When
+        String injectedCookie = variantCookie.setParameter(message, cookie("c", "d", 1), "c", null);
+        // Then
+        assertThat(injectedCookie, is(equalTo("c")));
+        assertThat(message, containsCookieHeader("a=b; c; e=f"));
+    }
+
+    @Test
+    public void shouldRemoveCookieIfNameAndValueAreNotInjected() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage message = createMessageWithCookies("a=b; c=d; e=f");
+        variantCookie.setMessage(message);
+        // When
+        String injectedCookie = variantCookie.setParameter(message, cookie("c", "d", 1), null, null);
+        // Then
+        assertThat(injectedCookie, is(nullValue()));
+        assertThat(message, containsCookieHeader("a=b; e=f"));
+    }
+
+    @Test
+    public void shouldRemoveCookieHeaderIfOnlyCookieIsRemoved() {
+        // Given
+        VariantCookie variantCookie = new VariantCookie();
+        HttpMessage message = createMessageWithCookies("a=b");
+        variantCookie.setMessage(message);
+        // When
+        String injectedCookie = variantCookie.setParameter(message, cookie("a", "b", 0), null, null);
+        // Then
+        assertThat(injectedCookie, is(nullValue()));
+        assertThat(message, hasNoCookieHeaders());
+    }
+
+    private static HttpMessage createMessageWithoutCookies() {
+        HttpMessage message = new HttpMessage();
+        try {
+            message.setRequestHeader("GET / HTTP/1.1\r\nHost: example.com\r\n");
+        } catch (HttpMalformedHeaderException e) {
+            throw new RuntimeException(e);
+        }
+        return message;
+    }
+
+    private static HttpMessage createMessageWithCookies(String... cookieHeaders) {
+        HttpMessage message = new HttpMessage();
+        try {
+            StringBuilder requestHeaderBuilder = new StringBuilder("GET / HTTP/1.1\r\nHost: example.com\r\n");
+            for (String cookieHeader : cookieHeaders) {
+                requestHeaderBuilder.append("Cookie: ");
+                requestHeaderBuilder.append(cookieHeader);
+                requestHeaderBuilder.append("\r\n");
+            }
+            message.setRequestHeader(requestHeaderBuilder.toString());
+        } catch (HttpMalformedHeaderException e) {
+            throw new RuntimeException(e);
+        }
+        return message;
+    }
+
+    private static NameValuePair cookie(String name, String value, int position) {
+        return new NameValuePair(NameValuePair.TYPE_COOKIE, name, value, position);
+    }
+
+    private static Matcher<HttpMessage> containsCookieHeader(final String cookies) {
+        return new BaseMatcher<HttpMessage>() {
+
+            @Override
+            public boolean matches(Object actualValue) {
+                HttpMessage message = (HttpMessage) actualValue;
+                Vector<String> cookieLines = message.getRequestHeader().getHeaders(HttpHeader.COOKIE);
+                if (cookieLines == null || cookieLines.size() != 1) {
+                    return false;
+                }
+                return cookies.equals(cookieLines.get(0));
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("cookie header ").appendValue(cookies);
+            }
+
+            public void describeMismatch(Object item, Description description) {
+                HttpMessage message = (HttpMessage) item;
+                Vector<String> cookieLines = message.getRequestHeader().getHeaders(HttpHeader.COOKIE);
+                if (cookieLines == null) {
+                    description.appendText("has no cookie headers");
+                } else if (cookieLines.size() == 1) {
+                    description.appendText("was ").appendValue(cookieLines.get(0));
+                } else {
+                    description.appendText("has multiple cookie headers ").appendValue(cookieLines);
+                }
+            }
+        };
+    }
+
+    private static Matcher<HttpMessage> hasNoCookieHeaders() {
+        return new BaseMatcher<HttpMessage>() {
+
+            @Override
+            public boolean matches(Object actualValue) {
+                HttpMessage message = (HttpMessage) actualValue;
+                Vector<String> cookieLines = message.getRequestHeader().getHeaders(HttpHeader.COOKIE);
+                if (cookieLines == null || cookieLines.isEmpty()) {
+                    return true;
+                }
+                return false;
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("no cookie header");
+            }
+
+            public void describeMismatch(Object item, Description description) {
+                HttpMessage message = (HttpMessage) item;
+                Vector<String> cookieLines = message.getRequestHeader().getHeaders(HttpHeader.COOKIE);
+                if (cookieLines.size() == 1) {
+                    description.appendText("has one cookie header ").appendValue(cookieLines.get(0));
+                } else {
+                    description.appendText("has multiple cookie headers ").appendValue(cookieLines);
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Change class VariantCookie to conform to the expected behaviour when the
parameter's (that is, the cookie) name and value are set to null, which
indicates the parameter should be removed, preventing
NullPointerExceptions, for example:
>ERROR org.zaproxy.zap.extension.ascanrules.TestParameterTamper -
> Error occurred while scanning a message:
>[...]
>java.lang.NullPointerException
> at java.net.HttpCookie.<init>(HttpCookie.java:143)
> at java.net.HttpCookie.<init>(HttpCookie.java:139)
> at VariantCookie.setParameter(VariantCookie.java:125)
> at VariantCookie.setParameter(VariantCookie.java:92)
> at AbstractAppParamPlugin.setParameter(AbstractAppParamPlugin.java:259)
> at TestParameterTamper.scan(TestParameterTamper.java:129)
>[...]

Also, change the class to:
 - Manually parse and create the cookie header to correctly handle null
 names and values (which would lead to similar exceptions if used with
 HttpCookie class);
 - Remove (now) redundant null checks from methods getEscapedValue and
 getUnescapedValue;
 - Update/add JavaDoc to class and methods.

Change class NameValuePair to add the methods hashCode(), equals(Object)
for proper use in collections and comparisons, and method toString() for
help with debug and remove redundant instance variable initialisations.
Add tests to assert the expected behaviour of classes VariantCookie and
NameValuePair.