### PR TITLE
Add lang directory to manifest of ZAP JAR

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -213,7 +213,7 @@
 				<fileset dir="${dist}/lib">
 					<include name="**/JBroFuzz.jar"/>
 				</fileset>
-				<!--path location="lang"/-->
+				<path location="${dist}/lang/" />
 			</classpath>
 		</manifestclasspath>
 


### PR DESCRIPTION
Change build.xml file to include the "lang" directory in the manifest of
ZAP jar, so that it's automatically included in the class path. The
"lang" directory contains the resource messages required to run ZAP.
In newer Java 9 (EA) versions the application class loader is no longer
an instance of URLClassLoader ("JEP 261: Module System") making ZAP to
fail (skip) to dynamically add the "lang" directory to the class path.

Related to #2602 - Java 9 (9-ea)