### PR TITLE
Restore message auto tagging

### DIFF
--- a/src/org/zaproxy/zap/extension/pscan/scanner/RegexAutoTagScanner.java
+++ b/src/org/zaproxy/zap/extension/pscan/scanner/RegexAutoTagScanner.java
@@ -311,7 +311,7 @@ public class RegexAutoTagScanner extends PluginPassiveScanner {
     }
     
 	private void matched(HttpMessage msg, int id) {
-		if (tagHistoryType(msg.getHistoryRef().getHistoryId())) {
+		if (tagHistoryType(msg.getHistoryRef().getHistoryType())) {
 			parent.addTag(id, this.getConf());
 		}
 		


### PR DESCRIPTION
Change the method RegexAutoTagScanner.matched(HttpMessage, int) to use
the type of the message instead of its ID, when checking if the type
matches the allowed types.

Reported by @kingthorin.