### PR TITLE
Do not access the EDT in daemon mode

### DIFF
--- a/src/org/parosproxy/paros/model/SiteNode.java
+++ b/src/org/parosproxy/paros/model/SiteNode.java
@@ -46,6 +46,7 @@
 // ZAP: 2015/04/02 Issue 1582: Low memory option
 // ZAP: 2015/10/21 Issue 1576: Support data driven content
 // ZAP: 2016/01/26 Fixed findbugs warning
+// ZAP: 2016/03/24 Do not access EDT in daemon mode
 
 package org.parosproxy.paros.model;
 
@@ -61,6 +62,7 @@ import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.model.SessionStructure;
 
 public class SiteNode extends DefaultMutableTreeNode {
@@ -291,7 +293,7 @@ public class SiteNode extends DefaultMutableTreeNode {
     }    
     
     private void nodeChanged() {
-    	if (this.siteMap == null) {
+    	if (this.siteMap == null || !View.isInitialised()) {
     		return;
     	}
         if (EventQueue.isDispatchThread()) {

--- a/src/org/zaproxy/zap/extension/spider/SpiderThread.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderThread.java
@@ -33,6 +33,7 @@ import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.ScanListenner;
 import org.zaproxy.zap.model.ScanThread;
@@ -394,16 +395,31 @@ public class SpiderThread extends ScanThread implements SpiderListener {
 			final HistoryReference historyRef = new HistoryReference(extension.getModel().getSession(),
 					HistoryReference.TYPE_SPIDER, msg);
 
-			EventQueue.invokeLater(new Runnable() {
-                @Override
-                public void run() {
-        			SessionStructure.addPath(Model.getSingleton().getSession(), historyRef, msg);
-                }
-            });
-			
+			addMessageToSitesTree(historyRef, msg);
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		}
+	}
+
+	/**
+	 * Adds the given message to the sites tree.
+	 *
+	 * @param historyReference the history reference of the message, must not be {@code null}
+	 * @param message the actual message, must not be {@code null}
+	 */
+	private static void addMessageToSitesTree(final HistoryReference historyReference, final HttpMessage message) {
+		if (View.isInitialised() && !EventQueue.isDispatchThread()) {
+			EventQueue.invokeLater(new Runnable() {
+
+				@Override
+				public void run() {
+					addMessageToSitesTree(historyReference, message);
+				}
+			});
+			return;
+		}
+
+		SessionStructure.addPath(Model.getSingleton().getSession(), historyReference, message);
 	}
 
 	@Override


### PR DESCRIPTION
Change class SpiderThread to not add the messages found wile spidering
to the sites tree through the EDT and change class SiteNode to skip the
notification of changes if there's no view to notify to (that is, when
running in daemon mode), preventing the EDT accesses.