### PR TITLE
Fix issues related to ParameterParser

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/Variant.java
+++ b/src/org/parosproxy/paros/core/scanner/Variant.java
@@ -20,6 +20,7 @@
  */
 // ZAP: 2013/07/02 Changed Vector to generic List
 // ZAP: 2013/07/02 Changed API to public for future extensible Variant model
+// ZAP: 2016/05/04 Add JavaDoc to getParamList()
 package org.parosproxy.paros.core.scanner;
 
 import java.util.List;
@@ -29,7 +30,14 @@ import org.parosproxy.paros.network.HttpMessage;
 public interface Variant {
 
     public void setMessage(HttpMessage msg);
+
+    /**
+     * Gets the list of parameters handled by this variant.
+     * 
+     * @return a {@code List} containing the parameters
+     */
     public List<NameValuePair> getParamList();
+
     public String setParameter(HttpMessage msg, NameValuePair originalPair, String param, String value);
     public String setEscapedParameter(HttpMessage msg, NameValuePair originalPair, String param, String value);
     

--- a/src/org/parosproxy/paros/core/scanner/VariantAbstractQuery.java
+++ b/src/org/parosproxy/paros/core/scanner/VariantAbstractQuery.java
@@ -27,9 +27,11 @@
 // ZAP: 2013/08/21 Added a new encoding/decoding model for a correct parameter value interpretation
 // ZAP: 2014/01/06 Issue 965: Support 'single page' apps and 'non standard' parameter separators
 // ZAP: 2014/02/08 Used the same constants used in ScanParam Target settings
-//
+// ZAP: 2016/05/04 Changes to address issues related to ParameterParser
+
 package org.parosproxy.paros.core.scanner;
 
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -65,6 +67,21 @@ public abstract class VariantAbstractQuery implements Variant {
     protected abstract String getEscapedValue(HttpMessage msg, String value);
 
     /**
+     * Gets parameter's name in encoded/escaped form.
+     * <p>
+     * Default implementation is to URL encode the name.
+     *
+     * @param msg the message that contains the parameter
+     * @param name the name to escape
+     * @return the escaped name
+     * @since TODO Add version
+     * @see URLEncoder#encode(String, String)
+     */
+    protected String getEscapedName(HttpMessage msg, String name) {
+        return name != null ? AbstractPlugin.getURLEncode(name) : "";
+    }
+
+    /**
      * Return unescaped mutate of the value. To be overridden by subclass.
      * 
      * @param value
@@ -73,9 +90,10 @@ public abstract class VariantAbstractQuery implements Variant {
     protected abstract String getUnescapedValue(String value);
 
     /**
-     * 
-     * @param params 
+     * @deprecated (TODO add version) use {@link #setParameters(int, List)} instead.
      */
+    @Deprecated
+    @SuppressWarnings("javadoc")
     protected void setParams(int type, Map<String, String> params) {
         int i = 0;
         for (Entry<String, String> param : params.entrySet()) {
@@ -85,9 +103,27 @@ public abstract class VariantAbstractQuery implements Variant {
     }
 
     /**
+     * Sets the given {@code parameters} of the given {@code type} as the list of parameters handled by this variant.
+     * <p>
+     * The names and values of the parameters are expected to be in decoded form.
      *
-     * @return
+     * @param type the type of parameters
+     * @param parameters the actual parameters to add
+     * @since TODO add version
+     * @see #getParamList()
+     * @see NameValuePair#TYPE_QUERY_STRING
+     * @see NameValuePair#TYPE_POST_DATA
      */
+    protected void setParameters(int type, List<org.zaproxy.zap.model.NameValuePair> parameters) {
+        listParam.clear();
+
+        int i = 0;
+        for (org.zaproxy.zap.model.NameValuePair parameter : parameters) {
+            listParam.add(new NameValuePair(type, parameter.getName(), parameter.getValue(), i));
+            i++;
+        }
+    }
+
     @Override
     public List<NameValuePair> getParamList() {
         return listParam;
@@ -124,10 +160,10 @@ public abstract class VariantAbstractQuery implements Variant {
         for (int i = 0; i < getParamList().size(); i++) {
             pair = getParamList().get(i);
             if (i == originalPair.getPosition()) {
-                isAppended = paramAppend(sb, name, encodedValue, parser);
+                isAppended = paramAppend(sb, getEscapedName(msg, name), encodedValue, parser);
 
             } else {
-                isAppended = paramAppend(sb, pair.getName(), getEscapedValue(msg, pair.getValue()), parser);
+                isAppended = paramAppend(sb, getEscapedName(msg, pair.getName()), getEscapedValue(msg, pair.getValue()), parser);
             }
 
             if (isAppended && i < getParamList().size() - 1) {

--- a/src/org/parosproxy/paros/core/scanner/VariantFormQuery.java
+++ b/src/org/parosproxy/paros/core/scanner/VariantFormQuery.java
@@ -26,7 +26,8 @@
 // ZAP: 2013/12/09 Solved NullPointerException when the request header doesn't contain "Content-Type" header field
 // ZAP: 2014/01/06 Issue 965: Support 'single page' apps and 'non standard' parameter separators
 // ZAP: 2014/02/08 Used the same constants used in ScanParam Target settings
-//
+// ZAP: 2016/05/04 Changed to use setParameters(int, List<NameValuePair>)
+
 package org.parosproxy.paros.core.scanner;
 
 import org.parosproxy.paros.model.Model;
@@ -48,7 +49,7 @@ public class VariantFormQuery extends VariantAbstractQuery {
         String contentType = msg.getRequestHeader().getHeader(HttpHeader.CONTENT_TYPE);
         // ZAP: added control for null contentType
         if (contentType != null && contentType.startsWith(WWW_APP_URL_ENCODED)) {
-        	this.setParams(NameValuePair.TYPE_POST_DATA, Model.getSingleton().getSession().getParams(msg, Type.form));
+        	this.setParameters(NameValuePair.TYPE_POST_DATA, Model.getSingleton().getSession().getParameters(msg, Type.form));
         }
     }
             

--- a/src/org/parosproxy/paros/core/scanner/VariantURLQuery.java
+++ b/src/org/parosproxy/paros/core/scanner/VariantURLQuery.java
@@ -24,7 +24,8 @@
 // ZAP: 2013/08/21 Added a new encoding/decoding model for a correct parameter value interpretation
 // ZAP: 2014/01/06 Issue 965: Support 'single page' apps and 'non standard' parameter separators
 // ZAP: 2014/02/08 Used the same constants used in ScanParam Target settings
-//
+// ZAP: 2016/05/04 Changed to use setParameters(int, List<NameValuePair>)
+
 package org.parosproxy.paros.core.scanner;
 
 import org.apache.commons.httpclient.URIException;
@@ -65,7 +66,7 @@ public class VariantURLQuery extends VariantAbstractQuery {
 
     @Override
     public void setMessage(HttpMessage msg) {
-       	this.setParams(NameValuePair.TYPE_QUERY_STRING, Model.getSingleton().getSession().getParams(msg, Type.url));
+       	this.setParameters(NameValuePair.TYPE_QUERY_STRING, Model.getSingleton().getSession().getParameters(msg, Type.url));
     }
 
     @Override

--- a/src/org/zaproxy/zap/model/DefaultNameValuePair.java
+++ b/src/org/zaproxy/zap/model/DefaultNameValuePair.java
@@ -1,0 +1,176 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.model;
+
+/**
+ * Default implementation of {@code NameValuePair}, in which the name and value are optional, that is, can be {@code null}.
+ * <p>
+ * The implementation is immutable thus thread safe.
+ *
+ * @since TODO add version
+ */
+public final class DefaultNameValuePair implements NameValuePair, Comparable<DefaultNameValuePair> {
+
+    /**
+     * The name of the pair, might be {@code null}.
+     */
+    private final String name;
+
+    /**
+     * The value of the pair, might be {@code null}.
+     */
+    private final String value;
+
+    /**
+     * Constructs a {@code DefaultNameValuePair} with no name nor value.
+     */
+    public DefaultNameValuePair() {
+        this(null, null);
+    }
+
+    /**
+     * Constructs a {@code DefaultNameValuePair} with the given {@code name} and no value.
+     *
+     * @param name the name, might be {@code null}
+     */
+    public DefaultNameValuePair(String name) {
+        this(name, null);
+    }
+
+    /**
+     * Constructs a {@code DefaultNameValuePair} with the given {@code name} and {@code value}.
+     *
+     * @param name the name, might be {@code null}
+     * @param value the value, might be {@code null}
+     */
+    public DefaultNameValuePair(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    /**
+     * @return the name, might be {@code null}
+     */
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return the value, might be {@code null}
+     */
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder strBuilder = new StringBuilder(75);
+        strBuilder.append("[");
+        if (name != null) {
+            strBuilder.append("Name=").append(name);
+        }
+        if (value != null) {
+            if (name != null) {
+                strBuilder.append(", ");
+            }
+            strBuilder.append("Value=").append(value);
+        }
+        strBuilder.append(']');
+        return strBuilder.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null) {
+            return false;
+        }
+        if (getClass() != object.getClass()) {
+            return false;
+        }
+
+        DefaultNameValuePair other = (DefaultNameValuePair) object;
+        if (!equalStrings(name, other.name)) {
+            return false;
+        }
+
+        if (!equalStrings(value, other.value)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static boolean equalStrings(String string, String otherString) {
+        if (string == null) {
+            if (otherString != null) {
+                return false;
+            }
+        } else if (!string.equals(otherString)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int compareTo(DefaultNameValuePair other) {
+        if (other == null) {
+            return 1;
+        }
+
+        int res = compareStrings(name, other.name);
+        if (res != 0) {
+            return res;
+        }
+
+        res = compareStrings(value, other.value);
+        if (res != 0) {
+            return res;
+        }
+
+        return 0;
+    }
+
+    private static int compareStrings(String string, String otherString) {
+        if (string == null) {
+            if (otherString != null) {
+                return -1;
+            }
+            return 0;
+        } else if (otherString == null) {
+            return 1;
+        }
+
+        return string.compareTo(otherString);
+    }
+}

--- a/src/org/zaproxy/zap/model/NameValuePair.java
+++ b/src/org/zaproxy/zap/model/NameValuePair.java
@@ -1,0 +1,45 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.model;
+
+/**
+ * A name/value pair.
+ * <p>
+ * How {@code null} name and/or value are handled is at the discretion of implementations, for example, some implementations
+ * might choose to require a name, but not a value (thus being {@code null}).
+ *
+ * @since TODO add version
+ */
+public interface NameValuePair {
+
+    /**
+     * Gets the name of the name/value pair.
+     *
+     * @return the name
+     */
+    String getName();
+
+    /**
+     * Gets the value of the name/value pair.
+     *
+     * @return the value
+     */
+    String getValue();
+}

--- a/src/org/zaproxy/zap/model/ParameterParser.java
+++ b/src/org/zaproxy/zap/model/ParameterParser.java
@@ -31,7 +31,41 @@ public interface ParameterParser {
 
 	Map<String, String> getParams(HttpMessage msg, HtmlParameter.Type type);
 
+	/**
+	 * Gets the parameters of the given {@code type} from the given {@code message}.
+	 * <p>
+	 * The parameters are split using the key value pair separator(s) and each resulting parameter is split into name/value
+	 * pairs using key value separator(s).
+	 * <p>
+	 * Parameters' names and values are in decoded form.
+	 *
+	 * @param msg the message whose parameters will be extracted from
+	 * @param type the type of parameters to extract
+	 * @return a {@code List} containing the parameters
+	 * @throws IllegalArgumentException if the {@code msg} or {@code type} is {@code null}.
+	 * @since TODO add version
+	 * @see #getDefaultKeyValuePairSeparator()
+	 * @see #getDefaultKeyValueSeparator()
+	 */
+	List<NameValuePair> getParameters(HttpMessage msg, HtmlParameter.Type type);
+
 	Map<String, String> parse(String paramStr);
+
+	/**
+	 * Parses the given {@code parameters} into a list of {@link NameValuePair}.
+	 * <p>
+	 * The parameters are split using the key value pair separator(s) and each resulting parameter is split into name/value
+	 * pairs using key value separator(s).
+	 * <p>
+	 * Parameters' names and values are in decoded form.
+	 *
+	 * @param parameters the String of parameters to parse, might be {@code null}
+	 * @return a {@code List} containing the parameters parsed
+	 * @since TODO add version
+	 * @see #getDefaultKeyValuePairSeparator()
+	 * @see #getDefaultKeyValueSeparator()
+	 */
+	List<NameValuePair> parseParameters(String parameters);
 
 	List<String> getTreePath(URI uri) throws URIException;
 	


### PR DESCRIPTION
Parse form/query parameters in encoded form, so they are correctly split
into name/value pairs even if the names and/or values have separator
characters (normally, '&' and '='), also allow to keep all parameters,
so requests that require multiple values with same name (e.g. arrays)
are still sent with all of them (instead of just one).
When rebuilding the query component of the URL, during active scan, make
sure to also encode parameters' names not just its values, otherwise the
query could be malformed if the names contain characters that should be
encoded (common when dealing with multiple vales which might use the
characters '[' and ']'), leading to exceptions and failing to properly
attack those parameters. (The same logic applies for form parameters.)

More detailed changes:
 - Variant, document the method getParamList();
 - VariantAbstractQuery:
  - Add method, getEscapedName(HttpMessage, String), to encode/escape
  parameter's name;
  - Add method, setParameters(int, List\<NameValuePair>), to allow
  extending classes to set (and finally send) all parameters even if
  they have the same name;
  - Deprecate the method setParams(int, Map\<String, String>) in favour
  of the new method.
 - VariantFormQuery and VarianURLQuery, change to obtain all the
 parameters using a new method in Session class and to set all of them
 using the new method of the class VariantAbstractQuery;
 - Session:
  - Add method, getParameters(HttpMessage, HtmlParameter.Type), that
  allows to obtain (all) URL or form parameters from a message;
  - Change method getUrlParams(URI) to parse the query in escaped form
   (and use the new method added to ParameterParser, which decodes the
   parameters names and values when parsing, as expected by callers);
 - Add interface NameValuePair and default implementation, class
 DefaultNameValuePair;
 - ParameterParser, add methods getParameters(...) and
 parseParameters(String) which return List\<NameValuePair>;
 - StandardParameterParser:
  - Add implementations of the methods added to the interface
  ParameterParser;
  - Change method getParams, getTreePath and getAncestorPath to use
  parseParameters(String) when parsing the (now escaped) query, so the
  parameters are correctly separated (and decoded).

Fix #1801 - URL StandardParameterParser not working correctly with
QueryString
Fix #1848 - VariantURLQuery throwing exceptions on active scan
Fix #2153 - 2.4.3 failed parse the POST Data containts bracket([])