### PR TITLE
Do not require a restart to show/hide the tool bar

### DIFF
--- a/src/org/parosproxy/paros/control/MenuToolsControl.java
+++ b/src/org/parosproxy/paros/control/MenuToolsControl.java
@@ -22,6 +22,7 @@
 //      options have changed.
 // ZAP: 2013/01/23 Clean up of exception handling/logging.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
+// ZAP: 2016/04/04 Do not require a restart to show/hide the tool bar
 package org.parosproxy.paros.control;
 
 import javax.swing.JOptionPane;
@@ -78,6 +79,8 @@ public class MenuToolsControl {
 		    // ZAP: Notify all OptionsChangedListener.
 		    control.getExtensionLoader().optionsChangedAllPlugin(model.getOptionsParam());
 		    
+		    view.setMainToolbarVisible(model.getOptionsParam().getViewParam().isShowMainToolbar());
+
 		    control.getProxy().stopServer();
 		    control.getProxy().startServer();
 		}

--- a/src/org/parosproxy/paros/extension/option/OptionsParamView.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsParamView.java
@@ -30,6 +30,7 @@
 // ZAP: 2014/10/09 Issue 1359: Options for splash screen
 // ZAP: 2014/12/16 Issue 1466: Config option for 'large display' size
 // ZAP: 2015/03/04 Added dev build warning option
+// ZAP: 2016/04/04 Do not require a restart to show/hide the tool bar
 
 package org.parosproxy.paros.extension.option;
 
@@ -149,13 +150,43 @@ public class OptionsParamView extends AbstractParam {
 		return !(processImages == 0);
 	}
 	
+	/**
+	 * @deprecated (TODO add version) Use {@link #isShowMainToolbar()} instead. It will be removed in a future release.
+	 */
+	@Deprecated
+	@SuppressWarnings("javadoc")
 	public int getShowMainToolbar() {
 		return showMainToolbar;
 	}
 	
+	/**
+	 * Tells whether or not the main tool bar should be shown.
+	 *
+	 * @return {@code true} if the main tool bar should be shown, {@code false} otherwise.
+	 * @since TODO add version
+	 */
+	public boolean isShowMainToolbar() {
+		return showMainToolbar != 0;
+	}
+
+	/**
+	 * @deprecated (TODO add version) Use {@link #setShowMainToolbar(boolean)} instead. It will be removed in a future release.
+	 */
+	@Deprecated
+	@SuppressWarnings("javadoc")
 	public void setShowMainToolbar(int showMainToolbar) {
-		this.showMainToolbar = showMainToolbar;
-		getConfig().setProperty(SHOW_MAIN_TOOLBAR_OPTION, Integer.toString(showMainToolbar));
+		setShowMainToolbar(showMainToolbar != 0);
+	}
+
+	/**
+	 * Sets whether or not the main tool bar should be shown.
+	 *
+	 * @param show {@code true} if the main tool bar should be shown, {@code false} otherwise.
+	 * @since TODO add version
+	 */
+	public void setShowMainToolbar(boolean show) {
+		this.showMainToolbar = show ? 1 : 0;
+		getConfig().setProperty(SHOW_MAIN_TOOLBAR_OPTION, showMainToolbar);
 	}
 
 	

--- a/src/org/parosproxy/paros/extension/option/OptionsViewPanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsViewPanel.java
@@ -25,6 +25,7 @@
 // ZAP: 2014/04/25 Issue 642: Add timestamps to Output tab(s)
 // ZAP: 2014/10/09 Issue 1359: Options for splash screen
 // ZAP: 2014/12/16 Issue 1466: Config option for 'large display' size
+// ZAP: 2016/04/04 Do not require a restart to show/hide the tool bar
 
 package org.parosproxy.paros.extension.option;
 
