### PR TITLE
Fix exceptions related to Http Sessions extension/tab

### DIFF
--- a/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
@@ -608,7 +608,7 @@ public class ExtensionHttpSessions extends ExtensionAdaptor implements SessionCh
 	@Override
 	public void onHttpResponseReceive(HttpMessage msg, int initiator, HttpSender sender) {
 		if (initiator == HttpSender.ACTIVE_SCANNER_INITIATOR || initiator == HttpSender.SPIDER_INITIATOR
-				|| initiator == HttpSender.CHECK_FOR_UPDATES_INITIATOR) {
+				|| initiator == HttpSender.CHECK_FOR_UPDATES_INITIATOR || initiator == HttpSender.FUZZER_INITIATOR) {
 			// Not a session we care about
 			return;
 		}

--- a/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsSite.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsSite.java
@@ -19,6 +19,8 @@ package org.zaproxy.zap.extension.httpsessions;
 
 import java.net.HttpCookie;
 import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -478,8 +480,11 @@ public class HttpSessionsSite {
 	 *         all the tokens
 	 */
 	private HttpSession getMatchingHttpSession(List<HttpCookie> cookies, final HttpSessionTokensSet siteTokens) {
-
-		return CookieBasedSessionManagementHelper.getMatchingHttpSession(sessions, cookies, siteTokens);
+		Collection<HttpSession> sessionsCopy;
+		synchronized (sessions) {
+			sessionsCopy = new ArrayList<>(sessions);
+		}
+		return CookieBasedSessionManagementHelper.getMatchingHttpSession(sessionsCopy, cookies, siteTokens);
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsTableModel.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsTableModel.java
@@ -17,14 +17,14 @@
  */
 package org.zaproxy.zap.extension.httpsessions;
 
+import java.awt.EventQueue;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 import javax.swing.ImageIcon;
 import javax.swing.table.AbstractTableModel;
 
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.View;
 
 /**
  * The Class HttpSessionsTableModel that is used as a TableModel for the Http Sessions Panel.
@@ -43,7 +43,7 @@ public class HttpSessionsTableModel extends AbstractTableModel {
 	private static final int COLUMN_COUNT = COLUMN_NAMES.length;
 
 	/** The http sessions. */
-	private List<HttpSession> sessions;
+	private ArrayList<HttpSession> sessions;
 
 	/** The site. */
 	private HttpSessionsSite site;
@@ -61,16 +61,7 @@ public class HttpSessionsTableModel extends AbstractTableModel {
 		super();
 
 		this.site = site;
-		sessions = createEmptySessionsList();
-	}
-
-	/**
-	 * Creates a new empty sessions list.
-	 * 
-	 * @return the list
-	 */
-	private List<HttpSession> createEmptySessionsList() {
-		return Collections.synchronizedList(new ArrayList<HttpSession>(2));
+		sessions = new ArrayList<>(2);
 	}
 
 	@Override
@@ -118,12 +109,20 @@ public class HttpSessionsTableModel extends AbstractTableModel {
 	 * Removes all the elements.
 	 */
 	public void removeAllElements() {
+		if (View.isInitialised() && !EventQueue.isDispatchThread()) {
+			EventQueue.invokeLater(new Runnable() {
+
+				@Override
+				public void run() {
+					removeAllElements();
+				}
+			});
+
+			return;
+		}
+
 		sessions.clear();
-		// When all the elements are removed a new list is created because the ArrayList doesn't
-		// shrink automatically. The method ArrayList.trimToSize() would have to be called, but as
-		// it is behind a synchronized list there is no direct access to it, so a
-		// new one is created.
-		sessions = createEmptySessionsList();
+		sessions.trimToSize();
 		fireTableDataChanged();
 	}
 
@@ -132,7 +131,19 @@ public class HttpSessionsTableModel extends AbstractTableModel {
 	 * 
 	 * @param session the session
 	 */
-	public void addHttpSession(HttpSession session) {
+	public void addHttpSession(final HttpSession session) {
+		if (View.isInitialised() && !EventQueue.isDispatchThread()) {
+			EventQueue.invokeLater(new Runnable() {
+
+				@Override
+				public void run() {
+					addHttpSession(session);
+				}
+			});
+
+			return;
+		}
+
 		if (sessions.contains(session))
 			return;
 		sessions.add(session);
@@ -201,7 +212,19 @@ public class HttpSessionsTableModel extends AbstractTableModel {
 	 * 
 	 * @param session the session
 	 */
-	public void removeHttpSession(HttpSession session) {
+	public void removeHttpSession(final HttpSession session) {
+		if (View.isInitialised() && !EventQueue.isDispatchThread()) {
+			EventQueue.invokeLater(new Runnable() {
+
+				@Override
+				public void run() {
+					removeHttpSession(session);
+				}
+			});
+
+			return;
+		}
+
 		int index = sessions.indexOf(session);
 		sessions.remove(index);
 		fireTableRowsDeleted(index, index);
@@ -212,7 +235,19 @@ public class HttpSessionsTableModel extends AbstractTableModel {
 	 * 
 	 * @param session the session
 	 */
-	public void fireHttpSessionUpdated(HttpSession session) {
+	public void fireHttpSessionUpdated(final HttpSession session) {
+		if (View.isInitialised() && !EventQueue.isDispatchThread()) {
+			EventQueue.invokeLater(new Runnable() {
+
+				@Override
+				public void run() {
+					fireHttpSessionUpdated(session);
+				}
+			});
+
+			return;
+		}
+
 		int index = sessions.indexOf(session);
 		fireTableRowsUpdated(index, index);
 	}


### PR DESCRIPTION
Change method HttpSessionsSite.getMatchingHttpSession(...) to create a
copy of the sessions (in a synchronised block) and pass the copy to a
method of CookieBasedSessionManagementHelper to prevent the exception
ConcurrentModificationException (which happened while iterating/copying
the original sessions collection in the method of the latter class).
Change class HttpSessionsTableModel to do the modifications to sessions
collection and notifications to the GUI in the EDT to prevent leaving
the view in inconsistent state, which would lead to exceptions like
"IndexOutOfBoundsException: Invalid range", when sorting the entries
added to the "Http Sessions" table.
Change method ExtensionHttpSessions.onHttpResponseReceive(...) to not
process the responses of fuzzed messages, which can potentially generate
thousands of "synthetic" sessions in ZAP (like the active scanner,
already excluded).
Fix #2142 - Fuzzer throwing exceptions