### PR TITLE
Improve scroll (speed) in Sites tab

### DIFF
--- a/src/org/parosproxy/paros/view/SiteMapPanel.java
+++ b/src/org/parosproxy/paros/view/SiteMapPanel.java
@@ -37,6 +37,7 @@
 // ZAP: 2015/02/10 Issue 1528: Support user defined font size
 // ZAP: 2015/06/01 Issue 1653: Support context menu key for trees
 // ZAP: 2016/04/14 Use View to display the HTTP messages
+// ZAP: 2016/07/01 Issue 2642: Slow mouse wheel scrolling in site tree
 
 package org.parosproxy.paros.view;
 
@@ -57,9 +58,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
-import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
-import javax.swing.JScrollPane;
 import javax.swing.JToggleButton;
 import javax.swing.JTree;
 import javax.swing.KeyStroke;
@@ -87,6 +86,7 @@ import org.zaproxy.zap.model.Target;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.ContextCreateDialog;
 import org.zaproxy.zap.view.ContextGeneralPanel;
+import org.zaproxy.zap.view.ContextsSitesPanel;
 import org.zaproxy.zap.view.ContextsTreeCellRenderer;
 import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.SiteMapListener;
@@ -106,7 +106,6 @@ public class SiteMapPanel extends AbstractPanel {
 	// ZAP: Added logger
     private static Logger log = Logger.getLogger(SiteMapPanel.class);
 
-	private JScrollPane jScrollPane = null;
 	private JTree treeSite = null;
 	private JTree treeContext = null;
 	private DefaultTreeModel contextTree = null;
@@ -155,7 +154,7 @@ public class SiteMapPanel extends AbstractPanel {
 		
 		this.setLayout(new GridBagLayout());
 		this.add(this.getPanelToolbar(), LayoutHelper.getGBC(0, 0, 1, 0, new Insets(2,2,2,2)));
-		this.add(getJScrollPane(), 
+		this.add(new ContextsSitesPanel(getTreeContext(), getTreeSite(), "sitesPanelScrollPane"), 
 				LayoutHelper.getGBC(0, 1, 1, 1.0, 1.0, GridBagConstraints.BOTH, new Insets(2,2,2,2)));
 
         expandRoot();
@@ -316,28 +315,6 @@ public class SiteMapPanel extends AbstractPanel {
 		return scopeButton;
 	}
 
-	
-	/**
-	 * This method initializes jScrollPane	
-	 * 	
-	 * @return javax.swing.JScrollPane	
-	 */    
-	private JScrollPane getJScrollPane() {
-		if (jScrollPane == null) {
-			jScrollPane = new JScrollPane();
-			jScrollPane.setPreferredSize(new java.awt.Dimension(200,400));
-			jScrollPane.setName("sitesPanelScrollPane");
-			
-			JPanel panel = new JPanel();
-			panel.setLayout(new GridBagLayout());
-			panel.add(this.getTreeContext(), LayoutHelper.getGBC(0, 0, 1, 1.0D, 0.0D));
-			panel.add(this.getTreeSite(), LayoutHelper.getGBC(0, 1, 1, 1.0D, 1.0D));
-			jScrollPane.setViewportView(panel);
-
-		}
-		return jScrollPane;
-	}
-	
 	/**
 	 * This method initializes treeSite	
 	 * 	

--- a/src/org/zaproxy/zap/view/ContextsSitesPanel.java
+++ b/src/org/zaproxy/zap/view/ContextsSitesPanel.java
@@ -1,0 +1,135 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.view;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Rectangle;
+
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTree;
+import javax.swing.Scrollable;
+import javax.swing.SwingUtilities;
+
+/**
+ * A {@code JPanel} containing two {@code JTree} shown one above the other, used to display the contexts and sites trees in the
+ * same panel.
+ *
+ * @since TODO add version
+ */
+public class ContextsSitesPanel extends JPanel {
+
+    private static final long serialVersionUID = -3325400144404304335L;
+
+    /**
+     * Constructs a {@code ContextsSitesPanel} with the given contexts and sites trees.
+     *
+     * @param contextsTree the contexts tree
+     * @param sitesTree the sites tree
+     * @throws IllegalArgumentException if any of the given parameters is {@code null}.
+     */
+    public ContextsSitesPanel(JTree contextsTree, JTree sitesTree) {
+        this(contextsTree, sitesTree, null);
+    }
+
+    /**
+     * Constructs a {@code ContextsSitesPanel} with the given contexts and sites trees and with the given name for the
+     * {@code JScrollPane}.
+     *
+     * @param contextsTree the contexts tree
+     * @param sitesTree the sites tree
+     * @param scrollPaneName the name of the {@code JScrollPane}, might be {@code null}
+     * @throws IllegalArgumentException if any of the trees is {@code null}.
+     */
+    public ContextsSitesPanel(JTree contextsTree, JTree sitesTree, String scrollPaneName) {
+        super(new BorderLayout());
+        validateNonNull(contextsTree, "contextsTree");
+        validateNonNull(sitesTree, "sitesTree");
+
+        JScrollPane scrollPane = new JScrollPane();
+        if (scrollPaneName != null) {
+            scrollPane.setName(scrollPaneName);
+        }
+
+        JPanel panel = new ScrollableTreesPanel(contextsTree, sitesTree);
+        scrollPane.setViewportView(panel);
+
+        add(scrollPane);
+    }
+
+    private static void validateNonNull(Object parameter, String parameterName) {
+        if (parameter == null) {
+            throw new IllegalArgumentException("The " + parameterName + " must not be null.");
+        }
+    }
+
+    private static class ScrollableTreesPanel extends JPanel implements Scrollable {
+
+        private static final long serialVersionUID = 2709986817434976954L;
+
+        private final JTree contextsTree;
+        private final JTree sitesTree;
+
+        public ScrollableTreesPanel(JTree contextsTree, JTree sitesTree) {
+            super(new BorderLayout());
+
+            this.contextsTree = contextsTree;
+            add(contextsTree, BorderLayout.NORTH);
+
+            this.sitesTree = sitesTree;
+            add(sitesTree, BorderLayout.CENTER);
+        }
+
+        @Override
+        public Dimension getPreferredScrollableViewportSize() {
+            Dimension dNT = contextsTree.getPreferredScrollableViewportSize();
+            Dimension dCT = sitesTree.getPreferredScrollableViewportSize();
+            dCT.setSize(Math.max(dNT.getWidth(), dCT.getWidth()), dNT.getHeight() + dCT.getHeight());
+            return dCT;
+        }
+
+        @Override
+        public int getScrollableUnitIncrement(Rectangle visibleRect, int orientation, int direction) {
+            if (visibleRect.getY() < sitesTree.getBounds().getY()) {
+                return contextsTree.getScrollableUnitIncrement(visibleRect, orientation, direction);
+            }
+            return sitesTree.getScrollableUnitIncrement(visibleRect, orientation, direction);
+        }
+
+        @Override
+        public int getScrollableBlockIncrement(Rectangle visibleRect, int orientation, int direction) {
+            // Same behaviour for both trees.
+            return sitesTree.getScrollableBlockIncrement(visibleRect, orientation, direction);
+        }
+
+        @Override
+        public boolean getScrollableTracksViewportWidth() {
+            int width = Math.max(sitesTree.getPreferredSize().width, contextsTree.getPreferredSize().width);
+            return SwingUtilities.getUnwrappedParent(this).getWidth() > width;
+        }
+
+        @Override
+        public boolean getScrollableTracksViewportHeight() {
+            return SwingUtilities.getUnwrappedParent(this)
+                    .getHeight() > (sitesTree.getPreferredSize().height + contextsTree.getPreferredSize().height);
+        }
+    }
+}

--- a/src/org/zaproxy/zap/view/NodeSelectDialog.java
+++ b/src/org/zaproxy/zap/view/NodeSelectDialog.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
 import javax.swing.JTree;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreeNode;
@@ -62,8 +61,6 @@ public class NodeSelectDialog extends AbstractDialog {
 	
 	private DefaultTreeModel contextTree = null;
 	private DefaultTreeModel siteTree = null;
-	
-	private JScrollPane jScrollPane = null;
 	
 	private SiteNode selectedSiteNode = null;
 	private Target selectedTarget = null;
@@ -254,7 +251,7 @@ public class NodeSelectDialog extends AbstractDialog {
 			gridBagConstraints15.ipadx = 0;
 			gridBagConstraints15.ipady = 10;
 
-			jPanel.add(getJScrollPane(), gridBagConstraints15);
+			jPanel.add(new ContextsSitesPanel(getTreeContext(), getTreeSite()), gridBagConstraints15);
 			jPanel.add(jLabel2, gridBagConstraints13);
 			jPanel.add(getCancelButton(), gridBagConstraints2);
 			jPanel.add(getSelectButton(), gridBagConstraints3);
@@ -419,25 +416,6 @@ public class NodeSelectDialog extends AbstractDialog {
 
 		}
 		return cancelButton;
-	}
-	
-	/**
-	 * This method initializes jScrollPane	
-	 * 	
-	 * @return javax.swing.JScrollPane	
-	 */    
-	private JScrollPane getJScrollPane() {
-		if (jScrollPane == null) {
-			jScrollPane = new JScrollPane();
-			jScrollPane.setHorizontalScrollBarPolicy(javax.swing.JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
-			jScrollPane.setVerticalScrollBarPolicy(javax.swing.JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
-			JPanel panel = new JPanel();
-			panel.setLayout(new GridBagLayout());
-			panel.add(this.getTreeContext(), LayoutHelper.getGBC(0, 0, 1, 1.0D, 0.0D));
-			panel.add(this.getTreeSite(), LayoutHelper.getGBC(0, 1, 1, 1.0D, 1.0D));
-			jScrollPane.setViewportView(panel);
-		}
-		return jScrollPane;
 	}
 
 	public boolean isAllowRoot() {


### PR DESCRIPTION
Change SiteMapPanel to use a panel that implements Scrollable allowing
to improve the scroll (speed) in the two trees show one above the other
(contexts and sites, respectively). The panel that was being added
didn't implement Scrollable leading to slow (the default) speed when
scrolling. The new panel, ContextsSitesPanel, delegates the scrolling to
the trees behaving/scrolling as if it was a single tree.
Change NodeSelectDialog to also use the new class, it also shows the
contexts and sites tree one above the other in a scroll pane.

Fix #2642 - Slow mouse wheel scrolling in site tree