### PR TITLE
Clean up spider task resources, when not consumed

### DIFF
--- a/src/org/zaproxy/zap/spider/Spider.java
+++ b/src/org/zaproxy/zap/spider/Spider.java
@@ -516,7 +516,9 @@ public class Spider {
 		try {
 			if (!this.threadPool.awaitTermination(2, TimeUnit.SECONDS)) {
 				log.warn("Failed to await for all spider threads to stop in the given time (2s)...");
-				this.threadPool.shutdownNow();
+				for (Runnable task : this.threadPool.shutdownNow()) {
+					((SpiderTask) task).cleanup();
+				}
 			}
 		} catch (InterruptedException ignore) {
 			log.warn("Interrupted while awaiting for all spider threads to stop...");


### PR DESCRIPTION
Clean up spider tasks' resources (persisted HTTP message) in all cases,
when it is and it isn't consumed. If the spider is stopped with pending
tasks it would leave a HTTP message per task in the database that would
not be deleted, ever.

Changes:
 - SpiderTask:
  - Change method run() to delete the message when stopped before
  consuming the message, also reorder the statements to prevent a
  (potential) NullPointerException when logging debug data;
  - Extracted a method, deleteHistoryReference(), to delete the
  persisted message, called when the message is consumed and when not;
  - Add a method to allow to cleanup its resources (called by Spider
  class);
 - Spider, call the method SpiderTask.cleanup() when the tasks are not
 executed.