### PR TITLE
Enhance alertFingerPrint

### DIFF
--- a/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -706,7 +706,7 @@ public class ExtensionAlert extends ExtensionAdaptor implements SessionChangedLi
     }
     
     private String alertFingerprint(Alert alert) {
-    	return alert.getPluginId() + "/" + alert.getRisk() + "/" + alert.getConfidence();
+    	return alert.getPluginId() + "/" + alert.getName() + "/" + alert.getRisk() + "/" + alert.getConfidence();
     }
 
     @Override


### PR DESCRIPTION
In order to accommodate scanners which report alerts via multiple names
update alertFingerprint within ExtensionAlert to include the name of the
alert as an element.