### PR TITLE
Remove JAR scan for authentication/session methods

### DIFF
--- a/src/org/zaproxy/zap/extension/authentication/ExtensionAuthentication.java
+++ b/src/org/zaproxy/zap/extension/authentication/ExtensionAuthentication.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.authentication;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,8 +41,11 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.zaproxy.zap.authentication.AuthenticationMethod;
 import org.zaproxy.zap.authentication.AuthenticationMethodType;
+import org.zaproxy.zap.authentication.FormBasedAuthenticationMethodType;
 import org.zaproxy.zap.authentication.FormBasedAuthenticationMethodType.FormBasedAuthenticationMethod;
-import org.zaproxy.zap.control.ExtensionFactory;
+import org.zaproxy.zap.authentication.HttpAuthenticationMethodType;
+import org.zaproxy.zap.authentication.ManualAuthenticationMethodType;
+import org.zaproxy.zap.authentication.ScriptBasedAuthenticationMethodType;
 import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.stdmenus.PopupContextMenuItemFactory;
 import org.zaproxy.zap.model.Context;
@@ -179,13 +183,17 @@ public class ExtensionAuthentication extends ExtensionAdaptor implements Context
 	}
 
 	/**
-	 * Load authentication method types using reflection and hooks them up.
+	 * Loads the authentication method types and hooks them up.
 	 * 
 	 * @param hook the extension hook
 	 */
 	private void loadAuthenticationMethodTypes(ExtensionHook hook) {
-		this.authenticationMethodTypes = ExtensionFactory.getAddOnLoader().getImplementors("org.zaproxy.zap",
-				AuthenticationMethodType.class);
+		this.authenticationMethodTypes = new ArrayList<>();
+		this.authenticationMethodTypes.add(new FormBasedAuthenticationMethodType());
+		this.authenticationMethodTypes.add(new HttpAuthenticationMethodType());
+		this.authenticationMethodTypes.add(new ManualAuthenticationMethodType());
+		this.authenticationMethodTypes.add(new ScriptBasedAuthenticationMethodType());
+
 		for (AuthenticationMethodType a : authenticationMethodTypes) {
 			a.hook(hook);
 		}

--- a/src/org/zaproxy/zap/extension/sessions/ExtensionSessionManagement.java
+++ b/src/org/zaproxy/zap/extension/sessions/ExtensionSessionManagement.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.sessions;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,10 +36,11 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
-import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.ContextDataFactory;
+import org.zaproxy.zap.session.CookieBasedSessionManagementMethodType;
+import org.zaproxy.zap.session.HttpAuthSessionManagementMethodType;
 import org.zaproxy.zap.session.SessionManagementMethod;
 import org.zaproxy.zap.session.SessionManagementMethodType;
 import org.zaproxy.zap.view.AbstractContextPropertiesPanel;
@@ -128,13 +130,14 @@ public class ExtensionSessionManagement extends ExtensionAdaptor implements Cont
 	}
 
 	/**
-	 * Load session management method types using reflection.
+	 * Loads session management method types and hooks them up.
 	 * 
 	 * @param extensionHook the extension hook
 	 */
 	private void loadSesssionManagementMethodTypes(ExtensionHook extensionHook) {
-		this.sessionManagementMethodTypes = ExtensionFactory.getAddOnLoader().getImplementors(
-				"org.zaproxy.zap", SessionManagementMethodType.class);
+		this.sessionManagementMethodTypes = new ArrayList<>();
+		this.sessionManagementMethodTypes.add(new CookieBasedSessionManagementMethodType());
+		this.sessionManagementMethodTypes.add(new HttpAuthSessionManagementMethodType());
 
 		for (SessionManagementMethodType t : sessionManagementMethodTypes) {
 			t.hook(extensionHook);


### PR DESCRIPTION
Change classes ExtensionAuthentication and ExtensionSessionManagement to
not scan the loaded JARs (core and add-ons) to load authentication and
session management methods, instead directly add/load the methods
provided by core code.
The change reduces the time required to start ZAP as it does not need to
scan all the JARs to load the methods, moreover it will also stop
loading any methods provided by add-ons (if any), the add-ons should
add/remove the methods to be properly installed/updated.

Related to #2620 - Allow to add/remove authentication and session
management methods