### PR TITLE
Change HTTP breakpoint dialogues to modal

### DIFF
--- a/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
+++ b/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
@@ -64,6 +64,10 @@ import org.zaproxy.zap.view.ZapMenuItem;
 
 public class ExtensionBreak extends ExtensionAdaptor implements SessionChangedListener, OptionsChangedListener {
 
+    /**
+     * @deprecated (TODO add version) Should not be used/relied on, breakpoint dialogues should be modal.
+     */
+    @Deprecated
     public enum DialogType {NONE, ADD, EDIT, REMOVE};
     
     public static final String NAME = "ExtensionBreak";
@@ -469,22 +473,42 @@ public class ExtensionBreak extends ExtensionAdaptor implements SessionChangedLi
         return menuHttpBreakpoint;
     }
 
+	/**
+     * @deprecated (TODO add version) Use modal breakpoint dialogues instead of relying on this behaviour.
+	 */
+    @Deprecated
 	public boolean canAddBreakpoint() {
 		return (currentDialogType == DialogType.NONE || currentDialogType == DialogType.ADD);
 	}
     
+    /**
+     * @deprecated (TODO add version) Use modal breakpoint dialogues instead of relying on this behaviour.
+     */
+    @Deprecated
 	public boolean canEditBreakpoint() {
 		return (currentDialogType == DialogType.NONE || currentDialogType == DialogType.EDIT);
 	}
 	
+    /**
+     * @deprecated (TODO add version) Use modal breakpoint dialogues instead of relying on this behaviour.
+     */
+    @Deprecated
 	public boolean canRemoveBreakpoint() {
 		return (currentDialogType == DialogType.NONE || currentDialogType == DialogType.REMOVE);
 	}
 	
+    /**
+     * @deprecated (TODO add version) Use modal breakpoint dialogues instead of relying on this behaviour.
+     */
+    @Deprecated
 	public void dialogShown(DialogType type) {
 	    currentDialogType = type;
 	}
 	
+    /**
+     * @deprecated (TODO add version) Use modal breakpoint dialogues instead of relying on this behaviour.
+     */
+    @Deprecated
 	public void dialogClosed() {
 	    currentDialogType = DialogType.NONE;
 	}

