### PR TITLE
Correct help page for Passive Scan Rules options

### DIFF
--- a/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanPanel.java
+++ b/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanPanel.java
@@ -236,6 +236,6 @@ public class PolicyPassiveScanPanel extends AbstractParamPanel {
 
     @Override
     public String getHelpIndex() {
-        return "ui.dialogs.options.pscan";
+        return "ui.dialogs.options.pscanrules";
     }
 }


### PR DESCRIPTION
Change the help index of PolicyPassiveScanPanel (Passive Scan Rules
options panel) to link to "Options Passive Scan Rules Screen" help page.
(It was linking to "Options Passive Scan Tags screen" help page.)