### PR TITLE
Allow to see local CONNECT requests in History tab

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -2032,6 +2032,7 @@ view.options.label.responsepanelpos.above   = Request Shown Above Response
 view.options.label.responsepanelpos.sideBySide = Panels Side by Side
 view.options.label.responsepanelpos.tabs    = Tabs Side by Side
 view.options.label.showSplashScreen			= Show splash screen
+view.options.label.showlocalconnectrequests = Show (local) CONNECT requests
 view.options.label.scaleImages				= Scale Images:
 view.options.label.showTabNames             = Show Tab Names
 view.options.label.showMainToolbar          = Show Main Toolbar

--- a/src/org/parosproxy/paros/control/Control.java
+++ b/src/org/parosproxy/paros/control/Control.java
@@ -59,6 +59,7 @@
 // ZAP: 2015/11/04 Issue 1920: Report the host:port ZAP is listening on in daemon mode, or exit if it cant
 // ZAP: 2016/03/23 Issue 2331: Custom Context Panels not show in existing contexts after installation of add-on
 // ZAP: 2016/04/22 Issue 2428: Memory leak on session creation/loading
+// ZAP: 2016/05/30 Issue 2494: ZAP Proxy is not showing the HTTP CONNECT Request in history tab
 
 package org.parosproxy.paros.control;
 
