### PR TITLE
Allow Active Rules to have just one scan method

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/ActiveScript2.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScript2.java
@@ -23,7 +23,7 @@ import javax.script.ScriptException;
 
 import org.parosproxy.paros.network.HttpMessage;
 
-public interface ActiveScript2 extends ActiveScript {
+public interface ActiveScript2 {
 
 	void scanNode(ScriptsActiveScanner sas, HttpMessage msg) throws ScriptException;
 }


### PR DESCRIPTION
Change interface ActiveScript2 to not extend ActiveScript, to allow
Active Rules (scripts) to implement just one of the scan methods.
Change class ScriptsActiveScanner to warn if the scripts do not
implement any of the interfaces (the warn is only issued if the message
being scanned contains "parameters", thus requiring both interfaces).

Fix #1786 - Activescan Scripts Silent Failure