### PR TITLE
Minor tidy up of SiteTreeFilter class

### DIFF
--- a/src/org/zaproxy/zap/view/SiteTreeFilter.java
+++ b/src/org/zaproxy/zap/view/SiteTreeFilter.java
@@ -19,14 +19,13 @@
  */
 package org.zaproxy.zap.view;
 
-import org.apache.log4j.Logger;
 import org.parosproxy.paros.extension.history.HistoryFilter;
 import org.parosproxy.paros.model.SiteNode;
 
 public class SiteTreeFilter {
 
 	private HistoryFilter historyFilter;
-	private boolean inScope = false;
+	private boolean inScope;
 	
 	public SiteTreeFilter(HistoryFilter historyFilter) {
 		this.historyFilter = historyFilter;
@@ -39,8 +38,6 @@ public class SiteTreeFilter {
 	public void setInScope(boolean inScope) {
 		this.inScope = inScope;
 	}
-	
-	Logger logger = Logger.getLogger(getClass());
 	
 	public boolean matches (SiteNode node) {
 		if (node.isRoot()) {


### PR DESCRIPTION
Remove unused instance variable ("logger") and unnecessary instance
variable initialisation (it's already initialised to false).