### PR TITLE
Correctly propagate Alert changes

### DIFF
--- a/src/org/parosproxy/paros/model/HistoryReference.java
+++ b/src/org/parosproxy/paros/model/HistoryReference.java
@@ -39,6 +39,7 @@
 // ZAP: 2014/08/14 Issue 1311: Differentiate temporary internal messages from temporary scanner messages
 // ZAP: 2014/12/11 Update the flag webSocketUpgrade sooner to avoid re-reading the message from database
 // ZAP: 2015/02/09 Issue 1525: Introduce a database interface layer to allow for alternative implementations
+// ZAP: 2016/04/12 Update the SiteNode when deleting alerts
 
 package org.parosproxy.paros.model;
 
@@ -436,6 +437,9 @@ public class HistoryReference {
    public synchronized void deleteAlert(Alert alert) {
 	   if (alerts != null) {
 		   alerts.remove(alert);
+		   if (siteNode != null) {
+		       siteNode.deleteAlert(alert);
+		   }
 	   }
    }
    

--- a/src/org/parosproxy/paros/model/SiteNode.java
+++ b/src/org/parosproxy/paros/model/SiteNode.java
@@ -47,6 +47,7 @@
 // ZAP: 2015/10/21 Issue 1576: Support data driven content
 // ZAP: 2016/01/26 Fixed findbugs warning
 // ZAP: 2016/03/24 Do not access EDT in daemon mode
+// ZAP: 2016/04/12 Notify of changes when an alert is updated
 
 package org.parosproxy.paros.model;
 
@@ -373,7 +374,7 @@ public class SiteNode extends DefaultMutableTreeNode {
 	    		// Updating an alert might affect the nodes visibility in a filtered tree
 	    		siteMap.applyFilter(this);
 	    	}
-		
+	    	this.nodeChanged();
 		}
     }
     

