### PR TITLE
Add auth and spider task types to temporary types

### DIFF
--- a/src/org/zaproxy/zap/db/sql/SqlTableHistory.java
+++ b/src/org/zaproxy/zap/db/sql/SqlTableHistory.java
@@ -26,10 +26,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -65,21 +62,6 @@ public class SqlTableHistory extends SqlAbstractTable implements TableHistory {
     private static final String NOTE        = DbSQL.getSQL("history.field.note");
     private static final String RESPONSE_FROM_TARGET_HOST = DbSQL.getSQL("history.field.responsefromtargethost");
     
-    /**
-     * The {@code Set} of history types marked as temporary.
-     * <p>
-     * By default the only temporary history types are {@code HistoryReference#TYPE_TEMPORARY} and
-     * {@code HistoryReference#TYPE_SCANNER_TEMPORARY}.
-     * <p>
-     * Iterations must be done in a {@code synchronized} block with {@code temporaryHistoryTypes}.
-     * 
-     * @since 2.4
-     * @see #setHistoryTypeAsTemporary(int)
-     * @see HistoryReference#TYPE_TEMPORARY
-     * @see HistoryReference#TYPE_SCANNER_TEMPORARY
-     * @see Collections#synchronizedSet(Set)
-     */
-    private static Set<Integer> temporaryHistoryTypes = Collections.synchronizedSet(new HashSet<Integer>());
     private int lastInsertedIndex;
     private static boolean isExistStatusCode = false;
 
@@ -87,11 +69,6 @@ public class SqlTableHistory extends SqlAbstractTable implements TableHistory {
     private static final Logger log = Logger.getLogger(SqlTableHistory.class);
 
     private boolean bodiesAsBytes; 
-
-    static {
-        temporaryHistoryTypes.add(Integer.valueOf(HistoryReference.TYPE_TEMPORARY));
-        temporaryHistoryTypes.add(Integer.valueOf(HistoryReference.TYPE_SCANNER_TEMPORARY));
-    }
 
     public SqlTableHistory() {
     }
@@ -609,35 +586,24 @@ public class SqlTableHistory extends SqlAbstractTable implements TableHistory {
     }
 
     /**
-     * Sets the given {@code historyType} as temporary.
-     *
+     * @deprecated (2.5.0) Use {@link HistoryReference#addTemporaryType(int)} instead.
      * @since 2.4
      * @param historyType the history type that will be set as temporary
-     * @see #unsetHistoryTypeAsTemporary(int)
      * @see #deleteTemporary()
      */
+    @Deprecated
     public static void setHistoryTypeAsTemporary(int historyType) {
-        temporaryHistoryTypes.add(Integer.valueOf(historyType));
     }
 
     /**
-     * Unsets the given {@code historyType} as temporary.
-     * <p>
-     * Attempting to remove a default temporary history type (
-     * {@code HistoryReference#TYPE_TEMPORARY} or {@code HistoryReference#TYPE_SCANNER_TEMPORARY})
-     * has no effect.
-     *
+     * @deprecated (2.5.0) Use {@link HistoryReference#removeTemporaryType(int)} instead.
      * @since 2.4
      * @param historyType the history type that will be marked as temporary
-     * @see #setHistoryTypeAsTemporary(int)
      * @see #deleteTemporary()
      */
+    @Deprecated
     public static void unsetHistoryTypeAsTemporary(int historyType) {
-        if (HistoryReference.TYPE_TEMPORARY == historyType
-                || HistoryReference.TYPE_SCANNER_TEMPORARY == historyType) {
-            return;
-        }
-        temporaryHistoryTypes.remove(Integer.valueOf(historyType));
+        HistoryReference.removeTemporaryType(historyType);
     }
 
     /* (non-Javadoc)
@@ -648,7 +614,7 @@ public class SqlTableHistory extends SqlAbstractTable implements TableHistory {
 	    SqlPreparedStatementWrapper psDeleteTemp = null;
         try {
 		    psDeleteTemp = DbSQL.getSingleton().getPreparedStatement( "history.ps.deletetemp");
-			for (Integer type : temporaryHistoryTypes) {
+			for (Integer type : HistoryReference.getTemporaryTypes()) {
 				psDeleteTemp.getPs().setInt(1, type);
 				psDeleteTemp.getPs().execute();
 			}


### PR DESCRIPTION
Add authentication and spider task types to the set of default temporary
types, types of message that are removed once the session is closed.
The authentication messages are shown temporarily in the History tab,
once the session is closed they become inaccessible (they are no longer
shown in any UI component), which would leak messages in the database as
it was not possible to delete them.
The spider task messages are also temporary and are automatically
removed by the spider when no longer needed, added the type to prevent
database leaks in case of exceptions in the spider execution.
Move the management of the history types to class HistoryReference,
since the types are "now" used by more than one TableHistory
implementation.