### PR TITLE
Fix NPE when invoking context menu in Alerts tab

### DIFF
--- a/src/org/zaproxy/zap/extension/alert/AlertPanel.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertPanel.java
@@ -21,15 +21,16 @@
 package org.zaproxy.zap.extension.alert;
 
 import java.awt.CardLayout;
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Event;
 import java.awt.EventQueue;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import java.awt.Rectangle;
+import java.awt.Point;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
+import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.SortedSet;
@@ -38,6 +39,7 @@ import java.util.TreeSet;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
 import javax.swing.JToggleButton;
@@ -410,27 +412,64 @@ public class AlertPanel extends AbstractPanel {
 	 */    
 	JTree getTreeAlert() {
 		if (treeAlert == null) {
-			treeAlert = new JTree();
+			treeAlert = new JTree() {
+
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				public Point getPopupLocation(final MouseEvent event) {
+					if (event != null) {
+						// Select item on right click
+						TreePath tp = treeAlert.getPathForLocation(event.getX(), event.getY());
+						if (tp != null) {
+							// Only select a new item if the current item is not
+							// already selected - this is to allow multiple items
+							// to be selected
+							if (!treeAlert.getSelectionModel().isPathSelected(tp)) {
+								treeAlert.getSelectionModel().setSelectionPath(tp);
+							}
+						}
+					}
+					return super.getPopupLocation(event);
+				}
+			};
 			treeAlert.setName(ALERT_TREE_PANEL_NAME);
 			treeAlert.setShowsRootHandles(true);
 			treeAlert.setBorder(javax.swing.BorderFactory.createEmptyBorder(0,0,0,0));
+			treeAlert.setComponentPopupMenu(new JPopupMenu() {
+
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				public void show(Component invoker, int x, int y) {
+					final int countSelectedNodes = treeAlert.getSelectionCount();
+					final ArrayList<HistoryReference> uniqueHistoryReferences = new ArrayList<>(countSelectedNodes);
+					if (countSelectedNodes > 0) {
+						SortedSet<Integer> historyReferenceIdsAdded = new TreeSet<>();
+						for (TreePath path : treeAlert.getSelectionPaths()) {
+							final AlertNode node = (AlertNode) path.getLastPathComponent();
+							final Object userObject = node.getUserObject();
+							if (userObject instanceof Alert) {
+								HistoryReference historyReference = ((Alert) userObject).getHistoryRef();
+								if (historyReference != null && !historyReferenceIdsAdded
+										.contains(Integer.valueOf(historyReference.getHistoryId()))) {
+									historyReferenceIdsAdded.add(Integer.valueOf(historyReference.getHistoryId()));
+									uniqueHistoryReferences.add(historyReference);
+								}
+							}
+						}
+						uniqueHistoryReferences.trimToSize();
+					}
+					SelectableHistoryReferencesContainer messageContainer = new DefaultSelectableHistoryReferencesContainer(
+							treeAlert.getName(),
+							treeAlert,
+							Collections.<HistoryReference> emptyList(),
+							uniqueHistoryReferences);
+					view.getPopupMenu().show(messageContainer, x, y);
+				}
+			});
+
 			treeAlert.addMouseListener(new java.awt.event.MouseAdapter() { 
-				@Override
-				public void mousePressed(java.awt.event.MouseEvent e) {
-					showPopupMenuIfTriggered(e);
-				}
-					
-				@Override
-				public void mouseReleased(java.awt.event.MouseEvent e) {
-					showPopupMenuIfTriggered(e);
-				}
-				
-				private void showPopupMenuIfTriggered(java.awt.event.MouseEvent e) {
-					// right mouse button action
-				    if (e.isPopupTrigger()) {
-				    	showPopupMenu(e.getX(), e.getY());
-				    }	
-				}
 
 				@Override
 				public void mouseClicked(java.awt.event.MouseEvent e) {
@@ -472,77 +511,9 @@ public class AlertPanel extends AbstractPanel {
 				    }
 				}
 			});
-			treeAlert.addKeyListener(new KeyListener(){
-
-				@Override
-				public void keyTyped(KeyEvent e) {
-				}
-
-				@Override
-				public void keyPressed(KeyEvent e) {
-					if (e.getKeyCode() == KeyEvent.VK_CONTEXT_MENU) {
-						Rectangle rec = treeAlert.getUI().getPathBounds(treeAlert, treeAlert.getSelectionPath());
-						showPopupMenu(rec.x, rec.y);
-					}
-				}
-
-				@Override
-				public void keyReleased(KeyEvent e) {
-				}});
 		}
 		return treeAlert;
 	}
-	
-	private void showPopupMenu (int x, int y) {
-		// Note that in theory it would be better to use setComponentPopupMenu
-		// but for some reason that didnt work - for the content menu key it selected the wrong node :/
-		
-		// Select site list item on right click
-    	TreePath tp = treeAlert.getPathForLocation(x, y);
-    	if ( tp != null ) {
-    		boolean select = true;
-    		// Only select a new item if the current item is not
-    		// already selected - this is to allow multiple items
-    		// to be selected
-	    	if (treeAlert.getSelectionPaths() != null) {
-	    		for (TreePath t : treeAlert.getSelectionPaths()) {
-	    			if (t.equals(tp)) {
-	    				select = false;
-	    				break;
-	    			}
-	    		}
-	    	}
-	    	if (select) {
-	    		treeAlert.getSelectionModel().setSelectionPath(tp);
-	    	}
-    	}
-        final int countSelectedNodes = treeAlert.getSelectionCount();
-        final ArrayList<HistoryReference> uniqueHistoryReferences = new ArrayList<>(countSelectedNodes);
-        if (countSelectedNodes > 0) {
-            SortedSet<Integer> historyReferenceIdsAdded = new TreeSet<>();
-            for (TreePath path : treeAlert.getSelectionPaths()) {
-                final AlertNode node = (AlertNode) path.getLastPathComponent();
-                final Object userObject = node.getUserObject();
-                if (userObject instanceof Alert) {
-                    HistoryReference historyReference = ((Alert) userObject).getHistoryRef();
-                    if (historyReference != null
-                            && !historyReferenceIdsAdded.contains(Integer.valueOf(historyReference.getHistoryId()))) {
-                        historyReferenceIdsAdded.add(Integer.valueOf(historyReference.getHistoryId()));
-                        uniqueHistoryReferences.add(historyReference);
-                    }
-                }
-            }
-            uniqueHistoryReferences.trimToSize();
-        }
-        SelectableHistoryReferencesContainer messageContainer = new DefaultSelectableHistoryReferencesContainer(
-                treeAlert.getName(),
-                treeAlert,
-                Collections.<HistoryReference> emptyList(),
-                uniqueHistoryReferences);
-        view.getPopupMenu().show(messageContainer, x, y);
-
-	}
-	
 	
 	/**
 	 * This method initializes paneScroll	


### PR DESCRIPTION
Fix NullPointerException when attempting to invoke the context menu of
Alerts tab using the keyboard when no entry was yet selected, following
excerpt of the exception's stack trace:
[AWT-EventQueue-0] ERROR org.zaproxy.zap.ZAP$UncaughtExceptionLogger  -
 Exception in thread "AWT-EventQueue-0"
 java.lang.NullPointerException
  at o.z.z.extension.alert.AlertPanel$5.keyPressed(AlertPanel.java:485)

the exception happened because there was no entry selected, therefore no
location existed (that is, null) when calculating where to show the pop
up menu.

Change class AlertPanel to set a JPopupMenu to the Alerts tree, which
already takes care to show the pop up menu in the most appropriate
location (when invoked with keyboard and with the mouse).