### PR TITLE
Add cookie handling when a redirect occurs

### DIFF
--- a/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
@@ -20,6 +20,7 @@ package org.zaproxy.zap.extension.httpsessions;
 import java.net.HttpCookie;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -28,6 +29,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.apache.commons.httpclient.HttpMethodDirector;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control.Mode;
@@ -626,8 +628,10 @@ public class ExtensionHttpSessions extends ExtensionAdaptor implements SessionCh
 			return;
 		}
 
-		// Check for default tokens set in response messages
-		List<HttpCookie> responseCookies = msg.getResponseHeader().getHttpCookies(msg.getRequestHeader().getHostName());
+		// Check for cookies set during redirects and set in response messages
+		ArrayList<HttpCookie> responseCookies = new ArrayList<>(HttpMethodDirector.getRedirectCookies());
+		responseCookies.addAll(msg.getResponseHeader().getHttpCookies(msg.getRequestHeader().getHostName()));
+
 		for (HttpCookie cookie : responseCookies) {
 			// If it's a default session token and it is not already marked as session token and was
 			// not previously removed by the user

--- a/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsSite.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsSite.java
@@ -32,6 +32,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.commons.httpclient.Cookie;
+import org.apache.commons.httpclient.HttpMethodDirector;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
@@ -382,9 +383,13 @@ public class HttpSessionsSite {
 		// Create an auxiliary map of token values and insert keys for every token
 		Map<String, Cookie> tokenValues = new HashMap<>();
 
-		// Get new values that were set for tokens (e.g. using SET-COOKIE headers), if any
-		
-		List<HttpCookie> cookiesToSet = message.getResponseHeader().getHttpCookies(message.getRequestHeader().getHostName());
+		// Retrieve cookies in the redirect list, if any
+		ArrayList<HttpCookie> cookiesToSet = new ArrayList<>(HttpMethodDirector.getRedirectCookies());
+		// Clear the static list of redirect cookies in order to put it in a clean state for the next time
+		HttpMethodDirector.emptyRedirectCookies();
+		// Retrieve cookies set in response messages (using SET-COOKIE headers), if any
+		cookiesToSet.addAll(message.getResponseHeader().getHttpCookies(message.getRequestHeader().getHostName()));
+
 		for (HttpCookie cookie : cookiesToSet) {
 			String lcCookieName = cookie.getName();
 			if (siteTokensSet.isSessionToken(lcCookieName)) {


### PR DESCRIPTION
Set-Cookie header is now handled when receiving a redirect response.

Cookies and session are correctly updated when sending a POST request with redirect enabled.
Session is updated at the end of the redirect process for GET requests with redirect enabled.
