### PR TITLE
Raise SiteMap Add or Remove Events

### DIFF
--- a/src/org/parosproxy/paros/model/SiteMapEventPublisher.java
+++ b/src/org/parosproxy/paros/model/SiteMapEventPublisher.java
@@ -28,6 +28,8 @@ public class SiteMapEventPublisher implements EventPublisher {
 	private static SiteMapEventPublisher publisher = null;
 	public static final String SITE_NODE_ADDED_EVENT	= "siteNode.added";
 	public static final String SITE_NODE_REMOVED_EVENT	= "siteNode.removed";
+	public static final String SITE_ADDED_EVENT	= "site.added";
+	public static final String SITE_REMOVED_EVENT	= "site.removed";
 	
 	@Override
 	public String getPublisherName() {
@@ -38,7 +40,7 @@ public class SiteMapEventPublisher implements EventPublisher {
 		if (publisher == null) {
 			publisher = new SiteMapEventPublisher(); 
 	        ZAP.getEventBus().registerPublisher(publisher, 
-	        		new String[] {SITE_NODE_ADDED_EVENT, SITE_NODE_REMOVED_EVENT});
+	        		new String[] {SITE_NODE_ADDED_EVENT, SITE_NODE_REMOVED_EVENT, SITE_ADDED_EVENT, SITE_REMOVED_EVENT});
 
 		}
 		return publisher;


### PR DESCRIPTION
Raise SiteMap Add or Remove Events

SiteMap 
- Add private method handleEvent: Called from findAndAddChild,
findAndAddLeaf, removeNodeFromParent. 
- Add private convenience method publishEvent that accepts an event and
node to publish the necessary event (leveraging
SiteMapEventPublisher). Node events are always published,
site events are also published when the parent is the root of the tree.
- New overridden removeNodeFromParent method that extracts the
node's parent, calls the super method, and makes the call for the event
to be handled.

SiteMapEventPublisher
- Added site events (node events already existed).

Fixes zaproxy/zaproxy#1171