### PR TITLE
Reset the charset of the body with null/empty name

### DIFF
--- a/src/org/parosproxy/paros/network/HttpBody.java
+++ b/src/org/parosproxy/paros/network/HttpBody.java
@@ -340,7 +340,10 @@ public abstract class HttpBody {
      * Sets the charset used for {@code String} related operations, for example, {@link #append(String)},
      * {@link #setBody(String)}, or {@link #toString()}.
      * <p>
-     * The charset is ignored if {@code null}, empty, or not valid (either the name is not valid or is unsupported).
+     * The charset is reset if {@code null} or empty (that is, it will use default charset or the charset determined internally
+     * by {@code HttpBody} implementations). The charset is ignored if not valid (either the name is not valid or is
+     * unsupported).
+     * <p>
      * 
      * @param charsetName the name of the charset to set
      * @see #getCharset()
@@ -348,6 +351,7 @@ public abstract class HttpBody {
      */
     public void setCharset(String charsetName) {
         if (StringUtils.isEmpty(charsetName)) {
+            setCharsetImpl(null);
             return;
         }
 
@@ -355,12 +359,23 @@ public abstract class HttpBody {
         try {
             newCharset = Charset.forName(charsetName);
             if (newCharset != charset) {
-                this.charset = newCharset;
-                this.cachedString = null;
+                setCharsetImpl(newCharset);
             }
         } catch (IllegalCharsetNameException | UnsupportedCharsetException e) {
             log.error("Failed to set charset: " + charsetName, e);
         }
+    }
+
+    /**
+     * Sets the charset to the given value and resets the cached string (that is, is set to {@code null}).
+     *
+     * @param newCharset the new charset to set, might be {@code null}
+     * @see #charset
+     * @see #cachedString
+     */
+    private void setCharsetImpl(Charset newCharset) {
+        this.charset = newCharset;
+        this.cachedString = null;
     }
     
 	@Override

--- a/test/org/parosproxy/paros/network/HttpBodyUnitTest.java
+++ b/test/org/parosproxy/paros/network/HttpBodyUnitTest.java
@@ -173,23 +173,23 @@ public class HttpBodyUnitTest extends HttpBodyTestUtils {
     }
 
     @Test
-    public void shouldIgnoreNullCharset() {
+    public void shouldResetCharsetWithNullCharset() {
         // Given
         HttpBody httpBody = new HttpBodyImpl();
-        String charset = null;
+        httpBody.setCharset(UTF_8_NAME);
         // When
-        httpBody.setCharset(charset);
+        httpBody.setCharset(null);
         // Then
         assertThat(httpBody.getCharset(), is(equalTo(DEFAULT_CHARSET_NAME)));
     }
 
     @Test
-    public void shouldIgnoreEmptyCharset() {
+    public void shouldResetCharsetWithEmptyCharset() {
         // Given
         HttpBody httpBody = new HttpBodyImpl();
-        String charset = "";
+        httpBody.setCharset(UTF_8_NAME);
         // When
-        httpBody.setCharset(charset);
+        httpBody.setCharset("");
         // Then
         assertThat(httpBody.getCharset(), is(equalTo(DEFAULT_CHARSET_NAME)));
     }
@@ -198,22 +198,22 @@ public class HttpBodyUnitTest extends HttpBodyTestUtils {
     public void shouldIgnoreInvalidCharset() {
         // Given
         HttpBody httpBody = new HttpBodyImpl();
-        String charset = "$_NotACharsetName";
+        httpBody.setCharset(UTF_8_NAME);
         // When
-        httpBody.setCharset(charset);
+        httpBody.setCharset("$_NotACharsetName");
         // Then
-        assertThat(httpBody.getCharset(), is(equalTo(DEFAULT_CHARSET_NAME)));
+        assertThat(httpBody.getCharset(), is(equalTo(UTF_8_NAME)));
     }
 
     @Test
     public void shouldIgnoreUnsupportedCharset() {
         // Given
         HttpBody httpBody = new HttpBodyImpl();
-        String charset = "UnsupportedCharset-12345";
+        httpBody.setCharset(UTF_8_NAME);
         // When
-        httpBody.setCharset(charset);
+        httpBody.setCharset("UnsupportedCharset-12345");
         // Then
-        assertThat(httpBody.getCharset(), is(equalTo(DEFAULT_CHARSET_NAME)));
+        assertThat(httpBody.getCharset(), is(equalTo(UTF_8_NAME)));
     }
 
     @Test


### PR DESCRIPTION
Change class HttpBody to reset the charset when it's set a null/empty
charset name, to ensure that it always uses the charset set from the
header (if reset it defaults to default charset or the one determined
internally by HttpBody implementations, like HttpResponseBody).
Change tests to assert the (new) expected behaviour of class HttpBody.

Related to #2493 - Always use charset set when changing the HTTP body
(Since those changes it no longer determines, always, the charset from
the response body when the cached string is re-created.)

Fix #2517 - Wrong charset used in resent response