### PR TITLE
Remove SessionChangedListener from ExtensionAPI

### DIFF
--- a/src/org/zaproxy/zap/extension/api/ExtensionAPI.java
+++ b/src/org/zaproxy/zap/extension/api/ExtensionAPI.java
@@ -25,17 +25,14 @@ import java.security.SecureRandom;
 import javax.swing.JOptionPane;
 
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.control.Control.Mode;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
-import org.parosproxy.paros.extension.SessionChangedListener;
 import org.parosproxy.paros.model.Model;
-import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.DesktopUtils;
 import org.zaproxy.zap.view.ZapMenuItem;
 
-public class ExtensionAPI extends ExtensionAdaptor implements SessionChangedListener {
+public class ExtensionAPI extends ExtensionAdaptor {
 
 	public static final String NAME = "ExtensionAPI";
 	public static final String API_URL = "http://zap/";
@@ -67,7 +64,6 @@ public class ExtensionAPI extends ExtensionAdaptor implements SessionChangedList
 	@Override
 	public void hook(ExtensionHook extensionHook) {
 	    super.hook(extensionHook);
-        extensionHook.addSessionListener(this);
 	    if (getView() != null) {
 	    	extensionHook.getHookView().addOptionPanel(getOptionsAPIPanel());
 	    	extensionHook.getHookMenu().addToolsMenuItem(getMenuAPI());
@@ -130,19 +126,6 @@ public class ExtensionAPI extends ExtensionAdaptor implements SessionChangedList
 	}
 
 	@Override
-	public void sessionChanged(Session session) {
-		//API.getInstance().setSession(session);
-	}
-
-	@Override
-	public void sessionAboutToChange(Session session) {
-	}
-	
-	@Override
-	public void sessionScopeChanged(Session session) {
-	}
-	
-	@Override
 	public String getAuthor() {
 		return Constant.ZAP_TEAM;
 	}
@@ -159,11 +142,6 @@ public class ExtensionAPI extends ExtensionAdaptor implements SessionChangedList
 		} catch (MalformedURLException e) {
 			return null;
 		}
-	}
-	
-	@Override
-	public void sessionModeChanged(Mode mode) {
-		// Ignore
 	}
 	
 	public CoreAPI getCoreAPI() {


### PR DESCRIPTION
The notifications provided by SessionChangedListener are not in
effective use.