### PR TITLE
spider: do not require a URL, through the API, if the context has seeds

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1764,7 +1764,7 @@ sites.spider.popup         = Spider...
 sites.showinsites.popup    = Show in Sites Tab
 
 spider.activeActionPrefix = Spidering: {0}
-spider.api.action.scan = Runs the spider against the given URL. Optionally, the 'maxChildren' parameter can be set to limit the number of children scanned, the 'recurse' parameter can be used to prevent the spider from seeding recursively and the parameter 'contextName' can be used to constrain the scan to a Context.
+spider.api.action.scan = Runs the spider against the given URL (or context). Optionally, the 'maxChildren' parameter can be set to limit the number of children scanned, the 'recurse' parameter can be used to prevent the spider from seeding recursively and the parameter 'contextName' can be used to constrain the scan to a Context.
 spider.api.action.scanAsUser = Runs the spider from the perspective of a User, obtained using the given Context ID and User ID. See 'scan' action for more details.
 spider.api.view.optionSendRefererHeader = Sets whether or not the 'Referer' header should be sent while spidering
 spider.custom.button.reset	= Reset

--- a/src/org/zaproxy/zap/model/Context.java
+++ b/src/org/zaproxy/zap/model/Context.java
@@ -212,12 +212,47 @@ public class Context {
 	 * every node in the Site Tree.
 	 * 
 	 * @return the nodes in scope from site tree
+	 * @see #hasNodesInContextFromSiteTree()
 	 */
 	public List<SiteNode> getNodesInContextFromSiteTree() {
 		List<SiteNode> nodes = new LinkedList<>();
 		SiteNode rootNode = (SiteNode) session.getSiteTree().getRoot();
 		fillNodesInContext(rootNode, nodes);
 		return nodes;
+	}
+
+	/**
+	 * Tells whether or not there's at least one node from the sites tree in context.
+	 * 
+	 * @return {@code true} if the context has at least one node from the sites tree in context, {@code false} otherwise
+	 * @since TODO add version
+	 * @see #getNodesInContextFromSiteTree()
+	 */
+	public boolean hasNodesInContextFromSiteTree() {
+		return hasNodesInContext((SiteNode) session.getSiteTree().getRoot());
+	}
+
+	/**
+	 * Tells whether or not there's at least one node from the sites tree in context.
+	 * <p>
+	 * The whole tree is traversed until is found one node in context.
+	 * 
+	 * @param node the node to check, recursively
+	 * @return {@code true} if the context has at least one node from the sites tree in context, {@code false} otherwise
+	 */
+	private boolean hasNodesInContext(SiteNode node) {
+		@SuppressWarnings("unchecked")
+		Enumeration<SiteNode> en = node.children();
+		while (en.hasMoreElements()) {
+			SiteNode sn = en.nextElement();
+			if (isInContext(sn)) {
+				return true;
+			}
+			if (hasNodesInContext(sn)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Change the SpiderAPI to not require a URL if the context provided
already has seeds. Also, if provided validate always that the URL is in
context and when in protected mode that the context is in scope.
Add helper method to Context class to check if there's any site tree
node (that is, seeds) in context.
 ---
Issue reported in IRC channel.