### PR TITLE
Reverse the uninstallation of add-on's extensions

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnInstaller.java
+++ b/src/org/zaproxy/zap/control/AddOnInstaller.java
@@ -210,6 +210,7 @@ public final class AddOnInstaller {
 
         callback.extensionsWillBeRemoved(addOn.getLoadedExtensions().size());
         List<Extension> extensions = new ArrayList<>(addOn.getLoadedExtensions());
+        Collections.reverse(extensions);
         for (Extension ext : extensions) {
             uninstalledWithoutErrors &= uninstallAddOnExtension(addOn, ext, callback);
         }


### PR DESCRIPTION
Change method AddOnInstaller.uninstallAddOnExtensions(...) to reverse
the order of uninstallation of the extensions of the add-ons, extensions
that are declared later in the manifest (ZapAddOn.xml) might depend on
extensions declared earlier, which might lead to exceptions if those are
uninstalled first. This is similar to the uninstallation order of other
components of an add-on, for example, active and passive scanners are
installed after extensions, when uninstalling the add-on they are
unsintalled before the extensions.

Fix #2436 - Unable to dynamically uninstall WebSockets add-on