### PR TITLE
Fix InterruptedException while stopping the spider

### DIFF
--- a/src/org/parosproxy/paros/view/OutputPanel.java
+++ b/src/org/parosproxy/paros/view/OutputPanel.java
@@ -214,4 +214,21 @@ public class OutputPanel extends AbstractPanel {
 			getTxtOutput().append(message);
 	}
 	
+	/**
+	 * Appends the given {@code message} to the panel, asynchronously in the EDT.
+	 *
+	 * @param message the message to append to the output panel
+	 * @since TODO add version
+	 * @see EventQueue#invokeLater(Runnable)
+	 */
+	public void appendAsync(final String message) {
+		EventQueue.invokeLater(new Runnable() {
+
+			@Override
+			public void run() {
+				doAppend(message);
+			}
+		});
+	}
+
   }  //  @jve:decl-index=0:visual-constraint="10,10"


### PR DESCRIPTION
Append the messages to output tab and add the messages to History tab
asynchronously in the EDT, preventing the exceptions (and "hanging" the
spider worker threads more time than needed).

More detailed changes:
 - AuthenticationHelper, append the authentication status messages
 to the OutputPanel and add the authentication messages to the
 ExtensionHistory, asynchronously (for the latter also check if the View
 is initialised, otherwise there's no point adding it);
 - OutputPanel, add a convenience method that adds a message
 asynchronously to the panel itself.

Fix #2429 - InterruptedExceptions while stopping the spider with user
authentication