### PR TITLE
Allow to spider a site's subtree

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1768,7 +1768,7 @@ sites.spider.popup         = Spider...
 sites.showinsites.popup    = Show in Sites Tab
 
 spider.activeActionPrefix = Spidering: {0}
-spider.api.action.scan = Runs the spider against the given URL (or context). Optionally, the 'maxChildren' parameter can be set to limit the number of children scanned, the 'recurse' parameter can be used to prevent the spider from seeding recursively and the parameter 'contextName' can be used to constrain the scan to a Context.
+spider.api.action.scan = Runs the spider against the given URL (or context). Optionally, the 'maxChildren' parameter can be set to limit the number of children scanned, the 'recurse' parameter can be used to prevent the spider from seeding recursively, the parameter 'contextName' can be used to constrain the scan to a Context and the parameter 'subtreeOnly' allows to restrict the spider under a site's subtree (using the specified 'url').
 spider.api.action.scanAsUser = Runs the spider from the perspective of a User, obtained using the given Context ID and User ID. See 'scan' action for more details.
 spider.api.view.optionSendRefererHeader = Sets whether or not the 'Referer' header should be sent while spidering
 spider.custom.button.reset	= Reset
@@ -1789,6 +1789,7 @@ spider.custom.label.handleOdata		= Handle OData parameters:
 spider.custom.label.processForms	= Process forms:
 spider.custom.label.recurse = Recurse:
 spider.custom.label.start	= Starting point:
+spider.custom.label.spiderSubtreeOnly = Spider Subtree Only
 spider.custom.label.user	= User:
 spider.custom.popup			= Spider...
 spider.custom.title			= Spider
@@ -1796,6 +1797,7 @@ spider.custom.tab.adv		= Advanced
 spider.custom.tab.scope		= Scope
 spider.custom.notSafe.error = Spider scans are not allowed in 'Safe' mode.
 spider.custom.nostart.error	= You must select a valid starting point\nincluding the protocol e.g. https://www.example.com
+spider.custom.noStartSubtreeOnly.error = A site node must be selected or a URL manually introduced, to spider a site's subtree.
 spider.custom.targetNotInScope.error = The following target is not allowed in 'Protected' mode:\n{0}
 
 spider.desc                     = Spider used for automatically finding URIs on a site

--- a/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
+++ b/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
@@ -57,6 +57,7 @@ import org.zaproxy.zap.model.Target;
 import org.zaproxy.zap.spider.SpiderParam;
 import org.zaproxy.zap.spider.filters.FetchFilter;
 import org.zaproxy.zap.spider.filters.ParseFilter;
+import org.zaproxy.zap.spider.filters.HttpPrefixFetchFilter;
 import org.zaproxy.zap.spider.parser.SpiderParser;
 import org.zaproxy.zap.users.User;
 import org.zaproxy.zap.view.ZapMenuItem;