--- a/src/org/zaproxy/zap/extension/brk/PopupMenuEditBreak.java
+++ b/src/org/zaproxy/zap/extension/brk/PopupMenuEditBreak.java
@@ -62,11 +62,6 @@ public class PopupMenuEditBreak extends ExtensionPopupMenuItem {
     @Override
     public boolean isEnableForComponent(Component invoker) {
         if (invoker.getName() != null && invoker.getName().equals(BreakpointsPanel.PANEL_NAME)) {
-            if (extension.canEditBreakpoint()) {
-                this.setEnabled(true);
-            } else {
-                this.setEnabled(false);
-            }
             return true;
         }
         return false;

--- a/src/org/zaproxy/zap/extension/brk/PopupMenuRemove.java
+++ b/src/org/zaproxy/zap/extension/brk/PopupMenuRemove.java
@@ -58,8 +58,10 @@ public class PopupMenuRemove extends ExtensionPopupMenuItem {
 	}
 	
     @Override
+    @SuppressWarnings("deprecation")
     public boolean isEnableForComponent(Component invoker) {
         if (invoker.getName() != null && invoker.getName().equals(BreakpointsPanel.PANEL_NAME)) {
+            // TODO remove once no longer needed (i.e. when all add-ons show modal dialogues).
             if (extension.canRemoveBreakpoint()) {
                 this.setEnabled(true);
             } else {

--- a/src/org/zaproxy/zap/extension/brk/impl/http/BreakAddEditDialog.java
+++ b/src/org/zaproxy/zap/extension/brk/impl/http/BreakAddEditDialog.java
@@ -46,8 +46,9 @@ public class BreakAddEditDialog extends StandardFieldsDialog {
 
 
 	public BreakAddEditDialog(HttpBreakpointsUiManagerInterface breakPointsManager, Frame owner, Dimension dim) {
-		super(owner, "brk.brkpoint.add.title", dim);
+		super(owner, "brk.brkpoint.add.title", dim, true);
 		this.breakPointsManager = breakPointsManager;
+		setDefaultCloseOperation(DISPOSE_ON_CLOSE);
 	}
 
 	public void init (HttpBreakpointMessage breakpoint, boolean add) {
@@ -124,11 +125,11 @@ public class BreakAddEditDialog extends StandardFieldsDialog {
 		
 		if (add) {
 		    breakPointsManager.addBreakpoint(brk);
-		    breakPointsManager.hideAddDialog();
+		    dispose();
 		} else {
 		    breakPointsManager.editBreakpoint(breakpoint, brk);
             breakpoint = null;
-		    breakPointsManager.hideEditDialog();
+		    dispose();
 		}
 	}
 
@@ -149,11 +150,7 @@ public class BreakAddEditDialog extends StandardFieldsDialog {
 	
 	@Override
 	public void cancelPressed() {
-		if ( add ) {
-			breakPointsManager.hideAddDialog(); 
-		} else {
-			breakPointsManager.hideEditDialog(); 
-		}
+		dispose();
 	}
 	
 }

--- a/src/org/zaproxy/zap/extension/brk/impl/http/HttpBreakpointsUiManagerInterface.java
+++ b/src/org/zaproxy/zap/extension/brk/impl/http/HttpBreakpointsUiManagerInterface.java
@@ -65,12 +65,10 @@ public class HttpBreakpointsUiManagerInterface implements BreakpointsUiManagerIn
 
     @Override
     public void handleAddBreakpoint(Message aMessage) {
-        extensionBreak.dialogShown(ExtensionBreak.DialogType.ADD);
         showAddDialog(aMessage);
     }
     
     public void handleAddBreakpoint(String url) {
-        extensionBreak.dialogShown(ExtensionBreak.DialogType.ADD);
         showAddDialog(url, HttpBreakpointMessage.Match.regex);
     }
 
@@ -80,7 +78,6 @@ public class HttpBreakpointsUiManagerInterface implements BreakpointsUiManagerIn
 
     @Override
     public void handleEditBreakpoint(BreakpointMessageInterface breakpoint) {
-        extensionBreak.dialogShown(ExtensionBreak.DialogType.EDIT);
         showEditDialog((HttpBreakpointMessage)breakpoint);
     }
 
@@ -134,11 +131,6 @@ public class HttpBreakpointsUiManagerInterface implements BreakpointsUiManagerIn
         }
         populateAddDialogAndSetVisible(url, match);
     }
-
-    void hideAddDialog() {
-    	breakDialog.dispose();
-        extensionBreak.dialogClosed();
-    }
     
     private void populateEditDialogAndSetVisible(HttpBreakpointMessage breakpoint) {
     	breakDialog.init(breakpoint, false);
@@ -152,14 +144,9 @@ public class HttpBreakpointsUiManagerInterface implements BreakpointsUiManagerIn
         populateEditDialogAndSetVisible(breakpoint);
     }
 
-    void hideEditDialog() {
-    	breakDialog.dispose();
-        extensionBreak.dialogClosed();
-    }
-
     private PopupMenuAddBreakSites getPopupMenuAddBreakSites() {
         if (popupMenuAddBreakSites == null) {
-            popupMenuAddBreakSites = new PopupMenuAddBreakSites(extensionBreak, this);
+            popupMenuAddBreakSites = new PopupMenuAddBreakSites(this);
         }
         return popupMenuAddBreakSites;
     }

--- a/src/org/zaproxy/zap/extension/brk/impl/http/PopupMenuAddBreakHistory.java
+++ b/src/org/zaproxy/zap/extension/brk/impl/http/PopupMenuAddBreakHistory.java
@@ -48,11 +48,6 @@ public class PopupMenuAddBreakHistory extends PopupMenuItemHistoryReferenceConta
     }
 
     @Override
-    public boolean isButtonEnabledForHistoryReference(HistoryReference href) {
-        return (extension.canAddBreakpoint() && super.isButtonEnabledForHistoryReference(href));
-    }
-
-    @Override
     public void performAction(HistoryReference href) {
         try {
             extension.addUiBreakpoint(href.getHttpMessage());

--- a/src/org/zaproxy/zap/extension/brk/impl/http/PopupMenuAddBreakSites.java
+++ b/src/org/zaproxy/zap/extension/brk/impl/http/PopupMenuAddBreakSites.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.extension.brk.impl.http;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.model.SiteNode;
-import org.zaproxy.zap.extension.brk.ExtensionBreak;
 import org.zaproxy.zap.model.StructuralSiteNode;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
@@ -31,24 +30,17 @@ public class PopupMenuAddBreakSites extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = -7635703590177283587L;
     
-    private ExtensionBreak extension;
     private HttpBreakpointsUiManagerInterface uiManager;
 
-    public PopupMenuAddBreakSites(ExtensionBreak extension, HttpBreakpointsUiManagerInterface uiManager) {
+    public PopupMenuAddBreakSites(HttpBreakpointsUiManagerInterface uiManager) {
         super(Constant.messages.getString("brk.add.popup"));
 
-        this.extension = extension;
         this.uiManager = uiManager;
     }
 
     @Override
     public boolean isEnableForInvoker(Invoker invoker, HttpMessageContainer httpMessageContainer) {
         return (invoker == Invoker.SITES_PANEL);
-    }
-
-    @Override
-    public boolean isButtonEnabledForSiteNode(SiteNode sn) {
-        return extension.canAddBreakpoint();
     }
 
     @Override


### PR DESCRIPTION
Change the (HTTP) breakpoint dialogues to be modal, to prevent
interactions with other UI components while the dialogues are shown.
Reduces code complexity in core (and add-ons), it's also less error
prone, since it no longer requires the break implementations and core
code to track/tell which type of dialogues (add/edit/remove) are
currently shown.
Deprecate methods used to track/tell if the dialogues are shown in
favour of using modal dialogues.