### PR TITLE
Remove unnecessary log warnings

### DIFF
--- a/src/org/zaproxy/zap/extension/globalexcludeurl/ExtensionGlobalExcludeURL.java
+++ b/src/org/zaproxy/zap/extension/globalexcludeurl/ExtensionGlobalExcludeURL.java
@@ -87,7 +87,6 @@ public class ExtensionGlobalExcludeURL extends ExtensionAdaptor  {
 	@Override
 	public void optionsLoaded() {
 		GlobalExcludeURLParam geup = getParam();
-		log.warn("GlobalExcludeURL.optionsLoaded()");
 		geup.parse();
 	}
 	

--- a/src/org/zaproxy/zap/extension/globalexcludeurl/OptionsGlobalExcludeURLPanel.java
+++ b/src/org/zaproxy/zap/extension/globalexcludeurl/OptionsGlobalExcludeURLPanel.java
@@ -106,11 +106,12 @@ public class OptionsGlobalExcludeURLPanel extends AbstractParamPanel {
 	    globalExcludeURLParam.parse();
 	    List<String> ignoredRegexs = globalExcludeURLParam.getTokensNames();
 
-	    log.warn(ignoredRegexs.toString());
 	    Model.getSingleton().getSession().setGlobalExcludeURLRegexs(ignoredRegexs);
 	    // after saving, force the proxy/spider/scanner to refresh the URL lists.
 	    Model.getSingleton().getSession().forceGlobalExcludeURLRefresh();
-	    log.debug("Done saving Global Exclude URL");
+	    if (log.isDebugEnabled()) {
+	        log.debug("Done saving Global Exclude URL: " + ignoredRegexs.toString());
+	    }
     }
 
     /**


### PR DESCRIPTION
Change method ExtensionGlobalExcludeURL.optionsLoaded() to remove the
existing log warning, not needed.
Change method OptionsGlobalExcludeURLPanel.saveParam(Object) to remove
the log warning (by moving the logged message, the ignored regular
expressions, to existing debug log statement and wrap it with a
"isDebugEnabled"), as with the previous warning it's not needed (as
warning).
 ---
From https://github.com/jenkinsci/zaproxy-plugin/issues/19#issuecomment-211820358.