--- a/src/org/zaproxy/zap/extension/alert/AlertEventPublisher.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertEventPublisher.java
@@ -27,10 +27,20 @@ public class AlertEventPublisher implements EventPublisher {
 	
 	private static AlertEventPublisher publisher = null;
 	public static final String ALERT_ADDED_EVENT	= "alert.added";
+	public static final String ALERT_CHANGED_EVENT = "alert.changed";
 	public static final String ALERT_REMOVED_EVENT	= "alert.removed";
 	public static final String ALL_ALERTS_REMOVED_EVENT	= "alert.all.removed";
 	
     public static final String ALERT_ID = "alertId";
+	/**
+	 * Indicates the {@code HistoryReference} ID of the alert.
+	 * <p>
+	 * The field is available in the events {@link #ALERT_ADDED_EVENT}, {@link #ALERT_CHANGED_EVENT} and
+	 * {@link #ALERT_REMOVED_EVENT}.
+	 * 
+	 * @since TODO add version
+	 */
+	public static final String HISTORY_REFERENCE_ID = "historyId";
 
 	@Override
 	public String getPublisherName() {
@@ -41,7 +51,7 @@ public class AlertEventPublisher implements EventPublisher {
 		if (publisher == null) {
 			publisher = new AlertEventPublisher(); 
 	        ZAP.getEventBus().registerPublisher(publisher, 
-	        		new String[] {ALERT_ADDED_EVENT, ALERT_REMOVED_EVENT, ALL_ALERTS_REMOVED_EVENT});
+	        		new String[] {ALERT_ADDED_EVENT, ALERT_CHANGED_EVENT, ALERT_REMOVED_EVENT, ALL_ALERTS_REMOVED_EVENT});
 
 		}
 		return publisher;

--- a/src/org/zaproxy/zap/extension/alert/AlertTreeModel.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertTreeModel.java
@@ -99,7 +99,7 @@ class AlertTreeModel extends DefaultTreeModel {
     }
     
     void updatePath(final Alert originalAlert, final Alert alert) {
-        if (EventQueue.isDispatchThread()) {
+        if (!View.isInitialised() || EventQueue.isDispatchThread()) {
         	updatePathEventHandler(originalAlert, alert);
         } else {
             try {

--- a/src/org/zaproxy/zap/extension/history/AlertAddDialog.java
+++ b/src/org/zaproxy/zap/extension/history/AlertAddDialog.java
@@ -208,10 +208,7 @@ public class AlertAddDialog extends AbstractDialog {
 								
 								// Update alert tree
 								extAlert.updateAlertInTree(alertViewPanel.getOriginalAlert(), alert);
-							}
-
-							// Update history tree
-							if (historyRef != null) {
+							} else if (historyRef != null) { // Update history tree
 								historyRef.updateAlert(alert);
 			                    extension.notifyHistoryItemChanged(historyRef);
 							}
@@ -221,11 +218,12 @@ public class AlertAddDialog extends AbstractDialog {
 						        historyRef = new HistoryReference(Model.getSingleton().getSession(), historyType, httpMessage);
 						    }
 						    
-							historyRef.addAlert(alert);
-		                    extension.notifyHistoryItemChanged(historyRef);
 						    // Raise it
 							if (extAlert != null) {
 								extAlert.alertFound(alert, historyRef);
+							} else {
+							    historyRef.addAlert(alert);
+							    extension.notifyHistoryItemChanged(historyRef);
 							}
 						}
 					} catch (Exception ex) {

--- a/src/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
+++ b/src/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
@@ -178,14 +178,6 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
 		if (currentId != id) {
 			logger.error("Alert id != currentId! " + id + " " + currentId);
 		}
-		alert.setSourceHistoryId(href.getHistoryId());
-		
-		try {
-			href.addAlert(alert);
-			notifyHistoryItemChanged(href);
-		} catch (Exception e) {
-			logger.error(e.getMessage(), e);
-		}
 	    // Raise the alert
 		extAlert.alertFound(alert, href);
 

--- a/src/org/zaproxy/zap/view/table/DefaultHistoryReferencesTableEntry.java
+++ b/src/org/zaproxy/zap/view/table/DefaultHistoryReferencesTableEntry.java
@@ -52,6 +52,7 @@ public class DefaultHistoryReferencesTableEntry extends AbstractHistoryReference
     private final Integer requestBodySize;
     private final Integer responseHeaderSize;
     private final Integer responseBodySize;
+    private AlertRiskTableCellItem alertRiskCellItem;
     private final boolean highestAlertColumn;
     private Boolean note;
     private final boolean noteColumn;
@@ -95,6 +96,8 @@ public class DefaultHistoryReferencesTableEntry extends AbstractHistoryReference
         highestAlertColumn = hasColumn(sortedColumns, Column.HIGHEST_ALERT);
         noteColumn = hasColumn(sortedColumns, Column.NOTE);
         tagsColumn = hasColumn(sortedColumns, Column.TAGS);
+
+        alertRiskCellItem = super.getHighestAlert();
 
         refreshCachedValues();
     }
@@ -194,10 +197,7 @@ public class DefaultHistoryReferencesTableEntry extends AbstractHistoryReference
 
     @Override
     public AlertRiskTableCellItem getHighestAlert() {
-        if (highestAlertColumn) {
-            return AlertRiskTableCellItem.getItemForRisk(getHistoryReference().getHighestAlert());
-        }
-        return super.getHighestAlert();
+        return alertRiskCellItem;
     }
 
     @Override
@@ -222,6 +222,9 @@ public class DefaultHistoryReferencesTableEntry extends AbstractHistoryReference
         }
         if (tagsColumn) {
             tags = listToCsv(getHistoryReference().getTags());
+        }
+        if (highestAlertColumn) {
+            alertRiskCellItem = AlertRiskTableCellItem.getItemForRisk(getHistoryReference().getHighestAlert());
         }
     }
 

--- a/src/org/zaproxy/zap/view/table/DefaultHistoryReferencesTableModel.java
+++ b/src/org/zaproxy/zap/view/table/DefaultHistoryReferencesTableModel.java
@@ -26,6 +26,8 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import javax.swing.event.TableModelEvent;
+
 import org.parosproxy.paros.model.HistoryReference;
 
 /**
@@ -135,6 +137,24 @@ public class DefaultHistoryReferencesTableModel extends AbstractHistoryReference
 
             fireTableRowsUpdated(rowIndex, rowIndex);
         }
+    }
+
+    public void refreshEntryRows() {
+        if (hrefList.isEmpty()) {
+            return;
+        }
+
+        for (DefaultHistoryReferencesTableEntry entry : hrefList) {
+            entry.refreshCachedValues();
+        }
+
+        fireTableChanged(
+                new TableModelEvent(
+                        this,
+                        0,
+                        hrefList.size() - 1,
+                        getColumnIndex(Column.HIGHEST_ALERT),
+                        TableModelEvent.UPDATE));
     }
 
     @Override


### PR DESCRIPTION
Make sure that the corresponding StructuralNode (Sites tree) of an Alert
exists when adding alerts and that the changes done to an alert are
correctly propagated to the corresponding StructuralNode and
HistoryReference. Also, publish events on Alert changes (so other
extensions can react accordingly).

Following more detailed explanation of the changes done to each class:
 - ExtensionAlert:
  - When adding alerts, alertFound(Alert, HistoryReference):
    - Make sure the Alert instance has the correct message ID by calling
    Alert.setSourceHistoryId(int), previously done in PassiveScanThread;
    - Add the StructuralNode, if not added already, to ensure  that it
    will have the Alert being raised;
    - Remove (now) redundant notification of changes in SiteNode.
  - Extracted a method to publish alert events;
  - Remove method no longer needed, siteNodeChangedEventHandler(...),
  notifications are no longer required (done by HistoryReference);
  - In addAlertToTreeEventHandler(Alert), remove the code that added the
  SiteNode to Sites tree, that's now done (with StructuralNode) in the
  method alertFound(...);
  - When modifying alerts, updateAlert(Alert), update the Alert in the
  corresponding HistoryReference and in the Alerts tree and publish an
  event about the change done;
  - In updateAlertInTree(...), change to return immediately if low
  memory option is set, to prevent adding the alerts to the tree;
  - Change deleteAlert(Alert), to use the extracted method to publish
  the events;
  - In deleteAlertFromDisplayEventHandler(Alert), remove notifications
  of changes and direct manipulation of SiteNode, that's done by
  HistoryReference;
 - ExtensionHistory, change to listen to Alert events to update the
 entries of the table model (PassiveScanThread no longer needs to do
 that when alerts are raised);
 - HistoryReference, change method deleteAlert(Alert) to remove the
 Alert from corresponding SiteNode;
 - SiteNode, change method updateAlert(Alert) to notify of changes;
 - AlertEventPublisher, add new event "alert.changed" and a new field,
 "historyId", that indicates the ID of the message that has the Alert;
 - AlertTreeModel, change method updatePath(...) to not access the EDT
 if the view is not initialised;
 - AlertAddDialog, update logic to no longer add/update the Alert to the
 HistoryReference and no longer notify ExtensionHistory of changes, if
 the ExtensionAlert is available (which takes care to do so);
 - PassiveScanThread, change method raiseAlert(int, Alert), to no longer
 add the Alert to the HistoryReference and no longer notify
 ExtensionHistory of changes, no longer needed as per previous changes;
 - DefaultHistoryReferencesTableEntry, change to cache the highest alert
 of the HistoryReference, the table entry is updated as needed (through
 alert change events);
 - DefaultHistoryReferencesTableModel, add a method to allow to refresh
 all entries (needed when all alerts are deleted).

Core changes for #2311 - HTML report reports the filtered false
positives as true results
 ---
Edited to add the changes of `DefaultHistoryReferencesTableModel`, done in the amended commit to fix the `NullPointerException`.