### PR TITLE
Internationalise text in Local Proxy options panel

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1516,6 +1516,7 @@ options.proxy.local.label.browser     = <html><body><br><p>Set your browser prox
 options.proxy.local.label.local       = Local Proxy
 options.proxy.local.label.misc        = Miscellaneous
 options.proxy.local.label.removeUnsupportedEncodings = Remove Unsupported Encodings
+options.proxy.local.label.address = Address (eg localhost, 127.0.0.1)
 options.proxy.local.label.port        = Port (eg 8080)
 options.proxy.local.label.rev.address = Address (eg 192.168.0.1)
 options.proxy.local.label.rev.local   = <html><body><p>The address should not be "localhost" because a reverse proxy should be accessed by browser from another computer.</p></body></html>

--- a/src/org/parosproxy/paros/extension/option/OptionsLocalProxyPanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsLocalProxyPanel.java
@@ -28,6 +28,7 @@
 // ZAP: 2014/03/23 Issue 968: Allow to choose the enabled SSL/TLS protocols
 // ZAP: 2015/02/10 Issue 1528: Support user defined font size
 // ZAP: 2016/06/13 Change option "Modify/Remove Accept-Encoding" to "Remove Unsupported Encodings"
+// ZAP: 2016/06/13 Internationalise string and remove unused instance variable
 
 package org.parosproxy.paros.extension.option;
 
@@ -54,7 +55,6 @@ public class OptionsLocalProxyPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = -1350537974139536669L;
 
-    private OptionsParam optionsParam = null;
     private JPanel panelLocalProxy = null;
     private JPanel panelReverseProxy = null;  //  @jve:decl-index=0:visual-constraint="520,10"
 
@@ -104,7 +104,7 @@ public class OptionsLocalProxyPanel extends AbstractParamPanel {
                     null, Constant.messages.getString("options.proxy.local.title"), javax.swing.border.TitledBorder.DEFAULT_JUSTIFICATION,
                     javax.swing.border.TitledBorder.DEFAULT_POSITION, FontUtils.getFont(FontUtils.Size.standard), java.awt.Color.black));	// ZAP: i18n
 
-            jLabel.setText("Address (eg localhost, 127.0.0.1)");
+            jLabel.setText(Constant.messages.getString("options.proxy.local.label.address"));
             
             gridBagConstraints4.gridx = 0;
             gridBagConstraints4.gridy = 0;


### PR DESCRIPTION
Change class OptionsLocalProxyPanel to internationalise address label's
text. Also, remove unused instance variable.