### PR TITLE
Show User Guide even if a search view has errors

### DIFF
--- a/src/org/zaproxy/zap/extension/help/ExtensionHelp.java
+++ b/src/org/zaproxy/zap/extension/help/ExtensionHelp.java
@@ -31,11 +31,13 @@ import javax.help.SwingHelpUtilities;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.KeyStroke;
+import javax.swing.UIManager;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.extension.ViewDelegate;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.utils.DisplayUtils;
@@ -78,11 +80,12 @@ public class ExtensionHelp extends ExtensionAdaptor {
         this.setOrder(10000);	// Set to a huge value so the help button is always on the far right of the toolbar 
 	}
 	
- 	@Override
-	public void init() {
-		super.init();
+	@Override
+	public void initView(ViewDelegate view) {
+		super.initView(view);
 
 		SwingHelpUtilities.setContentViewerUI(BasicOnlineContentViewerUI.class.getCanonicalName());
+		UIManager.getDefaults().put("ZapHelpSearchNavigatorUI", ZapBasicSearchNavigatorUI.class.getCanonicalName());
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/help/ZapBasicSearchNavigatorUI.java
+++ b/src/org/zaproxy/zap/extension/help/ZapBasicSearchNavigatorUI.java
@@ -1,0 +1,76 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.help;
+
+import java.util.Enumeration;
+
+import javax.help.HelpSet;
+import javax.help.JHelpSearchNavigator;
+import javax.help.NavigatorView;
+import javax.help.plaf.basic.BasicSearchNavigatorUI;
+import javax.swing.JComponent;
+import javax.swing.plaf.ComponentUI;
+
+import org.apache.log4j.Logger;
+
+/**
+ * A {@code BasicSearchNavigatorUI} that keeps merging views even if one of them is invalid.
+ *
+ * @since TODO add version
+ */
+public class ZapBasicSearchNavigatorUI extends BasicSearchNavigatorUI {
+
+    private static final Logger LOGGER = Logger.getLogger(ZapBasicSearchNavigatorUI.class);
+
+    public ZapBasicSearchNavigatorUI(JHelpSearchNavigator b) {
+        super(b);
+    }
+
+    @Override
+    protected void addSubHelpSets(HelpSet hs) {
+        for (Enumeration<?> e = hs.getHelpSets(); e.hasMoreElements();) {
+            HelpSet ehs = (HelpSet) e.nextElement();
+            // merge views
+            NavigatorView[] views = ehs.getNavigatorViews();
+            for (int i = 0; i < views.length; i++) {
+                mergeSearchView(views[i], ehs);
+            }
+            addSubHelpSets(ehs);
+        }
+    }
+
+    private void mergeSearchView(NavigatorView view, HelpSet ehs) {
+        try {
+            if (searchnav.canMerge(view)) {
+                searchnav.merge(view);
+            }
+        } catch (IllegalArgumentException ex) {
+            StringBuilder logMessage = new StringBuilder(150);
+            logMessage.append("Failed to merge Search view [").append(view.getName()).append("] ");
+            logMessage.append("from HelpSet [").append(ehs.getTitle()).append("]: ");
+            logMessage.append(ex.getMessage());
+            LOGGER.warn(logMessage.toString());
+        }
+    }
+
+    public static ComponentUI createUI(JComponent x) {
+        return new ZapBasicSearchNavigatorUI((JHelpSearchNavigator) x);
+    }
+}

--- a/src/org/zaproxy/zap/extension/help/ZapSearchView.java
+++ b/src/org/zaproxy/zap/extension/help/ZapSearchView.java
@@ -1,0 +1,61 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.help;
+
+import java.awt.Component;
+import java.util.Hashtable;
+import java.util.Locale;
+
+import javax.help.HelpModel;
+import javax.help.HelpSet;
+import javax.help.JHelpSearchNavigator;
+import javax.help.SearchView;
+
+/**
+ * A {@code SearchView} that uses a {@link ZapBasicSearchNavigatorUI} for its {@code JHelpSearchNavigator}.
+ * 
+ * @since TODO add version
+ */
+public class ZapSearchView extends SearchView {
+
+    private static final long serialVersionUID = 1L;
+
+    public ZapSearchView(HelpSet hs, String name, String label, Hashtable<?, ?> params) {
+        super(hs, name, label, params);
+    }
+
+    public ZapSearchView(HelpSet hs, String name, String label, Locale locale, Hashtable<?, ?> params) {
+        super(hs, name, label, locale, params);
+    }
+
+    @Override
+    public Component createNavigator(HelpModel model) {
+        return new JHelpSearchNavigator(this, model) {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getUIClassID() {
+                return "ZapHelpSearchNavigatorUI";
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
Add a SearchView whose underlying BasicSearchNavigatorUI keeps merging
(search) views even if one of them is invalid (that is, has errors). A
search view is invalid when, for example, it has no search indexes which
are required by the search engine implementation.
Core help pages (helpset) need to use the new SearchView implementation
to work as intended.