### PR TITLE
 spider: use the broadest target component for scan's display name

### DIFF
--- a/src/org/zaproxy/zap/extension/spider/SpiderAPI.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderAPI.java
@@ -372,7 +372,7 @@ public class SpiderAPI extends ApiImplementor {
 			objs.add(maxChildrenParseFilter);
 		}
 		
-		return extension.startScan(target.getDisplayName(), target, user, objs.toArray(new Object[objs.size()]));
+		return extension.startScan(target, user, objs.toArray(new Object[objs.size()]));
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/spider/SpiderDialog.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderDialog.java
@@ -321,17 +321,9 @@ public class SpiderDialog extends StandardFieldsDialog {
 			contextSpecificObjects.add(startUri);
 		}
         
-        String displayName;
         if (target == null || ! this.getStringValue(FIELD_START).equals(getTargetText(target))) {
        		// Clear the target as it doesnt match the value entered manually
 			target = new Target((StructuralNode)null);
-			displayName = startUri.toString();
-    		if (displayName.length() >= 30) {
-    			// Just use the first and last 14 chrs to prevent huge urls messing up the display
-    			displayName = displayName.substring(0, 14) + ".." + displayName.substring(displayName.length()-15, displayName.length());
-    		}
-        } else {
-        	displayName = target.getDisplayName();
         }
         
         // Save the adv option permanently for next time
@@ -344,7 +336,6 @@ public class SpiderDialog extends StandardFieldsDialog {
         }
 
         this.extension.startScan(
-        		displayName,
                 target,
                 getSelectedUser(), 
                 contextSpecificObjects.toArray());


### PR DESCRIPTION
Change spider to create the display name for the scans using all the
components of the target and custom configurations, with the following
order:
 - Context;
 - Just in scope;
 - Start node;
 - Start URL.

So, for example, if a start node is specified along with a context it
will display the context name instead of the start node (which is more
specific, narrow target when spidering).
Change class ExtensionSpider to follow the above rules using a new
method to start the scans, to ensure that all scans use the same display
name rules (the old method that allows to define the display name is
still available but its use is discouraged in favour of using the new
method).
Change classes ExtensionSpider, SpiderAPI and SpiderDialog to use the
new method, for the latter class also remove the creation of the custom
display name.

---
Old title/message (for the record):
Change Target display name to use the broadest target component first

Change the method Target.getDisplayName() to check first if there's a
context defined or if the target is "in scope only" to use that as the
display name, only if those are not defined use the start node. So, if a
start node is specified along with a context it will display the context
name instead of the start node (which is more specific, narrow target).
(Also, remove unnecessary Object array instantiation.)