### PR TITLE
Normalise Session dialogue tables "Exclude from"

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1368,6 +1368,19 @@ menu.view.tabs.pin            = Pin All Visible Tabs
 menu.view.tabs.show			  = Show All Tabs
 menu.view.tabs.unpin          = Unpin All Tabs
 
+multiple.options.regexes.table.header.regex = Regex
+multiple.options.regexes.dialog.add.regex.title = Add Regular Expression
+multiple.options.regexes.dialog.add.regex.button.confirm = Add
+multiple.options.regexes.dialog.modify.regex.title = Modify Regular Expression
+multiple.options.regexes.dialog.modify.regex.button.confirm = Modify
+multiple.options.regexes.dialog.remove.regex.title = Are you sure you want to remove the selected regular expression?
+multiple.options.regexes.dialog.remove.regex.text = Remove Regular Expression
+multiple.options.regexes.dialog.remove.regex.button.cancel = Cancel
+multiple.options.regexes.dialog.remove.regex.button.confirm = Remove
+multiple.options.regexes.dialog.remove.regex.checkbox.label = Do not show this message again
+multiple.options.regexes.dialog.regex.invalid.title = Invalid Regular Expression
+multiple.options.regexes.dialog.regex.invalid.text = The provided regular expression is not valid:\n{0}
+multiple.options.regexes.dialog.regex.label = Regex:
 
 multiple.options.panel.add.button.label                         = Add...
 multiple.options.panel.disableAll.button.label                  = Disable All
@@ -1723,7 +1736,6 @@ search.toolbar.tooltip.scope.unselected  = Search only URLs in Scope
 
 session.ascan.exclude.title        = Exclude from Scanner
 session.ascan.label.ignore         = URLs which will be ignored by the active scanner 
-session.ascan.table.header.ignore  = URL Regexs
 session.desc                       = Manage session tokens
 session.dialog.title               = Session
 session.general                    = General
@@ -1734,14 +1746,12 @@ session.label.name                 = Session Name
 session.properties.title           = Session Properties
 session.proxy.exclude.title        = Exclude from Proxy
 session.proxy.label.ignore         = URLs which will be ignored by the proxy 
-session.proxy.table.header.ignore  = URL Regexs
 session.scope.exclude.title        = Exclude from Scope
 session.scope.include.title        = Include in Scope
 session.select.session			   = Session:
 session.select.title			   = Open Session
 session.spider.exclude.title       = Exclude from Spider
 session.spider.label.ignore        = URLs which will be ignored by the spider 
-session.spider.table.header.ignore = URL Regexs
 session.untitled                   = Untitled Session
 
 sessionmanagement.panel.title				= Session Management

--- a/src/org/parosproxy/paros/extension/option/OptionsParamView.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsParamView.java
@@ -33,11 +33,14 @@
 // ZAP: 2016/04/04 Do not require a restart to show/hide the tool bar
 // ZAP: 2016/04/06 Fix layouts' issues
 // ZAP: 2016/04/27 Save, always, the Locale as String
+// ZAP: 2016/05/13 Add options to confirm removal of exclude from proxy, scanner and spider regexes
 
 package org.parosproxy.paros.extension.option;
 
 import java.util.Locale;
 
+import org.apache.commons.configuration.ConversionException;
+import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.common.AbstractParam;
 import org.parosproxy.paros.control.Control.Mode;
