### PR TITLE
Always use charset set when changing the HTTP body

### DIFF
--- a/src/org/parosproxy/paros/network/HttpBody.java
+++ b/src/org/parosproxy/paros/network/HttpBody.java
@@ -21,189 +21,276 @@
  */
 // ZAP: 2012/03/15 Changed to use byte[] instead of StringBuffer.
 // ZAP: 2014/11/26 Issue: 1415 Fixed file uploads > 128k
+// ZAP: 2016/05/18 Always use charset set when changing the HTTP body
 
 package org.parosproxy.paros.network;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.Arrays;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
 /**
  * Abstract a HTTP body in request or response messages.
+ * 
+ * @since 1.0.0
  */
 public abstract class HttpBody {
 
 	private static final Logger log = Logger.getLogger(HttpBody.class);
 	
-	public static final String DEFAULT_CHARSET = "8859_1";
+	/**
+	 * The name of the default charset ({@code ISO-8859-1}) used for {@code String} related operations, for example,
+	 * {@link #HttpBody(String)}, {@link #append(String)}, {@link #setBody(String)}, or {@link #toString()}.
+	 * 
+	 * @see #setCharset(String)
+	 */
+	public static final String DEFAULT_CHARSET = StandardCharsets.ISO_8859_1.name();
 
+	/**
+	 * The limit for the initial capacity, prevents allocating a bigger array when the Content-Length is wrong.
+	 */
+	public static final int LIMIT_INITIAL_CAPACITY = 128000;
+	
 	private byte[] body;
 	private int pos;
     private String cachedString;
-	private String charset = DEFAULT_CHARSET;
-	protected boolean isChangedCharset;
-    
+	private Charset charset;
+
+	/**
+	 * Constructs a {@code HttpBody} with no contents (that is, zero length).
+	 */
 	public HttpBody() {
-		body = new byte[0];
+		this(0);
 	}
 
 	/**
-	 *	Preallocate HttpBody of a certain size.  A maximum of 128K is fixed to avoid overwhelming
-	 * 	by incorrect contentlength.
+	 * Constructs a {@code HttpBody} with the given initial capacity.
+	 * <p>
+	 * The initial capacity is limited to {@value #LIMIT_INITIAL_CAPACITY} to prevent allocating big arrays.
+	 * 
+	 * @param capacity the initial capacity
 	 */
 	public HttpBody(int capacity) {
-	    if (capacity > 0) {
-	        if (capacity > 128000) {
-	            capacity = 128000;
-	        }
-	        body = new byte[capacity];
-	    } else {
-	    	body = new byte[0];
-	    }
-        pos = 0;
-	}
-	
-	/**
-	 * Construct a HttpBody from a String.
-	 * @param data
-	 */
-	public HttpBody(String data) {
-		setBody(data);
+		body = new byte[Math.max(Math.min(capacity, LIMIT_INITIAL_CAPACITY), 0)];
 	}
 
-	public void setBody(byte[] buf) {
-		if (buf == null) {
+	/**
+	 * Constructs a {@code HttpBody} with the given {@code contents}.
+	 * <p>
+	 * If the given {@code contents} are {@code null} the {@code HttpBody} will have no content.
+	 * 
+	 * @param contents the contents of the body, might be {@code null}
+	 * @since TODO add version
+	 */
+	public HttpBody(byte[] contents) {
+		if (contents != null) {
+			setBody(contents);
+		} else {
+			body = new byte[0];
+		}
+	}
+
+	/**
+	 * Constructs a {@code HttpBody} with the given {@code contents}, using default charset for {@code String} related
+	 * operations.
+	 * <p>
+	 * If the given {@code contents} are {@code null} the {@code HttpBody} will have no content.
+	 * <p>
+	 * <strong>Note:</strong> If the contents are not representable with the default charset it might lead to data loss.
+	 * 
+	 * @param contents the contents of the body, might be {@code null}
+	 * @see #DEFAULT_CHARSET
+	 * @see #HttpBody(byte[])
+	 */
+	public HttpBody(String contents) {
+		if (contents != null) {
+			setBody(contents);
+		} else {
+			body = new byte[0];
+		}
+	}
+
+	/**
+	 * Sets the given {@code contents} as the body.
+	 * <p>
+	 * If the {@code contents} are {@code null} the call to this method has no effect.
+	 *
+	 * @param contents the new contents of the body, might be {@code null}
+	 */
+	public void setBody(byte[] contents) {
+		if (contents == null) {
 			return;
 		}
 		cachedString = null;
 		
-		body = new byte[buf.length];
-		System.arraycopy(buf, 0, body, 0, buf.length);
+		body = new byte[contents.length];
+		System.arraycopy(contents, 0, body, 0, contents.length);
 		
 		pos = body.length;
 	}
 	
 	/**
-	 * Set this HttpBody to store the data supplied.
-	 * @param data
+	 * Sets the given {@code contents} as the body, using the current charset.
+	 * <p>
+	 * If the {@code contents} are {@code null} the call to this method has no effect.
+	 * <p>
+	 * <strong>Note:</strong> Setting the contents with incorrect charset might lead to data loss.
+	 *
+	 * @param contents the new contents of the body, might be {@code null}
+	 * @see #setCharset(String)
 	 */
-	public void setBody(String data)  {
-		if (data == null) {
+	public void setBody(String contents)  {
+		if (contents == null) {
 			return ;
 		}
 		
 		cachedString = null;
 		
-		try {
-			body = data.getBytes(charset);
-		} catch (UnsupportedEncodingException e) {
-			log.error(e.getMessage(), e);
-		}
+		body = contents.getBytes(getCharsetImpl());
 		
 		pos = body.length;
 	}
 
 	/**
-	 * Append a byte array with certain length to this body.
-	 * @param buf
-	 * @param len
+	 * Gets the {@code Charset} that should be used internally by the class for {@code String} related operations.
+	 * <p>
+	 * If no {@code Charset} was set (that is, is {@code null}) it falls back to {@code ISO-8859-1}, otherwise it returns the
+	 * {@code Charset} set.
+	 * 
+	 * @return the {@code Charset} to be used for {@code String} related operations, never {@code null}
+	 * @see #DEFAULT_CHARSET
+	 * @see #setCharset(String)
 	 */
-	public void append(byte[] buf, int len) {
-		if (buf == null) {
+	private Charset getCharsetImpl() {
+		if (charset != null) {
+			return charset;
+		}
+		return StandardCharsets.ISO_8859_1;
+	}
+
+	/**
+	 * Appends the given {@code contents} to the body, up to a certain length.
+	 * <p>
+	 * If the {@code contents} are {@code null} or the {@code length} negative or zero, the call to this method has no effect.
+	 * 
+	 * @param contents the contents to append, might be {@code null}
+	 * @param length the length of contents to append
+	 */
+	public void append(byte[] contents, int length) {
+		if (contents == null || length <= 0) {
 			return;
 		}
 		
+		int len = Math.min(contents.length, length);
 		if (pos + len > body.length) {
 			byte[] newBody = new byte[pos + len];
 			System.arraycopy(body, 0, newBody, 0, pos);
 			body = newBody;
 		}
-		System.arraycopy(buf, 0, body, pos, len);
+		System.arraycopy(contents, 0, body, pos, len);
 		pos += len;
 		
         cachedString = null;
 	}
 	
 	/**
-	 * Append a byte array to this body.
+	 * Appends the given {@code contents} to the body.
+	 * <p>
+	 * If the {@code contents} are {@code null} the call to this method has no effect.
 	 * 
-	 * @param buf
+	 * @param contents the contents to append, might be {@code null}
 	 */
-	public void append(byte[] buf) {
-		if (buf == null) {
+	public void append(byte[] contents) {
+		if (contents == null) {
 			return;
 		}
-		append(buf, buf.length);
+		append(contents, contents.length);
 	}
 
 	/**
-	 * Append a String to this body.
+	 * Appends the given {@code contents} to the body, using the current charset.
+	 * <p>
+	 * If the {@code contents} are {@code null} the call to this method has no effect.
+	 * <p>
+	 * <strong>Note:</strong> Setting the contents with incorrect charset might lead to data loss.
 	 * 
-	 * @param buf
+	 * @param contents the contents to append, might be {@code null}
+	 * @see #setCharset(String)
 	 */
-	public void append(String buf) {
-		if (buf == null) {
+	public void append(String contents) {
+		if (contents == null) {
 			return;
 		}
-	    try {
-	    	append(buf.getBytes(charset));
-		} catch (UnsupportedEncodingException e) {
-			log.error(e.getMessage(), e);
-		}
+		append(contents.getBytes(getCharsetImpl()));
 	}
 
-	/**
-	 * Get the content of the body as String.
-	 */
+    /**
+     * Gets the {@code String} representation of the body, using the current charset.
+     * <p>
+     * The {@code String} representation contains only the contents set so far, that is, increasing the length of the body
+     * manually (with {@link #HttpBody(int)} or {@link #setLength(int)}) does not affect the string representation.
+     * 
+     * @return the {@code String} representation of the body
+     * @see #getCharset()
+     */
 	@Override
 	public String toString() {
         if (cachedString != null) {
             return cachedString;
         }
-        
-        cachedString = createCachedString(charset);
 
+        cachedString = createString(charset);
         return cachedString;
 	}
-	
-	protected String createCachedString(String charset) {
-		String result = "";
-		
-		try {
-			if (isChangedCharset) {
-				result = new String(getBytes(), charset);
-				isChangedCharset = false;
-			} else {
-				result = new String(getBytes(), DEFAULT_CHARSET);
-				isChangedCharset = false;
-			}
-		} catch (UnsupportedEncodingException e1) {
-			log.error(e1.getMessage(), e1);
-			
-			try {
-				result = new String(getBytes(), DEFAULT_CHARSET);
-			} catch(UnsupportedEncodingException e2) {
-				log.error(e2.getMessage(), e2);
-			}
-		}
-		return result;
+
+	/**
+	 * Returns the {@code String} representation of the body.
+	 * <p>
+	 * Called when the cached string representation is no longer up-to-date.
+	 *
+	 * @param charset the current {@code Charset} set, {@code null} if none
+	 * @return the {@code String} representation of the body
+	 * @since TODO add version
+	 * @see #getBytes()
+	 */
+	protected String createString(Charset charset) {
+		return new String(getBytes(), 0, getPos(), charset != null ? charset : getCharsetImpl());
+	}
+
+	/**
+	 * Gets the actual (end) position of the contents in the byte array (different if the array was expanded, either by setting
+	 * the initial capacity or its length). Should be used when creating the string representation of the body to only return
+	 * the actual contents, set so far.
+	 * 
+	 * @return the end position of the contents in the byte array
+	 * @since TODO add version
+	 * @see #getBytes()
+	 * @see #createString(Charset)
+	 */
+	protected final int getPos() {
+		return pos;
 	}
 	
 	/**
-	 * Get the contents of the body as an array of bytes.
+	 * Gets the contents of the body as an array of bytes.
+	 * <p>
+	 * The returned array of bytes mustn't be modified. Is returned a reference instead of a copy to avoid more memory
+	 * allocations.
 	 * 
-	 * The returned array of bytes mustn't be modified.
-	 * Is returned a reference instead of a copy to avoid more memory allocations.
-	 * 
-	 * @return a reference to the content of this body as <code>byte[]</code>.
+	 * @return a reference to the content of this body as {@code byte[]}.
+	 * @since 1.4.0
 	 */
 	public byte[] getBytes() {
 		return body;
 	}
 
 	/**
-	 * Current length of the body.
+	 * Gets the current length of the body.
 	 * 
 	 * @return the current length of the body.
 	 */
@@ -212,42 +299,68 @@ public abstract class HttpBody {
 	}
 
 	/**
-	 * Set the current length of this body.  If the current content is
-	 * longer, the excessive data will be truncated.
+	 * Sets the current length of the body. If the current content is longer, the excessive data will be truncated.
 	 * 
 	 * @param length the new length to set.
 	 */
 	public void setLength(int length) {
-		if (body.length != length) {
-			pos = Math.min(body.length, length);
-	
-			byte[] newBody = new byte[length];
-			System.arraycopy(body, 0, newBody, 0, length);
-			body = newBody;
-			
+		if (length < 0 || body.length == length) {
+			return;
+		}
+
+		int oldPos = pos;
+		pos = Math.min(pos, length);
+
+		byte[] newBody = new byte[length];
+		System.arraycopy(body, 0, newBody, 0, pos);
+		body = newBody;
+		
+		if (oldPos > pos) {
 			cachedString = null;
 		}
 	}
 	
-	
-	
     /**
-     * @return Returns the charset.
+     * Gets the name of the charset used for {@code String} related operations.
+     * <p>
+     * If no charset was set it returns the default.
+     * 
+     * @return the name of the charset, never {@code null}
+     * @see #setCharset(String)
+     * @see #DEFAULT_CHARSET
      */
     public String getCharset() {
-        return charset;
+        if (charset != null) {
+            return charset.name();
+        }
+        return DEFAULT_CHARSET;
     }
     
     /**
-     * @param charset The charset to set.
+     * Sets the charset used for {@code String} related operations, for example, {@link #append(String)},
+     * {@link #setBody(String)}, or {@link #toString()}.
+     * <p>
+     * The charset is ignored if {@code null}, empty, or not valid (either the name is not valid or is unsupported).
+     * 
+     * @param charsetName the name of the charset to set
+     * @see #getCharset()
+     * @see #DEFAULT_CHARSET
      */
-    public void setCharset(String charset) {
-        if (charset == null || charset.equals("") || charset.equalsIgnoreCase(this.charset)) {
+    public void setCharset(String charsetName) {
+        if (StringUtils.isEmpty(charsetName)) {
             return;
         }
-        this.charset = charset;
-        this.isChangedCharset = true;
-        this.cachedString = null;
+
+        Charset newCharset = null;
+        try {
+            newCharset = Charset.forName(charsetName);
+            if (newCharset != charset) {
+                this.charset = newCharset;
+                this.cachedString = null;
+            }
+        } catch (IllegalCharsetNameException | UnsupportedCharsetException e) {
+            log.error("Failed to set charset: " + charsetName, e);
+        }
     }
     
 	@Override

--- a/src/org/zaproxy/zap/network/HttpResponseBody.java
+++ b/src/org/zaproxy/zap/network/HttpResponseBody.java
@@ -19,6 +19,8 @@
 package org.zaproxy.zap.network;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -32,57 +34,77 @@ public class HttpResponseBody extends HttpBody {
 	//private static Pattern patternCharset = Pattern.compile("<META +[^>]+charset=['\"]*([^>'\"])+['\"]*>", Pattern.CASE_INSENSITIVE| Pattern.MULTILINE);
 	private static final Pattern patternCharset = Pattern.compile("<META +[^>]+charset *= *['\\x22]?([^>'\\x22;]+)['\\x22]? *[/]?>", Pattern.CASE_INSENSITIVE);
 	
-	
+	/**
+	 * Constructs a {@code HttpResponseBody} with no contents (that is, zero length).
+	 */
 	public HttpResponseBody() {
 		super();
 	}
 
+	/**
+	 * Constructs a {@code HttpResponseBody} with the given initial capacity.
+	 * <p>
+	 * The initial capacity is limited to prevent allocating big arrays.
+	 * 
+	 * @param capacity the initial capacity
+	 * @see HttpBody#LIMIT_INITIAL_CAPACITY
+	 */
 	public HttpResponseBody(int capacity) {
 		super(capacity);
 	}
 
-	public HttpResponseBody(String data) {
-		super(data);
+	/**
+	 * Constructs a {@code HttpResponseBody} with the given {@code contents}, using default charset for {@code String} related
+	 * operations.
+	 * <p>
+	 * If the given {@code contents} are {@code null} the {@code HttpResponseBody} will have no content.
+	 * <p>
+	 * <strong>Note:</strong> If the contents are not representable with the default charset it might lead to data loss.
+	 * 
+	 * @param contents the contents of the body, might be {@code null}
+	 * @see #HttpResponseBody(byte[])
+	 * @see HttpBody#DEFAULT_CHARSET
+	 */
+	public HttpResponseBody(String contents) {
+		super(contents);
+	}
+
+	/**
+	 * Constructs a {@code HttpResponseBody} with the given {@code contents}.
+	 * <p>
+	 * If the given {@code contents} are {@code null} the {@code HttpResponseBody} will have no content.
+	 * 
+	 * @param contents the contents of the body, might be {@code null}
+	 * @since TODO add version
+	 */
+	public HttpResponseBody(byte[] contents) {
+		super(contents);
 	}
 
 	@Override
-	public String createCachedString(String charset) {
-		String result = null;
-		
-		if (isChangedCharset) {
-			try {
-				result = new String(getBytes(), charset);
-				isChangedCharset = false;
-			} catch (UnsupportedEncodingException e) {
-				log.error("Unable to encode with the \"Content-Type\" charset: " + e.getMessage());
-			}
+	protected String createString(Charset currentCharset) {
+		if (currentCharset != null) {
+			return super.createString(currentCharset);
 		}
-		
-		if (result == null) {
-			result = createCachedStringWithMetaCharset();
-		}
-		
-		return result;
+		return createStringWithMetaCharset();
 	}
 	
-	private String createCachedStringWithMetaCharset() {
+	private String createStringWithMetaCharset() {
 		String result = null;
 		String resultDefaultCharset = null;
 		
 		try{
-			resultDefaultCharset = new String(getBytes(), DEFAULT_CHARSET);
+			resultDefaultCharset = new String(getBytes(), 0, getPos(), StandardCharsets.ISO_8859_1);
 			Matcher matcher = patternCharset.matcher(resultDefaultCharset);
 			if (matcher.find()) {
 				final String charset = matcher.group(1);
-				result = new String(getBytes(), charset);
+				result = new String(getBytes(), 0, getPos(), charset);
 				setCharset(charset);
-				isChangedCharset = false;
 			} else {
 				String utf8 = toUTF8();
 				if (utf8 != null) {
 					// assume to be UTF8
-					setCharset("UTF8");
-					isChangedCharset = false;
+					setCharset(StandardCharsets.UTF_8.name());
 					result = utf8;
 				} else {
 					result = resultDefaultCharset;
@@ -90,7 +112,7 @@ public class HttpResponseBody extends HttpBody {
 			}
 		} catch(UnsupportedEncodingException e) {
 			log.error("Unable to encode with the (X)HTML meta charset: " + e.getMessage());
-			log.warn("Using default charset: 8859_1");
+			log.warn("Using default charset: " + DEFAULT_CHARSET);
 			
 			result = resultDefaultCharset;
 		}
@@ -99,28 +121,12 @@ public class HttpResponseBody extends HttpBody {
 	}
 	
 	private String toUTF8() {
-		String utf8 = null;
+		String utf8 = new String(getBytes(), 0, getPos(), StandardCharsets.UTF_8);
+		int length2 = utf8.getBytes(StandardCharsets.UTF_8).length;
 		
-		byte[] buf1 = getBytes();
-		int length2 = 0;
-		
-		try {
-			utf8 = new String(buf1, "UTF8");
-			length2 = utf8.getBytes("UTF8").length;
-		} catch (UnsupportedEncodingException e) {
-			log.warn("UTF8 not supported. Using 8859_1 instead.");
+		if (getPos() != length2) {
 			return null;
 		}
-		
-		if (buf1.length != length2) {
-			return null;
-		}
-		
-		//for(int i=0; i<buf1.length; i++) {
-		//	if (buf1[i] != buf2[i]) {
-		//		return null;
-		//	}
-		//}
 		
 		return utf8;
 	}

--- a/test/org/parosproxy/paros/network/HttpBodyUnitTest.java
+++ b/test/org/parosproxy/paros/network/HttpBodyUnitTest.java
@@ -1,0 +1,693 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.network;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.zaproxy.zap.network.HttpBodyTestUtils;
+
+/**
+ * Unit test for {@link HttpBody}.
+ */
+public class HttpBodyUnitTest extends HttpBodyTestUtils {
+
+    @Test
+    public void shouldHaveZeroLengthByDefault() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        // When
+        int length = httpBody.length();
+        // Then
+        assertThat(length, is(equalTo(0)));
+    }
+
+    @Test
+    public void shouldHaveEmptyByteContentByDefault() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        // When
+        byte[] content = httpBody.getBytes();
+        // Then
+        assertThat(content, is(not(nullValue())));
+        assertThat(content.length, is(equalTo(0)));
+    }
+
+    @Test
+    public void shouldHaveEmptyStringRepresentationByDefault() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        // When
+        String stringRepresentation = httpBody.toString();
+        // Then
+        assertThat(stringRepresentation, is(equalTo("")));
+    }
+
+    @Test
+    public void shouldCreateBodyWithNullByteArray() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl((byte[]) null);
+        // When / Then
+        assertThat(httpBody.length(), is(equalTo(0)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(allZeroBytes()));
+        assertThat(httpBody.getBytes().length, is(equalTo(0)));
+        assertThat(httpBody.toString(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldCreateBodyWithByteArray() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl(BODY_1_BYTES_DEFAULT_CHARSET);
+        // When / Then
+        assertThat(httpBody.length(), is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET)));
+        assertThat(httpBody.getBytes().length, is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET.length)));
+        assertThat(httpBody.toString(), is(equalTo(BODY_1_STRING_DEFAULT_CHARSET)));
+    }
+
+    @Test
+    public void shouldCreateBodyWithNullString() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl((String) null);
+        // When / Then
+        assertThat(httpBody.length(), is(equalTo(0)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(allZeroBytes()));
+        assertThat(httpBody.getBytes().length, is(equalTo(0)));
+        assertThat(httpBody.toString(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldCreateBodyWithStringUsingDefaultCharset() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl(BODY_1_STRING);
+        // When / Then
+        assertThat(httpBody.length(), is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET)));
+        assertThat(httpBody.getBytes().length, is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET.length)));
+        assertThat(httpBody.toString(), is(equalTo(BODY_1_STRING_DEFAULT_CHARSET)));
+    }
+
+    @Test
+    public void shouldCreateBodyWithInitialCapacity() {
+        // Given
+        int initialCapacity = 1024;
+        HttpBody httpBody = new HttpBodyImpl(initialCapacity);
+        // When / Then
+        assertThat(httpBody.length(), is(equalTo(initialCapacity)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(allZeroBytes()));
+        assertThat(httpBody.getBytes().length, is(equalTo(initialCapacity)));
+        assertThat(httpBody.toString(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldCreateBodyWithZeroLengthIfInitialCapacityIsNegative() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl(-1);
+        // When / Then
+        assertThat(httpBody.length(), is(equalTo(0)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(allZeroBytes()));
+        assertThat(httpBody.getBytes().length, is(equalTo(0)));
+        assertThat(httpBody.toString(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldLimitInitialCapacityTo128kBytes() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl(500000);
+        // When / Then
+        assertThat(httpBody.length(), is(equalTo(LIMIT_INITIAL_CAPACITY)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(allZeroBytes()));
+        assertThat(httpBody.getBytes().length, is(equalTo(LIMIT_INITIAL_CAPACITY)));
+        assertThat(httpBody.toString(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldHaveIso8859CharsetByDefault() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        // When
+        String charset = httpBody.getCharset();
+        // Then
+        assertThat(charset, is(equalTo(DEFAULT_CHARSET_NAME)));
+    }
+
+    @Test
+    public void shouldSetValidCharset() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        // When
+        httpBody.setCharset(UTF_8_NAME);
+        // Then
+        assertThat(httpBody.getCharset(), is(equalTo(UTF_8_NAME)));
+    }
+
+    @Test
+    public void shouldIgnoreNullCharset() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        String charset = null;
+        // When
+        httpBody.setCharset(charset);
+        // Then
+        assertThat(httpBody.getCharset(), is(equalTo(DEFAULT_CHARSET_NAME)));
+    }
+
+    @Test
+    public void shouldIgnoreEmptyCharset() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        String charset = "";
+        // When
+        httpBody.setCharset(charset);
+        // Then
+        assertThat(httpBody.getCharset(), is(equalTo(DEFAULT_CHARSET_NAME)));
+    }
+
+    @Test
+    public void shouldIgnoreInvalidCharset() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        String charset = "$_NotACharsetName";
+        // When
+        httpBody.setCharset(charset);
+        // Then
+        assertThat(httpBody.getCharset(), is(equalTo(DEFAULT_CHARSET_NAME)));
+    }
+
+    @Test
+    public void shouldIgnoreUnsupportedCharset() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        String charset = "UnsupportedCharset-12345";
+        // When
+        httpBody.setCharset(charset);
+        // Then
+        assertThat(httpBody.getCharset(), is(equalTo(DEFAULT_CHARSET_NAME)));
+    }
+
+    @Test
+    public void shouldIgnoreAlreadySetCharset() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        httpBody.setCharset(UTF_8_NAME);
+        // When
+        httpBody.setCharset(UTF_8_NAME);
+        // Then
+        assertThat(httpBody.getCharset(), is(equalTo(UTF_8_NAME)));
+    }
+
+    @Test
+    public void shouldIgnoreNullBytesBodySet() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl("\0");
+        // When
+        httpBody.setBody((byte[]) null);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(1)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(new byte[] { 0 })));
+        assertThat(httpBody.getBytes().length, is(equalTo(1)));
+        assertThat(httpBody.toString(), is(equalTo("\0")));
+    }
+
+    @Test
+    public void shouldIgnoreNullStringBodySet() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl("\0");
+        // When
+        httpBody.setBody((String) null);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(1)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(new byte[] { 0 })));
+        assertThat(httpBody.getBytes().length, is(equalTo(1)));
+        assertThat(httpBody.toString(), is(equalTo("\0")));
+    }
+
+    @Test
+    public void shouldSetBytesBodyUsingDefaultCharset() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        // When
+        httpBody.setBody(BODY_1_BYTES_DEFAULT_CHARSET);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET)));
+        assertThat(httpBody.getBytes().length, is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET.length)));
+        assertThat(httpBody.toString(), is(equalTo(BODY_1_STRING_DEFAULT_CHARSET)));
+    }
+
+    @Test
+    public void shouldSetStringBodyUsingDefaultCharset() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        // When
+        httpBody.setBody(BODY_1_STRING);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET)));
+        assertThat(httpBody.getBytes().length, is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET.length)));
+        assertThat(httpBody.toString(), is(equalTo(BODY_1_STRING_DEFAULT_CHARSET)));
+    }
+
+    @Test
+    public void shouldSetBytesBodyUsingCharsetSet() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        httpBody.setCharset(UTF_8_NAME);
+        // When
+        httpBody.setBody(BODY_1_BYTES_UTF_8);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(BODY_1_BYTES_UTF_8.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(BODY_1_BYTES_UTF_8)));
+        assertThat(httpBody.getBytes().length, is(equalTo(BODY_1_BYTES_UTF_8.length)));
+        assertThat(httpBody.toString(), is(equalTo(BODY_1_STRING_UTF_8)));
+    }
+
+    @Test
+    public void shouldSetStringBodyUsingCharsetSet() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        httpBody.setCharset(UTF_8_NAME);
+        // When
+        httpBody.setBody(BODY_1_STRING_UTF_8);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(BODY_1_BYTES_UTF_8.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(BODY_1_BYTES_UTF_8)));
+        assertThat(httpBody.getBytes().length, is(equalTo(BODY_1_BYTES_UTF_8.length)));
+        assertThat(httpBody.toString(), is(equalTo(BODY_1_STRING_UTF_8)));
+    }
+
+    @Test
+    public void shouldIgnoreNullBytesBodyAppended() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl("\0");
+        // When
+        httpBody.append((byte[]) null);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(1)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(new byte[] { 0 })));
+        assertThat(httpBody.getBytes().length, is(equalTo(1)));
+        assertThat(httpBody.toString(), is(equalTo("\0")));
+    }
+
+    @Test
+    public void shouldIgnoreNullStringBodyAppended() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl("\0");
+        // When
+        httpBody.append((String) null);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(1)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(new byte[] { 0 })));
+        assertThat(httpBody.getBytes().length, is(equalTo(1)));
+        assertThat(httpBody.toString(), is(equalTo("\0")));
+    }
+
+    @Test
+    public void shouldAppendBytesBodyUsingDefaultCharset() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl(BODY_1_STRING);
+        // When
+        httpBody.append(BODY_2_BYTES_DEFAULT_CHARSET);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(BODY_1_AND_2_BYTES_DEFAULT_CHARSET.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(BODY_1_AND_2_BYTES_DEFAULT_CHARSET)));
+        assertThat(httpBody.getBytes().length, is(equalTo(BODY_1_AND_2_BYTES_DEFAULT_CHARSET.length)));
+        assertThat(httpBody.toString(), is(equalTo(BODY_1_AND_2_STRING_DEFAULT_CHARSET)));
+    }
+
+    @Test
+    public void shouldAppendStringBodyUsingDefaultCharset() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl(BODY_1_STRING);
+        // When
+        httpBody.append(BODY_2_STRING);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(BODY_1_AND_2_BYTES_DEFAULT_CHARSET.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(BODY_1_AND_2_BYTES_DEFAULT_CHARSET)));
+        assertThat(httpBody.getBytes().length, is(equalTo(BODY_1_AND_2_BYTES_DEFAULT_CHARSET.length)));
+        assertThat(httpBody.toString(), is(equalTo(BODY_1_AND_2_STRING_DEFAULT_CHARSET)));
+    }
+
+    @Test
+    public void shouldAppendBytesBodyUsingCharsetSet() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl(BODY_1_BYTES_UTF_8);
+        httpBody.setCharset(UTF_8_NAME);
+        // When
+        httpBody.append(BODY_2_BYTES_UTF_8);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(BODY_1_AND_2_BYTES_UTF_8.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(BODY_1_AND_2_BYTES_UTF_8)));
+        assertThat(httpBody.getBytes().length, is(equalTo(BODY_1_AND_2_BYTES_UTF_8.length)));
+        assertThat(httpBody.toString(), is(equalTo(BODY_1_AND_2_STRING_UTF_8)));
+    }
+
+    @Test
+    public void shouldAppendStringBodyUsingCharsetSet() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl(BODY_1_BYTES_UTF_8);
+        httpBody.setCharset(UTF_8_NAME);
+        // When
+        httpBody.append(BODY_2_STRING_UTF_8);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(BODY_1_AND_2_BYTES_UTF_8.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(BODY_1_AND_2_BYTES_UTF_8)));
+        assertThat(httpBody.getBytes().length, is(equalTo(BODY_1_AND_2_BYTES_UTF_8.length)));
+        assertThat(httpBody.toString(), is(equalTo(BODY_1_AND_2_STRING_UTF_8)));
+    }
+
+    @Test
+    public void shouldAppendFullByteArray() {
+        // Given
+        byte[] chunk = { 0, 1, 2, 3, 4, 5 };
+        HttpBody httpBody = new HttpBodyImpl();
+        // When
+        httpBody.append(chunk, chunk.length);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(chunk.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(chunk)));
+        assertThat(httpBody.getBytes().length, is(equalTo(chunk.length)));
+        assertThat(httpBody.toString(), is(equalTo("\0\1\2\3\4\5")));
+    }
+
+    @Test
+    public void shouldAppendByteArrayChunk() {
+        // Given
+        byte[] bytes = { 1, 2, 3, 4, 5 };
+        int chunkLen = 3;
+        byte[] chunk = java.util.Arrays.copyOf(bytes, chunkLen);
+        HttpBody httpBody = new HttpBodyImpl();
+        // When
+        httpBody.append(bytes, chunkLen);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(chunk.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(chunk)));
+        assertThat(httpBody.getBytes().length, is(equalTo(chunk.length)));
+        assertThat(httpBody.toString(), is(equalTo("\1\2\3")));
+    }
+
+    @Test
+    public void shouldAppendByteArrayToExistingData() {
+        // Given
+        byte[] bytes = { 1, 2, 3, 4, 5, 6, 7 };
+        byte[] chunk = Arrays.copyOfRange(bytes, 3, bytes.length);
+        HttpBody httpBody = new HttpBodyImpl(Arrays.copyOf(bytes, bytes.length - chunk.length));
+        // When
+        httpBody.append(chunk, chunk.length);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(bytes.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(bytes)));
+        assertThat(httpBody.getBytes().length, is(equalTo(bytes.length)));
+        assertThat(httpBody.toString(), is(equalTo("\1\2\3\4\5\6\7")));
+    }
+
+    @Test
+    public void shouldAppendByteArrayToBodyWithHigherInitialCapacity() {
+        // Given
+        int initialCapacity = 10;
+        byte[] chunk = { 1, 2, 3, 4, 5 };
+        HttpBody httpBody = new HttpBodyImpl(initialCapacity);
+        byte[] expectedBytes = Arrays.copyOf(chunk, initialCapacity);
+        // When
+        httpBody.append(chunk, chunk.length);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(expectedBytes.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(expectedBytes)));
+        assertThat(httpBody.getBytes().length, is(equalTo(expectedBytes.length)));
+        assertThat(httpBody.toString(), is(equalTo("\1\2\3\4\5")));
+    }
+
+    @Test
+    public void shouldAppendByteArrayToBodyWithLowerInitialCapacity() {
+        // Given
+        byte[] chunk = { 1, 2, 3, 4, 5 };
+        HttpBody httpBody = new HttpBodyImpl(3);
+        // When
+        httpBody.append(chunk, chunk.length);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(chunk.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(chunk)));
+        assertThat(httpBody.getBytes().length, is(equalTo(chunk.length)));
+        assertThat(httpBody.toString(), is(equalTo("\1\2\3\4\5")));
+    }
+
+    @Test
+    public void shouldIgnoreAppendOfNullByteArray() {
+        // Given
+        byte[] chunk = { 1, 2, 3, 4, 5 };
+        HttpBody httpBody = new HttpBodyImpl();
+        // When
+        httpBody.append(null, 5);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(0)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(allZeroBytes()));
+        assertThat(httpBody.getBytes().length, is(equalTo(0)));
+        assertThat(httpBody.toString(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldIgnoreAppendOfByteArrayIfNegativeLength() {
+        // Given
+        byte[] chunk = { 1, 2, 3, 4, 5 };
+        HttpBody httpBody = new HttpBodyImpl();
+        // When
+        httpBody.append(chunk, -1);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(0)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(allZeroBytes()));
+        assertThat(httpBody.getBytes().length, is(equalTo(0)));
+        assertThat(httpBody.toString(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldApplyCharsetSetToStringRepresentation() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        // When
+        httpBody.setCharset(UTF_8_NAME);
+        httpBody.toString(); // force the creation of the "old" string representation
+        httpBody.setBody(BODY_1_BYTES_UTF_8);
+        // Then
+        assertThat(httpBody.toString(), is(equalTo(BODY_1_STRING_UTF_8)));
+    }
+
+    @Test
+    public void shouldExpandBodyWithSetLength() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        // When
+        httpBody.setLength(50);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(50)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(allZeroBytes()));
+        assertThat(httpBody.getBytes().length, is(equalTo(50)));
+        assertThat(httpBody.toString(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldTruncateBodyWithSetLength() {
+        // Given
+        byte[] body = { 1, 2, 3, 4, 5 };
+        HttpBody httpBody = new HttpBodyImpl(body);
+        byte[] expectedBytes = Arrays.copyOf(body, 3);
+        // When
+        httpBody.setLength(expectedBytes.length);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(expectedBytes.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(expectedBytes)));
+        assertThat(httpBody.getBytes().length, is(equalTo(expectedBytes.length)));
+        assertThat(httpBody.toString(), is(equalTo("\1\2\3")));
+    }
+
+    @Test
+    public void shouldProduceSameStringRepresentationEvenIfBodyIsExpandedWithSetLength() {
+        // Given
+        byte[] body = { 1, 2, 3, 4, 5 };
+        HttpBody httpBody = new HttpBodyImpl(body);
+        byte[] expectedBytes = concatenate(body, new byte[] { 0, 0 });
+        // When
+        httpBody.setLength(expectedBytes.length);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(expectedBytes.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(expectedBytes)));
+        assertThat(httpBody.getBytes().length, is(equalTo(expectedBytes.length)));
+        assertThat(httpBody.toString(), is(equalTo("\1\2\3\4\5")));
+    }
+
+    @Test
+    public void shouldIgnoreNegativeLengthSet() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        // When
+        httpBody.setLength(-1);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(0)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(allZeroBytes()));
+        assertThat(httpBody.getBytes().length, is(equalTo(0)));
+        assertThat(httpBody.toString(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldIgnoreSameLengthSet() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl(50);
+        // When
+        httpBody.setLength(50);
+        // Then
+        assertThat(httpBody.length(), is(equalTo(50)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(allZeroBytes()));
+        assertThat(httpBody.getBytes().length, is(equalTo(50)));
+        assertThat(httpBody.toString(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldReturnSameInstanceStringRepresentationOnConsecutiveCalls() {
+        // Given
+        String body = " X Y Z ";
+        HttpBody httpBody = new HttpBodyImpl(body);
+        // When
+        String string1 = httpBody.toString();
+        String string2 = httpBody.toString();
+        // Then
+        assertThat(string1, is(equalTo(body)));
+        assertThat(string2, is(sameInstance(string2)));
+    }
+
+    @Test
+    public void shouldNotBeEqualToNull() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        // When
+        boolean equals = httpBody.equals(null);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldBeEqualToEqualHttpBody() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        HttpBody otherHttpBody = new HttpBodyImpl();
+        // When / Then
+        assertThat(httpBody, is(equalTo(otherHttpBody)));
+    }
+
+    @Test
+    public void shouldBeEqualToSameInstance() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        // When / Then
+        assertThat(httpBody, is(equalTo(httpBody)));
+    }
+
+    @Test
+    public void shouldNotBeEqualToDifferentHttpBody() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        HttpBody otherDifferentHttpBody = new HttpBodyImpl("Different Contents");
+        // When / Then
+        assertThat(httpBody, is(not(equalTo(otherDifferentHttpBody))));
+    }
+
+    @Test
+    public void shouldNotBeEqualToDifferentHttpBodyImplementation() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        HttpBody otherHttpBodyImplementation = new HttpBody() {
+        };
+        // When / Then
+        assertThat(httpBody, is(not(equalTo(otherHttpBodyImplementation))));
+    }
+
+    @Test
+    public void shouldProduceSameHashCodeForEqualBody() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl("X A");
+        HttpBody otherHttpBody = new HttpBodyImpl("X A");
+        // When / Then
+        assertThat(httpBody.hashCode(), is(equalTo(otherHttpBody.hashCode())));
+    }
+
+    @Test
+    public void shouldProduceDifferentHashCodeFromDifferentBody() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl("_ X A 1");
+        HttpBody otherHttpBody = new HttpBodyImpl("X A 2");
+        // When / Then
+        assertThat(httpBody.hashCode(), is(not(equalTo(otherHttpBody.hashCode()))));
+    }
+
+    private static class HttpBodyImpl extends HttpBody {
+
+        public HttpBodyImpl() {
+        }
+
+        public HttpBodyImpl(int capacity) {
+            super(capacity);
+        }
+
+        public HttpBodyImpl(String data) {
+            super(data);
+        }
+
+        public HttpBodyImpl(byte[] data) {
+            super(data);
+        }
+    }
+
+}

