### PR TITLE
Always return 100% when spider stopped

### DIFF
--- a/src/org/zaproxy/zap/extension/spider/SpiderAPI.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderAPI.java
@@ -406,7 +406,11 @@ public class SpiderAPI extends ApiImplementor {
 			SpiderScan scan = (SpiderScan) this.getSpiderScan(params);
 			int progress = 0;
 			if (scan != null) {
-				progress = scan.getProgress();
+				if (scan.isStopped()) {
+					progress = 100;
+				} else {
+					progress = scan.getProgress();
+				}
 			}
 			result = new ApiResponseElement(name, Integer.toString(progress));
 		} else if (VIEW_RESULTS.equals(name)) {


### PR DESCRIPTION
If the maxDuration is set and takes effect the state stays at <100 and so the client cant tell its finished