### PR TITLE
Do not access the EDT in daemon mode

### DIFF
--- a/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -166,6 +166,10 @@ public class ExtensionAlert extends ExtensionAdaptor implements SessionChangedLi
     }
 
     private void siteNodeChanged(final TreeNode node) {
+        if (getView() == null) {
+            return;
+        }
+
         if (EventQueue.isDispatchThread()) {
         	siteNodeChangedEventHandler(this.getModel().getSession().getSiteTree(), node);
         } else {


### PR DESCRIPTION
Change class ExtensionAlert to skip the notification of changes in the
SiteNode(s) after raising an alert if there's no view to notify to (that
is, when running in daemon mode), preventing the EDT access.
Fix #2297 - AWT blocker activation interrupted -
java.lang.InterruptedException