### PR TITLE
Add default implementations to AbstractPlugin

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/src/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -47,6 +47,7 @@
 // ZAP: 2015/03/26 Issue 1573: Add option to inject plugin ID in header for all ascan requests
 // ZAP: 2015/07/26 Issue 1618: Target Technology Not Honored
 // ZAP: 2015/08/19 Issue 1785: Plugin enabled even if dependencies are not, "hangs" active scan
+// ZAP: 2016/03/22 Implement init() and getDependency() by default, most plugins do not use them
 
 package org.parosproxy.paros.core.scanner;
 
@@ -74,6 +75,8 @@ import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 
 public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
+
+    private static final String[] NO_DEPENDENCIES = {};
 
     /**
      * Default pattern used in pattern check for most plugins.
@@ -123,8 +126,16 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
         return result;
     }
 
+    /**
+     * Returns no dependencies by default.
+     * 
+     * @since TODO add version
+     * @return an empty array (that is, no dependencies)
+     */
     @Override
-    public abstract String[] getDependency();
+    public String[] getDependency() {
+        return NO_DEPENDENCIES;
+    }
 
     @Override
     public abstract String getDescription();
@@ -148,7 +159,17 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
         init();
     }
 
-    public abstract void init();
+    /**
+     * Finishes the initialisation of the plugin, subclasses should add any initialisation logic/code to this method.
+     * <p>
+     * Called after the plugin has been initialised with the message being scanned. By default it does nothing.
+     * <p>
+     * Since TODO add version it is no longer abstract.
+     * 
+     * @see #init(HttpMessage, HostProcess)
+     */
+    public void init() {
+    }
 
     /**
      * Obtain a new HttpMessage with the same request as the base. The response

--- a/test/org/parosproxy/paros/core/scanner/AbstractPluginUnitTest.java
+++ b/test/org/parosproxy/paros/core/scanner/AbstractPluginUnitTest.java
@@ -21,6 +21,7 @@ package org.parosproxy.paros.core.scanner;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.emptyArray;
 import static org.junit.Assert.assertThat;
 
 import org.apache.commons.configuration.Configuration;
@@ -60,6 +61,14 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
         AbstractPlugin plugin = createAbstractPlugin();
         // Then
         assertThat(plugin.getCodeName(), is(equalTo("PluginTestUtils$TestPlugin")));
+    }
+
+    @Test
+    public void shouldNotHaveDependenciesByDefault() {
+        // Given / When
+        AbstractPlugin plugin = createAbstractPlugin();
+        // Then
+        assertThat(plugin.getDependency(), is(emptyArray()));
     }
 
     @Test

--- a/test/org/parosproxy/paros/core/scanner/PluginTestUtils.java
+++ b/test/org/parosproxy/paros/core/scanner/PluginTestUtils.java
@@ -100,11 +100,6 @@ public class PluginTestUtils {
         }
 
         @Override
-        public String[] getDependency() {
-            return null;
-        }
-
-        @Override
         public String getDescription() {
             return null;
         }
@@ -122,10 +117,6 @@ public class PluginTestUtils {
         @Override
         public String getReference() {
             return null;
-        }
-
-        @Override
-        public void init() {
         }
 
         @Override


### PR DESCRIPTION
Change class AbstractPlugin to add (default) implementations to methods
init() (changed from abstract) and getDependency(), implementation of a
method from Plugin interface. The init() method does nothing by default
and the method getDependency() returns an empty array, that is, no
dependencies.

The methods init() and getDependency() are not usually needed by the
scanners which leads to forced implementation of empty methods. Given
that most of the scanners do not need to override those methods the base
class should implement them, reducing boilerplate code overall.