### PR TITLE
Fix infinite loop with Scan Progress dialogue

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/ActiveScan.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScan.java
@@ -164,7 +164,7 @@ public class ActiveScan extends org.parosproxy.paros.core.scanner.Scanner implem
 	            	rcLastSnapshot = currentSnapshot;
 	            }
 	        };
-	        schedHandle = scheduler.scheduleAtFixedRate(requestCounter, period, period, TimeUnit.SECONDS);
+	        schedHandle = scheduler.scheduleWithFixedDelay(requestCounter, period, period, TimeUnit.SECONDS);
 		}
 	}
 

--- a/src/org/zaproxy/zap/extension/ascan/ScanProgressDialog.java
+++ b/src/org/zaproxy/zap/extension/ascan/ScanProgressDialog.java
@@ -427,6 +427,7 @@ public class ScanProgressDialog extends AbstractDialog {
 			            }
 					} catch (Exception e) {
 						log.error(e.getMessage(), e);
+						snapshot = null;
 					}
 	            }
             }


### PR DESCRIPTION
Change ScanProgressDialog to clear the snapshot data (that is, set to
null) when an exception is caught while adding the data to the chart to
break the loop (and prevent the infinite loop in the EDT), the exception
was being thrown because the time stamp of the data was already added
(side effect of how the data update tasks were scheduled).
Change ActiveScan to schedule the tasks that update chart data with a
fixed delay instead of at a fixed rate to prevent execution bursts when
one of the tasks takes more time to complete than the delay defined,
ensuring that the tasks are executed always with different times (and
around the delay defined).

Fix #2550 - GUI freezes while opening Scan Progress dialogue