### PR TITLE
Change "context" view to wrap the context data with an object

### DIFF
--- a/src/org/zaproxy/zap/extension/api/ContextAPI.java
+++ b/src/org/zaproxy/zap/extension/api/ContextAPI.java
@@ -260,7 +260,7 @@ public class ContextAPI extends ApiImplementor {
             result = new ApiResponseElement(name, contextNames.toString());
             break;
         case VIEW_CONTEXT:
-        	result = buildResponseFromContext(getContext(params));
+        	result = new ApiResponseElement(buildResponseFromContext(getContext(params)));
         	break;
         case VIEW_ALL_TECHS:
         	resultList = new ApiResponseList(name);
@@ -341,7 +341,7 @@ public class ContextAPI extends ApiImplementor {
 		fields.put("postParameterParserClass", c.getPostParamParser().getClass().getCanonicalName());
 		fields.put("postParameterParserConfig", c.getPostParamParser().getConfig());
 		
-		return new ApiResponseSet(c.getName(), fields);
+		return new ApiResponseSet("context", fields);
 	}
 	
 	/**


### PR DESCRIPTION
Change class ContextAPI to wrap the context data with an object (as all
views do), called "context", instead of returning the context data
directly, so that the Python ZAP API client is able to correctly read
the data, which expects (and removes) the wrapper object.

The data returned is now, for example:
 {"context":{"id":"1", ..., "inScope":"true","loggedOutPattern":""}}

instead of:
 {"id":"1", ..., "inScope":"true","loggedOutPattern":""}

This change breaks existing custom clients that consume the JSON format.
The structure of XML format is unchanged.

Fix #2115 - Python API context.context("MyContext") is broken