### PR TITLE
Change README to inform about headless environment

### DIFF
--- a/src/doc/README
+++ b/src/doc/README
@@ -30,3 +30,11 @@ Generally, most user's tend to use the Mac OS build, which is a ordinary Mac OS
 app that can be started as any other app: Double-Click on the app to start it. 
 You can use the 'zap.sh' script, as per linux.
 
+Headless Environment
+--------------------
+
+By default ZAP will be started with a GUI which is not supported in headless
+environments, in those cases ZAP needs to be started inline, using the command
+line argument '-cmd', or in daemon mode, using '-daemon'.
+For more information about the command line arguments use '-help'.
+ZAP will show an information message and exit, if still started with GUI.

--- a/src/doc/README.weekly
+++ b/src/doc/README.weekly
@@ -29,3 +29,12 @@ On Windows use the 'zap.bat' file
 On Linux and Mac OS use the 'zap.sh' file
 
 Both of these files are in the installation directory. 
+
+Headless Environment
+--------------------
+
+By default ZAP will be started with a GUI which is not supported in headless
+environments, in those cases ZAP needs to be started inline, using the command
+line argument '-cmd', or in daemon mode, using '-daemon'.
+For more information about the command line arguments use '-help'.
+ZAP will show an information message and exit, if still started with GUI.


### PR DESCRIPTION
Add a new section ("Headless Environment") to README (and README.weekly)
to explain how ZAP should be started when running in a headless
environment (by using -cmd or -daemon command line arguments).

Fix #2390 - HeadlessException should be handled more gracefully & README
needs Headless details