### PR TITLE
Use Context factories when installed

### DIFF
--- a/src/org/parosproxy/paros/control/Control.java
+++ b/src/org/parosproxy/paros/control/Control.java
@@ -57,6 +57,7 @@
 // ZAP: 2015/04/02 Issue 321: Support multiple databases and Issue 1582: Low memory option
 // ZAP: 2015/09/17 Issue 1914: Support multiple add-on directories
 // ZAP: 2015/11/04 Issue 1920: Report the host:port ZAP is listening on in daemon mode, or exit if it cant
+// ZAP: 2016/03/23 Issue 2331: Custom Context Panels not show in existing contexts after installation of add-on
 
 package org.parosproxy.paros.control;
 
@@ -123,6 +124,7 @@ public class Control extends AbstractControl implements SessionListener {
 		    getExtensionLoader().hookSiteMapListener(view.getSiteTreePanel());
 		}
 		
+		model.postInit();
 		return proxy.startServer();
     }
 

--- a/src/org/parosproxy/paros/model/Model.java
+++ b/src/org/parosproxy/paros/model/Model.java
@@ -36,6 +36,7 @@
 // ZAP: 2015/02/09 Issue 1525: Introduce a database interface layer to allow for alternative implementations
 // ZAP: 2015/04/02 Issue 321: Support multiple databases
 // ZAP: 2016/02/10 Issue 1958: Allow to disable database (HSQLDB) log
+// ZAP: 2016/03/23 Issue 2331: Custom Context Panels not show in existing contexts after installation of add-on
 
 package org.parosproxy.paros.model;
 
@@ -76,6 +77,8 @@ public class Model {
 	private Logger logger = Logger.getLogger(Model.class);
 	private List<SessionListener> sessionListeners = new ArrayList<>();
 	private List<ContextDataFactory> contextDataFactories = new ArrayList<>();
+
+	private boolean postInitialisation;
 
 	public Model() {
 		// make sure the variable here will not refer back to model itself.
@@ -440,6 +443,12 @@ public class Model {
 
 	public void addContextDataFactory(ContextDataFactory cdf) {
 		this.contextDataFactories.add(cdf);
+
+		if (postInitialisation) {
+			for (Context context : getSession().getContexts()) {
+				cdf.loadContextData(getSession(), context);
+			}
+		}
 	}
 
 	public void loadContext(Context ctx) {
@@ -475,6 +484,17 @@ public class Model {
 		for (ContextDataFactory cdf : this.contextDataFactories) {
 			cdf.exportContextData(ctx, config);
 		}
+	}
+
+	/**
+	 * Notifies the model that the initialisation has been done.
+	 * <p>
+	 * <strong>Note:</strong> Should be called only by "core" code after the initialisation.
+	 * 
+	 * @since TODO add version
+	 */
+	public void postInit() {
+		postInitialisation = true;
 	}
 
 }


### PR DESCRIPTION
Use existing custom context data when adding a ContextDataFactory and
add custom context panels when adding ContextFactoryPanel, after full
initialisation (for example, when an add-on is installed), so that
existing Contexts show the correct data and custom panels.

Change class Control to notify the class Model once the initialisation
is done, by calling the (new) instance method Model.postInit().
Change class Model to call the method loadContextData(Session, Context)
on the added ContextDataFactory for all existing contexts, if it's being
added after the initialisation so that any existing custom context data
that's in the session is used/loaded, otherwise the data would be
missing when re-installing/updating an add-on.
Change class View to add the panels to all existing contexts after
initialisation, when a ContextPanelFactory is added to the view. Also,
some other refactorings were made:
 - Extract a method that obtains the ContextGeneralPanel of a context,
 used to create the path of the panels added;
 - Extract a method that adds the panels from a ContextPanelFactory for
 a context;
 - Reuse the same panel path (and contexts node name) when adding panels
 to an added Context, in method addContext(Context).

Fix #2331 - Custom Context Panels not show in existing contexts after
installation of add-on