### PR TITLE
Enable menu/button when help add-on is installed

### DIFF
--- a/src/org/parosproxy/paros/extension/ExtensionHook.java
+++ b/src/org/parosproxy/paros/extension/ExtensionHook.java
@@ -26,6 +26,7 @@
 // ZAP: 2014/03/23 Issue 1022: Proxy - Allow to override a proxied message
 // ZAP: 2014/10/25 Issue 1062: Added scannerhook to be added by extensions. 
 // ZAP: 2016/04/08 Allow to add ContextDataFactory
+// ZAP: 2016/05/30 Allow to add AddOnInstallationStatusListener
 
 package org.parosproxy.paros.extension;
 
@@ -41,6 +42,7 @@ import org.parosproxy.paros.core.scanner.ScannerHook;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.PersistentConnectionListener;
 import org.zaproxy.zap.extension.AddonFilesChangedListener;
+import org.zaproxy.zap.extension.AddOnInstallationStatusListener;
 import org.zaproxy.zap.model.ContextDataFactory;
 import org.zaproxy.zap.view.SiteMapListener;
 
@@ -72,6 +74,16 @@ public class ExtensionHook {
      * @see #getContextDataFactories()
      */
     private List<ContextDataFactory> contextDataFactories;
+
+    /**
+     * The {@link AddOnInstallationStatusListener}s added to this extension hook.
+     * <p>
+     * Lazily initialised.
+     * 
+     * @see #addAddOnInstallationStatusListener(AddOnInstallationStatusListener)
+     * @see #getAddOnInstallationStatusListeners()
+     */
+    private List<AddOnInstallationStatusListener> addOnInstallationStatusListeners;
     
     private ViewDelegate view = null;
     private CommandLineArgument[] arg = new CommandLineArgument[0];
@@ -125,6 +137,38 @@ public class ExtensionHook {
     
     public void addAddonFilesChangedListener(AddonFilesChangedListener listener) {
     	addonFilesChangedListenerList.add(listener);
+    }
+
+    /**
+     * Adds the given {@code listener} to the extension hook, to be later notified of changes in the installation status of the
+     * add-ons.
+     *
+     * @param listener the listener that will be added and then notified
+     * @throws IllegalArgumentException if the given {@code listener} is {@code null}.
+     * @since TODO add version
+     */
+    public void addAddOnInstallationStatusListener(AddOnInstallationStatusListener listener) {
+        if (listener == null) {
+            throw new IllegalArgumentException("Parameter listener must not be null.");
+        }
+
+        if (addOnInstallationStatusListeners == null) {
+            addOnInstallationStatusListeners = new ArrayList<>();
+        }
+        addOnInstallationStatusListeners.add(listener);
+    }
+
+    /**
+     * Gets the {@link AddOnInstallationStatusListener}s added to this hook.
+     *
+     * @return an unmodifiable {@code List} containing the added {@code AddOnInstallationStatusListener}s, never {@code null}.
+     * @since TODO add version
+     */
+    List<AddOnInstallationStatusListener> getAddOnInstallationStatusListeners() {
+        if (addOnInstallationStatusListeners == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableList(addOnInstallationStatusListeners);
     }
 
     /**

--- a/src/org/parosproxy/paros/extension/ExtensionLoader.java
+++ b/src/org/parosproxy/paros/extension/ExtensionLoader.java
@@ -62,6 +62,7 @@
 // ZAP: 2015/09/07 Start GUI on EDT
 // ZAP: 2016/04/06 Fix layouts' issues
 // ZAP: 2016/04/08 Hook ContextDataFactory/ContextPanelFactory 
+// ZAP: 2016/05/30 Notification of installation status of the add-ons
 
 package org.parosproxy.paros.extension;
 
@@ -99,7 +100,9 @@ import org.parosproxy.paros.view.SiteMapPanel;
 import org.parosproxy.paros.view.View;
 import org.parosproxy.paros.view.WorkbenchPanel;
 import org.zaproxy.zap.PersistentConnectionListener;
+import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.extension.AddonFilesChangedListener;
+import org.zaproxy.zap.extension.AddOnInstallationStatusListener;
 import org.zaproxy.zap.model.ContextDataFactory;
 import org.zaproxy.zap.view.ContextPanelFactory;
 import org.zaproxy.zap.view.SiteMapListener;
@@ -495,6 +498,62 @@ public class ExtensionLoader {
                     
                 } catch (Exception e) {
                     logger.error(e.getMessage(), e);
+                }
+            }
+        }
+    }
+    
+    /**
+     * Notifies {@code Extension}s' {@code AddOnInstallationStatusListener}s that the given add-on was installed.
+     *
+     * @param addOn the add-on that was installed, must not be {@code null}
+     * @since TODO add version
+     */
+    public void addOnInstalled(AddOn addOn) {
+        for (ExtensionHook hook : extensionHooks.values()) {
+            for (AddOnInstallationStatusListener listener : hook.getAddOnInstallationStatusListeners()) {
+                try {
+                    listener.addOnInstalled(addOn);
+                } catch (Exception e) {
+                    logger.error("An error occurred while notifying: " + listener.getClass().getCanonicalName(), e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Notifies {@code Extension}s' {@code AddOnInstallationStatusListener}s that the given add-on was soft uninstalled.
+     *
+     * @param addOn the add-on that was soft uninstalled, must not be {@code null}
+     * @param successfully if the soft uninstallation was successful, that is, no errors occurred while uninstalling it
+     * @since TODO add version
+     */
+    public void addOnSoftUninstalled(AddOn addOn, boolean successfully) {
+        for (ExtensionHook hook : extensionHooks.values()) {
+            for (AddOnInstallationStatusListener listener : hook.getAddOnInstallationStatusListeners()) {
+                try {
+                    listener.addOnSoftUninstalled(addOn, successfully);
+                } catch (Exception e) {
+                    logger.error("An error occurred while notifying: " + listener.getClass().getCanonicalName(), e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Notifies {@code Extension}s' {@code AddOnInstallationStatusListener}s that the given add-on was uninstalled.
+     *
+     * @param addOn the add-on that was uninstalled, must not be {@code null}
+     * @param successfully if the uninstallation was successful, that is, no errors occurred while uninstalling it
+     * @since TODO add version
+     */
+    public void addOnUninstalled(AddOn addOn, boolean successfully) {
+        for (ExtensionHook hook : extensionHooks.values()) {
+            for (AddOnInstallationStatusListener listener : hook.getAddOnInstallationStatusListeners()) {
+                try {
+                    listener.addOnUninstalled(addOn, successfully);
+                } catch (Exception e) {
+                    logger.error("An error occurred while notifying: " + listener.getClass().getCanonicalName(), e);
                 }
             }
         }

--- a/src/org/zaproxy/zap/control/AddOnLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnLoader.java
@@ -49,6 +49,7 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.AbstractPlugin;
 import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.model.Model;
@@ -367,6 +368,7 @@ public class AddOnLoader extends URLClassLoader {
 
 		AddOnInstaller.install(createAndAddAddOnClassLoader(ao), ao);
 		ao.setInstallationStatus(AddOn.InstallationStatus.INSTALLED);
+		Control.getSingleton().getExtensionLoader().addOnInstalled(ao);
 
         if (runnableAddOns.get(ao) == null) {
             runnableAddOns.put(ao, getRunnableExtensionsWithDeps(reqs));
@@ -491,6 +493,7 @@ public class AddOnLoader extends URLClassLoader {
 			removeAddOnClassLoader(ao);
 			deleteAddOnFile(ao, upgrading);
 			ao.setInstallationStatus(AddOn.InstallationStatus.UNINSTALLATION_FAILED);
+			Control.getSingleton().getExtensionLoader().addOnUninstalled(ao, false);
 			return false;
 		}
 
@@ -532,6 +535,7 @@ public class AddOnLoader extends URLClassLoader {
 				? AddOn.InstallationStatus.AVAILABLE
 				: AddOn.InstallationStatus.UNINSTALLATION_FAILED);
 
+		Control.getSingleton().getExtensionLoader().addOnUninstalled(ao, uninstalledWithoutErrors);
 		return uninstalledWithoutErrors;
 	}
 	
@@ -610,6 +614,9 @@ public class AddOnLoader extends URLClassLoader {
         }
 
         addOn.setInstallationStatus(status);
+        Control.getSingleton()
+                .getExtensionLoader()
+                .addOnSoftUninstalled(addOn, status == AddOn.InstallationStatus.NOT_INSTALLED);
     }
 
 	private void loadBlockList() {

--- a/src/org/zaproxy/zap/extension/AddOnInstallationStatusListener.java
+++ b/src/org/zaproxy/zap/extension/AddOnInstallationStatusListener.java
@@ -1,0 +1,58 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension;
+
+import org.zaproxy.zap.control.AddOn;
+
+/**
+ * A listener that will be notified when the installation status of the add-ons changes.
+ * 
+ * @since TODO add version
+ */
+public interface AddOnInstallationStatusListener {
+
+    /**
+     * Notifies that the given add-on was installed.
+     *
+     * @param addOn the add-on that was installed, never {@code null}
+     */
+    void addOnInstalled(AddOn addOn);
+
+    /**
+     * Notifies that the given add-on was soft uninstalled.
+     * <p>
+     * Soft uninstallation consists of uninstalling the Java classes ({@code Extension}s, {@code Plugin}s,
+     * {@code PassiveScanner}s) of an add-on, called when the add-on must be temporarily uninstalled for an update of a
+     * dependency.
+     *
+     * @param addOn the add-on that was soft uninstalled, never {@code null}
+     * @param successfully if the soft uninstallation was successful, that is, no errors occurred while uninstalling it
+     */
+    void addOnSoftUninstalled(AddOn addOn, boolean successfully);
+
+    /**
+     * Notifies that the given add-on was uninstalled.
+     *
+     * @param addOn the add-on that was uninstalled, never {@code null}
+     * @param successfully if the uninstallation was successful, that is, no errors occurred while uninstalling it
+     */
+    void addOnUninstalled(AddOn addOn, boolean successfully);
+
+}

--- a/src/org/zaproxy/zap/extension/help/ExtensionHelp.java
+++ b/src/org/zaproxy/zap/extension/help/ExtensionHelp.java
@@ -20,9 +20,12 @@
 package org.zaproxy.zap.extension.help;
 
 import java.awt.Component;
+import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Map.Entry;
+import java.util.WeakHashMap;
 
 import javax.help.CSH;
 import javax.help.HelpBroker;
@@ -30,6 +33,8 @@ import javax.help.HelpSet;
 import javax.help.SwingHelpUtilities;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JRootPane;
 import javax.swing.KeyStroke;
 import javax.swing.UIManager;
 
@@ -39,7 +44,9 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.ViewDelegate;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.control.ExtensionFactory;
+import org.zaproxy.zap.extension.AddOnInstallationStatusListener;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.ZapMenuItem;
 
@@ -47,6 +54,16 @@ import org.zaproxy.zap.view.ZapMenuItem;
  * Loads the core help files and provides GUI elements to access them.
  */
 public class ExtensionHelp extends ExtensionAdaptor {
+
+	/**
+	 * The name of the property that has the {@code HelpSet}, assigned to a {@code JComponent}.
+	 */
+	private static final String HELP_SET_PROPERTY = "HelpSet";
+
+	/**
+	 * The name of the property that has the ID of the help page, assigned to a {@code JComponent}.
+	 */
+	private static final String HELP_ID_PROPERTY = "HelpID";
 
 	private static final String HELP_SET_FILE_NAME = "helpset";
 	public static final ImageIcon HELP_ICON = DisplayUtils.getScaledIcon(
@@ -57,6 +74,24 @@ public class ExtensionHelp extends ExtensionAdaptor {
 
 	private static HelpSet hs = null;
 	private static HelpBroker hb = null;
+
+	/**
+	 * The {@code ActionListener} to show the help dialogue (with contents matching the focused UI component, if available).
+	 * <p>
+	 * Lazily initialised.
+	 * 
+	 * @see #createHelpBroker()
+	 */
+	private static ActionListener showHelpActionListener;
+
+	/**
+	 * A {@code WeakHashMap} of {@code JComponent}s to the ID of the help page assigned to them.
+	 * <p>
+	 * Used to add/remove the help page from the components when the help add-on is installed/uninstalled.
+	 * 
+	 * @see #setHelpEnabled(boolean)
+	 */
+	private static WeakHashMap<JComponent, String> componentsWithHelp;
 
 	private static final Logger logger = Logger.getLogger(ExtensionHelp.class);
 	
@@ -98,10 +133,95 @@ public class ExtensionHelp extends ExtensionAdaptor {
 	        View.getSingleton().addMainToolbarSeparator();
 	        View.getSingleton().addMainToolbarButton(this.getHelpButton());
 
+            enableHelpKey(this.getView().getSiteTreePanel(), "ui.tabs.sites");
+            enableHelpKey(this.getView().getRequestPanel(), "ui.tabs.request");
+            enableHelpKey(this.getView().getResponsePanel(), "ui.tabs.response");
+
+            setHelpEnabled(getHelpBroker() != null);
+
+            extensionHook.addAddOnInstallationStatusListener(new AddOnInstallationStatusListenerImpl());
 	    }
 
 	}
 	
+	/**
+	 * Tells whether or not the help is available.
+	 * <p>
+	 * The help is available when the help add-on for the currently set {@code Locale} is installed.
+	 *
+	 * @return {@code true} if the help is available, {@code false} otherwise
+	 * @since TODO add version
+	 */
+	public boolean isHelpAvailable() {
+		return hb != null;
+	}
+
+	/**
+	 * Sets whether or not the help is enabled (menu item, buttons and help for the components).
+	 * <p>
+	 * The call to this method has no effect if the view is not initialised.
+	 * 
+	 * @param enabled {@code true} if the help should be enabled, {@code false} otherwise
+	 * @see #findHelpSetUrl()
+	 */
+	private void setHelpEnabled(boolean enabled) {
+		if (getView() == null) {
+			return;
+		}
+
+		JRootPane rootPane = getView().getMainFrame().getRootPane();
+		if (enabled && findHelpSetUrl() != null) {
+			createHelpBroker();
+
+			getMenuHelpZapUserGuide().addActionListener(showHelpActionListener);
+			getMenuHelpZapUserGuide().setToolTipText(null);
+			getMenuHelpZapUserGuide().setEnabled(true);
+
+			// Enable the top level F1 help key
+			hb.enableHelpKey(rootPane, "zap.intro", hs, "javax.help.SecondaryWindow", null);
+
+			for (Entry<JComponent, String> entry : componentsWithHelp.entrySet()) {
+				hb.enableHelp(entry.getKey(), entry.getValue(), hs);
+			}
+
+			getHelpButton().setToolTipText(Constant.messages.getString("help.button.tooltip"));
+			getHelpButton().setEnabled(true);
+
+		} else {
+			String toolTipNoHelp = Constant.messages.getString("help.error.nohelp");
+			getMenuHelpZapUserGuide().setEnabled(false);
+			getMenuHelpZapUserGuide().setToolTipText(toolTipNoHelp);
+			getMenuHelpZapUserGuide().removeActionListener(showHelpActionListener);
+
+			rootPane.unregisterKeyboardAction(KeyStroke.getKeyStroke(KeyEvent.VK_HELP, 0));
+			rootPane.unregisterKeyboardAction(KeyStroke.getKeyStroke(KeyEvent.VK_F1, 0));
+			removeHelpProperties(rootPane);
+
+			for (JComponent component : componentsWithHelp.keySet()) {
+				removeHelpProperties(component);
+			}
+
+			getHelpButton().setEnabled(false);
+			getHelpButton().setToolTipText(toolTipNoHelp);
+
+			hb = null;
+			hs = null;
+			showHelpActionListener = null;
+		}
+	}
+
+	/**
+	 * Removes the help properties from the given component.
+	 *
+	 * @param component the component whose help properties will be removed, must not be {@code null}
+	 * @see #HELP_ID_PROPERTY
+	 * @see #HELP_SET_PROPERTY
+	 */
+	private void removeHelpProperties(JComponent component) {
+		component.putClientProperty(HELP_ID_PROPERTY, null);
+		component.putClientProperty(HELP_SET_PROPERTY, null);
+	}
+
 	public static HelpBroker getHelpBroker() {
 		if (hb == null) {
 			createHelpBroker();
@@ -112,21 +232,50 @@ public class ExtensionHelp extends ExtensionAdaptor {
 	private static synchronized void createHelpBroker() {
 		if (hb == null) {
 			try {
-				ClassLoader cl = ExtensionFactory.getAddOnLoader();  
-				URL hsUrl = HelpSet.findHelpSet( cl, HELP_SET_FILE_NAME, Constant.getLocale());
+				URL hsUrl = findHelpSetUrl();
 				if (hsUrl != null) {
-					hs = new HelpSet(cl, hsUrl);
+					hs = new HelpSet(ExtensionFactory.getAddOnLoader(), hsUrl);
 					hb = hs.createHelpBroker();
+					showHelpActionListener = new CSH.DisplayHelpFromFocus(hb);
 				}
 			} catch (Exception e) {
 				logger.error(e.getMessage(), e);
 			}
 		}
 	}
+
+	/**
+	 * Finds and returns the {@code URL} to the {@code HelpSet} that matches the currently set {@code Locale}.
+	 * <p>
+	 * The name of the {@code HelpSet} searched is {@value #HELP_SET_FILE_NAME}.
+	 *
+	 * @return the {@code URL} to the {@code HelpSet}, {@code null} if not found
+	 * @see Constant#getLocale()
+	 * @see HelpSet
+	 */
+	private static URL findHelpSetUrl() {
+		return HelpSet.findHelpSet(ExtensionFactory.getAddOnLoader(), HELP_SET_FILE_NAME, Constant.getLocale());
+	}
 	
-	public static void enableHelpKey (Component component, String key) {
-		if (getHelpBroker() != null) {
-			hb.enableHelp(component, key, hs);
+	/**
+	 * Enables the help for the given component using the given help page ID.
+	 * <p>
+	 * The help page is shown when the help keyboard shortcut (F1) is pressed, while the component is focused.
+	 *
+	 * @param component the component that will have a help page assigned
+	 * @param id the ID of the help page
+	 */
+	public static void enableHelpKey (Component component, String id) {
+		if (component instanceof JComponent) {
+			JComponent jComponent = (JComponent) component;
+			if (componentsWithHelp == null) {
+				componentsWithHelp = new WeakHashMap<>();
+			}
+			componentsWithHelp.put(jComponent, id);
+		}
+
+		if (hb != null) {
+			hb.enableHelp(component, id, hs);
 		}
 	}
 
@@ -169,32 +318,6 @@ public class ExtensionHelp extends ExtensionAdaptor {
 		if (menuHelpZap == null) {
 			menuHelpZap = new ZapMenuItem("help.menu.guide",
 					KeyStroke.getKeyStroke(KeyEvent.VK_F1, 0, false));
-			
-			if (getHelpBroker() != null) {
-
-				// Set up the help menu item
-				menuHelpZap.addActionListener(
-						new CSH.DisplayHelpFromFocus(hb));
-
-				// Enable the top level F1 help key
-				hb.enableHelpKey(this.getView().getMainFrame().getRootPane(), 
-						"zap.intro", hs, "javax.help.SecondaryWindow", null);
-
-				// Register all of the main tabs
-
-				hb.enableHelp(this.getView().getSiteTreePanel(), 
-						"ui.tabs.sites", hs);
-				
-				hb.enableHelp(this.getView().getRequestPanel(), 
-						"ui.tabs.request", hs);
-				hb.enableHelp(this.getView().getResponsePanel(), 
-						"ui.tabs.response", hs);
-
-			} else {
-				logger.debug("Failed to get helpset url");
-				menuHelpZap.setEnabled(false);
-				menuHelpZap.setToolTipText(Constant.messages.getString("help.error.nohelp"));
-			}
 		}
 		return menuHelpZap;
 	}
@@ -203,12 +326,6 @@ public class ExtensionHelp extends ExtensionAdaptor {
 		if (helpButton == null) {
 			helpButton = new JButton();
 			helpButton.setIcon(new ImageIcon(ExtensionHelp.class.getResource("/resource/icon/16/201.png")));
-			helpButton.setToolTipText(Constant.messages.getString("help.button.tooltip"));
-			
-			if (getHelpBroker() == null) {
-				helpButton.setEnabled(false);
-				helpButton.setToolTipText(Constant.messages.getString("help.error.nohelp"));
-			}
 			
 			helpButton.addActionListener(new java.awt.event.ActionListener() { 
 				@Override
@@ -246,4 +363,31 @@ public class ExtensionHelp extends ExtensionAdaptor {
 	public boolean supportsDb(String type) {
     	return true;
     }
+
+    /**
+     * An {@code AddOnInstallationStatusListener} responsible to enabled/disable help UI components when the help add-on is
+     * installed/uninstalled.
+     */
+    private class AddOnInstallationStatusListenerImpl implements AddOnInstallationStatusListener {
+
+        @Override
+        public void addOnInstalled(AddOn addOn) {
+            if (hb == null && findHelpSetUrl() != null) {
+                setHelpEnabled(true);
+            }
+        }
+
+        @Override
+        public void addOnSoftUninstalled(AddOn addOn, boolean successfully) {
+            addOnUninstalled(addOn, successfully);
+        }
+
+        @Override
+        public void addOnUninstalled(AddOn addOn, boolean successfully) {
+            if (hb != null && findHelpSetUrl() == null) {
+                setHelpEnabled(false);
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Enable/disable the main menu item (Help > OWASP ZAP User Guide) and main
tool bar help button when the help add-on (for the selected language) is
installed/uninstalled. Also, make sure to clean up any reference to the
help contents when uninstalling to ensure that the correct/latest help
contents are shown when the help add-on is updated and keep track of
components that have a help page assigned so that they can be set/unset
when the help is installed/uninstalled.

As part of the changes it's now possible for extensions to listen for
the installation status of the add-ons (required to dynamically enable
and disable the help related functionality when the help add-on is
installed/uninstalled).