### PR TITLE
Set focus back to table after displaying a message

### DIFF
--- a/src/org/zaproxy/zap/view/table/HistoryReferencesTable.java
+++ b/src/org/zaproxy/zap/view/table/HistoryReferencesTable.java
@@ -239,10 +239,15 @@ public class HistoryReferencesTable extends ZapTable {
                     return;
                 }
 
+                boolean focusOwner = isFocusOwner();
                 try {
                     displayMessage(hRef.getHttpMessage());
                 } catch (HttpMalformedHeaderException | DatabaseException e) {
                     LOGGER.error(e.getMessage(), e);
+                } finally {
+                    if (focusOwner) {
+                        requestFocusInWindow();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Change class HistoryReferencesTable.DisplayMessageOnSelectionValueChange
to request focus back to the table after displaying a message to allow
navigate the table entries with the keyboard more easily. The table
could lose focus if the message panel displayed a big request/response
body, requiring the user to transfer the focus through all the
components back to the table.