### PR TITLE
Change proxy option to remove unsupported encoding

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1514,7 +1514,7 @@ options.proxy.local.label.alwaysDecodeGzip = Always unzip gzipped content
 options.proxy.local.label.browser     = <html><body><br><p>Set your browser proxy setting using the above.  The HTTP port and HTTPS port must be the same port as above.</p></body></html>
 options.proxy.local.label.local       = Local Proxy
 options.proxy.local.label.misc        = Miscellaneous
-options.proxy.local.label.modifyAcceptHeader = Modify/Remove "Accept-Encoding" request-header
+options.proxy.local.label.removeUnsupportedEncodings = Remove Unsupported Encodings
 options.proxy.local.label.port        = Port (eg 8080)
 options.proxy.local.label.rev.address = Address (eg 192.168.0.1)
 options.proxy.local.label.rev.local   = <html><body><p>The address should not be "localhost" because a reverse proxy should be accessed by browser from another computer.</p></body></html>
@@ -1525,9 +1525,10 @@ options.proxy.local.title             = Local Proxy
 options.proxy.local.tooltip.alwaysDecodeGzip = <html>Always automatically unzip gzipped content. This option is needed for applications that ignore the modified \"Accept-Encoding\" header<br>\
 This option should be always enabled unless the decoding breaks the application being tested.<br>\
 The messages encoded will not be correctly scanned (either by passive and active scanners).</html>
-options.proxy.local.tooltip.modifyAccepHeader = <html>Allows the proxy to modify/remove the \"Accept-Encoding\" request-header field so no encoding transformations are done to the response.<br>\
+options.proxy.local.tooltip.removeUnsupportedEncodings = <html>Allows the Local Proxy to remove unsupported encodings from the \"Accept-Encoding\" request-header field, <br>\
+so no (unsupported) encoding transformations are done to the response.<br>\
 This option should be always enabled unless when testing the encoding transformations.<br>\
-The messages encoded will not be correctly scanned (either by passive and active scanners).</html>
+The HTTP responses encoded with unsupported encodings will not be correctly scanned (either by passive and active scanners).</html>
 
 options.script.table.header.dir       = Directory
 options.script.label.dirs             = <html><body><p>Scripts will be loaded from these directories.</p>\

--- a/src/org/parosproxy/paros/Constant.java
+++ b/src/org/parosproxy/paros/Constant.java
@@ -63,6 +63,7 @@
 // ZAP: 2016/02/17 Convert extensions' options to not use extensions' names as XML element names
 // ZAP: 2016/05/12 Use dev/weekly dir for plugin downloads when copying the existing 'release' config file
 // ZAP: 2016/06/07 Remove commented constants and statement that had no (actual) effect, add doc to a constant and init other
+// ZAP: 2016/06/13 Migrate config option "proxy.modifyAcceptEncoding" 
 
 package org.parosproxy.paros;
 
