### PR TITLE
Remove unused scanner messages

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1660,13 +1660,10 @@ scanner.category.inject  = Injection
 scanner.category.misc    = Miscellaneous
 scanner.category.server  = Server Security
 scanner.category.undef   = Undefined
-scanner.completed.label  = Scanning completed in {0}s.
 scanner.delete.popup     = Delete
 scanner.delete.confirm   = Are you sure you want to delete the alert(s)?
 scanner.edit.popup       = Edit...
-scanner.resend.popup     = Resend...
 scanner.save.warning     = Error saving policy.
-scanner.select.warning   = Please select a site/folder/URL in Sites panel.
 
 script.api.view.listEngines = Lists the script engines available
 script.api.view.listScripts = Lists the scripts available, with its engine, name, description, type and error state.


### PR DESCRIPTION
The following scanner messages are no longer in use:
 - scanner.completed.label;
 - scanner.resend.popup;
 - scanner.select.warning.

(The messages are not used by core code nor current add-ons.)