@@ -49,6 +52,8 @@ import org.zaproxy.zap.extension.httppanel.view.largeresponse.LargeResponseUtil;
 
 public class OptionsParamView extends AbstractParam {
 	
+	private static final Logger LOGGER = Logger.getLogger(OptionsParamView.class);
+
 	private static final String DEFAULT_TIME_STAMP_FORMAT =  Constant.messages.getString("timestamp.format.default");
 	
 	public static final String BASE_VIEW_KEY = "view";
@@ -78,6 +83,10 @@ public class OptionsParamView extends AbstractParam {
 	public static final String SCALE_IMAGES = "view.scaleImages";
 	public static final String SHOW_DEV_WARNING = "view.showDevWarning";
 
+    private static final String CONFIRM_REMOVE_PROXY_EXCLUDE_REGEX_KEY = "view.confirmRemoveProxyExcludeRegex";
+    private static final String CONFIRM_REMOVE_SCANNER_EXCLUDE_REGEX_KEY = "view.confirmRemoveScannerExcludeRegex";
+    private static final String CONFIRM_REMOVE_SPIDER_EXCLUDE_REGEX_KEY = "view.confirmRemoveSpiderExcludeRegex";
+
 	private int advancedViewEnabled = 0;
 	private int processImages = 0;
 	private int showMainToolbar = 1;
@@ -100,6 +109,10 @@ public class OptionsParamView extends AbstractParam {
     private String fontName = "";
     private boolean scaleImages = true;
     private boolean showDevWarning = true;
+
+    private boolean confirmRemoveProxyExcludeRegex;
+    private boolean confirmRemoveScannerExcludeRegex;
+    private boolean confirmRemoveSpiderExcludeRegex;
 	
     public OptionsParamView() {
     }
@@ -134,6 +147,24 @@ public class OptionsParamView extends AbstractParam {
 	    // Special cases - set via static methods
 	    LargeRequestUtil.setMinContentLength(largeRequestSize);
 	    LargeResponseUtil.setMinContentLength(largeResponseSize);
+
+        try {
+            this.confirmRemoveProxyExcludeRegex = getConfig().getBoolean(CONFIRM_REMOVE_PROXY_EXCLUDE_REGEX_KEY, false);
+        } catch (ConversionException e) {
+            LOGGER.error("Error while parsing config file: " + e.getMessage(), e);
+        }
+
+        try {
+            this.confirmRemoveScannerExcludeRegex = getConfig().getBoolean(CONFIRM_REMOVE_SCANNER_EXCLUDE_REGEX_KEY, false);
+        } catch (ConversionException e) {
+            LOGGER.error("Error while parsing config file: " + e.getMessage(), e);
+        }
+
+        try {
+            this.confirmRemoveSpiderExcludeRegex = getConfig().getBoolean(CONFIRM_REMOVE_SPIDER_EXCLUDE_REGEX_KEY, false);
+        } catch (ConversionException e) {
+            LOGGER.error("Error while parsing config file: " + e.getMessage(), e);
+        }
     }
 
 	/**
@@ -408,4 +439,30 @@ public class OptionsParamView extends AbstractParam {
 		getConfig().setProperty(SHOW_DEV_WARNING, showDevWarning);
 	}
 	
+    public boolean isConfirmRemoveProxyExcludeRegex() {
+        return this.confirmRemoveProxyExcludeRegex;
+    }
+
+    public void setConfirmRemoveProxyExcludeRegex(boolean confirmRemove) {
+        this.confirmRemoveProxyExcludeRegex = confirmRemove;
+        getConfig().setProperty(CONFIRM_REMOVE_PROXY_EXCLUDE_REGEX_KEY, Boolean.valueOf(confirmRemove));
+    }
+
+    public boolean isConfirmRemoveScannerExcludeRegex() {
+        return this.confirmRemoveScannerExcludeRegex;
+    }
+
+    public void setConfirmRemoveScannerExcludeRegex(boolean confirmRemove) {
+        this.confirmRemoveScannerExcludeRegex = confirmRemove;
+        getConfig().setProperty(CONFIRM_REMOVE_SCANNER_EXCLUDE_REGEX_KEY, Boolean.valueOf(confirmRemove));
+    }
+
+    public boolean isConfirmRemoveSpiderExcludeRegex() {
+        return this.confirmRemoveSpiderExcludeRegex;
+    }
+
+    public void setConfirmRemoveSpiderExcludeRegex(boolean confirmRemove) {
+        this.confirmRemoveSpiderExcludeRegex = confirmRemove;
+        getConfig().setProperty(CONFIRM_REMOVE_SPIDER_EXCLUDE_REGEX_KEY, Boolean.valueOf(confirmRemove));
+    }
 }

--- a/src/org/zaproxy/zap/view/MultipleRegexesOptionsPanel.java
+++ b/src/org/zaproxy/zap/view/MultipleRegexesOptionsPanel.java
@@ -1,0 +1,353 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.view;
+
+import java.awt.Dialog;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import javax.swing.GroupLayout;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.SortOrder;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.utils.ZapTextField;
+
+/**
+ * A {@code MultipleOptionsTablePanel} to manage regular expressions.
+ *
+ * @since TODO add version
+ */
+public class MultipleRegexesOptionsPanel extends AbstractMultipleOptionsBaseTablePanel<String> {
+
+    private static final long serialVersionUID = 1041782873016590998L;
+
+    private static final String REMOVE_DIALOG_TITLE = Constant.messages
+            .getString("multiple.options.regexes.dialog.remove.regex.title");
+    private static final String REMOVE_DIALOG_TEXT = Constant.messages
+            .getString("multiple.options.regexes.dialog.remove.regex.text");
+
+    private static final String REMOVE_DIALOG_CONFIRM_BUTTON_LABEL = Constant.messages
+            .getString("multiple.options.regexes.dialog.remove.regex.button.confirm");
+    private static final String REMOVE_DIALOG_CANCEL_BUTTON_LABEL = Constant.messages
+            .getString("multiple.options.regexes.dialog.remove.regex.button.cancel");
+
+    private static final String REMOVE_DIALOG_CHECKBOX_LABEL = Constant.messages
+            .getString("multiple.options.regexes.dialog.remove.regex.checkbox.label");
+
+    private DialogAddRegex addDialog;
+    private DialogModifyRegex modifyDialog;
+
+    private final Dialog owner;
+
+    public MultipleRegexesOptionsPanel(Dialog owner) {
+        this(owner, new RegexesTableModel());
+    }
+
+    public MultipleRegexesOptionsPanel(Dialog owner, RegexesTableModel model) {
+        super(model);
+
+        this.owner = owner;
+        getTable().setSortOrder(0, SortOrder.ASCENDING);
+    }
+
+    public void setRegexes(List<String> regexes) {
+        ((RegexesTableModel) getMultipleOptionsModel()).setElements(regexes);
+    }
+
+    public List<String> getRegexes() {
+        return ((RegexesTableModel) getMultipleOptionsModel()).getElements();
+    }
+
+    @Override
+    public String showAddDialogue() {
+        if (addDialog == null) {
+            addDialog = new DialogAddRegex(owner);
+            addDialog.pack();
+        }
+        addDialog.setVisible(true);
+
+        String regex = addDialog.getRegex();
+        addDialog.clear();
+
+        return regex;
+    }
+
+    @Override
+    public String showModifyDialogue(String e) {
+        if (modifyDialog == null) {
+            modifyDialog = new DialogModifyRegex(owner);
+            modifyDialog.pack();
+        }
+        modifyDialog.setRegex(e);
+        modifyDialog.setVisible(true);
+
+        String regex = modifyDialog.getRegex();
+        modifyDialog.clear();
+
+        if (!regex.equals(e)) {
+            return regex;
+        }
+
+        return null;
+    }
+
+    @Override
+    public boolean showRemoveDialogue(String e) {
+        JCheckBox removeWithoutConfirmationCheckBox = new JCheckBox(REMOVE_DIALOG_CHECKBOX_LABEL);
+        Object[] messages = { REMOVE_DIALOG_TEXT, " ", removeWithoutConfirmationCheckBox };
+        int option = JOptionPane.showOptionDialog(
+                View.getSingleton().getMainFrame(),
+                messages,
+                REMOVE_DIALOG_TITLE,
+                JOptionPane.OK_CANCEL_OPTION,
+                JOptionPane.QUESTION_MESSAGE,
+                null,
+                new String[] { REMOVE_DIALOG_CONFIRM_BUTTON_LABEL, REMOVE_DIALOG_CANCEL_BUTTON_LABEL },
+                null);
+
+        if (option == JOptionPane.OK_OPTION) {
+            setRemoveWithoutConfirmation(removeWithoutConfirmationCheckBox.isSelected());
+            return true;
+        }
+        return false;
+    }
+
+    protected static class DialogAddRegex extends AbstractFormDialog {
+
+        private static final long serialVersionUID = 9172864521259395417L;
+
+        private static final String DIALOG_TITLE = Constant.messages
+                .getString("multiple.options.regexes.dialog.add.regex.title");
+
+        private static final String CONFIRM_BUTTON_LABEL = Constant.messages
+                .getString("multiple.options.regexes.dialog.add.regex.button.confirm");
+
+        private static final String REGEX_FIELD_LABEL = Constant.messages
+                .getString("multiple.options.regexes.dialog.regex.label");
+
+        private static final String TITLE_INVALID_REGEX_DIALOG = Constant.messages
+                .getString("multiple.options.regexes.dialog.regex.invalid.title");
+        private static final String TEXT_INVALID_REGEX_DIALOG = Constant.messages
+                .getString("multiple.options.regexes.dialog.regex.invalid.text");
+
+        private ZapTextField regexTextField;
+
+        protected String regex;
+
+        public DialogAddRegex(Dialog owner) {
+            super(owner, DIALOG_TITLE);
+        }
+
+        protected DialogAddRegex(Dialog owner, String title) {
+            super(owner, title);
+        }
+
+        @Override
+        protected JPanel getFieldsPanel() {
+            JPanel fieldsPanel = new JPanel();
+
+            GroupLayout layout = new GroupLayout(fieldsPanel);
+            fieldsPanel.setLayout(layout);
+            layout.setAutoCreateGaps(true);
+            layout.setAutoCreateContainerGaps(true);
+
+            JLabel regexLabel = new JLabel(REGEX_FIELD_LABEL);
+
+            layout.setHorizontalGroup(
+                    layout.createSequentialGroup().addComponent(regexLabel).addComponent(getRegexTextField()));
+
+            layout.setVerticalGroup(
+                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                            .addComponent(regexLabel)
+                            .addComponent(getRegexTextField()));
+
+            return fieldsPanel;
+        }
+
+        @Override
+        protected String getConfirmButtonLabel() {
+            return CONFIRM_BUTTON_LABEL;
+        }
+
+        @Override
+        protected void init() {
+            getRegexTextField().setText("");
+            regex = null;
+        }
+
+        @Override
+        protected boolean validateFields() {
+            try {
+                Pattern.compile(getRegexTextField().getText(), Pattern.CASE_INSENSITIVE);
+            } catch (PatternSyntaxException e) {
+                JOptionPane.showMessageDialog(
+                        this,
+                        MessageFormat.format(TEXT_INVALID_REGEX_DIALOG, e.getLocalizedMessage()),
+                        TITLE_INVALID_REGEX_DIALOG,
+                        JOptionPane.INFORMATION_MESSAGE);
+                getRegexTextField().requestFocusInWindow();
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        protected void performAction() {
+            regex = getRegexTextField().getText();
+        }
+
+        @Override
+        protected void clearFields() {
+            getRegexTextField().setText("");
+            getRegexTextField().discardAllEdits();
+        }
+
+        public String getRegex() {
+            return regex;
+        }
+
+        protected ZapTextField getRegexTextField() {
+            if (regexTextField == null) {
+                regexTextField = new ZapTextField(30);
+                regexTextField.getDocument().addDocumentListener(new DocumentListener() {
+
+                    @Override
+                    public void removeUpdate(DocumentEvent e) {
+                        checkAndEnableConfirmButton();
+                    }
+
+                    @Override
+                    public void insertUpdate(DocumentEvent e) {
+                        checkAndEnableConfirmButton();
+                    }
+
+                    @Override
+                    public void changedUpdate(DocumentEvent e) {
+                        checkAndEnableConfirmButton();
+                    }
+
+                    private void checkAndEnableConfirmButton() {
+                        setConfirmButtonEnabled(getRegexTextField().getDocument().getLength() > 0);
+                    }
+                });
+            }
+
+            return regexTextField;
+        }
+
+        public void clear() {
+            this.regex = null;
+        }
+    }
+
+    protected static class DialogModifyRegex extends DialogAddRegex {
+
+        private static final long serialVersionUID = 3803499933691686617L;
+
+        private static final String DIALOG_TITLE = Constant.messages
+                .getString("multiple.options.regexes.dialog.modify.regex.title");
+
+        private static final String CONFIRM_BUTTON_LABEL = Constant.messages
+                .getString("multiple.options.regexes.dialog.modify.regex.button.confirm");
+
+        protected DialogModifyRegex(Dialog owner) {
+            super(owner, DIALOG_TITLE);
+        }
+
+        @Override
+        protected String getConfirmButtonLabel() {
+            return CONFIRM_BUTTON_LABEL;
+        }
+
+        public void setRegex(String regex) {
+            this.regex = regex;
+        }
+
+        @Override
+        protected void init() {
+            getRegexTextField().setText(regex);
+            getRegexTextField().discardAllEdits();
+        }
+
+    }
+
+    protected static class RegexesTableModel extends AbstractMultipleOptionsBaseTableModel<String> {
+
+        private static final long serialVersionUID = -7644711449311289615L;
+
+        private static final String[] COLUMN_NAMES = {
+                Constant.messages.getString("multiple.options.regexes.table.header.regex") };
+
+        private static final int COLUMN_COUNT = COLUMN_NAMES.length;
+
+        private List<String> elements;
+
+        public RegexesTableModel() {
+            elements = Collections.emptyList();
+        }
+
+        @Override
+        public String getColumnName(int col) {
+            return COLUMN_NAMES[col];
+        }
+
+        @Override
+        public int getColumnCount() {
+            return COLUMN_COUNT;
+        }
+
+        @Override
+        public Class<?> getColumnClass(int c) {
+            return String.class;
+        }
+
+        @Override
+        public int getRowCount() {
+            return elements.size();
+        }
+
+        @Override
+        public String getValueAt(int rowIndex, int columnIndex) {
+            return elements.get(rowIndex);
+        }
+
+        @Override
+        public List<String> getElements() {
+            return elements;
+        }
+
+        public void setElements(List<String> regexes) {
+            this.elements = new ArrayList<>(regexes);
+            fireTableDataChanged();
+        }
+
+    }
+}

--- a/src/org/zaproxy/zap/view/SessionExcludeFromProxyPanel.java
+++ b/src/org/zaproxy/zap/view/SessionExcludeFromProxyPanel.java
@@ -25,17 +25,15 @@ package org.zaproxy.zap.view;
 import java.awt.CardLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import java.util.regex.Pattern;
 
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
 
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.view.AbstractParamPanel;
-import org.zaproxy.zap.utils.DisplayUtils;
+import org.parosproxy.paros.view.View;
 
 public class SessionExcludeFromProxyPanel extends AbstractParamPanel {
 
@@ -43,9 +41,7 @@ public class SessionExcludeFromProxyPanel extends AbstractParamPanel {
 	private static final long serialVersionUID = -8337361808959321380L;
 	
 	private JPanel panelSession = null;
-	private JTable tableIgnore = null;
-	private JScrollPane jScrollPane = null;
-	private SingleColumnTableModel model = null;
+	private MultipleRegexesOptionsPanel regexesPanel;
 	
     public SessionExcludeFromProxyPanel() {
         super();
@@ -58,6 +54,7 @@ public class SessionExcludeFromProxyPanel extends AbstractParamPanel {
 	private void initialize() {
         this.setLayout(new CardLayout());
         this.setName(PANEL_NAME);
+        regexesPanel = new MultipleRegexesOptionsPanel(View.getSingleton().getSessionDialog());
         this.add(getPanelSession(), getPanelSession().getName());
 	}
 	
@@ -111,7 +108,7 @@ public class SessionExcludeFromProxyPanel extends AbstractParamPanel {
 	        gridBagConstraints3.anchor = java.awt.GridBagConstraints.SOUTH;
 
 	        panelSession.add(jLabel, gridBagConstraints1);
-	        panelSession.add(getJScrollPane(), gridBagConstraints2);
+	        panelSession.add(regexesPanel, gridBagConstraints2);
 	        panelSession.add(noteLabel, gridBagConstraints3);
 		}
 		return panelSession;
@@ -120,51 +117,21 @@ public class SessionExcludeFromProxyPanel extends AbstractParamPanel {
 	@Override
 	public void initParam(Object obj) {
 	    Session session = (Session) obj;
-	    getModel().setLines(session.getExcludeFromProxyRegexs());
+	    regexesPanel.setRegexes(session.getExcludeFromProxyRegexs());
+	    regexesPanel.setRemoveWithoutConfirmation(
+	            !Model.getSingleton().getOptionsParam().getViewParam().isConfirmRemoveProxyExcludeRegex());
 	}
 	
 	@Override
 	public void validateParam(Object obj) {
-	    // Check for valid regexs
-		for (String regex : getModel().getLines()) {
-			if (regex.trim().length() > 0) {
-				Pattern.compile(regex.trim(), Pattern.CASE_INSENSITIVE);
-			}
-		}
 	}
 	
 	@Override
 	public void saveParam (Object obj) throws Exception {
 	    Session session = (Session) obj;
-	    session.setExcludeFromProxyRegexs(getModel().getLines());
-	}
-	
-	private JTable getTableIgnore() {
-		if (tableIgnore == null) {
-			tableIgnore = new JTable();
-			tableIgnore.setModel(getModel());
-			tableIgnore.setRowHeight(DisplayUtils.getScaledSize(18));
-			// Issue 954: Force the JTable cell to auto-save when the focus changes.
-			// Example, edit cell, click OK for a panel dialog box, the data will get saved.
-			tableIgnore.putClientProperty("terminateEditOnFocusLost", Boolean.TRUE);
-		}
-		return tableIgnore;
-	}
-	
-	private JScrollPane getJScrollPane() {
-		if (jScrollPane == null) {
-			jScrollPane = new JScrollPane();
-			jScrollPane.setViewportView(getTableIgnore());
-			jScrollPane.setBorder(javax.swing.BorderFactory.createEtchedBorder(javax.swing.border.EtchedBorder.RAISED));
-		}
-		return jScrollPane;
-	}
-	
-	private SingleColumnTableModel getModel() {
-		if (model == null) {
-			model = new SingleColumnTableModel(Constant.messages.getString("session.proxy.table.header.ignore"));
-		}
-		return model;
+	    session.setExcludeFromProxyRegexs(regexesPanel.getRegexes());
+	    Model.getSingleton().getOptionsParam().getViewParam().setConfirmRemoveProxyExcludeRegex(
+	            !regexesPanel.isRemoveWithoutConfirmation());
 	}
 	
 	@Override

--- a/src/org/zaproxy/zap/view/SessionExcludeFromScanPanel.java
+++ b/src/org/zaproxy/zap/view/SessionExcludeFromScanPanel.java
@@ -25,17 +25,15 @@ package org.zaproxy.zap.view;
 import java.awt.CardLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import java.util.regex.Pattern;
 
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
 
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.view.AbstractParamPanel;
-import org.zaproxy.zap.utils.DisplayUtils;
+import org.parosproxy.paros.view.View;
 
 public class SessionExcludeFromScanPanel extends AbstractParamPanel {
 
@@ -43,9 +41,7 @@ public class SessionExcludeFromScanPanel extends AbstractParamPanel {
 	private static final long serialVersionUID = -8337361808959321380L;
 	
 	private JPanel panelSession = null;
-	private JTable tableIgnore = null;
-	private JScrollPane jScrollPane = null;
-	private SingleColumnTableModel model = null;
+	private MultipleRegexesOptionsPanel regexesPanel;
 	
     public SessionExcludeFromScanPanel() {
         super();
@@ -58,6 +54,7 @@ public class SessionExcludeFromScanPanel extends AbstractParamPanel {
 	private void initialize() {
         this.setLayout(new CardLayout());
         this.setName(PANEL_NAME);
+        regexesPanel = new MultipleRegexesOptionsPanel(View.getSingleton().getSessionDialog());
         this.add(getPanelSession(), getPanelSession().getName());
 	}
 	
@@ -111,7 +108,7 @@ public class SessionExcludeFromScanPanel extends AbstractParamPanel {
 	        gridBagConstraints3.anchor = java.awt.GridBagConstraints.SOUTH;
 
 	        panelSession.add(jLabel, gridBagConstraints1);
-	        panelSession.add(getJScrollPane(), gridBagConstraints2);
+	        panelSession.add(regexesPanel, gridBagConstraints2);
 	        panelSession.add(noteLabel, gridBagConstraints3);
 		}
 		return panelSession;
@@ -120,51 +117,21 @@ public class SessionExcludeFromScanPanel extends AbstractParamPanel {
 	@Override
 	public void initParam(Object obj) {
 	    Session session = (Session) obj;
-	    getModel().setLines(session.getExcludeFromScanRegexs());
+	    regexesPanel.setRegexes(session.getExcludeFromScanRegexs());
+	    regexesPanel.setRemoveWithoutConfirmation(
+	            !Model.getSingleton().getOptionsParam().getViewParam().isConfirmRemoveScannerExcludeRegex());
 	}
 	
 	@Override
 	public void validateParam(Object obj) {
-	    // Check for valid regexs
-		for (String regex : getModel().getLines()) {
-			if (regex.trim().length() > 0) {
-				Pattern.compile(regex.trim(), Pattern.CASE_INSENSITIVE);
-			}
-		}
 	}
 	
 	@Override
 	public void saveParam (Object obj) throws Exception {
 	    Session session = (Session) obj;
-	    session.setExcludeFromScanRegexs(getModel().getLines());
-	}
-	
-	private JTable getTableIgnore() {
-		if (tableIgnore == null) {
-			tableIgnore = new JTable();
-			tableIgnore.setModel(getModel());
-			tableIgnore.setRowHeight(DisplayUtils.getScaledSize(18));
-			// Issue 954: Force the JTable cell to auto-save when the focus changes.
-			// Example, edit cell, click OK for a panel dialog box, the data will get saved.
-			tableIgnore.putClientProperty("terminateEditOnFocusLost", Boolean.TRUE);
-		}
-		return tableIgnore;
-	}
-	
-	private JScrollPane getJScrollPane() {
-		if (jScrollPane == null) {
-			jScrollPane = new JScrollPane();
-			jScrollPane.setViewportView(getTableIgnore());
-			jScrollPane.setBorder(javax.swing.BorderFactory.createEtchedBorder(javax.swing.border.EtchedBorder.RAISED));
-		}
-		return jScrollPane;
-	}
-	
-	private SingleColumnTableModel getModel() {
-		if (model == null) {
-			model = new SingleColumnTableModel(Constant.messages.getString("session.ascan.table.header.ignore"));
-		}
-		return model;
+	    session.setExcludeFromScanRegexs(regexesPanel.getRegexes());
+	    Model.getSingleton().getOptionsParam().getViewParam().setConfirmRemoveScannerExcludeRegex(
+	            !regexesPanel.isRemoveWithoutConfirmation());
 	}
 
 	@Override


### PR DESCRIPTION
Change the Session dialogue panels "Exclude from Proxy", "Exclude from
Scanner" and "Exclude from Spider" to use the same tables as other
dialogues to manage multiple options (that is, table shown in one side
and buttons to add/modify/remove at the other).