### PR TITLE
Change README to inform about Xfvb, when headless

### DIFF
--- a/src/doc/README
+++ b/src/doc/README
@@ -38,3 +38,6 @@ environments, in those cases ZAP needs to be started inline, using the command
 line argument '-cmd', or in daemon mode, using '-daemon'.
 For more information about the command line arguments use '-help'.
 ZAP will show an information message and exit, if still started with GUI.
+
+Note, some of the ZAP features that require a display, for example, running AJAX
+Spider with Firefox, might still be run with the help of applications like Xvfb.

--- a/src/doc/README.weekly
+++ b/src/doc/README.weekly
@@ -38,3 +38,6 @@ environments, in those cases ZAP needs to be started inline, using the command
 line argument '-cmd', or in daemon mode, using '-daemon'.
 For more information about the command line arguments use '-help'.
 ZAP will show an information message and exit, if still started with GUI.
+
+Note, some of the ZAP features that require a display, for example, running AJAX
+Spider with Firefox, might still be run with the help of applications like Xvfb.


### PR DESCRIPTION
Update the section "Headless Environment" of README (and README.weekly)
to mention the use of applications like Xfvb when running in a headless
environment to use functionalities/add-ons that require a display.

Related to changes for #2390 - HeadlessException should be handled more
gracefully & README needs Headless details