### PR TITLE
Change View to allow to display a message

### DIFF
--- a/src/org/parosproxy/paros/extension/ViewDelegate.java
+++ b/src/org/parosproxy/paros/extension/ViewDelegate.java
@@ -24,6 +24,7 @@
 // ZAP: 2012/10/02 Issue 385: Added support for Contexts
 // ZAP: 2013/05/02 Removed redundant public modifiers from interface method declarations
 // ZAP: 2016/03/22 Allow to remove ContextPanelFactory
+// ZAP: 2016/04/14 Allow to display a message
 
 package org.parosproxy.paros.extension;
 
@@ -35,6 +36,7 @@ import org.parosproxy.paros.view.SiteMapPanel;
 import org.parosproxy.paros.view.WaitMessageDialog;
 import org.zaproxy.zap.extension.httppanel.HttpPanelRequest;
 import org.zaproxy.zap.extension.httppanel.HttpPanelResponse;
+import org.zaproxy.zap.extension.httppanel.Message;
 import org.zaproxy.zap.view.ContextPanelFactory;
 
 public interface ViewDelegate {
@@ -87,5 +89,17 @@ public interface ViewDelegate {
      * @see #addContextPanelFactory(ContextPanelFactory)
      */
     void removeContextPanelFactory(ContextPanelFactory contextPanelFactory);
+
+    /**
+     * Displays the given {@code message} in the main message panels (Request/Response).
+     * <p>
+     * If the given {@code message} is {@code null} the panels are cleared.
+     *
+     * @param message the message to display
+     * @since TODO add version
+     * @see #getRequestPanel()
+     * @see #getResponsePanel()
+     */
+    void displayMessage(Message message);
 
 }

--- a/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -63,6 +63,7 @@
 // ZAP: 2015/09/16 Issue 1890: ZAP can't completely scan OWASP Benchmark
 // ZAP: 2016/01/26 Fixed findbugs warning
 // ZAP: 2016/04/12 Listen to alert events to update the table model entries
+// ZAP: 2016/04/14 Use View to display the HTTP messages
 
 package org.parosproxy.paros.extension.history;
 
@@ -174,7 +175,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
 	 */    
 	private LogPanel getLogPanel() {
 		if (logPanel == null) {
-			logPanel = new LogPanel();
+			logPanel = new LogPanel(getView());
 			logPanel.setName(Constant.messages.getString("history.panel.title"));	// ZAP: i18n
 			// ZAP: Added History (calendar) icon
 			logPanel.setIcon(new ImageIcon(ExtensionHistory.class.getResource("/resource/icon/16/025.png")));	// 'calendar' icon
@@ -216,7 +217,6 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
 	    if (getView() != null) {
 		    ExtensionHookView pv = extensionHook.getHookView();
 		    pv.addStatusPanel(getLogPanel());
-		    getLogPanel().setDisplayPanel(getView().getRequestPanel(), getView().getResponsePanel());
 		    
             extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuTag());
             // ZAP: Added history notes
@@ -674,8 +674,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
 			historyIdToRef.clear();
 
 			if (getView() != null) { 
-				getView().getRequestPanel().clearView(true);
-				getView().getResponsePanel().clearView(false);
+				getView().displayMessage(null);
 			}
 		} else {
 			try {

--- a/src/org/parosproxy/paros/extension/history/LogPanel.java
+++ b/src/org/parosproxy/paros/extension/history/LogPanel.java
@@ -38,6 +38,7 @@
 // ZAP: 2014/03/23 Issue 503: Change the footer tabs to display the data
 // with tables instead of lists
 // ZAP: 2015/02/10 Issue 1528: Support user defined font size
+// ZAP: 2016/04/14 Use View to display the HTTP messages
 
 package org.parosproxy.paros.extension.history;
 
@@ -64,6 +65,7 @@ import javax.swing.tree.TreePath;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
+import org.parosproxy.paros.extension.ViewDelegate;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.SiteNode;
@@ -90,8 +92,6 @@ public class LogPanel extends AbstractPanel implements Runnable {
 	private JLabel filterStatus = null;
 	private ZapToggleButton scopeButton = null;
 	
-	private HttpPanel requestPanel = null;
-	private HttpPanel responsePanel = null;
     private ExtensionHistory extension = null;
 
 	private ZapToggleButton linkWithSitesTreeButton;
@@ -99,14 +99,23 @@ public class LogPanel extends AbstractPanel implements Runnable {
 	private LinkWithSitesTreeSelectionListener linkWithSitesTreeSelectionListener;
 
 	private DeselectableButtonGroup historyListFiltersButtonGroup;
+
+	private final ViewDelegate view;
 	
 	/**
-	 * This is the default constructor
+	 * @deprecated (TODO add version) Use {@link #LogPanel(ViewDelegate)} instead.
 	 */
+	@Deprecated
 	public LogPanel() {
+		this(View.getSingleton());
+	}
+
+	public LogPanel(ViewDelegate view) {
 		super();
+		this.view = view;
 		initialize();
 	}
+
 	/**
 	 * This method initializes this
 	 */
@@ -289,7 +298,7 @@ public class LogPanel extends AbstractPanel implements Runnable {
 
 	public void setLinkWithSitesTreeSelection(boolean enabled) {
 		linkWithSitesTreeButton.setSelected(enabled);
-		final JTree sitesTree = View.getSingleton().getSiteTreePanel().getTreeSite();
+		final JTree sitesTree = view.getSiteTreePanel().getTreeSite();
 		String baseUri = null;
 		if (enabled) {
 			final TreePath selectionPath = sitesTree.getSelectionPath();
@@ -323,7 +332,7 @@ public class LogPanel extends AbstractPanel implements Runnable {
 				@Override
 				public void mouseClicked(java.awt.event.MouseEvent e) {
 					if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount() > 1) {  // double click
-						requestPanel.setTabFocus();
+						view.getRequestPanel().setTabFocus();
 						return;
 				    }
 				}
@@ -413,25 +422,12 @@ public class LogPanel extends AbstractPanel implements Runnable {
     }
     
     
+    /**
+     * @deprecated (TODO add version) No longer used/needed.
+     */
+    @Deprecated
+    @SuppressWarnings("javadoc")
     public void setDisplayPanel(HttpPanel requestPanel, HttpPanel responsePanel) {
-        this.requestPanel = requestPanel;
-        this.responsePanel = responsePanel;
-
-    }
-    
-    private void displayMessage(HttpMessage msg) {
-        
-        if (msg.getRequestHeader().isEmpty()) {
-            requestPanel.clearView(true);
-        } else {
-            requestPanel.setMessage(msg);
-        }
-        
-        if (msg.getResponseHeader().isEmpty()) {
-            responsePanel.clearView(false);
-        } else {
-            responsePanel.setMessage(msg, true);
-        }
     }
 
     @Override
@@ -455,7 +451,7 @@ public class LogPanel extends AbstractPanel implements Runnable {
                 EventQueue.invokeAndWait(new Runnable() {
                     @Override
                     public void run() {
-                        displayMessage(msg);
+                        view.displayMessage(msg);
                         getHistoryReferenceTable().requestFocus();
 
                     }

--- a/src/org/parosproxy/paros/view/SiteMapPanel.java
+++ b/src/org/parosproxy/paros/view/SiteMapPanel.java
@@ -36,6 +36,7 @@
 // ZAP: 2015/02/09 Issue 1525: Introduce a database interface layer to allow for alternative implementations
 // ZAP: 2015/02/10 Issue 1528: Support user defined font size
 // ZAP: 2015/06/01 Issue 1653: Support context menu key for trees
+// ZAP: 2016/04/14 Use View to display the HTTP messages
 
 package org.parosproxy.paros.view;
 
@@ -81,7 +82,6 @@ import org.parosproxy.paros.model.SiteMap;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.history.HistoryFilterPlusDialog;
-import org.zaproxy.zap.extension.httppanel.HttpPanel;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.Target;
 import org.zaproxy.zap.utils.DisplayUtils;
@@ -370,20 +370,7 @@ public class SiteMapPanel extends AbstractPanel {
                             
                         }
 
-                        HttpPanel reqPanel = getView().getRequestPanel();
-				        HttpPanel resPanel = getView().getResponsePanel();
-				        
-				        if (msg.getRequestHeader().isEmpty()) {
-				        	reqPanel.clearView(true);
-				        } else {
-				        	reqPanel.setMessage(msg);
-				        }
-				        
-				        if (msg.getResponseHeader().isEmpty()) {
-				        	resPanel.clearView(false);
-				        } else {
-				        	resPanel.setMessage(msg, true);
-				        }
+                        getView().displayMessage(msg);
 
 			        	// ZAP: Call SiteMapListenners
 			            for (SiteMapListener listener : listeners) {
@@ -391,8 +378,7 @@ public class SiteMapPanel extends AbstractPanel {
 			            }
 				    } else {
 				    	// ZAP: clear the views when the root is selected
-                        getView().getRequestPanel().clearView(true);
-				        getView().getResponsePanel().clearView(false);
+				        getView().displayMessage(null);
 				    }
 	
 				}

--- a/src/org/parosproxy/paros/view/View.java
+++ b/src/org/parosproxy/paros/view/View.java
@@ -68,6 +68,7 @@
 // ZAP: 2016/03/23 Issue 2331: Custom Context Panels not show in existing contexts after installation of add-on
 // ZAP: 2016/04/04 Do not require a restart to show/hide the tool bar
 // ZAP: 2016/04/06 Fix layouts' issues
+// ZAP: 2016/04/14 Allow to display a message
 
 package org.parosproxy.paros.view;
 
@@ -110,12 +111,14 @@ import org.parosproxy.paros.extension.option.OptionsParamView;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.model.Session;
+import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.control.AddOn.Status;
 import org.zaproxy.zap.extension.ExtensionPopupMenu;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
 import org.zaproxy.zap.extension.httppanel.HttpPanelRequest;
 import org.zaproxy.zap.extension.httppanel.HttpPanelResponse;
+import org.zaproxy.zap.extension.httppanel.Message;
 import org.zaproxy.zap.extension.keyboard.ExtensionKeyboard;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.view.AbstractContextPropertiesPanel;
@@ -984,5 +987,38 @@ public class View implements ViewDelegate {
      */
     public void setMainToolbarVisible(boolean visible) {
         getMainFrame().setMainToolbarVisible(visible);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <strong>Note:</strong> Current implementation just supports {@link HttpMessage HTTP messages}. Attempting to display
+     * other message types has no effect.
+     */
+    @Override
+    public void displayMessage(Message message) {
+        if (message == null) {
+            getRequestPanel().clearView(true);
+            getResponsePanel().clearView(false);
+            return;
+        }
+
+        if (!(message instanceof HttpMessage)) {
+            logger.warn("Unable to display message: " + message.getClass().getCanonicalName());
+            return;
+        }
+
+        HttpMessage httpMessage = (HttpMessage) message;
+        if (httpMessage.getRequestHeader().isEmpty()) {
+            getRequestPanel().clearView(true);
+        } else {
+            getRequestPanel().setMessage(httpMessage);
+        }
+
+        if (httpMessage.getResponseHeader().isEmpty()) {
+            getResponsePanel().clearView(false);
+        } else {
+            getResponsePanel().setMessage(httpMessage, true);
+        }
     }
 }

--- a/src/org/zaproxy/zap/extension/alert/AlertPanel.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertPanel.java
@@ -605,23 +605,14 @@ public class AlertPanel extends AbstractPanel {
     }
 
 	private void setMessage(HttpMessage msg, String highlight) {
+        getView().displayMessage(msg);
         if (msg == null) {
             return;
         }
 
-	    HttpPanel requestPanel = getView().getRequestPanel();
-	    HttpPanel responsePanel = getView().getResponsePanel();
-	    
-	    if (msg.getRequestHeader().isEmpty()) {
-	    	requestPanel.clearView(true);
-	    } else {
-	        requestPanel.setMessage(msg);
-	    }
-
-	    if (msg.getResponseHeader().isEmpty()) {
-	    	responsePanel.clearView(false);
-	    } else {
-	        responsePanel.setMessage(msg, true);
+	    if (!msg.getResponseHeader().isEmpty()) {
+	        HttpPanel requestPanel = getView().getRequestPanel();
+	        HttpPanel responsePanel = getView().getResponsePanel();
 
 	        SearchMatch sm = null;
 	        int start;

--- a/src/org/zaproxy/zap/extension/search/ExtensionSearch.java
+++ b/src/org/zaproxy/zap/extension/search/ExtensionSearch.java
@@ -99,8 +99,6 @@ public class ExtensionSearch extends ExtensionAdaptor implements SessionChangedL
 	        extensionHook.getHookMenu().addEditMenuItem(getMenuNext());
 	        extensionHook.getHookMenu().addEditMenuItem(getMenuPrev());
 	        
-	        getSearchPanel().setDisplayPanel(getView().getRequestPanel(), getView().getResponsePanel());
-
 	        ExtensionHelp.enableHelpKey(getSearchPanel(), "ui.tabs.search");
 	    }
         API.getInstance().registerApiImplementor(new SearchAPI(this));
@@ -122,7 +120,7 @@ public class ExtensionSearch extends ExtensionAdaptor implements SessionChangedL
 
 	private SearchPanel getSearchPanel() {
 		if (searchPanel == null) {
-			searchPanel = new SearchPanel();
+			searchPanel = new SearchPanel(getView());
 			searchPanel.setExtension(this);
 		}
 		return searchPanel;

--- a/src/org/zaproxy/zap/extension/search/SearchPanel.java
+++ b/src/org/zaproxy/zap/extension/search/SearchPanel.java
@@ -42,6 +42,7 @@ import javax.swing.event.ListSelectionListener;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.AbstractPanel;
+import org.parosproxy.paros.extension.ViewDelegate;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.httppanel.HttpPanelRequest;
@@ -89,17 +90,23 @@ public class SearchPanel extends AbstractPanel implements SearchListenner {
 	private SearchResultsTable resultsTable;
 	private SearchResultsTableModel resultsModel;
 
-	private HttpPanelRequest requestPanel = null;
-	private HttpPanelResponse responsePanel = null;
+	private final ViewDelegate view;
 
     //private static Logger log = Logger.getLogger(SearchPanel.class);
 
     /**
-     * 
+     * @deprecated (TODO add version) Use {@link #SearchPanel(ViewDelegate)} instead.
      */
+    @Deprecated
     public SearchPanel() {
-        super();
+		this(View.getSingleton());
  		initialize();
+    }
+
+    public SearchPanel(ViewDelegate view) {
+        super();
+        this.view = view;
+        initialize();
     }
 
 	public ExtensionSearch getExtension() {
@@ -410,9 +417,12 @@ public class SearchPanel extends AbstractPanel implements SearchListenner {
 		}
 	}
 
+    /**
+     * @deprecated (TODO add version) No longer used/needed.
+     */
+    @Deprecated
+    @SuppressWarnings("javadoc")
     public void setDisplayPanel(HttpPanelRequest requestPanel, HttpPanelResponse responsePanel) {
-        this.requestPanel = requestPanel;
-        this.responsePanel = responsePanel;
     }
     
     private void doSearch() {
@@ -480,21 +490,12 @@ public class SearchPanel extends AbstractPanel implements SearchListenner {
     
     private void displayMessage(SearchResult sr) {
         HttpMessage msg = sr.getMessage();
+        view.displayMessage(msg);
+
         if (msg == null) {
             return;
         }
 
-        if (msg.getRequestHeader().isEmpty()) {
-            requestPanel.clearView(true);
-        } else {
-            requestPanel.setMessage(msg);
-        }
-        
-        if (msg.getResponseHeader().isEmpty()) {
-            responsePanel.clearView(false);
-        } else {
-            responsePanel.setMessage(msg, true);
-        }
         highlightFirstResult(sr);
     }
     
@@ -505,31 +506,31 @@ public class SearchPanel extends AbstractPanel implements SearchListenner {
     	
     	switch (sm.getLocation()) {
     	case REQUEST_HEAD:
-    		requestPanel.highlightHeader(sm);
-    		requestPanel.setTabFocus();
-    		requestPanel.requestFocus(); 
+    		view.getRequestPanel().highlightHeader(sm);
+    		view.getRequestPanel().setTabFocus();
+    		view.getRequestPanel().requestFocus(); 
     		break;
     	case REQUEST_BODY:	
-    		requestPanel.highlightBody(sm);
-    		requestPanel.setTabFocus();
-    		requestPanel.requestFocus(); 
+    		view.getRequestPanel().highlightBody(sm);
+    		view.getRequestPanel().setTabFocus();
+    		view.getRequestPanel().requestFocus(); 
     		break;
     	case RESPONSE_HEAD:	
-    		responsePanel.highlightHeader(sm);
-    		responsePanel.setTabFocus();
-    		responsePanel.requestFocus(); 
+    		view.getResponsePanel().highlightHeader(sm);
+    		view.getResponsePanel().setTabFocus();
+    		view.getResponsePanel().requestFocus(); 
     		break;
     	case RESPONSE_BODY:
-    		responsePanel.highlightBody(sm);
-    		responsePanel.setTabFocus();
-    		responsePanel.requestFocus(); 
+    		view.getResponsePanel().highlightBody(sm);
+    		view.getResponsePanel().setTabFocus();
+    		view.getResponsePanel().requestFocus(); 
     		break;
     	}
 
     }
     
     private void highlightFirstResult (SearchResult sr) {
-    	highlightMatch(sr.getFirstMatch(requestPanel, responsePanel));
+    	highlightMatch(sr.getFirstMatch(view.getRequestPanel(), view.getResponsePanel()));
     }
     
     protected void highlightFirstResult() {
@@ -563,7 +564,7 @@ public class SearchPanel extends AbstractPanel implements SearchListenner {
     }
 
     private void highlightLastResult (SearchResult sr) {
-    	highlightMatch(sr.getLastMatch(requestPanel, responsePanel));
+    	highlightMatch(sr.getLastMatch(view.getRequestPanel(), view.getResponsePanel()));
     }
 
     protected void highlightPrevResult () {

--- a/src/org/zaproxy/zap/view/HistoryReferenceTable.java
+++ b/src/org/zaproxy/zap/view/HistoryReferenceTable.java
@@ -146,26 +146,7 @@ public class HistoryReferenceTable extends JTable {
 	}
 	
     private void displayMessage(HttpMessage msg) {
-    	if (msg == null) {
-    		return;
-    	}
-    	if (msg.getRequestHeader() != null) {
-    		logger.debug("displayMessage " + msg.getRequestHeader().getURI());
-    	} else {
-    		logger.debug("displayMessage null header");
-    	}
-    	
-        if (msg.getRequestHeader() != null && msg.getRequestHeader().isEmpty()) {
-            View.getSingleton().getRequestPanel().clearView(true);
-        } else {
-        	View.getSingleton().getRequestPanel().setMessage(msg);
-        }
-        
-        if (msg.getResponseHeader() != null && msg.getResponseHeader().isEmpty()) {
-        	View.getSingleton().getResponsePanel().clearView(false);
-        } else {
-        	View.getSingleton().getResponsePanel().setMessage(msg, true);
-        }
+        View.getSingleton().displayMessage(msg);
     }
 
 	public HistoryReference getSelectedValue() {

--- a/src/org/zaproxy/zap/view/table/HistoryReferencesTable.java
+++ b/src/org/zaproxy/zap/view/table/HistoryReferencesTable.java
@@ -122,21 +122,7 @@ public class HistoryReferencesTable extends ZapTable {
     }
 
     protected void displayMessage(final HttpMessage msg) {
-        if (msg == null) {
-            return;
-        }
-
-        if (msg.getRequestHeader().isEmpty()) {
-            View.getSingleton().getRequestPanel().clearView(true);
-        } else {
-            View.getSingleton().getRequestPanel().setMessage(msg);
-        }
-
-        if (msg.getResponseHeader().isEmpty()) {
-            View.getSingleton().getResponsePanel().clearView(false);
-        } else {
-            View.getSingleton().getResponsePanel().setMessage(msg, true);
-        }
+        View.getSingleton().displayMessage(msg);
     }
 
     public HistoryReference getSelectedHistoryReference() {


### PR DESCRIPTION
Change interface ViewDelegate to allow to display a Message, through the
method displayMessage(Message), to reduce code duplication and
standardise how the messages are displayed.
Change class View to implement the method, current implementation just
supports HttpMessage (the only Message supported by core).
Change all classes to use the new method, instead of manually setting
the message to request/response panels.