### PR TITLE
Do not discard the session for file based database

### DIFF
--- a/src/org/parosproxy/paros/db/Database.java
+++ b/src/org/parosproxy/paros/db/Database.java
@@ -138,4 +138,17 @@ public interface Database {
 	 */
 	String getType();
 
+	/**
+	 * Discards the history associated with the given session ID, called when a session is not to be saved (and a new one is
+	 * about to be created).
+	 * <p>
+	 * Implementations might opt to do nothing, for example, if the database is file based (HSQLDB) and those files are deleted
+	 * if the session is not saved.
+	 *
+	 * @param sessionId the ID of the session
+	 * @throws DatabaseException If an error occurred while discarding the history of the session.
+	 * @since TODO add version
+	 */
+	void discardSession(long sessionId) throws DatabaseException;
+
 }

--- a/src/org/parosproxy/paros/db/paros/ParosDatabase.java
+++ b/src/org/parosproxy/paros/db/paros/ParosDatabase.java
@@ -36,6 +36,7 @@
 // ZAP: 2015/04/02 Issue 1582: Low memory option
 // ZAP: 2016/02/10 Issue 1958: Allow to disable database (HSQLDB) log
 // ZAP: 2016/04/22 Issue 2428: Memory leak on session creation/loading
+// ZAP: 2016/05/24 Add implementation of Database.discardSession(long)
 
 package org.parosproxy.paros.db.paros;
 
@@ -46,6 +47,7 @@ import java.util.List;
 
 import org.parosproxy.paros.db.AbstractDatabase;
 import org.parosproxy.paros.db.Database;
+import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.db.DatabaseListener;
 import org.parosproxy.paros.db.DatabaseServer;
 import org.parosproxy.paros.db.TableAlert;
@@ -323,5 +325,11 @@ public class ParosDatabase extends AbstractDatabase {
 			throw new IllegalArgumentException("Parameter databaseOptions must not be null.");
 		}
 		this.databaseOptions = databaseOptions;
+	}
+
+	@Override
+	public void discardSession(long sessionId) throws DatabaseException {
+		// Do nothing, the database files are going to be deleted anyway.
+		// getTableHistory().deleteHistorySession(sessionId);
 	}
 }

--- a/src/org/parosproxy/paros/model/Session.java
+++ b/src/org/parosproxy/paros/model/Session.java
@@ -58,6 +58,7 @@
 // ZAP: 2016/05/02 Issue 2451: Only a single Data Driven Node can be saved in a context
 // ZAP: 2016/05/04 Changes to address issues related to ParameterParser
 // ZAP: 2016/05/10 Use empty String for (URL) parameters with no value
+// ZAP: 2016/05/24 Call Database.discardSession(long) in Session.discard()
 
 package org.parosproxy.paros.model;
 
@@ -176,7 +177,7 @@ public class Session {
 
 	protected void discard() {
 	    try {
-	        model.getDb().getTableHistory().deleteHistorySession(getSessionId());
+	        model.getDb().discardSession(getSessionId());
         } catch (DatabaseException e) {
         	// ZAP: Log exceptions
         	log.warn(e.getMessage(), e);

--- a/src/org/zaproxy/zap/db/sql/SqlDatabase.java
+++ b/src/org/zaproxy/zap/db/sql/SqlDatabase.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.parosproxy.paros.db.AbstractDatabase;
+import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.db.DatabaseListener;
 import org.parosproxy.paros.db.DatabaseServer;
 import org.parosproxy.paros.db.TableAlert;
@@ -273,4 +274,10 @@ public class SqlDatabase extends AbstractDatabase {
 		return DbSQL.getDbType();
 	}
 
+	@Override
+	public void discardSession(long sessionId) throws DatabaseException {
+		if (!isFileBased()) {
+			getTableHistory().deleteHistorySession(sessionId);
+		}
+	}
 }


### PR DESCRIPTION
Ignore calls to discard the session if the database implementation is
file based (for example, HSQLDB), the files of those databases are
deleted when a session is discarded (that is, not to be saved), just
before creating a new one.
For file based databases the change improves the time it takes to create
new sessions when the previous session was not (effectively) saved.

More detailed changes:
 - Session, change to delegate the discard of the session to Database
 (which known the "type" of database it is);
 - Database, add method discardSession(long);
 - ParosDatabase, add implementation of discardSession(long), which
 (being HSQLDB) does not need to discard the session;
 - SqlDatabase, add implementation of discardSession(long), which only
 discards the session if it's not file based, for example, MySQL.