### PR TITLE
Fix (secure) ZAP API request loop

### DIFF
--- a/src/org/zaproxy/zap/extension/api/API.java
+++ b/src/org/zaproxy/zap/extension/api/API.java
@@ -173,7 +173,7 @@ public class API {
 		if (this.getOptionsParamApi().isSecureOnly() && ! requestHeader.isSecure()) {
 			// Insecure request with secure only set, always ignore
 			logger.debug("handleApiRequest rejecting insecure request");
-			return false;
+			return true;
 		}
 			
 		logger.debug("handleApiRequest " + url);


### PR DESCRIPTION
Change API class to consider insecure requests to secure ZAP API as
handled, otherwise the requests would be forward by the proxy which
would end up again (if local addresses) in the ZAP API, leading to a
request loop.
With the change insecure requests to secure API are simply dropped.