### PR TITLE
Remove deprecation in ExtensionBreak

### DIFF
--- a/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
+++ b/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
@@ -117,7 +117,6 @@ public class ExtensionBreak extends ExtensionAdaptor implements SessionChangedLi
 		return breakPanel;
 	}
 	
-	@SuppressWarnings("deprecation")
 	@Override
 	public void hook(ExtensionHook extensionHook) {
 	    super.hook(extensionHook);
@@ -131,8 +130,6 @@ public class ExtensionBreak extends ExtensionAdaptor implements SessionChangedLi
 	        ExtensionHookView pv = extensionHook.getHookView();
 	        pv.addWorkPanel(getBreakPanel());
 	        pv.addOptionPanel(getOptionsPanel());
-	        
-            extensionHook.getHookMenu().addAnalyseMenuItem(extensionHook.getHookMenu().getMenuSeparator());
 
 	        extensionHook.getHookView().addStatusPanel(getBreakpointsPanel());
 


### PR DESCRIPTION
The separator being added to "Analyse" top level menu is not necessary,
by default it's just shown one menu item and it's unrelated to
breakpoint functionalities.