### PR TITLE
Show more informative error on proxy read timeout

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1560,6 +1560,7 @@ proxy.error.host.unknow = Unknown host
 proxy.error.port = Cannot listen on port
 proxy.error.address = Cannot listen on address
 proxy.error.generic = An error occurred while starting the proxy:\n
+proxy.error.readtimeout = Failed to read {0} within {1} seconds, check to see if the site is available and if so consider adjusting ZAP''s read time out in the Connection options panel.
 
 pscan.api.action.setEnabled = Sets whether or not the passive scanning is enabled
 pscan.api.action.enableAllScanners = Enables all passive scanners


### PR DESCRIPTION
Change class ProxyThread to set a more informative error message into
the body of the HTTP response, indicating that a read timeout occurred
while reading the response after the seconds defined in the Connection
options panel (as proposed in the issue report).

Fix #2400 - Show a more informative message on read timeouts through the
proxy