### PR TITLE
Give focus to "Edit Keyboard Shortcut" dialogue

### DIFF
--- a/src/org/zaproxy/zap/extension/keyboard/DialogEditShortcut.java
+++ b/src/org/zaproxy/zap/extension/keyboard/DialogEditShortcut.java
@@ -20,6 +20,7 @@ package org.zaproxy.zap.extension.keyboard;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Frame;
+import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
@@ -45,6 +46,16 @@ public class DialogEditShortcut extends StandardFieldsDialog {
 
 	private KeyboardShortcut shortcut;
 	private KeyboardShortcutTableModel model;
+
+	/**
+	 * Constructs a modal {@code DialogEditShortcut}, with the given {@code Window} as its owner.
+	 *
+	 * @param owner the owner of the dialogue
+	 * @since TODO add version
+	 */
+	public DialogEditShortcut(Window owner) {
+		super(owner, "keyboard.dialog.title", new Dimension(300, 200), true);
+	}
 
 	public DialogEditShortcut(Frame owner) {
 		super(owner, "keyboard.dialog.title", new Dimension(300, 200));

--- a/src/org/zaproxy/zap/extension/keyboard/OptionsKeyboardShortcutPanel.java
+++ b/src/org/zaproxy/zap/extension/keyboard/OptionsKeyboardShortcutPanel.java
@@ -17,8 +17,6 @@
  */
 package org.zaproxy.zap.extension.keyboard;
 
-import java.awt.Container;
-import java.awt.Frame;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
@@ -239,16 +237,7 @@ public class OptionsKeyboardShortcutPanel extends AbstractParamPanel {
 
         public void showModifyDialogue(KeyboardShortcut shortcut) {
             if (modifyDialog == null) {
-            	Container c = View.getSingleton().getOptionsDialog(null);
-            	Frame f = null;
-            	while (f == null && c != null) {
-            		if (c instanceof Frame) {
-            			f = (Frame)c;
-            		} else {
-            			c = c.getParent(); 
-            		}
-            	}
-                modifyDialog = new DialogEditShortcut(f);
+                modifyDialog = new DialogEditShortcut(View.getSingleton().getOptionsDialog(null));
                 modifyDialog.pack();
             }
             modifyDialog.init(shortcut, model);


### PR DESCRIPTION
Use the "Options" dialogue (instead of main frame) as owner of the
dialogue "Edit Keyboard Shortcut" to allow the latter dialogue to
receive focus and be shown, always, in front of the former dialogue,
moreover change the "Edit Keyboard Shortcut" dialogue to be modal to
prevent navigation and modifications in the "Options" dialogue while
having it open.