### PR TITLE
Prevent headless exception when deleting a node via the API

### DIFF
--- a/src/org/zaproxy/zap/extension/history/PopupMenuPurgeHistory.java
+++ b/src/org/zaproxy/zap/extension/history/PopupMenuPurgeHistory.java
@@ -97,7 +97,8 @@ public class PopupMenuPurgeHistory extends PopupMenuItemHistoryReferenceContaine
 
         if (node.getHistoryReference() == ref) {
             // same active Node
-            PopupMenuPurgeSites.purge(map, node);
+            extension.purge(map, node);
+
         } else {
             node.getPastHistoryReference().remove(ref);
             map.removeHistoryReference(ref.getHistoryId());

--- a/src/org/zaproxy/zap/extension/history/PopupMenuPurgeSites.java
+++ b/src/org/zaproxy/zap/extension/history/PopupMenuPurgeSites.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import javax.swing.JOptionPane;
 
-import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
@@ -32,15 +31,12 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.SiteMap;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
 
 public class PopupMenuPurgeSites extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 4827464631678110752L;
-
-    private static final Logger logger = Logger.getLogger(PopupMenuPurgeSites.class);
 
     public PopupMenuPurgeSites() {
         super(Constant.messages.getString("sites.purge.popup"), true);
@@ -70,64 +66,27 @@ public class PopupMenuPurgeSites extends PopupMenuItemSiteNodeContainer {
 
     @Override
     public void performAction(SiteNode sn) {
-        purge(Model.getSingleton().getSession().getSiteTree(), sn);
-    }
+        ExtensionHistory extHistory =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
 
+        if (extHistory != null) {
+            extHistory.purge(Model.getSingleton().getSession().getSiteTree(), sn);
+        }
+    }
+    
+    /**
+     * @deprecated  As of release 2.5.0, replaced by 
+     * {@link org.parosproxy.paros.extension.history.ExtensionHistory#purge(
+     *      org.parosproxy.paros.model.SiteMap, org.parosproxy.paros.model.SiteNode)} 
+     */
+    @Deprecated
     public static void purge(SiteMap map, SiteNode node) {
-        SiteNode child = null;
-        synchronized (map) {
-            while (node.getChildCount() > 0) {
-                try {
-                    child = (SiteNode) node.getChildAt(0);
-                    purge(map, child);
-                } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
-                }
-            }
+        ExtensionHistory extHistory =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
 
-            if (node.isRoot()) {
-                return;
-            }
-
-            // delete reference in node
-            ExtensionHistory ext = (ExtensionHistory) Control.getSingleton()
-                    .getExtensionLoader()
-                    .getExtension(ExtensionHistory.NAME);
-            ext.removeFromHistoryList(node.getHistoryReference());
-            ext.clearLogPanelDisplayQueue();
-
-            ExtensionAlert extAlert = (ExtensionAlert) Control.getSingleton()
-                    .getExtensionLoader()
-                    .getExtension(ExtensionAlert.NAME);
-
-            if (node.getHistoryReference() != null) {
-                deleteAlertsFromExtensionAlert(extAlert, node.getHistoryReference());
-                node.getHistoryReference().delete();
-                map.removeHistoryReference(node.getHistoryReference().getHistoryId());
-            }
-
-            // delete past reference in node
-            while (node.getPastHistoryReference().size() > 0) {
-                HistoryReference ref = node.getPastHistoryReference().get(0);
-                deleteAlertsFromExtensionAlert(extAlert, ref);
-                ext.removeFromHistoryList(ref);
-                ext.clearLogPanelDisplayQueue();
-                ext.delete(ref);
-                node.getPastHistoryReference().remove(0);
-                map.removeHistoryReference(ref.getHistoryId());
-            }
-
-            map.removeNodeFromParent(node);
+        if (extHistory != null) {
+            extHistory.purge(map, node);
         }
-
-    }
-
-    private static void deleteAlertsFromExtensionAlert(ExtensionAlert extAlert, HistoryReference historyReference) {
-        if (extAlert == null) {
-            return;
-        }
-
-        extAlert.deleteHistoryReferenceAlerts(historyReference);
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/stdmenus/PopupExcludeFromProxyMenu.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/PopupExcludeFromProxyMenu.java
@@ -22,14 +22,15 @@ package org.zaproxy.zap.extension.stdmenus;
 import java.util.List;
 
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.db.DatabaseException;
+import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteMap;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.extension.history.PopupMenuPurgeSites;
 import org.zaproxy.zap.model.StructuralSiteNode;
 import org.zaproxy.zap.view.SessionExcludeFromProxyPanel;
 import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
@@ -68,7 +69,14 @@ public class PopupExcludeFromProxyMenu extends PopupMenuItemSiteNodeContainer {
 			session.getExcludeFromProxyRegexs().add(new StructuralSiteNode(sn).getRegexPattern());
 			SiteMap map = (SiteMap) View.getSingleton().getSiteTreePanel().getTreeSite().getModel();
 
-			PopupMenuPurgeSites.purge(map, sn);
+            ExtensionHistory extHistory =
+                    Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
+
+            if (extHistory != null) {
+                extHistory.purge(map, sn);
+            }
+
+			
 		} catch (DatabaseException e) {
 			// Ignore
 		}


### PR DESCRIPTION
Moved purge method from PopupMenuPurgeSites to ExtensionHistory - not ideal but couldnt think of a better place for now.