### PR TITLE
Use StatusUI in scanners' dialogues

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/PolicyAllCategoryPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/PolicyAllCategoryPanel.java
@@ -21,6 +21,7 @@
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
 // ZAP: 2013/11/28 Issue 923: Allow individual rule thresholds and strengths to be set via GUI
 // ZAP: 2016/01/19 Allow to obtain the ScanPolicy
+// ZAP: 2016/04/04 Use StatusUI in scanners' dialogues
 package org.zaproxy.zap.extension.ascan;
 
 import java.awt.GridBagConstraints;
@@ -53,6 +54,8 @@ import org.parosproxy.paros.core.scanner.Plugin;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
 import org.parosproxy.paros.view.AbstractParamPanel;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.LayoutHelper;
@@ -288,23 +291,49 @@ public class PolicyAllCategoryPanel extends AbstractParamPanel {
 
     private JComboBox<String> getApplyToThresholdTarget() {
         if (applyToThresholdTarget == null) {
-            applyToThresholdTarget = new JComboBox<>();
-            applyToThresholdTarget.addItem(Constant.messages.getString("ascan.policy.table.quality.all"));
-            applyToThresholdTarget.addItem(Constant.messages.getString("ascan.policy.table.quality.release"));
-            applyToThresholdTarget.addItem(Constant.messages.getString("ascan.policy.table.quality.beta"));
-            applyToThresholdTarget.addItem(Constant.messages.getString("ascan.policy.table.quality.alpha"));
+            applyToThresholdTarget = createStatusComboBox();
         }
         return applyToThresholdTarget;
     }
     
+    /**
+     * Creates a {@code JComboBox} with scanners' statuses, "all", release, beta and alpha.
+     *
+     * @return a {@code JComboBox} with scanners' statuses
+     */
+    private JComboBox<String> createStatusComboBox() {
+        JComboBox<String> comboBox = new JComboBox<>();
+        comboBox.addItem(Constant.messages.getString("ascan.policy.table.quality.all"));
+        View view = View.getSingleton();
+        comboBox.addItem(view.getStatusUI(AddOn.Status.release).toString());
+        comboBox.addItem(view.getStatusUI(AddOn.Status.beta).toString());
+        comboBox.addItem(view.getStatusUI(AddOn.Status.alpha).toString());
+        return comboBox;
+    }
+
     private void applyThreshold(AlertThreshold threshold, String target) {
     	for (Plugin plugin : policy.getPluginFactory().getAllPlugin()) {
-    		if (target.equals(Constant.messages.getString("ascan.policy.table.quality.all"))) {
-    			plugin.setAlertThreshold(threshold);
-    		} else if (target.equals(Constant.messages.getString("ascan.policy.table.quality." + plugin.getStatus().name()))) {
+    		if (hasSameStatus(plugin, target)) {
     			plugin.setAlertThreshold(threshold);
     		}
     	}
+    }
+
+    /**
+     * Tells whether or not the given {@code scanner} has the given {@code status}.
+     * <p>
+     * If the given {@code status} represents all statuses it returns always {@code true}.
+     *
+     * @param scanner the scanner that will be checked
+     * @param status the status to check
+     * @return {@code true} if it has the same status, {@code false} otherwise.
+     * @see Plugin#getStatus()
+     */
+    private boolean hasSameStatus(Plugin scanner, String status) {
+        if (status.equals(Constant.messages.getString("ascan.policy.table.quality.all"))) {
+            return true;
+        }
+        return status.equals(View.getSingleton().getStatusUI(scanner.getStatus()).toString());
     }
 
     private AttackStrength strToStrength(String str) {
@@ -337,20 +366,14 @@ public class PolicyAllCategoryPanel extends AbstractParamPanel {
 
     private JComboBox<String> getApplyToStrengthTarget() {
         if (applyToStrengthTarget == null) {
-            applyToStrengthTarget = new JComboBox<>();
-            applyToStrengthTarget.addItem(Constant.messages.getString("ascan.policy.table.quality.all"));
-            applyToStrengthTarget.addItem(Constant.messages.getString("ascan.policy.table.quality.release"));
-            applyToStrengthTarget.addItem(Constant.messages.getString("ascan.policy.table.quality.beta"));
-            applyToStrengthTarget.addItem(Constant.messages.getString("ascan.policy.table.quality.alpha"));
+            applyToStrengthTarget = createStatusComboBox();
         }
         return applyToStrengthTarget;
     }
     
     private void applyStrength(AttackStrength strength, String target) {
     	for (Plugin plugin : policy.getPluginFactory().getAllPlugin()) {
-    		if (target.equals(Constant.messages.getString("ascan.policy.table.quality.all"))) {
-    			plugin.setAttackStrength(strength);
-    		} else if (target.equals(Constant.messages.getString("ascan.policy.table.quality." + plugin.getStatus().name()))) {
+    		if (hasSameStatus(plugin, target)) {
     			plugin.setAttackStrength(strength);
     		}
     	}

--- a/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanPanel.java
+++ b/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanPanel.java
@@ -42,6 +42,8 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.view.AbstractParamPanel;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.LayoutHelper;
 
@@ -121,9 +123,10 @@ public class PolicyPassiveScanPanel extends AbstractParamPanel {
         if (applyToThresholdTarget == null) {
             applyToThresholdTarget = new JComboBox<>();
             applyToThresholdTarget.addItem(Constant.messages.getString("ascan.policy.table.quality.all"));
-            applyToThresholdTarget.addItem(Constant.messages.getString("ascan.policy.table.quality.release"));
-            applyToThresholdTarget.addItem(Constant.messages.getString("ascan.policy.table.quality.beta"));
-            applyToThresholdTarget.addItem(Constant.messages.getString("ascan.policy.table.quality.alpha"));
+            View view = View.getSingleton();
+            applyToThresholdTarget.addItem(view.getStatusUI(AddOn.Status.release).toString());
+            applyToThresholdTarget.addItem(view.getStatusUI(AddOn.Status.beta).toString());
+            applyToThresholdTarget.addItem(view.getStatusUI(AddOn.Status.alpha).toString());
         }
         return applyToThresholdTarget;
     }

--- a/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanTableModel.java
+++ b/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanTableModel.java
@@ -28,6 +28,8 @@ import javax.swing.table.DefaultTableModel;
 
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.view.StatusUI;
 
 public class PolicyPassiveScanTableModel extends DefaultTableModel {
 
@@ -37,6 +39,8 @@ public class PolicyPassiveScanTableModel extends DefaultTableModel {
         Constant.messages.getString("ascan.policy.table.testname"),
         Constant.messages.getString("ascan.policy.table.threshold"),
         Constant.messages.getString("ascan.policy.table.quality")};
+
+    private static final int QUALITY_COLUMN_IDX = 2;
 
     private List<ScannerWrapper> listScanners = new ArrayList<>();
     private Map<String, String> i18nToStr = null;
@@ -52,7 +56,7 @@ public class PolicyPassiveScanTableModel extends DefaultTableModel {
      * @param scanner 
      */
     public void addScanner(PluginPassiveScanner scanner) {
-        listScanners.add(new ScannerWrapper(scanner));   
+        listScanners.add(new ScannerWrapper(scanner, View.getSingleton().getStatusUI(scanner.getStatus())));
         fireTableDataChanged();
         
     }
@@ -76,7 +80,7 @@ public class PolicyPassiveScanTableModel extends DefaultTableModel {
     
     public void applyThreshold(AlertThreshold threshold, String quality) {
     	for (ScannerWrapper ss : this.listScanners) {
-    		if (quality.equals(ss.getQuality())) {
+    		if (quality.equals(ss.getQuality().toString())) {
     			ss.setThreshold(threshold);
     		}
     	}
@@ -110,6 +114,9 @@ public class PolicyPassiveScanTableModel extends DefaultTableModel {
      */
     @Override
     public Class<?> getColumnClass(int c) {
+        if (c == QUALITY_COLUMN_IDX) {
+            return StatusUI.class;
+        }
         return String.class;
 
     }
@@ -203,7 +210,7 @@ public class PolicyPassiveScanTableModel extends DefaultTableModel {
                 result = strToI18n(test.getThreshold().name());
                 break;
                 
-            case 2: // Quality Column
+            case QUALITY_COLUMN_IDX:
                 result = test.getQuality();
                 break;  
             
@@ -220,10 +227,12 @@ public class PolicyPassiveScanTableModel extends DefaultTableModel {
      */
     private static class ScannerWrapper {
     	private final PluginPassiveScanner scanner;
+    	private final StatusUI quality;
     	private AlertThreshold threshold;
 
-    	public ScannerWrapper(PluginPassiveScanner scanner) {
+    	public ScannerWrapper(PluginPassiveScanner scanner, StatusUI quality) {
     		this.scanner = scanner;
+    		this.quality = quality;
     		reset();
     	}
     	
@@ -253,8 +262,8 @@ public class PolicyPassiveScanTableModel extends DefaultTableModel {
 			this.threshold = threshold;
 		}
 
-		public String getQuality() {
-			return Constant.messages.getString("ascan.policy.table.quality."+ scanner.getStatus().name());
+		public StatusUI getQuality() {
+			return quality;
 		}
     }
 }


### PR DESCRIPTION
Change all dialogues that show the Quality of the active and passive
scanners to use StatusUI, for proper sorting of the values of the
Quality column.

Change class CategoryTableModel to use StatusUI for its Quality column
and change to use a List/ArrayList instead of a Vector to keep the table
entries, synchronisation provided by Vector class is not required.
Change class PolicyAllCategoryPanel to use StatusUI's string
representation in the quality combo boxes and extracted helper methods
to reduce code duplication.
Change class PolicyPassiveScanPanel to use StatusUI's string
representation in the quality combo box.
Change PolicyPassiveScanTableModel to use StatusUI for its Quality
column.