### PR TITLE
Fix issues related to active scanner request count

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/AbstractAppPlugin.java
+++ b/src/org/parosproxy/paros/core/scanner/AbstractAppPlugin.java
@@ -21,6 +21,7 @@
 // ZAP: 2012/04/25 Added @Override annotation to the appropriate method.
 // ZAP: 2013/05/02 Re-arranged all modifiers into Java coding standard order
 // ZAP: 2014/06/26 Added the possibility to evaluate the current plugin/process progress
+// ZAP: 2016/04/21 Remove manual progress change, HostProcess takes care of that
 
 package org.parosproxy.paros.core.scanner;
 
@@ -39,8 +40,5 @@ public abstract class AbstractAppPlugin extends AbstractPlugin {
         /*	no need to notify parent this plugin is completed.  HostProcess will wait each
          	AbstractAppPlugin to finish.
          */
-
-        // ZAP: set the progress in the HostProcess
-        parent.setTestCurrentCount(this, parent.getTestCurrentCount(this) + 1);
     }
 }

--- a/src/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/src/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -48,6 +48,7 @@
 // ZAP: 2015/07/26 Issue 1618: Target Technology Not Honored
 // ZAP: 2015/08/19 Issue 1785: Plugin enabled even if dependencies are not, "hangs" active scan
 // ZAP: 2016/03/22 Implement init() and getDependency() by default, most plugins do not use them
+// ZAP: 2016/04/21 Include Plugin itself when notifying of a new message sent
 
 package org.parosproxy.paros.core.scanner;
 
@@ -258,7 +259,7 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
         parent.getHttpSender().sendAndReceive(msg, isFollowRedirect);
         
         // ZAP: Notify parent
-        parent.notifyNewMessage(msg);
+        parent.notifyNewMessage(this, msg);
         
         //ZAP: Set the history reference back and run the "afterScan" methods of any ScannerHooks
         parent.performScannerHookAfterScan(msg, this);

--- a/src/org/parosproxy/paros/core/scanner/Analyser.java
+++ b/src/org/parosproxy/paros/core/scanner/Analyser.java
@@ -32,6 +32,7 @@
 // ZAP: 2015/02/09 Issue 1525: Introduce a database interface layer to allow for alternative implementations
 // ZAP: 2015/04/02 Issue 321: Support multiple databases and Issue 1582: Low memory option
 // ZAP: 2016/01/26 Fixed findbugs warning
+// ZAP: 2016/04/21 Allow to obtain the number of requests sent during the analysis
 
 package org.parosproxy.paros.core.scanner;
 
@@ -73,6 +74,14 @@ public class Analyser {
 
     // ZAP Added delayInMs
     private int delayInMs;
+
+    /**
+     * The count of requests sent (and received) during the analysis.
+     * 
+     * @see #sendAndReceive(HttpMessage)
+     * @see #getRequestCount()
+     */
+    private int requestCount;
 
     // ZAP: Added parent
     HostProcess parent = null;
@@ -469,6 +478,8 @@ public class Analyser {
         }
 
         httpSender.sendAndReceive(msg, true);
+        requestCount++;
+
         // ZAP: Notify parent
         if (parent != null) {
             parent.notifyNewMessage(msg);
@@ -481,6 +492,16 @@ public class Analyser {
 
     public void setDelayInMs(int delayInMs) {
         this.delayInMs = delayInMs;
+    }
+
+    /**
+     * Gets the request count, sent (and received) during the analysis.
+     *
+     * @return the request count
+     * @since TODO add version
+     */
+    public int getRequestCount() {
+        return requestCount;
     }
 
 }

--- a/src/org/zaproxy/zap/extension/ascan/ActiveScan.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScan.java
@@ -35,7 +35,6 @@ import javax.swing.DefaultListModel;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.HostProcess;
-import org.parosproxy.paros.core.scanner.Plugin;
 import org.parosproxy.paros.core.scanner.ScannerListener;
 import org.parosproxy.paros.core.scanner.ScannerParam;
 import org.parosproxy.paros.db.DatabaseException;
@@ -74,7 +73,6 @@ public class ActiveScan extends org.parosproxy.paros.core.scanner.Scanner implem
 	private Date timeStarted = null;
 	private Date timeFinished = null;
 	private int maxResultsToList = 0;
-	private int prevScanReqCount = 0;
 
 	private final List<Integer> hRefs = Collections.synchronizedList(new ArrayList<Integer>());
 	private final List<Integer> alerts = Collections.synchronizedList(new ArrayList<Integer>());
@@ -121,7 +119,11 @@ public class ActiveScan extends org.parosproxy.paros.core.scanner.Scanner implem
 	}
 
     public int getTotalRequests() {
-		return this.rcTotals.getTotal();
+		int total = 0;
+		for (HostProcess process : this.getHostProcesses()) {
+			total += process.getRequestCount();
+		}
+		return total;
 	}
 	
 	public ResponseCountSnapshot getRequestHistory() {
@@ -206,36 +208,15 @@ public class ActiveScan extends org.parosproxy.paros.core.scanner.Scanner implem
 			tot += process.getPercentageComplete();
 		}
 		this.progress = tot / this.getHostProcesses().size();
-		updatePluginRequestCounts();
 	}
 	
