### PR TITLE
Allow to remove context factories from View/Model

### DIFF
--- a/src/org/parosproxy/paros/extension/ViewDelegate.java
+++ b/src/org/parosproxy/paros/extension/ViewDelegate.java
@@ -23,6 +23,7 @@
 // ZAP: 2012/07/23 Added method getSessionDialog() to expose functionality.
 // ZAP: 2012/10/02 Issue 385: Added support for Contexts
 // ZAP: 2013/05/02 Removed redundant public modifiers from interface method declarations
+// ZAP: 2016/03/22 Allow to remove ContextPanelFactory
 
 package org.parosproxy.paros.extension;
 
@@ -65,6 +66,26 @@ public interface ViewDelegate {
     
     HttpPanelResponse getResponsePanel();
     
-    void addContextPanelFactory (ContextPanelFactory cpf);
+    /**
+     * Adds the given context panel factory to the view delegate.
+     * <p>
+     * The factory will be called whenever a panel is required for a context and notified when a context (or contexts) are no
+     * longer needed.
+     *
+     * @param contextPanelFactory the context panel factory that should be added
+     * @throws IllegalArgumentException if the context panel factory is {@code null}.
+     * @see #removeContextPanelFactory(ContextPanelFactory)
+     */
+    void addContextPanelFactory (ContextPanelFactory contextPanelFactory);
     
+    /**
+     * Removes the given context panel factory from the view delegate, and any previously created panels for the contexts.
+     *
+     * @param contextPanelFactory the context panel factory that should be removed
+     * @throws IllegalArgumentException if the context panel factory is {@code null}.
+     * @since TODO add version
+     * @see #addContextPanelFactory(ContextPanelFactory)
+     */
+    void removeContextPanelFactory(ContextPanelFactory contextPanelFactory);
+
 }

--- a/src/org/parosproxy/paros/model/Model.java
+++ b/src/org/parosproxy/paros/model/Model.java
@@ -36,6 +36,7 @@
 // ZAP: 2015/02/09 Issue 1525: Introduce a database interface layer to allow for alternative implementations
 // ZAP: 2015/04/02 Issue 321: Support multiple databases
 // ZAP: 2016/02/10 Issue 1958: Allow to disable database (HSQLDB) log
+// ZAP: 2016/03/22 Allow to remove ContextDataFactory
 // ZAP: 2016/03/23 Issue 2331: Custom Context Panels not show in existing contexts after installation of add-on
 
 package org.parosproxy.paros.model;
@@ -441,14 +442,39 @@ public class Model {
 		this.sessionListeners.add(listener);
 	}
 
-	public void addContextDataFactory(ContextDataFactory cdf) {
-		this.contextDataFactories.add(cdf);
+	/**
+	 * Adds the given context data factory to the model.
+	 *
+	 * @param contextDataFactory the context data factory that will be added.
+	 * @throws IllegalArgumentException if the given parameter is {@code null}.
+	 * @see #removeContextDataFactory(ContextDataFactory)
+	 */
+	public void addContextDataFactory(ContextDataFactory contextDataFactory) {
+		if (contextDataFactory == null) {
+			throw new IllegalArgumentException("Parameter contextDataFactory must not be null.");
+		}
+		this.contextDataFactories.add(contextDataFactory);
 
 		if (postInitialisation) {
 			for (Context context : getSession().getContexts()) {
-				cdf.loadContextData(getSession(), context);
+				contextDataFactory.loadContextData(getSession(), context);
 			}
 		}
+	}
+
+	/**
+	 * Removes the given context data factory from the model.
+	 *
+	 * @param contextDataFactory the context data factory that will be removed.
+	 * @throws IllegalArgumentException if the given parameter is {@code null}.
+	 * @since TODO add version
+	 * @see #addContextDataFactory(ContextDataFactory)
+	 */
+	public void removeContextDataFactory(ContextDataFactory contextDataFactory) {
+		if (contextDataFactory == null) {
+			throw new IllegalArgumentException("Parameter contextDataFactory must not be null.");
+		}
+		contextDataFactories.remove(contextDataFactory);
 	}
 
 	public void loadContext(Context ctx) {


### PR DESCRIPTION
Allow to remove ContextDataFactory from Model and ContextFactoryPanel
from View. The change is necessary for proper unloading of add-ons.

Change class Model to allow to remove ContextDataFactory, using the
method removeContextDataFactory(ContextDataFactory).
Change interface ViewDelegate to allow to remove a ContextPanelFactory,
using the method removeContextPanelFactory(ContextPanelFactory).
Change class View to implement the method, along with other required
changes.
Add JavaDoc, rename parameter and add non-null validation of parameter
to corresponding "add" methods.