@@ -490,7 +491,7 @@ public class OptionsViewPanel extends AbstractParamPanel {
 	    getChkProcessImages().setSelected(options.getViewParam().getProcessImages() > 0);
 	    displaySelect.setSelectedIndex(options.getViewParam().getDisplayOption());
 	    brkPanelViewSelect.setSelectedIndex(options.getViewParam().getBrkPanelViewOption());
-	    getChkShowMainToolbar().setSelected(options.getViewParam().getShowMainToolbar() > 0);
+	    getChkShowMainToolbar().setSelected(options.getViewParam().isShowMainToolbar());
 	    chkAdvancedView.setSelected(options.getViewParam().getAdvancedViewOption() > 0);
 	    chkAskOnExit.setSelected(options.getViewParam().getAskOnExitOption() > 0);
 	    chkWmUiHandling.setSelected(options.getViewParam().getWmUiHandlingOption() > 0);
@@ -516,7 +517,7 @@ public class OptionsViewPanel extends AbstractParamPanel {
 	    options.getViewParam().setProcessImages((getChkProcessImages().isSelected()) ? 1 : 0);
 	    options.getViewParam().setDisplayOption(displaySelect.getSelectedIndex());
 	    options.getViewParam().setBrkPanelViewOption(brkPanelViewSelect.getSelectedIndex());
-	    options.getViewParam().setShowMainToolbar((getChkShowMainToolbar().isSelected()) ? 1 : 0);
+	    options.getViewParam().setShowMainToolbar(getChkShowMainToolbar().isSelected());
 	    options.getViewParam().setAdvancedViewOption(getChkAdvancedView().isSelected() ? 1 : 0);
 	    options.getViewParam().setAskOnExitOption(getChkAskOnExit().isSelected() ? 1 : 0);
 	    options.getViewParam().setWmUiHandlingOption(getChkWmUiHandling().isSelected() ? 1 : 0);

--- a/src/org/parosproxy/paros/view/MainFrame.java
+++ b/src/org/parosproxy/paros/view/MainFrame.java
@@ -25,6 +25,7 @@
 // "txtStatus".
 // ZAP: 2013/07/23 Issue 738: Options to hide tabs
 // ZAP: 2015/01/29 Issue 1489: Version number in window title
+// ZAP: 2016/04/04 Do not require a restart to show/hide the tool bar
 
 package org.parosproxy.paros.view;
 
@@ -99,9 +100,7 @@ public class MainFrame extends AbstractFrame {
 			paneContent.setLayout(new BoxLayout(getPaneContent(), BoxLayout.Y_AXIS));
 			paneContent.setEnabled(true);
 
-			if (Model.getSingleton().getOptionsParam().getViewParam().getShowMainToolbar() == 1) {
-				paneContent.add(getMainToolbarPanel(), null);
-			}
+			paneContent.add(getMainToolbarPanel(), null);
 
 			paneContent.add(getPaneDisplay(), null);
 			paneContent.add(getMainFooterPanel(), null);
@@ -198,5 +197,15 @@ public class MainFrame extends AbstractFrame {
 		}
 		strBuilder.append(Constant.PROGRAM_NAME).append(' ').append(Constant.PROGRAM_VERSION);
 		super.setTitle(strBuilder.toString());
+	}
+
+	/**
+	 * Sets whether or not the main tool bar should be visible.
+	 *
+	 * @param visible {@code true} if the main tool bar should be visible, {@code false} otherwise.
+	 * @since TODO add version
+	 */
+	public void setMainToolbarVisible(boolean visible) {
+		getMainToolbarPanel().setVisible(visible);
 	}
 }

--- a/src/org/parosproxy/paros/view/View.java
+++ b/src/org/parosproxy/paros/view/View.java
@@ -66,6 +66,7 @@
 // ZAP: 2016/03/16 Add StatusUI handling
 // ZAP: 2016/03/22 Allow to remove ContextPanelFactory
 // ZAP: 2016/03/23 Issue 2331: Custom Context Panels not show in existing contexts after installation of add-on
+// ZAP: 2016/04/04 Do not require a restart to show/hide the tool bar
 
 package org.parosproxy.paros.view;
 
@@ -259,6 +260,8 @@ public class View implements ViewDelegate {
         	}
         	statusMap.put(status, new StatusUI(status, statusString));
         }
+
+        setMainToolbarVisible(Model.getSingleton().getOptionsParam().getViewParam().isShowMainToolbar());
     }
 
     public void postInit() {
@@ -999,5 +1002,15 @@ public class View implements ViewDelegate {
      */
     public StatusUI getStatusUI(AddOn.Status status) {
     	return statusMap.get(status);
+    }
+
+    /**
+     * Sets whether or not the main tool bar should be visible.
+     *
+     * @param visible {@code true} if the main tool bar should be visible, {@code false} otherwise.
+     * @since TODO add version
+     */
+    public void setMainToolbarVisible(boolean visible) {
+        getMainFrame().setMainToolbarVisible(visible);
     }
 }

--- a/src/org/zaproxy/zap/extension/brk/BreakPanel.java
+++ b/src/org/zaproxy/zap/extension/brk/BreakPanel.java
@@ -90,11 +90,6 @@ public class BreakPanel extends AbstractPanel implements Tab {
 	private final BreakButtonsUI responseBreakButtons;
 
 	/**
-	 * Flag that tells whether or not the main tool bar is hidden.
-	 */
-	private final boolean mainToolBarHidden;
-
-	/**
 	 * The current location of the break buttons.
 	 * 
 	 * @see #setButtonsLocation(int)
@@ -164,19 +159,18 @@ public class BreakPanel extends AbstractPanel implements Tab {
 		responsePanel.addOptions(responseBreakButtons.getComponent(), HttpPanel.OptionsLocation.AFTER_COMPONENTS);
 
 		currentButtonsLocation = -1;
-
-		mainToolBarHidden = extension.getModel().getOptionsParam().getViewParam().getShowMainToolbar() == 0;
 	}
 
 	/**
 	 * Sets the location of the break buttons.
 	 * <p>
-	 * If the location is already set no change is done.
+	 * If the location is already set and the main tool bar visibility is the same, no change is done.
 	 * 
 	 * @param location the location to set
 	 */
 	void setButtonsLocation(int location) {
 		if (currentButtonsLocation == location) {
+			mainBreakButtons.setVisible(location == 0 && isMainToolBarHidden());
 			return;
 		}
 		currentButtonsLocation = location;
@@ -210,7 +204,7 @@ public class BreakPanel extends AbstractPanel implements Tab {
 	 * @return {@code true} if the main tool bar is hidden, {@code false} otherwise
 	 */
 	private boolean isMainToolBarHidden() {
-		return mainToolBarHidden;
+		return !extension.getModel().getOptionsParam().getViewParam().isShowMainToolbar();
 	}
 
 	public boolean isBreakRequest() {


### PR DESCRIPTION
Change class MainFrame to always add the main tool bar, so that it can
be shown/hidden at any time, also add a method to allow to change its
visible state.
Change class View to apply the main tool bar visibility option when it
is initialised and add a method to allow to change the visible state of
the main tool bar (which calls the method of MainFrame class).
Change class MenuToolsControl to update the View with the main tool bar
visibility option, after the options are set.
Change class BreakPanel to take into account the changes done to
visibility of the main tool bar (to show/hide the buttons in the break
panel if the main tool bar is hidden/shown and the option is to show or
not the buttons in the tool bar).
Change class OptionsParamView to use boolean (for external code) instead
of an int for the visibility option of the main tool bar and deprecate
the methods that use int.
Change class OptionsViewPanel to use the boolean methods of class
OptionsParamView.

Fix #2368 - Do not require a restart to show/hide the main tool bar