@@ -454,6 +455,11 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
 	 * @return a {@code String} containing the display name, never {@code null}
 	 */
 	private String createDisplayName(Target target, Object[] customConfigurations) {
+		HttpPrefixFetchFilter subtreeFecthFilter = getUriPrefixFecthFilter(customConfigurations);
+		if (subtreeFecthFilter != null) {
+			return abbreviateDisplayName(subtreeFecthFilter.getNormalisedPrefix());
+		}
+
 		if (target.getContext() != null) {
 			return Constant.messages.getString("context.prefixName", target.getContext().getName());
 		} else if (target.isInScopeOnly()) {
@@ -469,6 +475,23 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
 			return Constant.messages.getString("target.empty");
 		}
 		return abbreviateDisplayName(target.getStartNode().getHierarchicNodeName(false));
+	}
+
+	/**
+	 * Gets the {@code HttpPrefixFetchFilter} from the given {@code customConfigurations}.
+	 *
+	 * @param customConfigurations the custom configurations of the spider
+	 * @return the {@code HttpPrefixFetchFilter} found, {@code null} otherwise.
+	 */
+	private HttpPrefixFetchFilter getUriPrefixFecthFilter(Object[] customConfigurations) {
+		if (customConfigurations != null) {
+			for (Object customConfiguration : customConfigurations) {
+				if (customConfiguration instanceof HttpPrefixFetchFilter) {
+					return (HttpPrefixFetchFilter) customConfiguration;
+				}
+			}
+		}
+		return null;
 	}
 
 	/**

--- a/src/org/zaproxy/zap/spider/filters/HttpPrefixFetchFilter.java
+++ b/src/org/zaproxy/zap/spider/filters/HttpPrefixFetchFilter.java
@@ -1,0 +1,320 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.spider.filters;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.apache.log4j.Logger;
+
+/**
+ * A {@code FetchFilter} that filters based on a HTTP or HTTPS {@code URI}.
+ * <p>
+ * The filtered {@code URI}s are required to start with the {@code URI} (the prefix) to be considered valid.
+ * 
+ * @since TODO add version
+ * @see #checkFilter(URI)
+ */
+public class HttpPrefixFetchFilter extends FetchFilter {
+
+    private static final Logger LOGGER = Logger.getLogger(HttpPrefixFetchFilter.class);
+
+    /** The normalised form of HTTP scheme, that is, all letters lowercase. */
+    private static final String HTTP_SCHEME = "http";
+    /** The normalised form of HTTPS scheme, that is, all letters lowercase. */
+    private static final String HTTPS_SCHEME = "https";
+
+    /** The port number that indicates that a port is the default of a scheme. */
+    private static final int DEFAULT_PORT = -1;
+    /** The port number that indicates that a port is of an unknown scheme (that is, non HTTP and HTTPS). */
+    private static final int UNKNOWN_PORT = -2;
+    /** The default port number of HTTP scheme. */
+    private static final int DEFAULT_HTTP_PORT = 80;
+    /** The default port number of HTTPS scheme. */
+    private static final int DEFAULT_HTTPS_PORT = 443;
+
+    /** The scheme used for filtering. Never {@code null}. */
+    private final String scheme;
+
+    /** The host used for filtering. Never {@code null}. */
+    private final String host;
+
+    /** The port used for filtering. */
+    private final int port;
+
+    /** The path used for filtering. Might be {@code null}. */
+    private final char[] path;
+
+    /**
+     * Constructs a {@code HttpPrefixFetchFilter} using the given {@code URI} as prefix.
+     * <p>
+     * The user info, query component and fragment of the given {@code URI} are discarded. The scheme and domain comparisons are
+     * done in a case insensitive way while the path component comparison is case sensitive.
+     *
+     * @param prefix the {@code URI} that will be used as prefix
+     * @throws IllegalArgumentException if any of the following conditions is {@code true}:
+     *             <ul>
+     *             <li>The given {@code prefix} is {@code null};</li>
+     *             <li>The given {@code prefix} has {@code null} scheme;</li>
+     *             <li>The scheme of the given {@code prefix} is not HTTP or HTTPS;</li>
+     *             <li>The given {@code prefix} has {@code null} host;</li>
+     *             <li>The given {@code prefix} has malformed host.</li>
+     *             </ul>
+     */
+    public HttpPrefixFetchFilter(URI prefix) {
+        if (prefix == null) {
+            throw new IllegalArgumentException("Parameter prefix must not be null.");
+        }
+
+        char[] rawScheme = prefix.getRawScheme();
+        if (rawScheme == null) {
+            throw new IllegalArgumentException("Parameter prefix must have a scheme.");
+        }
+        String normalisedScheme = normalisedScheme(rawScheme);
+        if (!isHttpOrHttps(normalisedScheme)) {
+            throw new IllegalArgumentException("The prefix's scheme must be HTTP or HTTPS.");
+        }
+        scheme = normalisedScheme;
+
+        if (prefix.getRawHost() == null) {
+            throw new IllegalArgumentException("Parameter prefix must have a host.");
+        }
+        try {
+            host = normalisedHost(prefix);
+        } catch (URIException e) {
+            throw new IllegalArgumentException("Failed to obtain the host from the prefix:", e);
+        }
+
+        port = normalisedPort(scheme, prefix.getPort());
+        path = prefix.getRawPath();
+    }
+
+    /**
+     * Returns the normalised form of the given {@code scheme}.
+     * <p>
+     * The normalisation process consists in converting the scheme to lowercase, if {@code null} it is returned an empty
+     * {@code String}.
+     *
+     * @param scheme the scheme that will be normalised
+     * @return a {@code String} with the host scheme, never {@code null}
+     * @see URI#getRawScheme()
+     */
+    private static String normalisedScheme(char[] scheme) {
+        if (scheme == null) {
+            return "";
+        }
+        return new String(scheme).toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Tells whether or not the given {@code scheme} is HTTP or HTTPS.
+     *
+     * @param scheme the normalised scheme, might be {@code null}
+     * @return {@code true} if the {@code scheme} is HTTP or HTTPS, {@code false} otherwise
+     */
+    private static boolean isHttpOrHttps(String scheme) {
+        return isHttp(scheme) || isHttps(scheme);
+    }
+
+    /**
+     * Tells whether or not the given {@code scheme} is HTTP.
+     *
+     * @param scheme the normalised scheme, might be {@code null}
+     * @return {@code true} if the {@code scheme} is HTTP, {@code false} otherwise
+     */
+    private static boolean isHttp(String scheme) {
+        return HTTP_SCHEME.equals(scheme);
+    }
+
+    /**
+     * Tells whether or not the given {@code scheme} is HTTPS.
+     *
+     * @param scheme the normalised scheme, might be {@code null}
+     * @return {@code true} if the {@code scheme} is HTTPS, {@code false} otherwise
+     */
+    private static boolean isHttps(String scheme) {
+        return HTTPS_SCHEME.equals(scheme);
+    }
+
+    /**
+     * Returns the normalised form of the host of the given {@code uri}.
+     * <p>
+     * The normalisation process consists in converting the host to lowercase, if {@code null} it is returned an empty
+     * {@code String}.
+     *
+     * @param uri the URI whose host will be extracted and normalised
+     * @return a {@code String} with the host normalised, never {@code null}
+     * @throws URIException if the host of the given {@code uri} is malformed
+     */
+    private static String normalisedHost(URI uri) throws URIException {
+        if (uri.getRawHost() == null) {
+            return "";
+        }
+        return uri.getHost().toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Returns the normalised form of the given {@code port}, based on the given {@code scheme}.
+     * <p>
+     * If the port is non-default (as given by {@link #DEFAULT_PORT}), it's immediately returned. Otherwise, for schemes HTTP
+     * and HTTPS it's returned 80 and 443, respectively, for any other scheme it's returned {@link #UNKNOWN_PORT}.
+     *
+     * @param scheme the (normalised) scheme of the URI where the port was defined
+     * @param port the port to normalise
+     * @return the normalised port
+     * @see #normalisedScheme(char[])
+     * @see URI#getPort()
+     */
+    private static int normalisedPort(String scheme, int port) {
+        if (port != DEFAULT_PORT) {
+            return port;
+        }
+
+        if (isHttp(scheme)) {
+            return DEFAULT_HTTP_PORT;
+        }
+
+        if (isHttps(scheme)) {
+            return DEFAULT_HTTPS_PORT;
+        }
+
+        return UNKNOWN_PORT;
+    }
+
+    /**
+     * Gets the prefix normalised, as it is used to filter the {@code URI}s.
+     *
+     * @return a {@code String} with the prefix normalised
+     * @see #checkFilter(URI)
+     */
+    public String getNormalisedPrefix() {
+        StringBuilder strBuilder = new StringBuilder();
+        strBuilder.append(scheme).append("://").append(host);
+        if (!isDefaultHttpOrHttpsPort(scheme, port)) {
+            strBuilder.append(':').append(port);
+        }
+        if (path != null) {
+            strBuilder.append(path);
+        }
+        return strBuilder.toString();
+    }
+
+    /**
+     * Tells whether or not the given {@code port} is the default for the given {@code scheme}.
+     * <p>
+     * The method returns always {@code false} for non HTTP or HTTPS schemes.
+     *
+     * @param scheme the scheme of a URI, might be {@code null}
+     * @param port the port of a URI
+     * @return {@code true} if the {@code port} is the default for the given {@code scheme}, {@code false} otherwise
+     */
+    private static boolean isDefaultHttpOrHttpsPort(String scheme, int port) {
+        if (port == DEFAULT_HTTP_PORT && isHttp(scheme)) {
+            return true;
+        }
+        if (port == DEFAULT_HTTPS_PORT && isHttps(scheme)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Filters any URI that does not start with the defined prefix.
+     * 
+     * @return {@code FetchStatus.VALID} if the {@code uri} starts with the {@code prefix}, {@code FetchStatus.OUT_OF_SCOPE}
+     *         otherwise
+     */
+    @Override
+    public FetchStatus checkFilter(URI uri) {
+        if (uri == null) {
+            return FetchStatus.OUT_OF_SCOPE;
+        }
+
+        String otherScheme = normalisedScheme(uri.getRawScheme());
+        if (port != normalisedPort(otherScheme, uri.getPort())) {
+            return FetchStatus.OUT_OF_SCOPE;
+        }
+
+        if (!scheme.equals(otherScheme)) {
+            return FetchStatus.OUT_OF_SCOPE;
+        }
+
+        if (!hasSameHost(uri)) {
+            return FetchStatus.OUT_OF_SCOPE;
+        }
+
+        if (!startsWith(uri.getRawPath(), path)) {
+            return FetchStatus.OUT_OF_SCOPE;
+        }
+
+        return FetchStatus.VALID;
+    }
+
+    /**
+     * Tells whether or not the given {@code uri} has the same host as required by this prefix.
+     * <p>
+     * For malformed hosts it returns always {@code false}.
+     *
+     * @param uri the {@code URI} whose host will be checked
+     * @return {@code true} if the host is same, {@code false} otherwise
+     */
+    private boolean hasSameHost(URI uri) {
+        try {
+            return host.equals(normalisedHost(uri));
+        } catch (URIException e) {
+            LOGGER.warn("Failed to normalise host: " + Arrays.toString(uri.getRawHost()), e);
+        }
+        return false;
+    }
+
+    /**
+     * Tells whether or not the given {@code array} starts with the given {@code prefix}.
+     * <p>
+     * The {@code prefix} might be {@code null} in which case it's considered that the {@code array} starts with the prefix.
+     *
+     * @param array the array that will be tested if starts with the prefix, might be {@code null}
+     * @param prefix the array used as prefix, might be {@code null}
+     * @return {@code true} if the {@code array} starts with the {@code prefix}, {@code false} otherwise
+     */
+    private static boolean startsWith(char[] array, char[] prefix) {
+        if (prefix == null) {
+            return true;
+        }
+
+        if (array == null) {
+            return false;
+        }
+
+        int length = prefix.length;
+        if (array.length < length) {
+            return false;
+        }
+
+        for (int i = 0; i < length; i++) {
+            if (prefix[i] != array[i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/test/org/zaproxy/zap/spider/filters/HttpPrefixFetchFilterUnitTest.java
+++ b/test/org/zaproxy/zap/spider/filters/HttpPrefixFetchFilterUnitTest.java
@@ -1,0 +1,353 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.spider.filters;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.log4j.Logger;
+import org.apache.log4j.varia.NullAppender;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.zaproxy.zap.spider.filters.FetchFilter.FetchStatus;
+
+/**
+ * Unit test for {@link HttpPrefixFetchFilter}.
+ */
+public class HttpPrefixFetchFilterUnitTest {
+
+    @BeforeClass
+    public static void suppressLogging() {
+        Logger.getRootLogger().addAppender(new NullAppender());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToCreateFetchFilterWithUndefinedURI() {
+        // Given / When
+        new HttpPrefixFetchFilter(null);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToCreateFetchFilterWithNoScheme() throws Exception {
+        // Given
+        URI prefixUri = new URI("example.org/", true);
+        // When
+        new HttpPrefixFetchFilter(prefixUri);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToCreateFetchFilterWithNonHttpOrHttpsScheme() throws Exception {
+        // Given
+        URI prefixUri = new URI("ftp://example.org/", true);
+        // When
+        new HttpPrefixFetchFilter(prefixUri);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToCreateFetchFilterWithNoHost() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://", true);
+        // When
+        new HttpPrefixFetchFilter(prefixUri);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToCreateFetchFilterWithMalformedHost() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://a%0/", true);
+        // When
+        new HttpPrefixFetchFilter(prefixUri);
+        // Then = IllegalArgumentException
+    }
+
+    @Test
+    public void shouldNotAddPathToNormalisedPrefixIfPrefixDoesNotHavePath() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://example.org", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        // When
+        String normalisedPrefix = fetchFilter.getNormalisedPrefix();
+        // Then
+        assertThat(normalisedPrefix, is(equalTo("http://example.org")));
+    }
+
+    @Test
+    public void shouldDiscardUserInfoFromPrefix() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://user:pass@example.org", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        // When
+        String normalisedPrefix = fetchFilter.getNormalisedPrefix();
+        // Then
+        assertThat(normalisedPrefix, is(equalTo("http://example.org")));
+    }
+
+    @Test
+    public void shouldDiscardEverythingAfterPathComponentFromPrefix() throws Exception {
+        // Given
+        URI prefixUri = new URI("https://example.org/path?query#fragment", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        // When
+        String normalisedPrefix = fetchFilter.getNormalisedPrefix();
+        // Then
+        assertThat(normalisedPrefix, is(equalTo("https://example.org/path")));
+    }
+
+    @Test
+    public void shouldDiscardDefaultHttpPortFromPrefix() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://example.org:80/", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        // When
+        String normalisedPrefix = fetchFilter.getNormalisedPrefix();
+        // Then
+        assertThat(normalisedPrefix, is(equalTo("http://example.org/")));
+    }
+
+    @Test
+    public void shouldDiscardDefaultHttpsPortFromPrefix() throws Exception {
+        // Given
+        URI prefixUri = new URI("https://example.org:443/", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        // When
+        String normalisedPrefix = fetchFilter.getNormalisedPrefix();
+        // Then
+        assertThat(normalisedPrefix, is(equalTo("https://example.org/")));
+    }
+
+    @Test
+    public void shouldKeepNonDefaultPortFromPrefix() throws Exception {
+        // Given
+        URI prefixUri = new URI("https://example.org:8443/", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        // When
+        String normalisedPrefix = fetchFilter.getNormalisedPrefix();
+        // Then
+        assertThat(normalisedPrefix, is(equalTo("https://example.org:8443/")));
+    }
+
+    @Test
+    public void shouldKeepDefaultHttpPortInHttpsPrefix() throws Exception {
+        // Given
+        URI prefixUri = new URI("https://example.org:80/", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        // When
+        String normalisedPrefix = fetchFilter.getNormalisedPrefix();
+        // Then
+        assertThat(normalisedPrefix, is(equalTo("https://example.org:80/")));
+    }
+
+    @Test
+    public void shouldKeepDefaultHttpsPortInHttpPrefix() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://example.org:443/", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        // When
+        String normalisedPrefix = fetchFilter.getNormalisedPrefix();
+        // Then
+        assertThat(normalisedPrefix, is(equalTo("http://example.org:443/")));
+    }
+
+    @Test
+    public void shouldFilterUndefinedUriAsOutOfScope() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://example.org/", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        // When
+        FetchStatus filterStatus = fetchFilter.checkFilter(null);
+        // Then
+        assertThat(filterStatus, is(equalTo(FetchStatus.OUT_OF_SCOPE)));
+    }
+
+    @Test
+    public void shouldFilterUriWithNoSchemeAsOutOfScope() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://example.org/", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        URI uri = new URI("/path", true);
+        // When
+        FetchStatus filterStatus = fetchFilter.checkFilter(uri);
+        // Then
+        assertThat(filterStatus, is(equalTo(FetchStatus.OUT_OF_SCOPE)));
+    }
+
+    @Test
+    public void shouldFilterUriWithNonHttpOrHttpsSchemeAsOutOfScope() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://example.org/", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        URI uri = new URI("ftp://example.org/", true);
+        // When
+        FetchStatus filterStatus = fetchFilter.checkFilter(uri);
+        // Then
+        assertThat(filterStatus, is(equalTo(FetchStatus.OUT_OF_SCOPE)));
+    }
+
+    @Test
+    public void shouldFilterUriWithNoHostAsOutOfScope() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://example.org/", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        URI uri = new URI("http://", true);
+        // When
+        FetchStatus filterStatus = fetchFilter.checkFilter(uri);
+        // Then
+        assertThat(filterStatus, is(equalTo(FetchStatus.OUT_OF_SCOPE)));
+    }
+
+    @Test
+    public void shouldFilterUriWithMalformedHostAsOutOfScope() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://example.org/", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        URI uri = new URI("http://a%0/", true);
+        // When
+        FetchStatus filterStatus = fetchFilter.checkFilter(uri);
+        // Then
+        assertThat(filterStatus, is(equalTo(FetchStatus.OUT_OF_SCOPE)));
+    }
+
+    @Test
+    public void shouldFilterUriWithDifferentSchemeAsOutOfScope() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://example.org/", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        URI uri = new URI("https://example.org/", true);
+        // When
+        FetchStatus filterStatus = fetchFilter.checkFilter(uri);
+        // Then
+        assertThat(filterStatus, is(equalTo(FetchStatus.OUT_OF_SCOPE)));
+    }
+
+    @Test
+    public void shouldFilterUriWithDifferentSchemeButSamePortAsOutOfScope() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://example.org/", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        URI uri = new URI("https://example.org:80/", true);
+        // When
+        FetchStatus filterStatus = fetchFilter.checkFilter(uri);
+        // Then
+        assertThat(filterStatus, is(equalTo(FetchStatus.OUT_OF_SCOPE)));
+    }
+
+    @Test
+    public void shouldFilterUriWithDifferentPortAsOutOfScope() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://example.org/", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        URI uri = new URI("http://example.org:1234/", true);
+        // When
+        FetchStatus filterStatus = fetchFilter.checkFilter(uri);
+        // Then
+        assertThat(filterStatus, is(equalTo(FetchStatus.OUT_OF_SCOPE)));
+    }
+
+    @Test
+    public void shouldFilterUriWithDifferentHostAsOutOfScope() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://example.org/", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        URI uri = new URI("http://domain.example.org/", true);
+        // When
+        FetchStatus filterStatus = fetchFilter.checkFilter(uri);
+        // Then
+        assertThat(filterStatus, is(equalTo(FetchStatus.OUT_OF_SCOPE)));
+    }
+
+    @Test
+    public void shouldFilterUriWithDifferentSmallerPathAsOutOfScope() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://example.org/path", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        URI uri = new URI("http://example.org/p", true);
+        // When
+        FetchStatus filterStatus = fetchFilter.checkFilter(uri);
+        // Then
+        assertThat(filterStatus, is(equalTo(FetchStatus.OUT_OF_SCOPE)));
+    }
+
+    @Test
+    public void shouldFilterUriWithDifferentPathAsOutOfScope() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://example.org/path", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        URI uri = new URI("http://example.org/not/same/path", true);
+        // When
+        FetchStatus filterStatus = fetchFilter.checkFilter(uri);
+        // Then
+        assertThat(filterStatus, is(equalTo(FetchStatus.OUT_OF_SCOPE)));
+    }
+
+    @Test
+    public void shouldFilterUriWithDifferentNonEmptyPathAsOutOfScope() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://example.org/", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        URI uri = new URI("http://example.org", true);
+        // When
+        FetchStatus filterStatus = fetchFilter.checkFilter(uri);
+        // Then
+        assertThat(filterStatus, is(equalTo(FetchStatus.OUT_OF_SCOPE)));
+    }
+
+    @Test
+    public void shouldFilterUriWithSamePathPrefixAsValid() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://example.org/path", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        URI uri = new URI("http://example.org/path/subtree", true);
+        // When
+        FetchStatus filterStatus = fetchFilter.checkFilter(uri);
+        // Then
+        assertThat(filterStatus, is(equalTo(FetchStatus.VALID)));
+    }
+
+    @Test
+    public void shouldFilterUriAsValidWhenPathPrefixIsEmpty() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://example.org", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        URI uri = new URI("http://example.org/path/subtree", true);
+        // When
+        FetchStatus filterStatus = fetchFilter.checkFilter(uri);
+        // Then
+        assertThat(filterStatus, is(equalTo(FetchStatus.VALID)));
+    }
+
+    @Test
+    public void shouldFilterUriWithSamePathPrefixEvenIfHasQueryOrFragmentAsValid() throws Exception {
+        // Given
+        URI prefixUri = new URI("http://example.org/path", true);
+        HttpPrefixFetchFilter fetchFilter = new HttpPrefixFetchFilter(prefixUri);
+        URI uri = new URI("http://example.org/path/subtree/a?query#fragment", true);
+        // When
+        FetchStatus filterStatus = fetchFilter.checkFilter(uri);
+        // Then
+        assertThat(filterStatus, is(equalTo(FetchStatus.VALID)));
+    }
+
+}


### PR DESCRIPTION
Add a new option to Spider dialogue ("Spider Subtree Only") and a
parameter to spider ZAP API ("subtreeOnly") to allow to spider just a
site's subtree. In both cases it's required a URI (manually set or
previously accessed), that's used as the subtree to spider. It's only
used the scheme, host, port and path component of the URI when
considering if a resource found while spidering is under or not the
specified subtree. For example, if the seed URI is:
 http://example.com:8080/path/?a=b#c
it's used only:
 http://example.com:8080/path/

The spider will exclude any resources found not under the subtree by
using a new FetchFilter, HttpPrefixFetchFilter, that allows to filter
URIs based on a URI prefix, in this use case the subtree URI.
Add tests to assert the expected behaviour of HttpPrefixFetchFilter.
Fix #2274 - Allow to spider just a site's subtree