### PR TITLE
Allow to wait for ZAP to start with ClientApi

### DIFF
--- a/src/org/zaproxy/clientapi/core/ClientApiException.java
+++ b/src/org/zaproxy/clientapi/core/ClientApiException.java
@@ -39,6 +39,12 @@ public class ClientApiException extends Exception {
 		this.detail = null;
 	}
 
+	public ClientApiException(String message, Exception cause) {
+		super(message, cause);
+		this.code = null;
+		this.detail = null;
+	}
+
 	public ClientApiException(String message, String code, String detail) {
 		super(message);
 		this.code = code;


### PR DESCRIPTION
Add methods to class ClientApi that allow to wait for ZAP to be ready to
receive API calls, useful when ZAP is started programmatically.
 ---
From OWASP ZAP User Group: https://groups.google.com/d/topic/zaproxy-users/53jLHmK8IW8/discussion