### PR TITLE
Set AWT as headless when ZAP is in a headless mode

### DIFF
--- a/src/org/zaproxy/zap/HeadlessBootstrap.java
+++ b/src/org/zaproxy/zap/HeadlessBootstrap.java
@@ -42,6 +42,8 @@ abstract class HeadlessBootstrap extends ZapBootstrap {
 
     public HeadlessBootstrap(CommandLine args) {
         super(args);
+
+        System.setProperty("java.awt.headless", "true");
     }
 
     /**


### PR DESCRIPTION
Change class HeadlessBootstrap to set AWT as headless, to ensure that
daemon and command line modes fail always to use view components that
require a display, not just when there's no display available. Allows to
detect (wrong) use of view components more easily (HeadlessException is
thrown even if there's a display available) when in daemon and command
line modes.