### PR TITLE
Fix memory leak on session creation/loading

### DIFF
--- a/src/org/parosproxy/paros/control/Control.java
+++ b/src/org/parosproxy/paros/control/Control.java
@@ -58,6 +58,7 @@
 // ZAP: 2015/09/17 Issue 1914: Support multiple add-on directories
 // ZAP: 2015/11/04 Issue 1920: Report the host:port ZAP is listening on in daemon mode, or exit if it cant
 // ZAP: 2016/03/23 Issue 2331: Custom Context Panels not show in existing contexts after installation of add-on
+// ZAP: 2016/04/22 Issue 2428: Memory leak on session creation/loading
 
 package org.parosproxy.paros.control;
 
@@ -327,8 +328,8 @@ public class Control extends AbstractControl implements SessionListener {
 		}
 
 	    log.info("New session file created");
-		control.getExtensionLoader().sessionChangedAllPlugin(session);
 		control.getExtensionLoader().databaseOpen(model.getDb());
+		control.getExtensionLoader().sessionChangedAllPlugin(session);
 	}
     
     public void runCommandLineOpenSession(String fileName) throws Exception {
@@ -338,8 +339,8 @@ public class Control extends AbstractControl implements SessionListener {
     	Session session = Model.getSingleton().getSession();
     	Model.getSingleton().openSession(fileName);
 	    log.info("Session file opened");
-		control.getExtensionLoader().sessionChangedAllPlugin(session);
 		control.getExtensionLoader().databaseOpen(model.getDb());
+		control.getExtensionLoader().sessionChangedAllPlugin(session);
     }
 
     public void setExcludeFromProxyUrls(List<String> urls) {
@@ -366,8 +367,8 @@ public class Control extends AbstractControl implements SessionListener {
 	    log.info("New Session");
 		getExtensionLoader().sessionAboutToChangeAllPlugin(null);
 		final Session session = model.newSession();
-		getExtensionLoader().sessionChangedAllPlugin(session);
 		getExtensionLoader().databaseOpen(model.getDb());
+		getExtensionLoader().sessionChangedAllPlugin(session);
 
 		if (View.isInitialised()) {
 			SwingUtilities.invokeLater(new Runnable() {
@@ -431,14 +432,14 @@ public class Control extends AbstractControl implements SessionListener {
 		getExtensionLoader().sessionAboutToChangeAllPlugin(null);
 		model.closeSession();
 		model.createAndOpenUntitledDb();
-		getExtensionLoader().sessionChangedAllPlugin(model.getSession());
 		getExtensionLoader().databaseOpen(model.getDb());
+		getExtensionLoader().sessionChangedAllPlugin(model.getSession());
 	}
 
 	@Override
 	public void sessionOpened(File file, Exception e) {
-		getExtensionLoader().sessionChangedAllPlugin(model.getSession());
 		getExtensionLoader().databaseOpen(model.getDb());
+		getExtensionLoader().sessionChangedAllPlugin(model.getSession());
 		if (lastCallback != null) {
 			lastCallback.sessionOpened(file, e);
 			lastCallback = null;
@@ -448,8 +449,8 @@ public class Control extends AbstractControl implements SessionListener {
 
 	@Override
 	public void sessionSaved(Exception e) {
-		getExtensionLoader().sessionChangedAllPlugin(model.getSession());
 		getExtensionLoader().databaseOpen(model.getDb());
+		getExtensionLoader().sessionChangedAllPlugin(model.getSession());
 		if (lastCallback != null) {
 			lastCallback.sessionSaved(e);
 			lastCallback = null;

--- a/src/org/parosproxy/paros/db/AbstractDatabase.java
+++ b/src/org/parosproxy/paros/db/AbstractDatabase.java
@@ -1,0 +1,114 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.db;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+
+/**
+ * An abstract implementation of {@link Database}, it allows to manage {@link DatabaseListener DatabaseListeners}.
+ * 
+ * @since TODO add version
+ */
+public abstract class AbstractDatabase implements Database {
+
+    protected final Logger logger = Logger.getLogger(getClass());
+
+    private final List<DatabaseListener> databaseListeners;
+
+    public AbstractDatabase() {
+        databaseListeners = new ArrayList<>();
+    }
+
+    /**
+     * Gets the database listeners added.
+     *
+     * @return the database listeners
+     * @see #addDatabaseListener(DatabaseListener)
+     */
+    protected List<DatabaseListener> getDatabaseListeners() {
+        return databaseListeners;
+    }
+
+    @Override
+    public void addDatabaseListener(DatabaseListener listener) {
+        databaseListeners.add(listener);
+    }
+
+    @Override
+    public void removeDatabaseListener(DatabaseListener listener) {
+        databaseListeners.remove(listener);
+    }
+
+    @Override
+    public void close(boolean compact) {
+        close(compact, true);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Also, removes the database listeners added previously.
+     */
+    @Override
+    public void close(boolean compact, boolean cleanup) {
+        removeDatabaseListeners();
+    }
+
+    /**
+     * Removes all database listeners added.
+     * 
+     * @see #removeDatabaseListener(DatabaseListener)
+     */
+    protected void removeDatabaseListeners() {
+        databaseListeners.clear();
+    }
+
+    /**
+     * Notifies the given listeners that the given database server was opened.
+     *
+     * @param listeners the listeners that will be notified
+     * @param databaseServer the database server that was opened
+     * @throws DatabaseException if an error occurred while notifying the database listeners.
+     */
+    protected void notifyListenersDatabaseOpen(Collection<DatabaseListener> listeners, DatabaseServer databaseServer)
+            throws DatabaseException {
+        for (DatabaseListener databaseListener : listeners) {
+            try {
+                databaseListener.databaseOpen(databaseServer);
+            } catch (DatabaseUnsupportedException e) {
+                logger.error(e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * Notifies the database listeners added that the given database server was opened.
+     *
+     * @param databaseServer the database server that was opened
+     * @throws DatabaseException if an error occurred while notifying the database listeners.
+     */
+    protected void notifyListenersDatabaseOpen(DatabaseServer databaseServer) throws DatabaseException {
+        notifyListenersDatabaseOpen(databaseListeners, databaseServer);
+    }
+}

--- a/src/org/zaproxy/zap/db/sql/HsqldbDatabase.java
+++ b/src/org/zaproxy/zap/db/sql/HsqldbDatabase.java
@@ -22,29 +22,11 @@ package org.zaproxy.zap.db.sql;
 
 import java.io.File;
 
-import org.apache.log4j.Logger;
-import org.parosproxy.paros.db.Database;
-
-
-
-public class HsqldbDatabase extends SqlDatabase implements Database {
+public class HsqldbDatabase extends SqlDatabase {
 	
-    private static final Logger log = Logger.getLogger(HsqldbDatabase.class);
-
 	public HsqldbDatabase() {
 		super();
 	}
-	
-    /* (non-Javadoc)
-	 * @see org.parosproxy.paros.db.DatabaseIF#close(boolean)
-	 */
-    // ZAP: Added JavaDoc.
-    @Override
-	public void close(boolean compact) {
-        // ZAP: Moved the content of this method to the method close(boolean,
-        // boolean) and changed to call that method instead.
-        close(compact, true);
-    }
 
     /* (non-Javadoc)
 	 * @see org.parosproxy.paros.db.DatabaseIF#deleteSession(java.lang.String)
@@ -52,7 +34,7 @@ public class HsqldbDatabase extends SqlDatabase implements Database {
     @Override
 	public void deleteSession(String sessionName) {
     	super.deleteSession(sessionName);
-		log.debug("deleteSession " + sessionName);
+		logger.debug("deleteSession " + sessionName);
 
 		deleteDbFile(new File(sessionName));
         deleteDbFile(new File(sessionName + ".data"));
@@ -63,19 +45,17 @@ public class HsqldbDatabase extends SqlDatabase implements Database {
     }
     
     private void deleteDbFile (File file) {
-    	log.debug("Deleting " + file.getAbsolutePath());
+    	logger.debug("Deleting " + file.getAbsolutePath());
 		if (file.exists()) {
 			if (! file.delete()) {
-	            log.error("Failed to delete " + file.getAbsolutePath());
+	            logger.error("Failed to delete " + file.getAbsolutePath());
 			}
 		}
     }
 
 	@Override
-	public void open(String path) throws ClassNotFoundException, Exception {
-		log.debug("open " + path);
-	    setDatabaseServer(new HsqldbDatabaseServer(path));
-	    notifyListenerDatabaseOpen();
+	protected SqlDatabaseServer createDatabaseServer(String path) throws Exception {
+	    return new HsqldbDatabaseServer(path);
 	}
 
     /* (non-Javadoc)
@@ -83,7 +63,7 @@ public class HsqldbDatabase extends SqlDatabase implements Database {
 	 */
 	@Override
 	public void close(boolean compact, boolean cleanup) {
-		log.debug("close");
+		logger.debug("close");
 		super.close(compact, cleanup);
 	    if (this.getDatabaseServer() == null) {
 	    	return;
@@ -93,7 +73,7 @@ public class HsqldbDatabase extends SqlDatabase implements Database {
 	        // shutdown
 	    	((HsqldbDatabaseServer)this.getDatabaseServer()).shutdown(compact);
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            logger.error(e.getMessage(), e);
         }
 	}
 	


### PR DESCRIPTION
Remove the database listeners added by add-ons, once the database is
closed (database listeners are added by add-ons when a new database is
opened, so removing when closed ensures that there are no more database
listeners than it is necessary and preventing the memory leak).

More detailed changes:
 - Control, change to notify that a database was opened before notifying
 that the session was changed, some add-ons might need a database
 connection to handle the changed session (not a problem before because
 several database listeners were kept in memory);
 - Add AbstractDatabase class to manage the DatabaseListeners and to
 remove them when the database is closed;
 - Change ParosDatabase, HsqlbDatabase and SqlDatabase to use/extend the
 class AbstractDatabase.

Fix #2428 - Memory leak on session creation/loading