### PR TITLE
Normalise Alert.equals/hashCode/compareTo

### DIFF
--- a/src/org/zaproxy/zap/extension/alert/AlertTreeModel.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertTreeModel.java
@@ -215,31 +215,7 @@ class AlertTreeModel extends DefaultTreeModel {
 
         @Override
         public int compare(AlertNode alertNode, AlertNode anotherAlertNode) {
-            int result = alertNode.getNodeName().compareTo(anotherAlertNode.getNodeName());
-            if (result != 0) {
-                return result;
-            }
-
-            Alert alert = alertNode.getUserObject();
-            Alert anotherAlert = anotherAlertNode.getUserObject();
-
-            result = alert.getParam().compareTo(anotherAlert.getParam());
-            if (result != 0) {
-                return result;
-            }
-
-            if (alert.getAttack() == null) {
-                if (anotherAlert.getAttack() == null) {
-                    return 0;
-                }
-                return -1;
-            }
-
-            if (anotherAlert.getAttack() == null) {
-                return 1;
-            }
-
-            return alert.getAttack().compareTo(anotherAlert.getAttack());
+            return alertNode.getUserObject().compareTo(anotherAlertNode.getUserObject());
         }
     }
 }


### PR DESCRIPTION
Normalise the implementation of Alert's methods equals and compareTo and
implement the method hashCode for consistency when used in different
collections.
Two alerts are considered the same if the following properties are
equal:
 - Plugin ID;
 - Name;
 - Risk;
 - Confidence;
 - URI;
 - Parameter;
 - Evidence;
 - Attack;
 - Other Info.

Change class AlertTreeModel to use the method Alert.compareTo instead of
comparing manually the alerts to ensure that the alerts shown in the
Alerts tab are the same as the ones included in the report.

Fix #2132 - Zap Report Counting Bug