### PR TITLE
Do not log when cloning PluginFactory

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/PluginFactory.java
+++ b/src/org/parosproxy/paros/core/scanner/PluginFactory.java
@@ -44,6 +44,7 @@
 // ZAP: 2016/01/26 Fixed findbugs warning
 // ZAP: 2016/05/04 Use existing Plugin instances when setting them as completed
 // ZAP: 2016/06/27 Reduce log level when loading the plugins
+// ZAP: 2016/06/29 Do not log when cloning PluginFactory
 
 package org.parosproxy.paros.core.scanner;
 
@@ -476,7 +477,28 @@ public class PluginFactory {
     public boolean addPlugin(String name) {
         try {
         	Class<?> c = ExtensionFactory.getAddOnLoader().loadClass(name);
-        	return this.addPlugin((AbstractPlugin) c.newInstance());
+        	Plugin plugin = (AbstractPlugin) c.newInstance();
+
+            boolean duplicatedId = mapAllPlugin.get(Integer.valueOf(plugin.getId())) != null;
+            if (this.addPlugin(plugin)) {
+                log.info("loaded plugin " + plugin.getName());
+                if (duplicatedId) {
+                    log.error("Duplicate id " + plugin.getName() + " "
+                            + mapAllPlugin.get(Integer.valueOf(plugin.getId())).getName());
+                }
+                return true;
+            }
+
+            if (!plugin.isVisible()) {
+                log.info("Plugin " + plugin.getName() + " not visible");
+                return false;
+            }
+
+            if (plugin.isDepreciated()) {
+                log.info("Plugin " + plugin.getName() + " deprecated");
+                return false;
+            }
+            return false;
         } catch (Exception e) {
             log.error(e.getMessage(), e);
             return false;
@@ -489,20 +511,11 @@ public class PluginFactory {
 
         plugin.createParamIfNotExist();
         if (!plugin.isVisible()) {
-            log.info("Plugin " + plugin.getName() + " not visible");
             return false;
         }
         
         if (plugin.isDepreciated()) {
-            // ZAP: ignore all depreciated plugins
-            log.info("Plugin " + plugin.getName() + " depricated");
             return false;
-        }
-        
-        log.info("loaded plugin " + plugin.getName());
-        if (mapAllPlugin.get(Integer.valueOf(plugin.getId())) != null) {
-            log.error("Duplicate id " + plugin.getName() + " "
-                    + mapAllPlugin.get(Integer.valueOf(plugin.getId())).getName());
         }
         
         mapAllPlugin.put(Integer.valueOf(plugin.getId()), plugin);


### PR DESCRIPTION
Change method PluginFactory.addPlugin(Plugin) to not do any logging, by
moving the logging to a more appropriate method, addPlugin(String).
The former method is also called when cloning the PluginFactory, which
does not require logging that information once again.

Related to #2632 - Reduce log level in PluginFactory