### PR TITLE
Remove unnecessary extensions' constructors

### DIFF
--- a/src/org/parosproxy/paros/extension/edit/ExtensionEdit.java
+++ b/src/org/parosproxy/paros/extension/edit/ExtensionEdit.java
@@ -24,6 +24,7 @@
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
 // ZAP: 2014/01/28 Issue 207: Support keyboard shortcuts 
 // ZAP: 2015/03/16 Issue 1525: Further database independence changes
+// ZAP: 2016/06/20 Removed unnecessary/unused constructor
 
 package org.parosproxy.paros.extension.edit;
 
@@ -50,22 +51,7 @@ public class ExtensionEdit extends ExtensionAdaptor {
      * 
      */
     public ExtensionEdit() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionEdit(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setName("ExtensionEdit");
+        super("ExtensionEdit");
         this.setOrder(4);
 	}
 	

--- a/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -67,6 +67,7 @@
 // ZAP: 2016/04/05 Issue 2458: Fix xlint warning messages 
 // ZAP: 2016/05/20 Moved purge method to here from PopupMenuPurgeSites
 // ZAP: 2016/05/30 Issue 2494: ZAP Proxy is not showing the HTTP CONNECT Request in history tab
+// ZAP: 2016/06/20 Removed unnecessary/unused constructor
 
 package org.parosproxy.paros.extension.history;
 
@@ -154,22 +155,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
      * 
      */
     public ExtensionHistory() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionHistory(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setName(NAME);
+        super(NAME);
         this.setOrder(16);
 
 	}

--- a/src/org/parosproxy/paros/extension/manualrequest/ExtensionManualRequestEditor.java
+++ b/src/org/parosproxy/paros/extension/manualrequest/ExtensionManualRequestEditor.java
@@ -38,6 +38,7 @@
 // ZAP: 2014/08/14 Issue 1292: NullPointerException while attempting to remove an unregistered ManualRequestEditorDialog
 // ZAP: 2014/12/12 Issue 1449: Added help button
 // ZAP: 2015/03/16 Issue 1525: Further database independence changes
+// ZAP: 2016/06/20 Removed unnecessary/unused constructor
 
 package org.parosproxy.paros.extension.manualrequest;
 
@@ -69,17 +70,7 @@ public class ExtensionManualRequestEditor extends ExtensionAdaptor implements Se
 
 	
 	public ExtensionManualRequestEditor() {
-		super();
-		initialize();
-	}
-
-	
-	public ExtensionManualRequestEditor(String name) {
-		super(name);
-	}
-	
-	private void initialize() {
-		this.setName(NAME);
+		super(NAME);
         this.setOrder(36);
         
 	}

--- a/src/org/parosproxy/paros/extension/option/ExtensionOption.java
+++ b/src/org/parosproxy/paros/extension/option/ExtensionOption.java
@@ -28,6 +28,7 @@
 // ZAP: 2015/03/16 Issue 1525: Further database independence changes
 // ZAP: 2015/08/17 Issue 1795: Allow JVM options to be configured via GUI
 // ZAP: 2016/04/05 Issue 2458: Fix xlint warning messages 
+// ZAP: 2016/06/20 Removed unnecessary/unused constructor
 
 package org.parosproxy.paros.extension.option;
 
@@ -59,16 +60,7 @@ public class ExtensionOption extends ExtensionAdaptor {
 
 	
     public ExtensionOption() {
-        super();
- 		initialize();
-    }
-
-    public ExtensionOption(String name) {
-        super(name);
-    }
-
-	private void initialize() {
-        this.setName("ExtensionViewOption");
+        super("ExtensionViewOption");
         this.setOrder(2);
 	}
 	

--- a/src/org/parosproxy/paros/extension/report/ExtensionReport.java
+++ b/src/org/parosproxy/paros/extension/report/ExtensionReport.java
@@ -27,6 +27,7 @@
 // ZAP: 2013/12/03 Issue 934: Handle files on the command line via extension
 // ZAP: 2014/01/28 Issue 207: Support keyboard shortcuts 
 // ZAP: 2015/10/06 Issue 1962: Install and update add-ons from the command line
+// ZAP: 2016/06/20 Removed unnecessary/unused constructor
 
 package org.parosproxy.paros.extension.report;
 
@@ -53,26 +54,10 @@ public class ExtensionReport extends ExtensionAdaptor implements CommandLineList
      * 
      */
     public ExtensionReport() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionReport(String name) {
-        super(name);
+        super("ExtensionReport");
         this.setOrder(14);
     }
 
-	/**
-	 * This method initializes this
-	 * 
-	 */
-	private void initialize() {
-        this.setName("ExtensionReport");
-			
-	}
 	@Override
 	public void hook(ExtensionHook extensionHook) {
 	    super.hook(extensionHook);

--- a/src/org/parosproxy/paros/extension/state/ExtensionState.java
+++ b/src/org/parosproxy/paros/extension/state/ExtensionState.java
@@ -31,6 +31,7 @@
 // ZAP: 2014/01/28 Issue 207: Support keyboard shortcuts 
 // ZAP: 2015/03/16 Issue 1525: Further database independence changes
 // ZAP: 2016/04/05 Issue 2458: Fix xlint warning messages 
+// ZAP: 2016/06/20 Removed unnecessary/unused constructor
 
 package org.parosproxy.paros.extension.state;
 
@@ -55,22 +56,7 @@ public class ExtensionState extends ExtensionAdaptor implements SessionChangedLi
      * 
      */
     public ExtensionState() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionState(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setName("ExtensionState");
+        super("ExtensionState");
         this.setOrder(12);
 	}
 	

--- a/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -80,22 +80,7 @@ public class ExtensionAlert extends ExtensionAdaptor implements SessionChangedLi
      *
      */
     public ExtensionAlert() {
-        super();
-        initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionAlert(String name) {
-        super(name);
-    }
-
-    /**
-     * This method initializes this
-     */
-    private void initialize() {
-        this.setName(NAME);
+        super(NAME);
         this.setOrder(27);
     }
 

--- a/src/org/zaproxy/zap/extension/api/ExtensionAPI.java
+++ b/src/org/zaproxy/zap/extension/api/ExtensionAPI.java
@@ -42,22 +42,7 @@ public class ExtensionAPI extends ExtensionAdaptor {
     private CoreAPI coreApi = null;
 	
     public ExtensionAPI() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionAPI(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setName(NAME);
+        super(NAME);
         this.setOrder(10);
 	}
 

--- a/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -122,22 +122,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
      *
      */
     public ExtensionActiveScan() {
-        super();
-        initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionActiveScan(String name) {
-        super(name);
-    }
-
-    /**
-     * This method initializes this
-     */
-    private void initialize() {
-        this.setName(NAME);
+        super(NAME);
         this.setOrder(28);
         policyManager = new PolicyManager(this);
         ascanController = new ActiveScanController(this);

--- a/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
+++ b/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
@@ -105,18 +105,7 @@ public class ExtensionBreak extends ExtensionAdaptor implements SessionChangedLi
 
 	
     public ExtensionBreak() {
-        super();
- 		initialize();
-    }
-
-    
-    public ExtensionBreak(String name) {
-        super(name);
-    }
-
-	
-	private void initialize() {
-        this.setName(NAME);
+        super(NAME);
         this.setOrder(24);
 	}
 	

--- a/src/org/zaproxy/zap/extension/compare/ExtensionCompare.java
+++ b/src/org/zaproxy/zap/extension/compare/ExtensionCompare.java
@@ -66,22 +66,7 @@ public class ExtensionCompare extends ExtensionAdaptor implements SessionChanged
      * 
      */
     public ExtensionCompare() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionCompare(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setName("ExtensionCompare");
+        super("ExtensionCompare");
         this.setOrder(44);
 	}
 	

--- a/src/org/zaproxy/zap/extension/encoder2/ExtensionEncoder2.java
+++ b/src/org/zaproxy/zap/extension/encoder2/ExtensionEncoder2.java
@@ -49,22 +49,7 @@ public class ExtensionEncoder2 extends ExtensionAdaptor implements OptionsChange
      * 
      */
     public ExtensionEncoder2() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionEncoder2(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setName("ExtensionEncode2");
+        super("ExtensionEncode2");
         this.setOrder(22);
 	}
 	

--- a/src/org/zaproxy/zap/extension/help/ExtensionHelp.java
+++ b/src/org/zaproxy/zap/extension/help/ExtensionHelp.java
@@ -96,22 +96,7 @@ public class ExtensionHelp extends ExtensionAdaptor {
 	private static final Logger logger = Logger.getLogger(ExtensionHelp.class);
 	
     public ExtensionHelp() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionHelp(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setName("ExtensionHelp");
+        super("ExtensionHelp");
         this.setOrder(10000);	// Set to a huge value so the help button is always on the far right of the toolbar 
 	}
 	

--- a/src/org/zaproxy/zap/extension/log4j/ExtensionLog4j.java
+++ b/src/org/zaproxy/zap/extension/log4j/ExtensionLog4j.java
@@ -47,22 +47,7 @@ public class ExtensionLog4j extends ExtensionAdaptor {
      * 
      */
     public ExtensionLog4j() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionLog4j(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setName("ExtensionLog4j");
+        super("ExtensionLog4j");
         this.setOrder(56);
 
 		if (Constant.isDevBuild()) {

--- a/src/org/zaproxy/zap/extension/params/ExtensionParams.java
+++ b/src/org/zaproxy/zap/extension/params/ExtensionParams.java
@@ -77,23 +77,7 @@ public class ExtensionParams extends ExtensionAdaptor
      * 
      */
     public ExtensionParams() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionParams(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 * 
-	 */
-	private void initialize() {
-        this.setName(NAME);
+        super(NAME);
         this.setOrder(58);
 
         API.getInstance().registerApiImplementor(new ParamsAPI(this));

--- a/src/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/src/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -129,22 +129,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 	private boolean shouldLoadTemplatesOnScriptTypeRegistration;
 	
     public ExtensionScript() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionScript(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setName(NAME);
+        super(NAME);
         this.setOrder(EXTENSION_ORDER);
         
         ScriptEngine se = mgr.getEngineByName("ECMAScript");

--- a/src/org/zaproxy/zap/extension/search/ExtensionSearch.java
+++ b/src/org/zaproxy/zap/extension/search/ExtensionSearch.java
@@ -67,22 +67,7 @@ public class ExtensionSearch extends ExtensionAdaptor implements SessionChangedL
      * 
      */
     public ExtensionSearch() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionSearch(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setName(NAME);
+        super(NAME);
         this.setOrder(20);
 
 	}

--- a/src/org/zaproxy/zap/extension/siterefresh/ExtensionSitesRefresh.java
+++ b/src/org/zaproxy/zap/extension/siterefresh/ExtensionSitesRefresh.java
@@ -31,22 +31,7 @@ public class ExtensionSitesRefresh extends ExtensionAdaptor {
      * 
      */
     public ExtensionSitesRefresh() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionSitesRefresh(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setName("ExtensionSitesRefresh");
+        super("ExtensionSitesRefresh");
         this.setOrder(1000);	// Want this to be as low as possible :)
 	}
 	

--- a/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
+++ b/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
@@ -111,15 +111,6 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
 	}
 
 	/**
-	 * Instantiates a new extension spider.
-	 * 
-	 * @param name the name
-	 */
-	public ExtensionSpider(String name) {
-		super(name);
-	}
-
-	/**
 	 * This method initializes this extension.
 	 */
 	private void initialize() {

--- a/src/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
+++ b/src/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
@@ -49,23 +49,7 @@ public class ExtensionUiUtils extends ExtensionAdaptor implements SessionChanged
      * 
      */
     public ExtensionUiUtils() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionUiUtils(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 * 
-	 */
-	private void initialize() {
-        this.setName(NAME);
+        super(NAME);
         this.setOrder(200);
 
 	}


### PR DESCRIPTION
Remove unnecessary extensions' constructors, they are not required nor
used by core code to start/load the extensions (it's enough with the
no-arg constructor moreover add-ons do not need nor should start other
extensions). Also, in the cases where an auxiliary "initialize" method
was in use it was merged into the no-arg constructor (in most of the
cases it was only being called by the no-arg constructor).