### PR TITLE
Guard against exceptions from ScriptUI

### DIFF
--- a/src/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/src/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -244,7 +244,11 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 		this.loadTemplates(wrapper);
 
 		if (scriptUI != null) {
-			scriptUI.engineAdded(wrapper);
+			try {
+				scriptUI.engineAdded(wrapper);
+			} catch (Exception e) {
+				logger.error("An error occurred while notifying ScriptUI:", e);
+			}
 		}
 	}
 	
@@ -351,7 +355,11 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 		logger.debug("Removing script engine: " + wrapper.getLanguageName() + " : " + wrapper.getEngineName());
 		if (this.engineWrappers.remove(wrapper)) {
 			if (scriptUI != null) {
-				scriptUI.engineRemoved(wrapper);
+				try {
+					scriptUI.engineRemoved(wrapper);
+				} catch (Exception e) {
+					logger.error("An error occurred while notifying ScriptUI:", e);
+				}
 			}
 
 			setScriptEngineWrapper(getTreeModel().getScriptsNode(), wrapper, null);


### PR DESCRIPTION
Change ExtensionScript to catch exceptions (possibly) thrown by ScriptUI
implementation, when notifying of engines added or removed, preventing
the exceptions from escalating and causing issues in other areas of ZAP.
For example, an issue in ScriptUI implementation [1] prevented the Zest
add-on from being successfully uninstalled.

[1] zaproxy/zap-extensions#388