### PR TITLE
Correct highlight offset calc in request header

### DIFF
--- a/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/split/request/HttpRequestHeaderPanelSyntaxHighlightTextView.java
+++ b/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/split/request/HttpRequestHeaderPanelSyntaxHighlightTextView.java
@@ -177,9 +177,11 @@ public class HttpRequestHeaderPanelSyntaxHighlightTextView extends HttpPanelSynt
                 return null;
             }
 
-            while ((pos = header.indexOf("\r\n", pos)) != -1 && pos < textLocation.getEnd()) {
-                pos += 2;
-                ++excessChars;
+            if (pos != -1) {
+                while ((pos = header.indexOf("\r\n", pos)) != -1 && pos < textLocation.getEnd()) {
+                    pos += 2;
+                    ++excessChars;
+                }
             }
 
             int finalEndPos = textLocation.getEnd() - excessChars;


### PR DESCRIPTION
Change the class HttpRequestHeaderPanelSyntaxHighlightTextArea to skip
highlight's end offset calculation if the end of the request header was
already reached (thus same offset applies to begin and end positions).
Fix #2336 - BadLocationException thrown when using Fuzzer