### PR TITLE
Change filters to use "filter" home directory

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -148,9 +148,6 @@
 		<copy todir="${dist}/db">
 			<fileset dir="${src}/db" excludes="**/.svn/** **/_svn/**" />
 		</copy>
-		<copy todir="${dist}/filter">
-			<fileset dir="${src}/filter" excludes="**/.svn/** **/_svn/**" />
-		</copy>
 		<copy todir="${dist}/plugin">
 			<fileset dir="${src}/plugin" excludes="**/.svn/** **/_svn/**" />
 		</copy>

--- a/src/filter/dummy.txt
+++ b/src/filter/dummy.txt
@@ -1,4 +1,0 @@
-10 FilterIfModifiedSince
-20 FilterLogGetQuery
-40 FilterLogRequestResponse
-

--- a/src/org/parosproxy/paros/Constant.java
+++ b/src/org/parosproxy/paros/Constant.java
@@ -63,6 +63,7 @@
 // ZAP: 2016/02/17 Convert extensions' options to not use extensions' names as XML element names
 // ZAP: 2016/05/12 Use dev/weekly dir for plugin downloads when copying the existing 'release' config file
 // ZAP: 2016/06/07 Remove commented constants and statement that had no (actual) effect, add doc to a constant and init other
+// ZAP: 2016/06/07 Use filter directory in ZAP's home directory
 // ZAP: 2016/06/13 Migrate config option "proxy.modifyAcceptEncoding" 
 
 package org.parosproxy.paros;
@@ -160,6 +161,12 @@ public final class Constant {
     public static final String FILE_CONFIG_DEFAULT = "xml/config.xml";
     public static final String FILE_CONFIG_NAME = "config.xml";
     public static final String FOLDER_PLUGIN = "plugin";
+    /**
+     * The name of the directory for filter related files (the path should be built using {@link #getZapHome()} as the parent
+     * directory).
+     * 
+     * @since 1.0.0
+     */
     public static final String FOLDER_FILTER = "filter";
 
     /**
@@ -438,6 +445,13 @@ public final class Constant {
                 if (! f.mkdir() ) {
                 	// ZAP: report failure to create directory
                 	System.out.println("Failed to create directory " + f.getAbsolutePath());
+                }
+            }
+            f = new File(zapHome, FOLDER_FILTER);
+            if (!f.isDirectory()) {
+                log.info("Creating directory: " + f.getAbsolutePath());
+                if (!f.mkdir()) {
+                    System.out.println("Failed to create directory " + f.getAbsolutePath());
                 }
             }
 

--- a/src/org/parosproxy/paros/extension/filter/FilterLogGetQuery.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterLogGetQuery.java
@@ -25,6 +25,7 @@
 // ZAP: 2012/07/29 Corrected init method and log errors
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
+// ZAP: 2016/06/07 Use ZAP's home filter directory
 
 package org.parosproxy.paros.extension.filter;
 
@@ -32,6 +33,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.regex.Matcher;
@@ -47,6 +49,7 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 
 public class FilterLogGetQuery extends FilterAdaptor {
 
+    private static final String LOG_FILE = Paths.get(Constant.FOLDER_FILTER, "get.xls").toString();
     private static final String delim = "\t";   
     private static final String CRLF = "\r\n";
     private File outFile;		    
@@ -70,11 +73,11 @@ public class FilterLogGetQuery extends FilterAdaptor {
     
     @Override
     public void init(Model model) {
-     	outFile = new File(getLogFileName());
+     	outFile = new File(Constant.getZapHome(), getLogFileName());
     }
 
     protected String getLogFileName() {
-        return "filter/get.xls";
+        return LOG_FILE;
     }
     
     @Override

--- a/src/org/parosproxy/paros/extension/filter/FilterLogPostQuery.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterLogPostQuery.java
@@ -24,9 +24,11 @@
 // ZAP: 2013/01/23 Clean up of exception handling/logging.
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
+// ZAP: 2016/06/07 Use Constant.FOLDER_FILTER
 
 package org.parosproxy.paros.extension.filter;
 
+import java.nio.file.Paths;
 import java.util.Hashtable;
 
 import org.apache.commons.httpclient.URI;
@@ -38,6 +40,7 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 
 public class FilterLogPostQuery extends FilterLogGetQuery {
 
+    private static final String LOG_FILE = Paths.get(Constant.FOLDER_FILTER, "post.xls").toString();
     private static final Logger logger = Logger.getLogger(FilterLogPostQuery.class);
 
     @Override
@@ -53,7 +56,7 @@ public class FilterLogPostQuery extends FilterLogGetQuery {
 
     @Override
     protected String getLogFileName() {
-        return "filter/post.xls";
+        return LOG_FILE;
     }
     
     @Override

--- a/src/org/parosproxy/paros/extension/filter/FilterLogRequestResponse.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterLogRequestResponse.java
@@ -24,6 +24,7 @@
 // ZAP: 2012/04/25 Added @Override annotation to all appropriate methods.
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
+// ZAP: 2016/06/07 Use ZAP's home filter directory
 
 package org.parosproxy.paros.extension.filter;
 
@@ -31,6 +32,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Paths;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -39,10 +41,10 @@ import org.parosproxy.paros.network.HttpMessage;
 
 public class FilterLogRequestResponse extends FilterAdaptor {
 
-    private static final String logFile = "filter/message.txt";
+    private static final String logFile = Paths.get(Constant.FOLDER_FILTER, "message.txt").toString();
     private static final String delim = "====================================";   
     private static final String CRLF = "\r\n";
-    private File outFile = new File(logFile);
+    private File outFile = new File(Constant.getZapHome(), logFile);
     private BufferedWriter writer = null;
     private long lastWriteTime = System.currentTimeMillis();
     private int counter = 1;


### PR DESCRIPTION
Change the classes FilterLogGetQuery, FilterLogPostQuery and
FilterLogRequestResponse to use the filter directory in ZAP's home
directory instead of installation directory. Depending on how ZAP is
installed it might not even be writable, leading to, for example:
   java.io.FileNotFoundException: filter/get.xls (Permission denied)

Change class Constant to create a filter directory in ZAP's home
directory if it does not exist already, also document the constant
FOLDER_FILTER to indicate that it should be used along the ZAP's home
directory.

Remove the (installation) filter directory, since it would no longer be
needed, this might affect 3rd party filters (although very unlikely,
given it's use is discouraged, scripts are recommended instead). The
track of the IDs that was done in the dummy.txt is lost, it was outdated
moreover the filters are no longer actively maintained.
Remove the filter directory from the build file.