### PR TITLE
Do not allow to save/write to read-only files

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1630,7 +1630,8 @@ report.unknown.error=Failed to write to file {0}, see log for detail
 report.write.overwrite.dialog.title=Existing File
 report.write.overwrite.dialog.message= The selected file already exists. Do you want to replace it?
 report.write.permission.dialog.title=Permissions Failure
-report.write.permission.dialog.message=File or Directory not writable: \n{0}\n Please select a different location.
+report.write.permission.dir.dialog.message=Directory not writable:\n{0}\nPlease select a different location.
+report.write.permission.file.dialog.message=File not writable:\n{0}\nPlease select a different location.
 
 scanner.category.browser = Client Browser
 scanner.category.info    = Information Gathering

--- a/src/org/zaproxy/zap/view/widgets/WritableFileChooser.java
+++ b/src/org/zaproxy/zap/view/widgets/WritableFileChooser.java
@@ -1,6 +1,7 @@
 package org.zaproxy.zap.view.widgets;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.text.MessageFormat;
 
 import javax.swing.JFileChooser;
@@ -25,15 +26,16 @@ public class WritableFileChooser extends JFileChooser {
 	public void approveSelection() {
 		File selectedFile = getSelectedFile();
 
-		if (!java.nio.file.Files.isWritable(selectedFile.getParentFile().toPath())) {
-			JOptionPane.showMessageDialog(this,
-					MessageFormat.format(Constant.messages.getString("report.write.permission.dialog.message"),
-		                	selectedFile.getAbsolutePath()),
-					Constant.messages.getString("report.write.permission.dialog.title"),
-					JOptionPane.ERROR_MESSAGE);
+		if (!Files.isWritable(selectedFile.getParentFile().toPath())) {
+			warnNotWritable("report.write.permission.dir.dialog.message", selectedFile.getParentFile().getAbsolutePath());
 			return;
 		}
 		if (selectedFile.exists()) {
+			if (!Files.isWritable(selectedFile.toPath())) {
+				warnNotWritable("report.write.permission.file.dialog.message", selectedFile.getAbsolutePath());
+				return;
+			}
+
 			int result = JOptionPane.showConfirmDialog(this,
 					Constant.messages.getString("report.write.overwrite.dialog.message"),
 					Constant.messages.getString("report.write.overwrite.dialog.title"),
@@ -50,5 +52,12 @@ public class WritableFileChooser extends JFileChooser {
 		// Store the user directory as the currently selected one
 		Model.getSingleton().getOptionsParam().setUserDirectory(getCurrentDirectory());
 		super.approveSelection();
+	}
+
+	private void warnNotWritable(String i18nKeyMessage, String path) {
+		JOptionPane.showMessageDialog(this,
+				MessageFormat.format(Constant.messages.getString(i18nKeyMessage), path),
+				Constant.messages.getString("report.write.permission.dialog.title"),
+				JOptionPane.ERROR_MESSAGE);
 	}
 }


### PR DESCRIPTION
Change class WritableFileChooser to validate, when the file exists, that
it is writable, otherwise the process could continue and end up in an
exception: "java.io.FileNotFoundException: /file (Permission denied)".
Add a message that indicates that the file is not writable and tweak
existing message (and path used in the warning dialogue) to only mention
directory, which is what was being tested.
Extract a method to show the warning dialogue for the write permissions.