### PR TITLE
Disable "Show in History Tab" if message not valid

### DIFF
--- a/src/org/zaproxy/zap/extension/history/PopupMenuShowInHistory.java
+++ b/src/org/zaproxy/zap/extension/history/PopupMenuShowInHistory.java
@@ -23,6 +23,10 @@ import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer;
 
 
+/**
+ * @deprecated (TODO add version) No longer used, replaced by {@link org.zaproxy.zap.extension.stdmenus.PopupMenuShowInHistory}.
+ */
+@Deprecated
 public class PopupMenuShowInHistory extends PopupMenuItemHistoryReferenceContainer {
 
 	private static final long serialVersionUID = 1L;

--- a/src/org/zaproxy/zap/extension/stdmenus/PopupMenuShowInHistory.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/PopupMenuShowInHistory.java
@@ -48,12 +48,24 @@ public class PopupMenuShowInHistory extends PopupMenuItemHistoryReferenceContain
 		case FORCED_BROWSE_PANEL:
 		case FUZZER_PANEL:
 		case HISTORY_PANEL:
+		case SPIDER_PANEL:
 			return false;
 		case ALERTS_PANEL:
 		case SITES_PANEL:
 		case SEARCH_PANEL:
 		default:
 			return true;
+		}
+	}
+
+	@Override
+	protected boolean isButtonEnabledForHistoryReference(HistoryReference historyReference) {
+		switch (historyReference.getHistoryType()) {
+		case HistoryReference.TYPE_ZAP_USER:
+		case HistoryReference.TYPE_PROXIED:
+			return true;
+		default:
+			return false;
 		}
 	}
 	


### PR DESCRIPTION
Disable the menu item "Show in History Tab" if the type of the selected
message is not valid for the History tab (only manual or proxied
requests are shown in that tab). Prevents the menu item from being
enabled for other message types (for example, scanner, spider) which
would have no effect other than showing/focusing the History tab.
 ---
From #2354.