### PR TITLE
Allow to access a URL through the ZAP API

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -852,6 +852,7 @@ context.api.action.excludeAllContextTechnologies = Excludes all built in technol
 copy.copy.popup = Copy
 copy.desc       = Provides a right click option to copy highlighted text to the clipboard
 
+core.api.action.accessUrl = Convenient and simple action to access a URL, optionally following redirections. Returns the request sent and response received and followed redirections, if any. Other actions are available which offer more control on what is sent, like, 'sendRequest' or 'sendHarRequest'.
 core.api.action.deleteSiteNode = Deletes the site node found in the Sites Tree on the basis of the URL, HTTP method, and post data (if applicable and specified). 
 core.api.action.loadSession = Loads the session with the given name. If a relative path is specified it will be resolved against the "session" directory in ZAP "home" dir.
 core.api.action.newSession = Creates a new session, optionally overwriting existing files. If a relative path is specified it will be resolved against the "session" directory in ZAP "home" dir.


### PR DESCRIPTION
Add a convenient and simple action to CoreAPI, called "accessUrl", that
allows to access a URL, optionally following redirections. Since the URL
is accessed from within ZAP it does not require external applications to
trust ZAP's root CA certificate when accessing HTTPS URLs. As with the
other actions that allow to send requests this one also returns the
request sent and response received (and redirections followed, if any).
 ---
From OWASP ZAP Developer Group: https://groups.google.com/d/topic/zaproxy-develop/PPqg7QCaSmM/discussion