--- a/test/org/zaproxy/zap/network/HttpBodyTestUtils.java
+++ b/test/org/zaproxy/zap/network/HttpBodyTestUtils.java
@@ -1,0 +1,108 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.network;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.log4j.Logger;
+import org.apache.log4j.varia.NullAppender;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.BeforeClass;
+import org.parosproxy.paros.core.scanner.Plugin;
+
+/**
+ * Class with helper/utility methods to help testing classes involving {@code HttpBody} class and its implementations.
+ *
+ * @see Plugin
+ */
+public class HttpBodyTestUtils {
+
+    protected static final int LIMIT_INITIAL_CAPACITY = 128000;
+
+    protected static final Charset DEFAULT_CHARSET = StandardCharsets.ISO_8859_1;
+    protected static final String DEFAULT_CHARSET_NAME = DEFAULT_CHARSET.name();
+
+    protected static final String UTF_8_NAME = StandardCharsets.UTF_8.name();
+
+    protected static final String BODY_1_STRING = "[Body1 A B C ぁ]";
+
+    protected static final byte[] BODY_1_BYTES_DEFAULT_CHARSET = BODY_1_STRING.getBytes(DEFAULT_CHARSET);
+    protected static final String BODY_1_STRING_DEFAULT_CHARSET = new String(BODY_1_BYTES_DEFAULT_CHARSET, DEFAULT_CHARSET);
+
+    protected static final byte[] BODY_1_BYTES_UTF_8 = BODY_1_STRING.getBytes(StandardCharsets.UTF_8);
+    protected static final String BODY_1_STRING_UTF_8 = new String(BODY_1_BYTES_UTF_8, StandardCharsets.UTF_8);
+
+    protected static final String BODY_2_STRING = "[Body2 X Y Z ぁ]";
+
+    protected static final byte[] BODY_2_BYTES_DEFAULT_CHARSET = BODY_2_STRING.getBytes(DEFAULT_CHARSET);
+    protected static final String BODY_2_STRING_DEFAULT_CHARSET = new String(BODY_2_BYTES_DEFAULT_CHARSET, DEFAULT_CHARSET);
+
+    protected static final byte[] BODY_2_BYTES_UTF_8 = BODY_2_STRING.getBytes(StandardCharsets.UTF_8);
+    protected static final String BODY_2_STRING_UTF_8 = new String(BODY_2_BYTES_UTF_8, StandardCharsets.UTF_8);
+
+    protected static final byte[] BODY_1_AND_2_BYTES_DEFAULT_CHARSET = concatenate(
+            BODY_1_BYTES_DEFAULT_CHARSET,
+            BODY_2_BYTES_DEFAULT_CHARSET);
+    protected static final String BODY_1_AND_2_STRING_DEFAULT_CHARSET = BODY_1_STRING_DEFAULT_CHARSET
+            + BODY_2_STRING_DEFAULT_CHARSET;
+    protected static final byte[] BODY_1_AND_2_BYTES_UTF_8 = concatenate(BODY_1_BYTES_UTF_8, BODY_2_BYTES_UTF_8);
+    protected static final String BODY_1_AND_2_STRING_UTF_8 = BODY_1_STRING_UTF_8 + BODY_2_STRING_UTF_8;
+
+    @BeforeClass
+    public static void suppressLogging() {
+        Logger.getRootLogger().addAppender(new NullAppender());
+    }
+
+    protected static byte[] concatenate(byte[] array, byte[] array2) {
+        int newlen = array.length + array2.length;
+        byte[] newArray = new byte[newlen];
+        System.arraycopy(array, 0, newArray, 0, array.length);
+        System.arraycopy(array2, 0, newArray, array.length, array2.length);
+        return newArray;
+    }
+
+    protected static Matcher<byte[]> allZeroBytes() {
+        return new BaseMatcher<byte[]>() {
+
+            @Override
+            public boolean matches(Object actualValue) {
+                byte[] bytes = (byte[]) actualValue;
+                for (byte data : bytes) {
+                    if (data != 0) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("all zero bytes");
+            }
+
+            public void describeMismatch(Object item, Description description) {
+                description.appendText("has at least one non-zero byte ").appendValue(item);
+            }
+        };
+    }
+}

--- a/test/org/zaproxy/zap/network/HttpResponseBodyUnitTest.java
+++ b/test/org/zaproxy/zap/network/HttpResponseBodyUnitTest.java
@@ -1,0 +1,210 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.network;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.log4j.Logger;
+import org.apache.log4j.varia.NullAppender;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link HttpResponseBody}.
+ */
+public class HttpResponseBodyUnitTest extends HttpBodyTestUtils {
+
+    private static final byte[] BODY_1_BYTES_UTF_16 = BODY_1_STRING.getBytes(StandardCharsets.UTF_16);
+
+    @BeforeClass
+    public static void suppressLogging() {
+        Logger.getRootLogger().addAppender(new NullAppender());
+    }
+
+    @Test
+    public void shouldCreateBodyWithNullByteArray() {
+        // Given
+        HttpResponseBody httpBody = new HttpResponseBody((byte[]) null);
+        // When / Then
+        assertThat(httpBody.length(), is(equalTo(0)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(allZeroBytes()));
+        assertThat(httpBody.getBytes().length, is(equalTo(0)));
+        assertThat(httpBody.toString(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldCreateBodyWithByteArray() {
+        // Given
+        HttpResponseBody httpBody = new HttpResponseBody(BODY_1_BYTES_DEFAULT_CHARSET);
+        // When / Then
+        assertThat(httpBody.length(), is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET)));
+        assertThat(httpBody.getBytes().length, is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET.length)));
+        assertThat(httpBody.toString(), is(equalTo(BODY_1_STRING_DEFAULT_CHARSET)));
+    }
+
+    @Test
+    public void shouldCreateBodyWithNullString() {
+        // Given
+        HttpResponseBody httpBody = new HttpResponseBody((String) null);
+        // When / Then
+        assertThat(httpBody.length(), is(equalTo(0)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(allZeroBytes()));
+        assertThat(httpBody.getBytes().length, is(equalTo(0)));
+        assertThat(httpBody.toString(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldCreateBodyWithStringUsingDefaultCharset() {
+        // Given
+        HttpResponseBody httpBody = new HttpResponseBody(BODY_1_STRING);
+        // When / Then
+        assertThat(httpBody.length(), is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET)));
+        assertThat(httpBody.getBytes().length, is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET.length)));
+        assertThat(httpBody.toString(), is(equalTo(BODY_1_STRING_DEFAULT_CHARSET)));
+    }
+
+    @Test
+    public void shouldCreateBodyWithInitialCapacity() {
+        // Given
+        int initialCapacity = 1024;
+        HttpResponseBody httpBody = new HttpResponseBody(initialCapacity);
+        // When / Then
+        assertThat(httpBody.length(), is(equalTo(initialCapacity)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(allZeroBytes()));
+        assertThat(httpBody.getBytes().length, is(equalTo(initialCapacity)));
+        assertThat(httpBody.toString(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldCreateBodyWithZeroLengthIfInitialCapacityIsNegative() {
+        // Given
+        HttpResponseBody httpBody = new HttpResponseBody(-1);
+        // When / Then
+        assertThat(httpBody.length(), is(equalTo(0)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(allZeroBytes()));
+        assertThat(httpBody.getBytes().length, is(equalTo(0)));
+        assertThat(httpBody.toString(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldLimitInitialCapacityTo128kBytes() {
+        // Given
+        HttpResponseBody httpBody = new HttpResponseBody(500000);
+        // When / Then
+        assertThat(httpBody.length(), is(equalTo(LIMIT_INITIAL_CAPACITY)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(allZeroBytes()));
+        assertThat(httpBody.getBytes().length, is(equalTo(LIMIT_INITIAL_CAPACITY)));
+        assertThat(httpBody.toString(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldHaveEmptyStringRepresentationByDefault() {
+        // Given
+        HttpResponseBody httpBody = new HttpResponseBody();
+        // When
+        String stringRepresentation = httpBody.toString();
+        // Then
+        assertThat(stringRepresentation, is(equalTo("")));
+    }
+
+    @Test
+    public void shouldProduceStringRepresentationWithCharsetSet() {
+        // Given
+        HttpResponseBody httpBody = new HttpResponseBody(BODY_1_BYTES_UTF_8);
+        httpBody.setCharset(UTF_8_NAME);
+        // When
+        String stringRepresentation = httpBody.toString();
+        // Then
+        assertThat(stringRepresentation, is(equalTo(BODY_1_STRING_UTF_8)));
+    }
+
+    @Test
+    public void shouldHaveIso8859CharsetByDefault() {
+        // Given
+        HttpResponseBody httpBody = new HttpResponseBody();
+        // When
+        String charset = httpBody.getCharset();
+        // Then
+        assertThat(charset, is(equalTo(DEFAULT_CHARSET_NAME)));
+    }
+
+    @Test
+    public void shouldDefaultToIso8859CharsetIfCharsetOfContentsIsNotSetNorDefined() {
+        // Given
+        HttpResponseBody httpBody = new HttpResponseBody(BODY_1_BYTES_UTF_16);
+        // When
+        String stringRepresentation = httpBody.toString();
+        // Then
+        assertThat(httpBody.getCharset(), is(equalTo(DEFAULT_CHARSET_NAME)));
+        assertThat(stringRepresentation, is(startsWith("þÿ"))); // Wrong contents...
+    }
+
+    @Test
+    public void shouldDefaultToUft8CharsetIfCharsetOfContentsIsNotSetNorDefinedButMatchUtf8() {
+        // Given
+        HttpResponseBody httpBody = new HttpResponseBody(BODY_1_BYTES_UTF_8);
+        // When
+        String stringRepresentation = httpBody.toString();
+        // Then
+        assertThat(httpBody.getCharset(), is(equalTo(UTF_8_NAME)));
+        assertThat(stringRepresentation, is(equalTo(BODY_1_STRING_UTF_8)));
+    }
+
+    @Test
+    public void shouldDefaultToIso8859CharsetIfCharsetOfTheContentsIsDefinedButUnsupported() {
+        // Given
+        String contents = "<meta  charset='UnsupportedCharset-12345' />";
+        HttpResponseBody httpBody = new HttpResponseBody(contents);
+        // When
+        String stringRepresentation = httpBody.toString();
+        // Then
+        assertThat(httpBody.getCharset(), is(equalTo(DEFAULT_CHARSET_NAME)));
+        assertThat(stringRepresentation, is(equalTo(contents)));
+    }
+
+    @Test
+    public void shouldUseCharsetOfTheContentsIfDefinedAndSupported() {
+        // Given
+        String contents = "<meta  charset='UTF-8' />";
+        HttpResponseBody httpBody = new HttpResponseBody(contents);
+        // When
+        String stringRepresentation = httpBody.toString();
+        // Then
+        assertThat(httpBody.getCharset(), is(equalTo(UTF_8_NAME)));
+        assertThat(stringRepresentation, is(equalTo(contents)));
+    }
+
+}


### PR DESCRIPTION
Change class HttpBody to always use the charset set when creating the
String representation of the body (it could happen in some cases that it
would use the default charset instead of the one set, leading to wrong
encoding of the characters). Also, fix undocumented exceptions/behaviour
and change to use StandardCharsets/Charset (instead of String) when
obtaining the bytes from the String or converting the bytes to String.
Change class HttpResponseBody to also use StandardCharsets/Charset and
use the new code to create the String representation.
Add tests to assert the expected behaviour of classes HttpBody and
HttpResponseBody.

Fix #2487 - Wrong charset used in HTTP body