### PR TITLE
Inform if GUI is started on headless environment

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1884,6 +1884,7 @@ start.gui.cmdline.session.does.not.exist = Session given at command line does no
 start.gui.cmdline.newsession.already.exist = New session given at command line already exists.\n\nA new empty session will be created in {0}
 start.gui.dialog.fatal.error.title = Failed to start ZAP
 start.gui.dialog.fatal.error.message = A fatal error occurred that prevents ZAP from start.\nConsider reporting the error with following details:
+start.gui.headless = ZAP GUI is not supported on a headless environment.\nRun ZAP inline or in daemon mode, use {0} command line argument for more details.\n(Note, some of the ZAP features that require a display, for example, running AJAX Spider with Firefox, might still be run with the help of applications like Xvfb.)
 start.gui.warn.addOnsOrExtensionsNoLongerRunning = The following add-ons, or its extensions, will no longer be run\nuntil its requirements are restored:
 start.splash.start			= Starting ZAP...\n
 start.splash.tips.loading	= Loading ZAP Tips and Tricks...

--- a/src/org/zaproxy/zap/GuiBootstrap.java
+++ b/src/org/zaproxy/zap/GuiBootstrap.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap;
 
 import java.awt.EventQueue;
+import java.awt.GraphicsEnvironment;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -74,6 +75,22 @@ public class GuiBootstrap extends ZapBootstrap {
 
     @Override
     public int start() {
+        int rc = super.start();
+        if (rc != 0) {
+            return rc;
+        }
+
+        BasicConfigurator.configure();
+
+        logger.info(getStartingMessage());
+
+        if (GraphicsEnvironment.isHeadless()) {
+            String headlessMessage = Constant.messages.getString("start.gui.headless", CommandLine.HELP);
+            logger.fatal(headlessMessage);
+            System.err.println(headlessMessage);
+            return 1;
+        }
+
         EventQueue.invokeLater(new Runnable() {
 
             @Override
@@ -85,15 +102,6 @@ public class GuiBootstrap extends ZapBootstrap {
     }
 
     private void startImpl() {
-        int rc = super.start();
-        if (rc != 0) {
-            System.exit(rc);
-        }
-
-        BasicConfigurator.configure();
-
-        logger.info(getStartingMessage());
-
         setDefaultViewLocale(Constant.getLocale());
         setupLookAndFeel();
 


### PR DESCRIPTION
Change class GuiBootStrap to check and inform if ZAP (GUI) is being
started in a headless environment (preventing the HeadlessException).

Code changes for #2390 - HeadlessException should be handled more
gracefully & README needs Headless details