### PR TITLE
Fix issue during uninstallation of named extension

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnInstaller.java
+++ b/src/org/zaproxy/zap/control/AddOnInstaller.java
@@ -232,6 +232,7 @@ public final class AddOnInstaller {
             AddOnUninstallationProgressCallback callback) {
         boolean uninstalledWithoutErrors = true;
         if (extension.isEnabled()) {
+            String extUiName = extension.getUIName();
             if (extension.canUnload()) {
                 logger.debug("Unloading ext: " + extension.getName());
                 try {
@@ -246,7 +247,7 @@ public final class AddOnInstaller {
                 logger.debug("Cant dynamically unload ext: " + extension.getName());
                 uninstalledWithoutErrors = false;
             }
-            callback.extensionRemoved(extension.getUIName());
+            callback.extensionRemoved(extUiName);
         }
         addOn.removeLoadedExtension(extension);
 


### PR DESCRIPTION
Obtain the UI name of the extension before uninstalling it, otherwise it
might lead to an exception (MissingResourceException, if the UI name of
the extension is internationalised) preventing the corresponding add-on
from being successfully uninstalled, dynamically.