### PR TITLE
Remove redundant inits in HTTP message classes

### DIFF
--- a/src/org/parosproxy/paros/network/HttpHeader.java
+++ b/src/org/parosproxy/paros/network/HttpHeader.java
@@ -33,6 +33,7 @@
 // the request body is not "x-www-form-urlencoded"
 // ZAP: 2015/03/26 Issue 1573: Add option to inject plugin ID in header for all ascan requests
 // ZAP: 2016/06/17 Be lenient when parsing charset and accept single quote chars around the value
+// ZAP: 2016/06/17 Remove redundant initialisations of instance variables
 
 package org.parosproxy.paros.network;
 
@@ -105,13 +106,13 @@ public abstract class HttpHeader implements java.io.Serializable {
     protected static final String p_VERSION = "(HTTP/\\d+\\.\\d+)";
     protected static final String p_STATUS_CODE = "(\\d{3})";
     protected static final String p_REASON_PHRASE = "(" + p_TEXT + ")";
-    protected String mStartLine = "";
-    protected String mMsgHeader = "";
-    protected boolean mMalformedHeader = false;
-    protected Hashtable<String, Vector<String>> mHeaderFields = new Hashtable<>();
-    protected int mContentLength = -1;
-    protected String mLineDelimiter = CRLF;
-    protected String mVersion = HttpHeader.HTTP10;
+    protected String mStartLine;
+    protected String mMsgHeader;
+    protected boolean mMalformedHeader;
+    protected Hashtable<String, Vector<String>> mHeaderFields;
+    protected int mContentLength;
+    protected String mLineDelimiter;
+    protected String mVersion;
     // ZAP: added CORS headers
     public static final String ACCESS_CONTROL_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
 	public static final String ACCESS_CONTROL_ALLOW_HEADERS = "Access-Control-Allow-Headers";
@@ -138,7 +139,6 @@ public abstract class HttpHeader implements java.io.Serializable {
      * @throws HttpMalformedHeaderException
      */
     public HttpHeader(String data) throws HttpMalformedHeaderException {
-        this();
         setMessage(data);
     }
 
@@ -162,9 +162,7 @@ public abstract class HttpHeader implements java.io.Serializable {
      * @throws HttpMalformedHeaderException
      */
     public void setMessage(String data) throws HttpMalformedHeaderException {
-        init();
-
-        mMsgHeader = data;
+        clear();
         try {
             if (!this.parse(data)) {
                 mMalformedHeader = true;

--- a/src/org/parosproxy/paros/network/HttpRequestHeader.java
+++ b/src/org/parosproxy/paros/network/HttpRequestHeader.java
@@ -39,6 +39,7 @@
 // ZAP: 2013/05/02 Re-arranged all modifiers into Java coding standard order
 // ZAP: 2013/12/09 Set Content-type only in case of POST or PUT HTTP methods
 // ZAP: 2015/08/07 Issue 1768: Update to use a more recent default user agent
+// ZAP: 2016/06/17 Remove redundant initialisations of instance variables
 
 package org.parosproxy.paros.network;
 
@@ -80,33 +81,37 @@ public class HttpRequestHeader extends HttpHeader {
     //	= Pattern.compile("([^:]+)\\s*?:?\\s*?(\\d*?)");
     private static final Pattern patternImage = Pattern.compile("\\.(bmp|ico|jpg|jpeg|gif|tiff|tif|png)\\z", Pattern.CASE_INSENSITIVE);
     private static final Pattern patternPartialRequestLine = Pattern.compile("\\A *(OPTIONS|GET|HEAD|POST|PUT|DELETE|TRACE|CONNECT)\\b", Pattern.CASE_INSENSITIVE);
-    private String mMethod = "";
-    private URI mUri = null;
-    private String mHostName = "";
+    private String mMethod;
+    private URI mUri;
+    private String mHostName;
     
     /**
      * The host port number of this request message, a non-negative integer.
+     * <p>
+     * Default is {@code 80}.
      * <p>
      * <strong>Note:</strong> All the modifications to the instance variable
      * {@code mHostPort} must be done through the method
      * {@code setHostPort(int)}, so a valid and correct value is set when no
      * port number is defined (which is represented with the negative integer
      * -1).
-     * </p>
      *
      * @see #getHostPort()
      * @see #setHostPort(int)
      * @see URI#getPort()
      */
     private int mHostPort;
-    private boolean mIsSecure = false;
+    private boolean mIsSecure;
 
     /**
      * Constructor for an empty header.
      *
      */
     public HttpRequestHeader() {
-        clear();
+        super();
+        mMethod = "";
+        mHostName = "";
+        mHostPort = 80;
     }
 
     /**
@@ -118,7 +123,6 @@ public class HttpRequestHeader extends HttpHeader {
      * @throws HttpMalformedHeaderException
      */
     public HttpRequestHeader(String data, boolean isSecure) throws HttpMalformedHeaderException {
-        this();
         setMessage(data, isSecure);
     }
 
@@ -130,7 +134,6 @@ public class HttpRequestHeader extends HttpHeader {
      * @throws HttpMalformedHeaderException
      */
     public HttpRequestHeader(String data) throws HttpMalformedHeaderException {
-        this();
         setMessage(data);
     }
 
@@ -142,7 +145,6 @@ public class HttpRequestHeader extends HttpHeader {
         mUri = null;
         mHostName = "";
         setHostPort(-1);
-        mMsgHeader = "";
 
     }
 

--- a/src/org/parosproxy/paros/network/HttpResponseHeader.java
+++ b/src/org/parosproxy/paros/network/HttpResponseHeader.java
@@ -29,6 +29,7 @@
 // ZAP: 2014/02/21 i1046: The getHttpCookies() method in the HttpResponseHeader does not properly set the domain
 // ZAP: 2014/04/09 i1145: Cookie parsing error if a comma is used
 // ZAP: 2015/02/26 Include json as a text content type
+// ZAP: 2016/06/17 Remove redundant initialisations of instance variables
 
 package org.parosproxy.paros.network;
 
@@ -63,17 +64,17 @@ public class HttpResponseHeader extends HttpHeader {
 	private static final Pattern patternPartialStatusLine 
 		= Pattern.compile("\\A *" + p_VERSION, Pattern.CASE_INSENSITIVE);
 
-    private String mStatusCodeString = "";
-    private int mStatusCode = 0;
-    private String mReasonPhrase	= "";
+    private String mStatusCodeString;
+    private int mStatusCode;
+    private String mReasonPhrase;
 	
     public HttpResponseHeader() {
-		clear();
+        mStatusCodeString = "";
+        mReasonPhrase = "";
     }
 
     public HttpResponseHeader(String data) throws HttpMalformedHeaderException {
-        this();
-        setMessage(data);
+        super(data);
     }
 
     @Override
@@ -121,9 +122,7 @@ public class HttpResponseHeader extends HttpHeader {
 		mStatusCodeString	= matcher.group(2);
 		String tmp 			= matcher.group(3);
 
-		if (tmp != null) {
-			mReasonPhrase		= tmp;
-		}
+		mReasonPhrase = (tmp != null) ? tmp : "";
 		 
         if (!mVersion.equalsIgnoreCase(HTTP10) && !mVersion.equalsIgnoreCase(HTTP11)) {
 			mMalformedHeader = true;


### PR DESCRIPTION
Remove redundant instance variable initialisations in HTTP message
related classes:
 - HttpHeader:
  - Remove initialisations done in the instance variables as they are
  already being initialised either in the constructors or other methods
  called by the constructor;
  - HttpHeader(String), do not call the default constructor it would
  lead to redundant initialisations, since the variables are already
  being initialised in the method called, setMessage(data);
  - setMessage(data), change to call clear() instead of init() which
  also clears the state of extending classes and remove the
  initialisation of mMsgHeader, which is done in the following method,
  parse(String).
 - HttpRequestHeader:
  - Remove initialisations done in the instance variables as they are
  already being initialised either in the constructors or other methods
  called by the constructors;
  - HttpRequestHeader(), change to not call clear() and initialise only
  the required instance variables;
  - HttpRequestHeader(String) and HttpRequestHeader(String, boolean), do
  not call the default constructor it would lead to redundant
  initialisations, since the variables are already being initialised in
  the method called, setMessage(data);
 - HttpResponseHeader:
  - Remove initialisations done in the instance variables as they are
  already being initialised either in the constructors or other methods
  called by the constructors;
  - HttpResponseHeader(), change to not call clear() and initialise only
  the required instance variables;
  - HttpResponseHeader(String), do not call the default constructor and
  use base constructor, HttpHeader(String), which already takes care to
  call the appropriate method.