### PR TITLE
Updated Weekly Dockerfile to reduce size

### DIFF
--- a/build/docker/Dockerfile-weekly
+++ b/build/docker/Dockerfile-weekly
@@ -2,29 +2,62 @@
 FROM ubuntu:15.04
 MAINTAINER Simon Bennetts "psiinon@gmail.com"
 
-RUN apt-get update && apt-get clean
-RUN apt-get install -q -y make automake autoconf gcc g++ openjdk-7-jre-headless openjdk-7-jdk ruby wget curl xmlstarlet unzip git x11vnc xvfb openbox xterm net-tools ruby-dev && apt-get clean
+
+RUN apt-get update && apt-get install -q -y --fix-missing \
+	make \
+	automake \
+	autoconf \
+	gcc g++ \
+	openjdk-7-jre-headless \
+	openjdk-7-jdk \
+	ruby \
+	wget \
+	curl \
+	xmlstarlet \
+	unzip \
+	git \
+	x11vnc \
+	xvfb \
+	openbox \
+	xterm \
+	net-tools \
+	ruby-dev \
+	python-pip \
+	firefox \
+	xvfb \
+	x11vnc && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
+
+
 RUN gem install zapr
-RUN apt-get --assume-yes --fix-missing install python-pip x11vnc xvfb firefox
 RUN pip install python-owasp-zap-v2.4
 RUN pip install zapcli
 
-RUN mkdir /zap 
-WORKDIR /zap
-# Download and expand the latest weekly release 
-RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions-dev.xml | xmlstarlet sel -t -v //url |grep -i weekly | wget --content-disposition -i - 
-RUN unzip *.zip && rm *.zip
-# mv fails on some systems (https://github.com/docker/docker/issues/4570)
-RUN cp -R ZAP*/* . && rm -R ZAP*
-
-# Download and expand WebSwing
-RUN curl -s -L https://bitbucket.org/meszarv/webswing/downloads/webswing-2.3-distribution.zip > webswing.zip
-RUN unzip *.zip && rm *.zip
-
 RUN useradd -d /home/zap -m -s /bin/bash zap 
 RUN echo zap:zap | chpasswd
+RUN mkdir /zap 
+WORKDIR /zap
+RUN chown zap /zap && \
+	chgrp zap /zap
+
+#Change to the zap user so things get done as the right person (apart from copy)
+USER zap
 
 RUN mkdir /home/zap/.vnc
+
+
+
+# Download and expand the latest weekly release 
+RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions-dev.xml | xmlstarlet sel -t -v //url |grep -i weekly | wget --content-disposition -i - && \
+	unzip *.zip && \
+	rm *.zip && \
+	cp -R ZAP*/* . &&  \
+	rm -R ZAP* && \
+	curl -s -L https://bitbucket.org/meszarv/webswing/downloads/webswing-2.3-distribution.zip > webswing.zip && \
+	unzip *.zip && \
+	rm *.zip
+
 
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64/
 ENV PATH $JAVA_HOME/bin:/zap/:$PATH
@@ -34,20 +67,26 @@ ENV ZAP_PATH /zap/zap.sh
 ENV ZAP_PORT 8080
 ENV HOME /home/zap/
 
+
 COPY zap-x.sh /zap/ 
 COPY zap-baseline.py /zap/ 
 COPY zap-webswing.sh /zap/ 
 COPY webswing.config /zap/webswing-2.3/ 
-
-COPY .xinitrc /home/zap/ 
-RUN chmod a+x /home/zap/.xinitrc
-
 COPY policies /home/zap/.ZAP_D/policies/
+COPY .xinitrc /home/zap/
 
-RUN chown -R zap /zap/
-RUN chgrp -R zap /zap/
 
-RUN chown -R zap /home/zap/
-RUN chgrp -R zap /home/zap/
-RUN chmod -R u+rw /home/zap/
+#Copy doesn't respect USER directives so we need to chown and to do that we need to be root
+USER root
+
+RUN chown zap:zap /zap/zap-x.sh && \
+	chown zap:zap /zap/zap-baseline.py && \
+	chown zap:zap /zap/zap-webswing.sh && \
+	chown zap:zap /zap/webswing-2.3/webswing.config && \
+	chown zap:zap -R /home/zap/.ZAP_D/ && \
+	chown zap:zap /home/zap/.xinitrc && \
+	chmod a+x /home/zap/.xinitrc
+#Change back to zap at the end
+USER zap
+
 


### PR DESCRIPTION
So this makes some changes to the Dockerfile syntax to try and reduce the size without (hopefully!) breaking anything.

I noticed from https://imagelayers.io/?images=owasp%2Fzap2docker-weekly:latest that quite a bit of the size was coming from chown and chgrp operations which were essentially recreating a load of files (due to the copy-on-write filesystem that docker uses) so used the USER directive to go to the zap user early.

The only bit that doesn't work for is COPY operations (this is an open issue with Docker), so had to do some limited chown/chmod stuff there.

Also collapsed all the apt-get items to one layer to make the clean up work well.

As a first pass this gets the Docker image down from 1.724GB to 1.069GB.  There's probably more that could be done but this looked like a decent quick win.