### PR TITLE
Do not clean up unsaved (file based) sessions

### DIFF
--- a/src/org/parosproxy/paros/model/Model.java
+++ b/src/org/parosproxy/paros/model/Model.java
@@ -38,6 +38,7 @@
 // ZAP: 2016/02/10 Issue 1958: Allow to disable database (HSQLDB) log
 // ZAP: 2016/03/22 Allow to remove ContextDataFactory
 // ZAP: 2016/03/23 Issue 2331: Custom Context Panels not show in existing contexts after installation of add-on
+// ZAP: 2016/06/10 Do not clean up the database if the current session does not require it
 
 package org.parosproxy.paros.model;
 
@@ -359,7 +360,7 @@ public class Model {
 	// TODO disable for non file based sessions
 	public void createAndOpenUntitledDb() throws ClassNotFoundException, Exception {
 
-		getDb().close(false);
+		getDb().close(false, session.isCleanUpRequired());
 
 		// delete all untitled session db in "session" directory
 		File dir = new File(getSession().getSessionFolder());


### PR DESCRIPTION
Do not clean up the database (that is, remove temporary messages) of
unsaved sessions if the database implementation is HSQLDB (file based),
the files of that database are deleted if the session is not saved, just
before creating or opening a new one.
The change improves the time it takes to create or open a session when
the previous session was not (effectively) saved.

More detailed changes:
 - Session, add a method that tells if the session requires a clean up
 or not and change it to use that method when closing the database (to
 clean or not the database), before opening a session;
 - Model, change to check if the session requires clean up when closing
 the database, before creating a new session.

Related to #2506 - Do not discard the session for file based database