### PR TITLE
Reserved a Plugin ID for the Active Scan Rule HttpOnlySite

### DIFF
--- a/src/doc/alerts.xml
+++ b/src/doc/alerts.xml
@@ -107,6 +107,7 @@ This list the alerts
 10103   Image Location Scanner - passive scanner finding
 10104   TestUserAgent
 10105   Weak Authentication Method
+10106   Http Only Site
 
 20000	Cold Fusion default file (Depreciated)
 20001	Lotus Domino default files (Depreciated)


### PR DESCRIPTION
As mentioned by @kingthorin in zaproxy/zap-extensions#277 I have reserved a Plugin ID in alerts.xml file for the Active Scan Rule "Http Only Site"