+	/**
+	 * @deprecated (TODO Add version) No longer used/needed, the request count is automatically updated/maintained by
+	 *             {@link HostProcess}.
+	 */
+	@Deprecated
 	public void updatePluginRequestCounts() {
-		List<Plugin> pluginList;
-		if (this.getHostProcesses().size() == 1) {
-			// Currently only support 1 HostProcess
-			HostProcess process = this.getHostProcesses().get(0);
-			pluginList = process.getRunning();
-			int totReqs = this.getTotalRequests();
-			int pluginReqs = totReqs - prevScanReqCount;
-			if (pluginList.size() > 1) {
-				// Thats a bit unexpected
-				log.debug("More than 1 plugin running: " + pluginList.size() + " unable to calculate request counts");
-			} else if (pluginReqs > 0) {
-				// We have something to count
-				if (pluginList.size() == 1) {
-					// Theres one running
-					process.setPluginRequestCount(pluginList.get(0).getId(), pluginReqs);
-				} else {
-					pluginList = process.getCompleted();
-					if (pluginList.size() > 0) {
-						// One must have just finished, update it and record the current level
-						log.debug("Plugin " + pluginList.get(pluginList.size()-1).getId() + " total # reqs: " + pluginReqs);
-						process.setPluginRequestCount(pluginList.get(pluginList.size()-1).getId(), pluginReqs);
-						prevScanReqCount = totReqs;
-					}
-				}
-			}
-		}
+		// No longer used.
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
@@ -607,7 +607,6 @@ public class ActiveScanAPI extends ApiImplementor {
 			resultList = new ApiResponseList(name);
 			activeScan = getActiveScan(params);
 			if (activeScan != null) {
-				activeScan.updatePluginRequestCounts();
 				for (HostProcess hp : activeScan.getHostProcesses()) {
 					ApiResponseList hpList = new ApiResponseList("HostProcess");
 					resultList.addItem(new ApiResponseElement("id", XMLStringUtil.escapeControlChrs(hp.getHostAndPort())));

--- a/src/org/zaproxy/zap/extension/ascan/ScanProgressTableModel.java
+++ b/src/org/zaproxy/zap/extension/ascan/ScanProgressTableModel.java
@@ -238,7 +238,6 @@ public class ScanProgressTableModel extends AbstractTableModel {
      */
     public void updateValues(ActiveScan scan, HostProcess hp) {
         values.clear();
-        scan.updatePluginRequestCounts();
         
         // Iterate all Plugins
         for (Plugin plugin : hp.getCompleted()) {


### PR DESCRIPTION
Allow scanners to notify that a (non-HTTP) message was sent and change
HostProcess to keep track of the requests sent (that is, notified) by
each scanner, so that the request count is more accurate.

More detailed changes:
 - HostProcess:
   - Add methods notifyNewMessage(Plugin plugin, HttpMessage), to know
   which scanner sent the HTTP message, and notifyNewMessage(Plugin),
   for the same purpose but for non-HTTP messages;
   - Add method getRequestCount(), to obtain the request count (of all
   scanners and Analyser);
   - Refactor the management of the stats collected from each scanner
   (start time, progress and request count), by using a nested class
   (PluginStats) and replacing the existing maps (plugin ID to each
   stat) with only one (plugin ID to PluginStats).
   - Change processPlugin(Plugin) to initialise the PluginStats of the
   scanner being processed;
   - Change scanSingleNode(Plugin, StructuralNode) to increase the
   progress of Plugin;
   - Change getTestCurrentCount(Plugin), getPluginRequestCount(int) and
   pluginCompleted(Plugin) to use the new stats map/class;
   - Deprecate setTestCurrentCount(Plugin, int), no longer needed the
   progress is now maintained internally;
   - Deprecate setPluginRequestCount(int, int), no longer needed the
   request count is now maintained internally;
 - AbstractAppPlugin, remove the manual setting of Plugin's progress, no
 longer needed, HostProcess takes care of keeping track of progress;
 - AbstractPlugin, change to notify the HostProcess with Plugin itself,
 so the requests sent are correctly counted;
 - Analyser, change to allow to obtain the request count, included in
 the total request count of the HostProcess;
 - ActiveScan, change to obtain the request counts from the HostProcess
 instead of calculating manually (and deprecate the method that was
 doing that);
 - ActiveScanAPI and ScanProgressTableModel, remove calls to ActiveScan
 to update the request counts.

Fix #2420 - Allow active scanners to notify that a message was sent
Fix #2421 - Active scanner request count mismatch