### PR TITLE
Use default User-Agent for CONNECT requests

### DIFF
--- a/src/org/apache/commons/httpclient/HttpMethodDirector.java
+++ b/src/org/apache/commons/httpclient/HttpMethodDirector.java
@@ -84,6 +84,12 @@ public class HttpMethodDirector {
      */
     public static final String PARAM_REMOVE_USER_DEFINED_AUTH_HEADERS = "remove.user.defined.auth.headers";
 
+    /**
+     * Parameter to set/obtain the default {@code User-Agent} of internal CONNECT requests (if {@code null} no
+     * {@code User-Agent} is set).
+     */
+    public static final String PARAM_DEFAULT_USER_AGENT_CONNECT_REQUESTS = "method.connect.default.user.agent";
+
     /** The www authenticate challange header. */
     public static final String WWW_AUTH_CHALLENGE = "WWW-Authenticate";
 
@@ -545,6 +551,10 @@ public class HttpMethodDirector {
 
         this.connectMethod = new ConnectMethod(this.hostConfiguration);
         this.connectMethod.getParams().setDefaults(this.hostConfiguration.getParams());
+        String agent = (String) getParams().getParameter(PARAM_DEFAULT_USER_AGENT_CONNECT_REQUESTS);
+        if (agent != null) {
+            this.connectMethod.setRequestHeader("User-Agent", agent);
+        }
         
         int code;
         for (;;) {

--- a/src/org/parosproxy/paros/network/HttpSender.java
+++ b/src/org/parosproxy/paros/network/HttpSender.java
@@ -57,6 +57,7 @@
 // ZAP: 2015/06/12 Issue 1459: Add an HTTP sender listener script
 // ZAP: 2016/05/24 Issue 2463: Websocket not proxied when outgoing proxy is set
 // ZAP: 2016/05/27 Issue 2484: Circular Redirects
+// ZAP: 2016/06/08 Set User-Agent header defined in options as default for (internal) CONNECT requests
 
 package org.parosproxy.paros.network;
 
@@ -184,6 +185,9 @@ public class HttpSender {
 				singleCookieRequestHeader);
 		clientViaProxy.getParams().setBooleanParameter(HttpMethodParams.SINGLE_COOKIE_HEADER,
 				singleCookieRequestHeader);
+		String defaultUserAgent = param.getDefaultUserAgent();
+		client.getParams().setParameter(HttpMethodDirector.PARAM_DEFAULT_USER_AGENT_CONNECT_REQUESTS, defaultUserAgent);
+		clientViaProxy.getParams().setParameter(HttpMethodDirector.PARAM_DEFAULT_USER_AGENT_CONNECT_REQUESTS, defaultUserAgent);
 
 		if (useGlobalState) {
 			checkState();


### PR DESCRIPTION
Change class HttpSender to set the default User-Agent defined in the
options as the default User-Agent for internal CONNECT requests (that
is, CONNECT requests sent by ZAP to the configured outgoing proxy).
Change class HttpMethodDirector to allow to set the default User-Agent
for CONNECT requests.