### PR TITLE
Properly convert (old) excluded proxy domains

### DIFF
--- a/src/org/parosproxy/paros/network/ConnectionParam.java
+++ b/src/org/parosproxy/paros/network/ConnectionParam.java
@@ -245,7 +245,7 @@ public class ConnectionParam extends AbstractParam {
                 if (excludedDomain.contains("*")) {
                     excludedDomain = excludedDomain.replace(".", "\\.").replace("*", ".*?");
                     try {
-                        Pattern pattern = Pattern.compile(name, Pattern.CASE_INSENSITIVE);
+                        Pattern pattern = Pattern.compile(excludedDomain, Pattern.CASE_INSENSITIVE);
                         excludedDomains.add(new ProxyExcludedDomainMatcher(pattern));
                     } catch (IllegalArgumentException e) {
                         log.error("Failed to migrate the excluded domain name: " + name, e);


### PR DESCRIPTION
Use the correct variable when converting (to Pattern) the old excluded
domains that use wildcard char '*', otherwise the conversion would not
be properly done thus not matching the expected domains.