### PR TITLE
Fix exception while opening Active Scan dialogue

### DIFF
--- a/src/org/parosproxy/paros/extension/option/OptionsParamView.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsParamView.java
@@ -32,6 +32,7 @@
 // ZAP: 2015/03/04 Added dev build warning option
 // ZAP: 2016/04/04 Do not require a restart to show/hide the tool bar
 // ZAP: 2016/04/06 Fix layouts' issues
+// ZAP: 2016/04/27 Save, always, the Locale as String
 
 package org.parosproxy.paros.extension.option;
 
@@ -218,8 +219,7 @@ public class OptionsParamView extends AbstractParam {
 			sb.append(locale.getLanguage());
 			if (locale.getCountry().length() > 0) sb.append("_").append(locale.getCountry());
 			if (locale.getVariant().length() > 0) sb.append("_").append(locale.getVariant());
-			this.locale = sb.toString();
-			getConfig().setProperty(LOCALE, locale);
+			setLocale(sb.toString());
 		}
 	}
 

--- a/src/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
+++ b/src/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
@@ -54,8 +54,6 @@ import javax.swing.text.Highlighter.Highlight;
 import javax.swing.text.Highlighter.HighlightPainter;
 
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.ConfigurationUtils;
-import org.apache.commons.configuration.XMLConfiguration;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -64,7 +62,6 @@ import org.parosproxy.paros.core.scanner.ScannerParam;
 import org.parosproxy.paros.core.scanner.VariantUserDefined;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.model.Model;
-import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
@@ -116,7 +113,6 @@ public class CustomScanDialog extends StandardFieldsDialog {
     private Target target = null;
 
     private ScannerParam scannerParam = null;
-    private OptionsParam optionsParam = null;
 
     private JPanel customPanel = null;
     private JPanel techPanel = null;
@@ -694,20 +690,7 @@ public class CustomScanDialog extends StandardFieldsDialog {
     }
 
     private void reset(boolean refreshUi) {
-        
-        // From Apache Commons source code:
-        // Note: This method won't work well on hierarchical configurations because it is not able to 
-        // copy information about the properties' structure. 
-        // So when dealing with hierarchical configuration objects their clone() methods should be used.        
-        //FileConfiguration fileConfig = new XMLConfiguration();
-        //ConfigurationUtils.copy(extension.getScannerParam().getConfig(), fileConfig);
-        XMLConfiguration fileConfig = (XMLConfiguration)ConfigurationUtils.cloneConfiguration(extension.getScannerParam().getConfig());
-
-        scannerParam = new ScannerParam();
-        scannerParam.load(fileConfig);
-
-        optionsParam = new OptionsParam();
-        optionsParam.load(fileConfig);
+        scannerParam = (ScannerParam) extension.getScannerParam().clone();
 
         if (refreshUi) {
             init(target);


### PR DESCRIPTION
Change method OptionsParamView.setLocale(Locale) to save the locale as
String instead of Locale (call existing method setLocale(String),
preventing the issue if the OptionsParamView is (re)loaded.
Remove instance variable CustomScanDialog.optionsParam and corresponding
load of configurations (which was triggering the issue) when the
dialogue is reset, the optionsParam is not being used. Also, change to
use the method ScannerParam.clone() instead of doing the clone manually.

Fix #2440 - Exception while opening the Active Scan dialogue