### PR TITLE
Reduce the number of session/db notifications

### DIFF
--- a/src/org/parosproxy/paros/control/MenuFileControl.java
+++ b/src/org/parosproxy/paros/control/MenuFileControl.java
@@ -106,7 +106,6 @@ public class MenuFileControl implements SessionListener {
 		    } else if (view.showConfirmDialog(Constant.messages.getString("menu.file.closeSession")) != JOptionPane.OK_OPTION) {
 				return;
 			}
-			control.createAndOpenUntitledDb();
 		}
 		
 		int newSessionOption = model.getOptionsParam().getDatabaseParam().getNewSessionOption();

--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -345,12 +345,11 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 				// Create a new 'unnamed' session
 				Control.getSingleton().discardSession();
 				try {
-					Control.getSingleton().createAndOpenUntitledDb();
+					Control.getSingleton().newSession();
 				} catch (Exception e) {
 					throw new ApiException(ApiException.Type.INTERNAL_ERROR,
 							e.getMessage());
 				}
-				Control.getSingleton().newSession();
 			} else {
 				Path sessionPath = SessionUtils.getSessionPath(sessionName);
 				String filename = sessionPath.toAbsolutePath().toString();


### PR DESCRIPTION
Reduce the number of session/db notifications (sessionChangedAllPlugin,
sessionAboutToChangeAllPlugin and databaseOpen) when creating a new
session by creating the database at the same time as the session (which
no longer requires calling the previously mentioned methods twice).

More detailed changes:
 - Control:
  - Change methods newSession() and newSession(String, SessionListener)
  to also create the empty database and no longer notify of
  sessionAboutToChangeAllPlugin (done by new method);
  - Deprecate the method createAndOpenUntitledDb(), no longer needs to
  be called by external code;
  - Add helper method that creates the database and only notifies of
  sessionAboutToChangeAllPlugin;
 - CoreAPI and MenuFileControl, remove the calls to the method
 Control.createAndOpenUntitledDb().