### PR TITLE
Prevent GUI hang when adding messages to History

### DIFF
--- a/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -68,6 +68,7 @@
 // ZAP: 2016/05/20 Moved purge method to here from PopupMenuPurgeSites
 // ZAP: 2016/05/30 Issue 2494: ZAP Proxy is not showing the HTTP CONNECT Request in history tab
 // ZAP: 2016/06/20 Removed unnecessary/unused constructor
+// ZAP: 2016/06/21 Prevent deadlock between EDT and threads adding messages to the History tab
 
 package org.parosproxy.paros.extension.history;
 
@@ -386,16 +387,12 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
         if (!View.isInitialised() || EventQueue.isDispatchThread()) {
             historyTableModel.addHistoryReference(ref);
         } else {
-            try {
-                EventQueue.invokeAndWait(new Runnable() {
-                    @Override
-                    public void run() {
-                        addHistoryInEventQueue(ref);
-                    }
-                });
-            } catch (final Exception e) {
-                logger.error(e.getMessage(), e);
-            }
+            EventQueue.invokeLater(new Runnable() {
+                @Override
+                public void run() {
+                    addHistoryInEventQueue(ref);
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Change ExtensionHistory to add the HTTP messages (HistoryReference)
asynchronously in the EDT to prevent a deadlock between the EDT and
thread(s) adding messages to the History tab. The ExtensionHistory
synchronises on the history table model object when adding the messages
but it would also add the message synchronously in the EDT, so it would
wait for the EDT while holding the lock, if the EDT tried to add a
message in the meantime a deadlock would happen (since it would try to
sync with the history table model object, already locked).
  ---
Issue mentioned in https://github.com/zaproxy/zaproxy/issues/1871#issuecomment-226903369 (a thread dump was provided through IRC).