### PR TITLE
Fix issues related to break buttons

### DIFF
--- a/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
+++ b/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
@@ -610,17 +610,29 @@ public class ExtensionBreak extends ExtensionAdaptor implements SessionChangedLi
 
 	@Override
 	public void optionsChanged(OptionsParam optionsParam) {
-		if (View.isInitialised()) {
-			this.getBreakPanel().setButtonMode(
-					optionsParam.getParamSet(BreakpointsParam.class).getButtonMode());
+		applyViewOptions(optionsParam);
+	}
+
+	/**
+	 * Applies the given (view) options to the break components, by setting the location of the break buttons and the break
+	 * buttons mode.
+	 * <p>
+	 * The call to this method has no effect if there's no view.
+	 *
+	 * @param options the current options
+	 */
+	private void applyViewOptions(OptionsParam options) {
+		if (getView() == null) {
+			return;
 		}
+
+		getBreakPanel().setButtonsLocation(options.getViewParam().getBrkPanelViewOption());
+		getBreakPanel().setButtonMode(options.getParamSet(BreakpointsParam.class).getButtonMode());
 	}
 
 	@Override
 	public void optionsLoaded() {
-		if (View.isInitialised()) {
-			this.getBreakPanel().setButtonMode(this.getOptionsParam().getButtonMode());
-		}
+		applyViewOptions(getModel().getOptionsParam());
 	}
 	
 	public boolean isInScopeOnly() {


### PR DESCRIPTION
Change the location of the break buttons without restarting ZAP and fix
break buttons inconsistencies.

Change class ExtensionBreak to set the location of the break buttons
when the options are loaded and when changed, through a (new) helper
method applyViewOptions(OptionsParam).
Change class BreakPanel to show/hide the tool bars/buttons depending on
the option set, also show corresponding break buttons in all tool bars
(using helper class BreakButtonsUI).

Fix #2366 - Inconsistencies in break buttons shown
Fix #2367 - Change break buttons location without restarting ZAP