### PR TITLE
Check if (ZAP API) spider's seed is "in context"

### DIFF
--- a/src/org/zaproxy/zap/extension/spider/SpiderAPI.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderAPI.java
@@ -324,7 +324,7 @@ public class SpiderAPI extends ApiImplementor {
 				throw new ApiException(Type.MISSING_PARAMETER, PARAM_URL);
 			}
 			useUrl = false;
-		} else if (context != null && !context.isIncluded(url)) {
+		} else if (context != null && !context.isInContext(url)) {
 			throw new ApiException(Type.URL_NOT_IN_CONTEXT, PARAM_URL);
 		}
 


### PR DESCRIPTION
Change SpiderAPI to check if the provided seed for spidering is "in
context", that is, it's included and not explicitly excluded.
This could lead to the start of the spider with (potentially) no effect
(instead of failing the API call), since the seed would not be actually
used.