@@ -119,6 +120,7 @@ public class Control extends AbstractControl implements SessionListener {
 	    Proxy proxy = getProxy(overrides);
 	    getExtensionLoader().hookProxyListener(proxy);
 	    getExtensionLoader().hookPersistentConnectionListener(proxy);
+	    getExtensionLoader().hookConnectRequestProxyListeners(proxy);
 		
 		if (view != null) {
 		    // ZAP: Add site map listeners

--- a/src/org/parosproxy/paros/control/Proxy.java
+++ b/src/org/parosproxy/paros/control/Proxy.java
@@ -27,11 +27,13 @@
 // ZAP: 2014/03/23 Issue 1022: Proxy - Allow to override a proxied message
 // ZAP: 2015/01/04 Issue 1387: Unable to change the proxy's port/address if the port/address was specified through the command line
 // ZAP: 2015/11/04 Issue 1920: Report the host:port ZAP is listening on in daemon mode, or exit if it cant
+// ZAP: 2016/05/30 Issue 2494: ZAP Proxy is not showing the HTTP CONNECT Request in history tab
 package org.parosproxy.paros.control;
  
 import java.util.List;
 
 import org.parosproxy.paros.core.proxy.CacheProcessingItem;
+import org.parosproxy.paros.core.proxy.ConnectRequestProxyListener;
 import org.parosproxy.paros.core.proxy.OverrideMessageProxyListener;
 import org.parosproxy.paros.core.proxy.ProxyListener;
 import org.parosproxy.paros.core.proxy.ProxyServer;
@@ -156,6 +158,44 @@ public class Proxy {
 	    proxyServer.removePersistentConnectionListener(listener);
 	    proxyServerSSL.removePersistentConnectionListener(listener);
 	}
+
+    /**
+     * Adds the given {@code listener}, that will be notified of the received CONNECT requests.
+     *
+     * @param listener the listener that will be added
+     * @throws IllegalArgumentException if the given {@code listener} is {@code null}.
+     * @since TODO add version
+     */
+    public void addConnectRequestProxyListener(ConnectRequestProxyListener listener) {
+        validateListenerNotNull(listener);
+        proxyServer.addConnectRequestProxyListener(listener);
+        proxyServerSSL.addConnectRequestProxyListener(listener);
+    }
+
+    /**
+     * Validates that the given {@code listener} is not {@code null}, throwing an {@code IllegalArgumentException} if it is.
+     *
+     * @param listener the listener that will be validated
+     * @throws IllegalArgumentException if the given {@code listener} is {@code null}.
+     */
+    private static void validateListenerNotNull(Object listener) {
+        if (listener == null) {
+            throw new IllegalArgumentException("Parameter listener must not be null.");
+        }
+    }
+
+    /**
+     * Removes the given {@code listener}, to no longer be notified of the received CONNECT requests.
+     *
+     * @param listener the listener that should be removed
+     * @throws IllegalArgumentException if the given {@code listener} is {@code null}.
+     * @since TODO add version
+     */
+    public void removeConnectRequestProxyListener(ConnectRequestProxyListener listener) {
+        validateListenerNotNull(listener);
+        proxyServer.removeConnectRequestProxyListener(listener);
+        proxyServerSSL.removeConnectRequestProxyListener(listener);
+    }
 
     /**
      * @return Returns the reverseProxy.

--- a/src/org/parosproxy/paros/core/proxy/ConnectRequestProxyListener.java
+++ b/src/org/parosproxy/paros/core/proxy/ConnectRequestProxyListener.java
@@ -1,0 +1,41 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.core.proxy;
+
+import org.parosproxy.paros.network.HttpMessage;
+
+/**
+ * A listener that will be notified when a HTTP CONNECT request is received from a client.
+ * 
+ * @since TODO add version
+ * @see ProxyListener
+ * @see OverrideMessageProxyListener
+ */
+public interface ConnectRequestProxyListener {
+
+    /**
+     * Notifies that a HTTP CONNECT request was received from a client.
+     * <p>
+     * The {@code HttpMessage} {@code connectMessage} should not be modified.
+     * 
+     * @param connectMessage the HTTP CONNECT request received from a client
+     */
+    void receivedConnectRequest(HttpMessage connectMessage);
+}

--- a/src/org/parosproxy/paros/core/proxy/OverrideMessageProxyListener.java
+++ b/src/org/parosproxy/paros/core/proxy/OverrideMessageProxyListener.java
@@ -31,6 +31,7 @@ import org.parosproxy.paros.network.HttpMessage;
  * 
  * @since 2.3.0
  * @see ProxyListener
+ * @see ConnectRequestProxyListener
  */
 public interface OverrideMessageProxyListener extends ArrangeableProxyListener {
 

--- a/src/org/parosproxy/paros/core/proxy/ProxyListener.java
+++ b/src/org/parosproxy/paros/core/proxy/ProxyListener.java
@@ -31,6 +31,7 @@ import org.parosproxy.paros.network.HttpMessage;
  * to the server and when a new response is ready to be forwarded to the client.
  * 
  * @see OverrideMessageProxyListener
+ * @see ConnectRequestProxyListener
  */
 // ZAP: Changed the JavaDoc.
 public interface ProxyListener extends ArrangeableProxyListener {

--- a/src/org/parosproxy/paros/core/proxy/ProxyServer.java
+++ b/src/org/parosproxy/paros/core/proxy/ProxyServer.java
@@ -30,6 +30,7 @@
 // ZAP: 2014/03/23 Issue 1022: Proxy - Allow to override a proxied message
 // ZAP: 2014/08/14 Issue 1312: Misleading error message when unable to bind the local proxy to specified address
 // ZAP: 2015/11/04 Issue 1920: Report the host:port ZAP is listening on in daemon mode, or exit if it cant
+// ZAP: 2016/05/30 Issue 2494: ZAP Proxy is not showing the HTTP CONNECT Request in history tab
 
 package org.parosproxy.paros.core.proxy;
 
@@ -66,6 +67,7 @@ public class ProxyServer implements Runnable {
     protected Vector<ProxyListener> listenerList = new Vector<>();
     protected Vector<OverrideMessageProxyListener> overrideListeners = new Vector<>();
     protected Vector<PersistentConnectionListener> persistentConnectionListenerList = new Vector<>();
+    private final List<ConnectRequestProxyListener> connectRequestProxyListeners;
     // ZAP: Added listenersComparator.
     private static Comparator<ArrangeableProxyListener> listenersComparator;
     protected boolean serialize = false;
@@ -100,6 +102,7 @@ public class ProxyServer implements Runnable {
     }
 
     public ProxyServer() {
+        connectRequestProxyListeners = new ArrayList<>(1);
     }
 
     public void setProxyParam(ProxyParam param) {
@@ -312,6 +315,51 @@ public class ProxyServer implements Runnable {
 
     List<OverrideMessageProxyListener> getOverrideMessageProxyListeners() {
         return overrideListeners;
+    }
+
+    /**
+     * Adds the given {@code listener}, that will be notified of the received CONNECT requests.
+     *
+     * @param listener the listener that will be added
+     * @throws IllegalArgumentException if the given {@code listener} is {@code null}.
+     * @since TODO add version
+     */
+    public void addConnectRequestProxyListener(ConnectRequestProxyListener listener) {
+        connectRequestProxyListeners.add(listener);
+    }
+
+    /**
+     * Validates that the given {@code listener} is not {@code null}, throwing an {@code IllegalArgumentException} if it is.
+     *
+     * @param listener the listener that will be validated
+     * @throws IllegalArgumentException if the given {@code listener} is {@code null}.
+     */
+    private static void validateListenerNotNull(Object listener) {
+        if (listener == null) {
+            throw new IllegalArgumentException("Parameter listener must not be null.");
+        }
+    }
+
+    /**
+     * Removes the given {@code listener}, to no longer be notified of the received CONNECT requests.
+     *
+     * @param listener the listener that should be removed
+     * @throws IllegalArgumentException if the given {@code listener} is {@code null}.
+     * @since TODO add version
+     */
+    public void removeConnectRequestProxyListener(ConnectRequestProxyListener listener) {
+        validateListenerNotNull(listener);
+        connectRequestProxyListeners.remove(listener);
+    }
+
+    /**
+     * Gets the {@code ConnectRequestProxyListener}s added.
+     *
+     * @return an unmodifiable {@code List} with the {@code ConnectRequestProxyListener}s, never {@code null}
+     * @since TODO add version
+     */
+    List<ConnectRequestProxyListener> getConnectRequestProxyListeners() {
+        return Collections.unmodifiableList(connectRequestProxyListeners);
     }
 
     public boolean isAnyProxyThreadRunning() {

--- a/src/org/parosproxy/paros/extension/ExtensionHook.java
+++ b/src/org/parosproxy/paros/extension/ExtensionHook.java
@@ -27,6 +27,7 @@
 // ZAP: 2014/10/25 Issue 1062: Added scannerhook to be added by extensions. 
 // ZAP: 2016/04/08 Allow to add ContextDataFactory
 // ZAP: 2016/05/30 Allow to add AddOnInstallationStatusListener
+// ZAP: 2016/05/30 Issue 2494: ZAP Proxy is not showing the HTTP CONNECT Request in history tab
 
 package org.parosproxy.paros.extension;
 
@@ -36,6 +37,7 @@ import java.util.List;
 import java.util.Vector;
 
 import org.parosproxy.paros.common.AbstractParam;
+import org.parosproxy.paros.core.proxy.ConnectRequestProxyListener;
 import org.parosproxy.paros.core.proxy.OverrideMessageProxyListener;
 import org.parosproxy.paros.core.proxy.ProxyListener;
 import org.parosproxy.paros.core.scanner.ScannerHook;
@@ -56,6 +58,16 @@ public class ExtensionHook {
 
     private Vector<ProxyListener> proxyListenerList = new Vector<>();
     private List<OverrideMessageProxyListener> overrideMessageProxyListenersList = new ArrayList<>();
+
+    /**
+     * The {@link ConnectRequestProxyListener}s added to this extension hook.
+     * <p>
+     * Lazily initialised.
+     * 
+     * @see #addConnectionRequestProxyListener(ConnectRequestProxyListener)
+     * @see #getConnectRequestProxyListeners()
+     */
+    private List<ConnectRequestProxyListener> connectRequestProxyListeners;
     private Vector<SessionChangedListener> sessionListenerList = new Vector<>();
     private Vector<AbstractParam> optionsParamSetList = new Vector<>();
     // ZAP: Added support for site map listeners
@@ -103,6 +115,41 @@ public class ExtensionHook {
 
     public void addProxyListener(ProxyListener listener) {
         proxyListenerList.add(listener);
+    }
+
+    /**
+     * Adds the given {@link ConnectRequestProxyListener} to the extension hook, to be later notified of CONNECT requests
+     * received by the local proxy.
+     * <p>
+     * By default, the {@code ConnectRequestProxyListener}s added are removed from the local proxy when the extension is
+     * unloaded.
+     *
+     * @param listener the {@code ConnectRequestProxyListener} that will be added and then notified
+     * @throws IllegalArgumentException if the given {@code listener} is {@code null}.
+     * @since TODO add version
+     */
+    public void addConnectionRequestProxyListener(ConnectRequestProxyListener listener) {
+        if (listener == null) {
+            throw new IllegalArgumentException("Parameter listener must not be null.");
+        }
+
+        if (connectRequestProxyListeners == null) {
+            connectRequestProxyListeners = new ArrayList<>();
+        }
+        connectRequestProxyListeners.add(listener);
+    }
+
+    /**
+     * Gets the {@link ConnectRequestProxyListener}s added to this hook.
+     *
+     * @return an unmodifiable {@code List} containing the added {@code ConnectRequestProxyListener}s, never {@code null}.
+     * @since TODO add version
+     */
+    List<ConnectRequestProxyListener> getConnectRequestProxyListeners() {
+        if (connectRequestProxyListeners == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableList(connectRequestProxyListeners);
     }
     
     public void addSessionListener(SessionChangedListener listener) {

--- a/src/org/parosproxy/paros/extension/history/ProxyListenerLog.java
+++ b/src/org/parosproxy/paros/extension/history/ProxyListenerLog.java
@@ -28,6 +28,7 @@
 // ZAP: 2013/11/16 Issue 869: Differentiate proxied requests from (ZAP) user requests
 // ZAP: 2015/04/02 Issue 1582: Low memory option
 // ZAP: 2015/09/07 Issue 1872: EDT accessed in daemon mode
+// ZAP: 2016/05/30 Issue 2494: ZAP Proxy is not showing the HTTP CONNECT Request in history tab
 
 package org.parosproxy.paros.extension.history;
  
@@ -35,6 +36,7 @@ import java.awt.EventQueue;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.proxy.ConnectRequestProxyListener;
 import org.parosproxy.paros.core.proxy.ProxyListener;
 import org.parosproxy.paros.extension.ViewDelegate;
 import org.parosproxy.paros.model.HistoryReference;
@@ -46,7 +48,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.model.SessionStructure;
 
 
-public class ProxyListenerLog implements ProxyListener {
+public class ProxyListenerLog implements ProxyListener, ConnectRequestProxyListener {
 
 	// ZAP: Added logger
     private static final Logger log = Logger.getLogger(ProxyListenerLog.class);
@@ -116,7 +118,7 @@ public class ProxyListenerLog implements ProxyListener {
 		Thread t = new Thread(new Runnable() {
 		    @Override
 		    public void run() {
-		        addHistory(msg, finalType);
+		        createAndAddMessage(msg, finalType);
 		    }
 		});
 		t.start();
@@ -133,25 +135,25 @@ public class ProxyListenerLog implements ProxyListener {
 				
 	}
     
-    private void addHistory(HttpMessage msg, int type) {
-        
-        HistoryReference historyRef = null;
-
-        try {
-            historyRef = new HistoryReference(model.getSession(), type, msg);
-        } catch (Exception e) {
-        	// ZAP: Log exceptions
-        	log.warn(e.getMessage(), e);
+    private void createAndAddMessage(HttpMessage msg, int type) {
+        HistoryReference historyRef = createHistoryReference(msg, type);
+        if (historyRef == null || (type != HistoryReference.TYPE_PROXIED && type != HistoryReference.TYPE_HIDDEN)) {
             return;
         }
 
-        if (type != HistoryReference.TYPE_PROXIED && type != HistoryReference.TYPE_HIDDEN) {
-            return;
-        }
-        
         extension.addHistory(historyRef);
 
         addToSiteMap(historyRef, msg);
+    }
+
+    private HistoryReference createHistoryReference(HttpMessage message, int type) {
+        try {
+            return new HistoryReference(model.getSession(), type, message);
+        } catch (Exception e) {
+            // ZAP: Log exceptions
+            log.warn(e.getMessage(), e);
+        }
+        return null;
     }
 
     private void addToSiteMap(final HistoryReference ref, final HttpMessage msg) {
@@ -177,5 +179,23 @@ public class ProxyListenerLog implements ProxyListener {
                 view.getSiteTreePanel().expandRoot();
             }
         }
+    }
+
+    @Override
+    public void receivedConnectRequest(final HttpMessage connectMessage) {
+        if (!model.getOptionsParam().getViewParam().isShowLocalConnectRequests()) {
+            return;
+        }
+
+        Thread t = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                HistoryReference historyRef = createHistoryReference(connectMessage, HistoryReference.TYPE_PROXY_CONNECT);
+                if (historyRef != null) {
+                    extension.addHistory(historyRef);
+                }
+            }
+        });
+        t.start();
     }
 }

--- a/src/org/parosproxy/paros/extension/option/OptionsParamView.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsParamView.java
@@ -75,6 +75,12 @@ public class OptionsParamView extends AbstractParam {
 	public static final String TAB_PIN_OPTION = "view.tab.pin";
 	public static final String OUTPUT_TAB_TIMESTAMPING_OPTION = "view.outputTabsTimeStampsOption"; 
 	public static final String OUTPUT_TAB_TIMESTAMP_FORMAT = "view.outputTabsTimeStampsFormat"; 
+
+	/**
+	 * The configuration key used to save/load the option {@link #showLocalConnectRequests}.
+	 */
+	private static final String SHOW_LOCAL_CONNECT_REQUESTS = "view.showLocalConnectRequests";
+
 	public static final String SPLASHSCREEN_OPTION = "view.splashScreen";
 	public static final String LARGE_REQUEST_SIZE = "view.largeRequest";
 	public static final String LARGE_RESPONSE_SIZE = "view.largeResponse";
@@ -102,6 +108,16 @@ public class OptionsParamView extends AbstractParam {
 	private String mode = Mode.standard.name();
 	private boolean outputTabTimeStampingEnabled = false; 
 	private String outputTabTimeStampFormat = DEFAULT_TIME_STAMP_FORMAT; 
+
+	/**
+	 * Flag that indicates if the HTTP CONNECT requests received by the local proxy should be (persisted and) shown in the UI.
+	 * 
+	 * @see #SHOW_LOCAL_CONNECT_REQUESTS
+	 * @see #isShowLocalConnectRequests()
+	 * @see #setShowLocalConnectRequests(boolean)
+	 */
+	private boolean showLocalConnectRequests;
+	
     private boolean showSplashScreen = true;
     private int largeRequestSize = LargeRequestUtil.DEFAULT_MIN_CONTENT_LENGTH;
     private int largeResponseSize = LargeResponseUtil.DEFAULT_MIN_CONTENT_LENGTH;
@@ -136,6 +152,13 @@ public class OptionsParamView extends AbstractParam {
 	    mode = getConfig().getString(MODE_OPTION, Mode.standard.name());
 	    outputTabTimeStampingEnabled = getConfig().getBoolean(OUTPUT_TAB_TIMESTAMPING_OPTION, false); 
 	    outputTabTimeStampFormat = getConfig().getString(OUTPUT_TAB_TIMESTAMP_FORMAT, DEFAULT_TIME_STAMP_FORMAT);
+
+        try {
+            showLocalConnectRequests = getConfig().getBoolean(SHOW_LOCAL_CONNECT_REQUESTS, false);
+        } catch (ConversionException e) {
+            LOGGER.error("Error while parsing config file: " + e.getMessage(), e);
+        }
+
 	    showSplashScreen = getConfig().getBoolean(SPLASHSCREEN_OPTION, true);
 	    largeRequestSize = getConfig().getInteger(LARGE_REQUEST_SIZE, LargeRequestUtil.DEFAULT_MIN_CONTENT_LENGTH);
 	    largeResponseSize = getConfig().getInteger(LARGE_RESPONSE_SIZE, LargeResponseUtil.DEFAULT_MIN_CONTENT_LENGTH);
@@ -372,6 +395,33 @@ public class OptionsParamView extends AbstractParam {
 
 	public String getOutputTabTimeStampsFormat() {
 		return outputTabTimeStampFormat;
+	}
+
+	/**
+	 * Sets whether or not the HTTP CONNECT requests received by the local proxy should be (persisted and) shown in the UI.
+	 *
+	 * @param showConnectRequests {@code true} if the HTTP CONNECT requests should be shown, {@code false} otherwise
+	 * @since TODO add version
+	 * @see #isShowLocalConnectRequests()
+	 */
+	public void setShowLocalConnectRequests(boolean showConnectRequests) {
+		if (showLocalConnectRequests != showConnectRequests) {
+			showLocalConnectRequests = showConnectRequests;
+			getConfig().setProperty(SHOW_LOCAL_CONNECT_REQUESTS, showConnectRequests);
+		}
+	}
+
+	/**
+	 * Tells whether or not the HTTP CONNECT requests received by the local proxy should be (persisted and) shown in the UI.
+	 * <p>
+	 * The default is to not show the HTTP CONNECT requests.
+	 *
+	 * @return {@code true} if the HTTP CONNECT requests should be shown, {@code false} otherwise
+	 * @since TODO add version
+	 * @see #setShowLocalConnectRequests(boolean)
+	 */
+	public boolean isShowLocalConnectRequests() {
+		return showLocalConnectRequests;
 	}
 
 	public boolean isShowSplashScreen() {

--- a/src/org/parosproxy/paros/extension/option/OptionsViewPanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsViewPanel.java
@@ -36,6 +36,7 @@ import java.awt.Component;
 import java.awt.Font;
 import java.awt.GraphicsEnvironment;
 import java.awt.GridBagLayout;
+import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
@@ -85,6 +86,7 @@ public class OptionsViewPanel extends AbstractParamPanel {
 	private JCheckBox chkOutputTabTimeStamping = null; 
 	private JCheckBox chkShowSplashScreen = null;
 	private JCheckBox scaleImages = null;
+	private JCheckBox showLocalConnectRequestsCheckbox;
 	
 	private JComboBox<String> brkPanelViewSelect = null;
 	private JComboBox<String> displaySelect = null;
@@ -226,6 +228,14 @@ public class OptionsViewPanel extends AbstractParamPanel {
 					LayoutHelper.getGBC(0, row, 1, 1.0D, new java.awt.Insets(2,2,2,2)));
 			panelMisc.add(getChkProcessImages(),  
 					LayoutHelper.getGBC(1, row, 1, 1.0D, new java.awt.Insets(2,2,2,2)));
+
+			row++;
+			Insets insets = new Insets(2, 2, 2, 2);
+			String labelText = Constant.messages.getString("view.options.label.showlocalconnectrequests");
+			JLabel showConnectRequestLabel = new JLabel(labelText);
+			showConnectRequestLabel.setLabelFor(getShowLocalConnectRequestsCheckbox());
+			panelMisc.add(showConnectRequestLabel, LayoutHelper.getGBC(0, row, 1, 1.0D, insets));
+			panelMisc.add(getShowLocalConnectRequestsCheckbox(), LayoutHelper.getGBC(1, row, 1, 1.0D, insets));
 
 			row++;
 			showTabNamesLabel.setLabelFor(getShowTabNames());
@@ -437,6 +447,13 @@ public class OptionsViewPanel extends AbstractParamPanel {
 		return timeStampsFormatSelect; 
 	}
 	
+	private JCheckBox getShowLocalConnectRequestsCheckbox() {
+		if (showLocalConnectRequestsCheckbox == null) {
+			showLocalConnectRequestsCheckbox = new JCheckBox();
+		}
+		return showLocalConnectRequestsCheckbox;
+	}
+
 	private ZapNumberSpinner getLargeRequestSize() {
 		if (largeRequestSize == null) {
 			largeRequestSize = new ZapNumberSpinner(-1, LargeRequestUtil.DEFAULT_MIN_CONTENT_LENGTH, Integer.MAX_VALUE);
@@ -540,6 +557,7 @@ public class OptionsViewPanel extends AbstractParamPanel {
 	    chkWmUiHandling.setSelected(options.getViewParam().getWmUiHandlingOption() > 0);
 	    getChkOutputTabTimeStamps().setSelected(options.getViewParam().isOutputTabTimeStampingEnabled()); 
 	    timeStampsFormatSelect.setSelectedItem(options.getViewParam().getOutputTabTimeStampsFormat());
+	    getShowLocalConnectRequestsCheckbox().setSelected(options.getViewParam().isShowLocalConnectRequests());
 	    largeRequestSize.setValue(options.getViewParam().getLargeRequestSize());
 	    largeResponseSize.setValue(options.getViewParam().getLargeResponseSize());
 	    getFontSize().setValue(options.getViewParam().getFontSize());
@@ -582,6 +600,7 @@ public class OptionsViewPanel extends AbstractParamPanel {
 	    options.getViewParam().setWmUiHandlingOption(getChkWmUiHandling().isSelected() ? 1 : 0);
 	    options.getViewParam().setOutputTabTimeStampingEnabled(getChkOutputTabTimeStamps().isSelected()); 
 	    options.getViewParam().setOutputTabTimeStampsFormat((String) getTimeStampsFormatSelect().getSelectedItem()); 
+	    options.getViewParam().setShowLocalConnectRequests(getShowLocalConnectRequestsCheckbox().isSelected());
 	    options.getViewParam().setLargeRequestSize(getLargeRequestSize().getValue());
 	    options.getViewParam().setLargeResponseSize(getLargeResponseSize().getValue());
 	    options.getViewParam().setFontSize(getFontSize().getValue());

--- a/src/org/parosproxy/paros/model/HistoryReference.java
+++ b/src/org/parosproxy/paros/model/HistoryReference.java
@@ -41,6 +41,7 @@
 // ZAP: 2015/02/09 Issue 1525: Introduce a database interface layer to allow for alternative implementations
 // ZAP: 2016/04/12 Update the SiteNode when deleting alerts
 // ZAP: 2016/05/27 Moved the temporary types to this class
+// ZAP: 2016/05/30 Add new type for CONNECT requests received by the proxy
 
 package org.parosproxy.paros.model;
 
@@ -158,6 +159,13 @@ public class HistoryReference {
      * @see #getTemporaryTypes()
      */
     public static final Set<Integer> DEFAULT_TEMPORARY_HISTORY_TYPES;
+
+    /**
+     * A HTTP CONNECT request received (and processed) by the local proxy.
+     * 
+     * @since TODO add version
+     */
+    public static final int TYPE_PROXY_CONNECT = 16;
 
    private static java.text.DecimalFormat decimalFormat = new java.text.DecimalFormat("##0.###");
 	private static TableHistory staticTableHistory = null;


### PR DESCRIPTION
Add an option to "Options" > "Display" called "Persist and show (local)
CONNECT requests" that allows to see the HTTP CONNECT requests received
by the local proxy in the History tab (the option is disabled by
default).

Fix #2494 - ZAP Proxy is not showing the HTTP CONNECT Request in history
tab