### PR TITLE
Fix concurrent modification in spider API

### DIFF
--- a/src/org/zaproxy/zap/extension/spider/SpiderAPI.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderAPI.java
@@ -423,7 +423,7 @@ public class SpiderAPI extends ApiImplementor {
 			ApiResponseList resultUrls = new ApiResponseList(name);
 			SpiderScan scan = (SpiderScan) this.getSpiderScan(params);
 			ApiResponseList resultList = new ApiResponseList("urlsInScope");
-			synchronized (scan.getResults()) {
+			synchronized (scan.getResourcesFound()) {
 				for (SpiderResource sr : scan.getResourcesFound()) {
 					Map<String, String> map = new HashMap<>();
 					map.put("messageId", Integer.toString(sr.getHistoryId()));


### PR DESCRIPTION
Correct the object used in the synchronized block, by using
SpiderScan.getResourcesFound() instead of getResults(), when iterating
the resources found by the spider, to fix (a possible)
ConcurrentModificationException.