### PR TITLE
Implemented deletion of nodes via API. Fixes #2342

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -854,6 +854,7 @@ context.api.action.excludeAllContextTechnologies = Excludes all built in technol
 copy.copy.popup = Copy
 copy.desc       = Provides a right click option to copy highlighted text to the clipboard
 
+core.api.action.deleteSiteNode = Deletes the site node found in the Sites Tree on the basis of the URL, HTTP method, and post data (if applicable and specified). 
 core.api.action.loadSession = Loads the session with the given name. If a relative path is specified it will be resolved against the "session" directory in ZAP "home" dir.
 core.api.action.newSession = Creates a new session, optionally overwriting existing files. If a relative path is specified it will be resolved against the "session" directory in ZAP "home" dir.
 core.api.action.saveSession = Saves the session with the name supplied, optionally overwriting existing files. If a relative path is specified it will be resolved against the "session" directory in ZAP "home" dir.

--- a/src/org/parosproxy/paros/model/SiteMap.java
+++ b/src/org/parosproxy/paros/model/SiteMap.java
@@ -47,6 +47,7 @@
 // ZAP: 2015/10/21 Issue 1576: Support data driven content
 // ZAP: 2015/11/05 Change findNode(..) methods to match top level nodes
 // ZAP: 2015/11/09 Fix NullPointerException when creating a HistoryReference with a request URI without path
+// ZAP: 2016/04/21 Issue 2342: Checks non-empty method for deletion of SiteNodes via API 
 
 package org.parosproxy.paros.model;
 
@@ -546,7 +547,7 @@ public class SiteMap extends DefaultTreeModel {
     private String getLeafName(String nodeName, URI uri, String method, String postData) {
         String leafName;
         
-        if (method != null) {
+        if (method != null && !method.isEmpty()) {
         	leafName = method + ":" + nodeName;
         } else {
         	leafName = nodeName;

--- a/src/org/zaproxy/clientapi/gen/Core.java
+++ b/src/org/zaproxy/clientapi/gen/Core.java
@@ -532,6 +532,21 @@ public class Core {
 		return api.callApi("core", "action", "setOptionUseProxyChainAuth", map);
 	}
 
+	public ApiResponse deleteSiteNode(String apikey, String url, String method, String postData) throws ClientApiException {
+		Map<String, String> map = new HashMap<String, String>();
+		if (apikey != null) {
+			map.put("apikey", apikey);
+		}
+		map.put("url", url);
+		if (method != null) {
+			map.put("method", method);
+		}
+		if (postData != null) {
+			map.put("postData", postData);
+		}
+		return api.callApi("core", "action", "deleteSiteNode", map);
+	}
+
 	public byte[] proxypac(String apikey) throws ClientApiException {
 		Map<String, String> map = null;
 		map = new HashMap<String, String>();


### PR DESCRIPTION
This patch will fix the issue #2342 . The user will now be able to delete the Site Nodes of the scanned site via the API too and not just the GUI. The functionality for now is just similar to the GUI that is if a parent is chosen then all of its children are deleted as well without the choice of leaving the children and just deleting the parent. The user can also specify the method as a parameter.

Would like your reviews @thc202 , @kingthorin , @psiinon  :)