### PR TITLE
Include scanners' quality in API scanners views

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
@@ -798,6 +798,7 @@ public class ActiveScanAPI extends ApiImplementor {
 			scannerData.put("alertThreshold", String.valueOf(scanner.getAlertThreshold(true)));
 			scannerData.put("policyId", String.valueOf(scanner.getCategory()));
 			scannerData.put("enabled", String.valueOf(scanner.isEnabled()));
+			scannerData.put("quality", scanner.getStatus().toString());
 
 			boolean allDepsAvailable = policy.getPluginFactory().hasAllDependenciesAvailable(scanner);
 			scannerData.put("allDependenciesAvailable", Boolean.toString(allDepsAvailable));

--- a/src/org/zaproxy/zap/extension/pscan/PassiveScanAPI.java
+++ b/src/org/zaproxy/zap/extension/pscan/PassiveScanAPI.java
@@ -163,6 +163,7 @@ public class PassiveScanAPI extends ApiImplementor {
 				map.put("name", scanner.getName());
 				map.put("enabled", String.valueOf(scanner.isEnabled()));
 				map.put("alertThreshold", scanner.getLevel(true).name());
+				map.put("quality", scanner.getStatus().toString());
 				resultList.addItem(new ApiResponseSet("scanner", map));
 			}
 			


### PR DESCRIPTION
Change classes ActiveScanAPI and PassiveScanAPI to include the quality
of the scanners in the "scanners" view.
The response will now include a field called "quality" for each scanner,
with the corresponding quality ("alpha", "beta" and "release").