### PR TITLE
Change API authorization view to wrap its object

### DIFF
--- a/src/org/zaproxy/zap/extension/authorization/AuthorizationAPI.java
+++ b/src/org/zaproxy/zap/extension/authorization/AuthorizationAPI.java
@@ -71,7 +71,7 @@ public class AuthorizationAPI extends ApiImplementor {
 		switch (name) {
 		case VIEW_GET_AUTHORIZATION_METHOD:
 			Context context = ApiUtils.getContextByParamId(params, PARAM_CONTEXT_ID);
-			return context.getAuthorizationDetectionMethod().getApiResponseRepresentation();
+			return new ApiResponseElement(context.getAuthorizationDetectionMethod().getApiResponseRepresentation());
 		default:
 			throw new ApiException(Type.BAD_VIEW);
 		}


### PR DESCRIPTION
Change class AuthorizationAPI to wrap the authorization data with an
object (as all views do), called "authorizationDetectionMethod", instead
of returning the authorization data directly, so that the Python ZAP API
client is able to correctly read the data, which expects (and removes)
the wrapper object.

The data returned is now, for example:
 {"authorizationDetectionMethod":{"statusCode":"-1"..."headerRegex":""}}

instead of:
 {"statusCode":"-1"..."headerRegex":""}

This change breaks existing custom clients that consume the JSON format.
The structure of XML format is unchanged.
 ---
Issue reported in OWASP ZAP User Group: https://groups.google.com/d/msg/zaproxy-users/7-DZTINjsuM/kB9xTJoBDAAJ