@@ -121,9 +122,10 @@ public final class Constant {
     public static final String ALPHA_VERSION = "alpha";
     public static final String BETA_VERSION = "beta";
     
-    private static final long VERSION_TAG = 2004003;
+    private static final long VERSION_TAG = 2005000;
     
     // Old version numbers - for upgrade
+    private static final long V_2_5_0_TAG = 2005000;
     private static final long V_2_4_3_TAG = 2004003;
     private static final long V_2_3_1_TAG = 2003001;
     private static final long V_2_2_0_TAG = 2002000;
@@ -513,6 +515,9 @@ public final class Constant {
                     if (ver <= V_2_4_3_TAG) {
                         upgradeFrom2_4_3(config);
                     }
+                    if (ver <= V_2_5_0_TAG) {
+                        upgradeFrom2_5_0(config);
+                    }
 	            	log.info("Upgraded from " + ver);
             		
             		// Update the version
@@ -793,6 +798,12 @@ public final class Constant {
             config.setProperty(elementBaseKey + "name", data[0]);
             config.setProperty(elementBaseKey + "enabled", data[1]);
         }
+    }
+
+    private static void upgradeFrom2_5_0(XMLConfiguration config) {
+        String oldConfigKey = "proxy.modifyAcceptEncoding";
+        config.setProperty("proxy.removeUnsupportedEncodings", config.getBoolean(oldConfigKey, true));
+        config.clearProperty(oldConfigKey);
     }
 
 	public static void setLocale (String loc) {

--- a/src/org/parosproxy/paros/core/proxy/ProxyParam.java
+++ b/src/org/parosproxy/paros/core/proxy/ProxyParam.java
@@ -30,6 +30,7 @@
 // ZAP: 2014/03/23 Issue 968: Allow to choose the enabled SSL/TLS protocols
 // ZAP: 2014/03/23 Issue 1017: Proxy set to 0.0.0.0 causes incorrect PAC file to be generated
 // ZAP: 2015/11/04 Issue 1920: Report the host:port ZAP is listening on in daemon mode, or exit if it cant
+// ZAP: 2016/06/13 Change option "Accept-Encoding" request-header to Remove Unsupported Encodings
 
 package org.parosproxy.paros.core.proxy;
 
@@ -69,10 +70,9 @@ public class ProxyParam extends AbstractParam {
     private static final String ALL_SECURITY_PROTOCOLS_ENABLED_KEY = SECURITY_PROTOCOLS_ENABLED + ".protocol";
 
     /**
-     * The configuration key for the option that controls whether the proxy
-     * should modify/remove the "Accept-Encoding" request-header field or not.
+     * The configuration key to save/load the option {@link #removeUnsupportedEncodings}.
      */
-    private static final String MODIFY_ACCEPT_ENCODING_HEADER = "proxy.modifyAcceptEncoding";
+    private static final String REMOVE_UNSUPPORTED_ENCODINGS = "proxy.removeUnsupportedEncodings";
 
     /**
      * The configuration key for the option that controls whether the proxy
@@ -96,10 +96,15 @@ public class ProxyParam extends AbstractParam {
     private boolean proxyIpAnyLocalAddress;
 
     /**
-     * The option that controls whether the proxy should modify/remove the
-     * "Accept-Encoding" request-header field or not.
+     * Flag that controls whether or not the local proxy should remove unsupported encodings from the "Accept-Encoding"
+     * request-header field.
+     * <p>
+     * Default is {@code true}.
+     * 
+     * @see #REMOVE_UNSUPPORTED_ENCODINGS
+     * @see #setRemoveUnsupportedEncodings(boolean)
      */
-    private boolean modifyAcceptEncodingHeader = true;
+    private boolean removeUnsupportedEncodings = true;
     /**
      * The option that controls whether the proxy should always decode gzipped content or not.
      */
@@ -140,7 +145,7 @@ public class ProxyParam extends AbstractParam {
         reverseProxyHttpsPort = getConfig().getInt(REVERSE_PROXY_HTTPS_PORT, 443);
         useReverseProxy = getConfig().getInt(USE_REVERSE_PROXY, 0);
 
-        modifyAcceptEncodingHeader = getConfig().getBoolean(MODIFY_ACCEPT_ENCODING_HEADER, true);
+        removeUnsupportedEncodings = getConfig().getBoolean(REMOVE_UNSUPPORTED_ENCODINGS, true);
         alwaysDecodeGzip = getConfig().getBoolean(ALWAYS_DECODE_GZIP, true);
 
         loadSecurityProtocolsEnabled();
@@ -246,10 +251,12 @@ public class ProxyParam extends AbstractParam {
      * @param modifyAcceptEncodingHeader {@code true} if the proxy should
      * modify/remove the "Accept-Encoding" request-header field, {@code false}
      * otherwise
+     * @deprecated (TODO add version) Use {@link #setRemoveUnsupportedEncodings(boolean)} instead.
+     * @since 2.0.0
      */
+    @Deprecated
     public void setModifyAcceptEncodingHeader(boolean modifyAcceptEncodingHeader) {
-        this.modifyAcceptEncodingHeader = modifyAcceptEncodingHeader;
-        getConfig().setProperty(MODIFY_ACCEPT_ENCODING_HEADER, Boolean.valueOf(modifyAcceptEncodingHeader));
+        setRemoveUnsupportedEncodings(modifyAcceptEncodingHeader);
     }
 
     /**
@@ -258,9 +265,41 @@ public class ProxyParam extends AbstractParam {
      *
      * @return {@code true} if the proxy should modify/remove the
      * "Accept-Encoding" request-header field, {@code false} otherwise
+     * @deprecated (TODO add version) Use {@link #isRemoveUnsupportedEncodings()} instead.
+     * @since 2.0.0
      */
+    @Deprecated
     public boolean isModifyAcceptEncodingHeader() {
-        return modifyAcceptEncodingHeader;
+        return isRemoveUnsupportedEncodings();
+    }
+
+    /**
+     * Sets whether or not the local proxy should remove unsupported encodings from the "Accept-Encoding" request-header field.
+     * <p>
+     * The whole header is removed if empty after the removal of unsupported encodings.
+     *
+     * @param remove {@code true} if the local proxy should remove unsupported encodings, {@code false} otherwise
+     * @since TODO add version
+     * @see #isRemoveUnsupportedEncodings()
+     */
+    public void setRemoveUnsupportedEncodings(boolean remove) {
+        if (removeUnsupportedEncodings != remove) {
+            this.removeUnsupportedEncodings = remove;
+            getConfig().setProperty(REMOVE_UNSUPPORTED_ENCODINGS, Boolean.valueOf(removeUnsupportedEncodings));
+        }
+    }
+
+    /**
+     * Tells whether or not the local proxy should remove unsupported encodings from the "Accept-Encoding" request-header field.
+     * <p>
+     * The whole header is removed if empty after the removal of unsupported encodings.
+     *
+     * @return {@code true} if the local proxy should remove unsupported encodings, {@code false} otherwise
+     * @since TODO add version
+     * @see #setRemoveUnsupportedEncodings(boolean)
+     */
+    public boolean isRemoveUnsupportedEncodings() {
+        return removeUnsupportedEncodings;
     }
 
     /**

--- a/src/org/parosproxy/paros/extension/option/OptionsLocalProxyPanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsLocalProxyPanel.java
@@ -27,6 +27,7 @@
 // ZAP: 2014/03/06 Issue 1063: Add option to decode all gzipped content
 // ZAP: 2014/03/23 Issue 968: Allow to choose the enabled SSL/TLS protocols
 // ZAP: 2015/02/10 Issue 1528: Support user defined font size
+// ZAP: 2016/06/13 Change option "Modify/Remove Accept-Encoding" to "Remove Unsupported Encodings"
 
 package org.parosproxy.paros.extension.option;
 
@@ -61,7 +62,7 @@ public class OptionsLocalProxyPanel extends AbstractParamPanel {
     private ZapTextField txtProxyIp = null;
     private ZapTextField txtReverseProxyIp = null;
 
-    private JCheckBox chkModifyAcceptEncodingHeader = null;
+    private JCheckBox chkRemoveUnsupportedEncodings = null;
     private JCheckBox chkAlwaysDecodeGzip = null;
 
     private SecurityProtocolsPanel securityProtocolsPanel;
@@ -165,7 +166,7 @@ public class OptionsLocalProxyPanel extends AbstractParamPanel {
             gbc.weightx = 1.0D;
             gbc.gridwidth = java.awt.GridBagConstraints.REMAINDER;
             gbc.anchor = java.awt.GridBagConstraints.PAGE_START;
-            panelLocalProxy.add(getChkModifyAcceptEncodingHeader(), gbc);
+            panelLocalProxy.add(getChkRemoveUnsupportedEncodings(), gbc);
 
             // TODO hacking
             panelLocalProxy.add(this.getChkAlwaysDecodeGzip(), 
@@ -404,12 +405,12 @@ public class OptionsLocalProxyPanel extends AbstractParamPanel {
         return txtReverseProxyIp;
     }
 
-    public JCheckBox getChkModifyAcceptEncodingHeader() {
-        if (chkModifyAcceptEncodingHeader == null) {
-            chkModifyAcceptEncodingHeader = new JCheckBox(Constant.messages.getString("options.proxy.local.label.modifyAcceptHeader"));
-            chkModifyAcceptEncodingHeader.setToolTipText(Constant.messages.getString("options.proxy.local.tooltip.modifyAccepHeader"));
+    public JCheckBox getChkRemoveUnsupportedEncodings() {
+        if (chkRemoveUnsupportedEncodings == null) {
+            chkRemoveUnsupportedEncodings = new JCheckBox(Constant.messages.getString("options.proxy.local.label.removeUnsupportedEncodings"));
+            chkRemoveUnsupportedEncodings.setToolTipText(Constant.messages.getString("options.proxy.local.tooltip.removeUnsupportedEncodings"));
         }
-        return chkModifyAcceptEncodingHeader;
+        return chkRemoveUnsupportedEncodings;
     }
     
     private JCheckBox getChkAlwaysDecodeGzip() {
@@ -479,7 +480,7 @@ public class OptionsLocalProxyPanel extends AbstractParamPanel {
         // ZAP: Do not allow invalid port numbers
         spinnerProxyPort.setValue(proxyParam.getProxyPort());
 
-        chkModifyAcceptEncodingHeader.setSelected(proxyParam.isModifyAcceptEncodingHeader());
+        chkRemoveUnsupportedEncodings.setSelected(proxyParam.isRemoveUnsupportedEncodings());
         chkAlwaysDecodeGzip.setSelected(proxyParam.isAlwaysDecodeGzip());
 
         // set reverse proxy param
@@ -510,7 +511,7 @@ public class OptionsLocalProxyPanel extends AbstractParamPanel {
         // ZAP: Do not allow invalid port numbers
         proxyParam.setProxyPort(spinnerProxyPort.getValue());
 
-        proxyParam.setModifyAcceptEncodingHeader(getChkModifyAcceptEncodingHeader().isSelected());
+        proxyParam.setRemoveUnsupportedEncodings(getChkRemoveUnsupportedEncodings().isSelected());
         // TODO hacking
         proxyParam.setAlwaysDecodeGzip(getChkAlwaysDecodeGzip().isSelected());
 


### PR DESCRIPTION
Change Local Proxy option Modify/Remove "Accept-Encoding" request-header
to Remove Unsupported Encodings, as that prevents unsupported encodings
from being used, the previous behaviour just removed specific encodings
(for example, deflate, compress, gzip) allowing to pass/use the ones
that were also not supported like SDCH, brotli and others.

More detailed changes:
 - Messages.properties, update label and tool tip to match the behaviour
 of the new option;
 - Constant, convert the old option to be under a new key configuration
 when updating from 2.5.0;
 - ProxyParam, add methods to get/set the new option and deprecate the
 methods of the old option and rename the existing variables and its
 configuration key;
 - ProxyThread, change to remove the unsupported encodings instead of
 just some (currently all encodings are removed as the HttpBody
 implementations do not handle the encodings);
 - OptionsLocalProxyPanel, rename the variable/methods of the old option
 and change to use the new methods of ProxyParam class.