### PR TITLE
Add missing EDT check to ExtensionAlert.alertFound

### DIFF
--- a/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -150,7 +150,7 @@ public class ExtensionAlert extends ExtensionAdaptor implements SessionChangedLi
             writeAlertToDB(alert, ref);
 
             try {
-                if (getView() == null) {
+                if (getView() == null || EventQueue.isDispatchThread()) {
                     SessionStructure.addPath(Model.getSingleton().getSession(), ref, alert.getMessage());
                 } else {
                     final HistoryReference fRef = ref;


### PR DESCRIPTION
Change an if statement in ExtensionAlert.alertFound(...) to also check
if the current thread is already the EDT when adding the StructuralNodes
(if it's already the EDT it just needs to add the nodes).
Fixes the following exception when manually adding alerts:
ERROR org.zaproxy.zap.ZAP$UncaughtExceptionLogger  - Exception in thread
"AWT-EventQueue-0"
java.lang.Error: Cannot call invokeAndWait from the event dispatcher
thread
  at java.awt.EventQueue.invokeAndWait(EventQueue.java:1270)
  at java.awt.EventQueue.invokeAndWait(EventQueue.java:1263)
  at o.z.z.e.alert.ExtensionAlert.alertFound(ExtensionAlert.java:158)
  at o.z.z.e.h.AlertAddDialog$2.actionPerformed(AlertAddDialog.java:223)

Issue introduced in #2393.