### PR TITLE
Minor tidy up of ZAP API client generators

### DIFF
--- a/src/org/zaproxy/zap/extension/api/AbstractAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/AbstractAPIGenerator.java
@@ -1,0 +1,127 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.api;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.parosproxy.paros.Constant;
+
+/**
+ * The base class for ZAP API client generators.
+ */
+abstract class AbstractAPIGenerator {
+
+    protected static final String OPTIONAL_MESSAGE = "This component is optional and therefore the API will only work if it is installed";
+
+    protected static final String VIEW_ENDPOINT = "view";
+    protected static final String ACTION_ENDPOINT = "action";
+    protected static final String OTHER_ENDPOINT = "other";
+
+    private final Path directory;
+    private final boolean optional;
+
+    private final ResourceBundle messages;
+
+    /**
+     * Constructs an {@code AbstractAPIGenerator} with the given directory.
+     *
+     * @param directory the directory where the API client files should be generated
+     */
+    protected AbstractAPIGenerator(String directory) {
+        this(directory, false);
+    }
+
+    /**
+     * Constructs an {@code AbstractAPIGenerator} with the given directory and optional state.
+     *
+     * @param directory the directory where the API client files should be generated
+     * @param optional {@code true} if the API client files are optional, {@code false} otherwise
+     */
+    protected AbstractAPIGenerator(String directory, boolean optional) {
+        this.directory = Paths.get(directory);
+        this.optional = optional;
+
+        messages = ResourceBundle.getBundle(
+                "lang." + Constant.MESSAGES_PREFIX,
+                Locale.ENGLISH,
+                ResourceBundle.Control.getControl(ResourceBundle.Control.FORMAT_PROPERTIES));
+    }
+
+    /**
+     * Gets the directory where the API client files should be generated.
+     *
+     * @return the directory where the API client files should be generated
+     */
+    protected Path getDirectory() {
+        return directory;
+    }
+
+    /**
+     * If the API client files being generated are optional, that is, belong to an add-on.
+     *
+     * @return {@code true} if the API client files are optional, {@code false} otherwise
+     */
+    protected boolean isOptional() {
+        return optional;
+    }
+
+    /**
+     * Gets the messages for doc of the generated classes.
+     *
+     * @return the {@code ResourceBundle} with the messages for doc
+     */
+    protected ResourceBundle getMessages() {
+        return messages;
+    }
+
+    /**
+     * Generates the API client files for the core API implementors.
+     *
+     * @throws IOException if an error occurred while writing the API files
+     */
+    public void generateCoreAPIFiles() throws IOException {
+        generateAPIFiles(ApiGeneratorUtils.getAllImplementors());
+    }
+
+    /**
+     * Generates the API client files of the given API implementors.
+     *
+     * @param implementors the API implementors, must not be {@code null}
+     * @throws IOException if an error occurred while writing the API files
+     */
+    public void generateAPIFiles(List<ApiImplementor> implementors) throws IOException {
+        for (ApiImplementor implementor : implementors) {
+            this.generateAPIFiles(implementor);
+        }
+    }
+
+    /**
+     * Generates the API client files of the given API implementor.
+     *
+     * @param implementor the API implementor, must not be {@code null}
+     * @throws IOException if an error occurred while writing the API files
+     */
+    protected abstract void generateAPIFiles(ApiImplementor implementor) throws IOException;
+}

--- a/src/org/zaproxy/zap/extension/api/GoAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/GoAPIGenerator.java
@@ -1,29 +1,22 @@
 package org.zaproxy.zap.extension.api;
 
-import java.io.File;
-import java.io.FileWriter;
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.ResourceBundle;
 
 import org.apache.commons.lang.StringUtils;
-import org.parosproxy.paros.Constant;
 
-public class GoAPIGenerator {
+public class GoAPIGenerator extends AbstractAPIGenerator {
 
-	private File dir;
-	private boolean optional = false;
 	private boolean addImports = false;
 
 	private final String HEADER = "// Zed Attack Proxy (ZAP) and its related class files.\n" + "//\n"
@@ -39,11 +32,6 @@ public class GoAPIGenerator {
 			+ "// See the License for the specific language governing permissions and\n"
 			+ "// limitations under the License.\n";
 
-	private final String OPTIONAL_MASSAGE = "This component is optional and therefore the API will only work if it is installed";
-
-	private ResourceBundle msgs = ResourceBundle.getBundle("lang." + Constant.MESSAGES_PREFIX, Locale.ENGLISH,
-			ResourceBundle.Control.getControl(ResourceBundle.Control.FORMAT_PROPERTIES));
-
 	/**
 	 * Map any names which are reserved in Go to something legal
 	 */
@@ -56,55 +44,47 @@ public class GoAPIGenerator {
 	}
 
 	public GoAPIGenerator() {
-		dir = new File("../zap-api-go/zap/");
+		super("../zap-api-go/zap/");
 	}
 
 	public GoAPIGenerator(String path, boolean optional) {
-		dir = new File(path);
-		this.optional = optional;
+		super(path, optional);
 	}
 
-	public void generateGoFiles(List<ApiImplementor> implementors) throws IOException {
-		for (ApiImplementor imp : implementors) {
-			this.generateGoComponent(imp);
-		}
-	}
-
-	private void generateGoComponent(ApiImplementor imp) throws IOException {
+	@Override
+	protected void generateAPIFiles(ApiImplementor imp) throws IOException {
 		String className = imp.getPrefix().substring(0, 1).toUpperCase() + imp.getPrefix().substring(1);
 		String pkgName = safeName(camelCaseToLowerCaseDash(className));
 
-		File f = new File(dir, pkgName + ".go");
-		System.out.println("Generating " + f.getAbsolutePath());
-		FileWriter out = new FileWriter(f);
+		Path file = getDirectory().resolve(pkgName + ".go");
+		System.out.println("Generating " + file.toAbsolutePath());
+		try (BufferedWriter out = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
+			out.write(HEADER);
+			out.write("//\n");
+			out.write("// *** This file was automatically generated. ***\n");
+			out.write("//\n\n");
+			out.write("package zap\n\n");
+			out.write("_imports_");
+			out.write("type " + className + " struct {}" + "\n\n");
 
-		out.write(HEADER);
-		out.write("//\n");
-		out.write("// *** This file was automatically generated. ***\n");
-		out.write("//\n\n");
-		out.write("package zap\n\n");
-		out.write("_imports_");
-		out.write("type " + className + " struct {}" + "\n\n");
-
-		for (ApiElement view : imp.getApiViews()) {
-			this.generateGoElement(view, className, imp.getPrefix(), "view", out);
+			for (ApiElement view : imp.getApiViews()) {
+				this.generateGoElement(view, className, imp.getPrefix(), VIEW_ENDPOINT, out);
+			}
+			for (ApiElement action : imp.getApiActions()) {
+				this.generateGoElement(action, className, imp.getPrefix(), ACTION_ENDPOINT, out);
+			}
+			for (ApiElement other : imp.getApiOthers()) {
+				this.generateGoElement(other, className, imp.getPrefix(), OTHER_ENDPOINT, out);
+			}
 		}
-		for (ApiElement action : imp.getApiActions()) {
-			this.generateGoElement(action, className, imp.getPrefix(), "action", out);
-		}
-		for (ApiElement other : imp.getApiOthers()) {
-			this.generateGoElement(other, className, imp.getPrefix(), "other", out);
-		}
-
-		out.close();
-		addImports(f, addImports);
+		addImports(file, addImports);
 		addImports = false;
 	}
 
 	private void generateGoElement(ApiElement element, String className, String component, String type, Writer out)
 			throws IOException {
 
-		boolean typeOther = type.equals("other");
+		boolean typeOther = type.equals(OTHER_ENDPOINT);
 		boolean hasParams = (element.getMandatoryParamNames() != null && element.getMandatoryParamNames().size() > 0)
 				|| (element.getOptionalParamNames() != null && element.getOptionalParamNames().size() > 0);
 
@@ -115,17 +95,17 @@ public class GoAPIGenerator {
 			descTag = component + ".api." + type + "." + element.getName();
 		}
 		try {
-			String desc = msgs.getString(descTag);
+			String desc = getMessages().getString(descTag);
 			out.write("// " + desc + "\n");
-			if (optional) {
+			if (isOptional()) {
 				out.write("//\n");
-				out.write("// " + OPTIONAL_MASSAGE + "\n");
+				out.write("// " + OPTIONAL_MESSAGE + "\n");
 			}
 		} catch (Exception e) {
 			// Might not be set, so just print out the ones that are missing
 			System.out.println("No i18n for: " + descTag);
-			if (optional) {
-				out.write("// " + OPTIONAL_MASSAGE + "\n");
+			if (isOptional()) {
+				out.write("// " + OPTIONAL_MESSAGE + "\n");
 			}
 		}
 
@@ -273,22 +253,21 @@ public class GoAPIGenerator {
 
 	// It replaces the placeholder _imports_ with the proper import packages,
 	// or removes it in case there isn't any packages to import
-	private static void addImports(File file, boolean addImports) throws IOException {
-		Path path = Paths.get(file.getPath());
+	private static void addImports(Path file, boolean addImports) throws IOException {
 		Charset charset = StandardCharsets.UTF_8;
-		String content = new String(Files.readAllBytes(path), charset);
+		String content = new String(Files.readAllBytes(file), charset);
 		if (addImports) {
 			content = content.replaceAll("_imports_", "import \"strconv\"\n\n");
 		} else {
 			content = content.replaceAll("_imports_", "");
 		}
-		Files.write(path, content.getBytes(charset));
+		Files.write(file, content.getBytes(charset));
 	}
 
 	public static void main(String[] args) throws Exception {
 		// Command for generating a java version of the ZAP API
 		GoAPIGenerator gapi = new GoAPIGenerator();
-		gapi.generateGoFiles(ApiGeneratorUtils.getAllImplementors());
+		gapi.generateCoreAPIFiles();
 	}
 
 }

--- a/src/org/zaproxy/zap/extension/api/JavaAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/JavaAPIGenerator.java
@@ -17,22 +17,18 @@
  */
 package org.zaproxy.zap.extension.api;
 
-import java.io.File;
-import java.io.FileWriter;
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.ResourceBundle;
 
-import org.parosproxy.paros.Constant;
-
-public class JavaAPIGenerator {
+public class JavaAPIGenerator extends AbstractAPIGenerator {
 
 	/**
 	 * The path of the package where the generated classes are deployed.
@@ -44,10 +40,7 @@ public class JavaAPIGenerator {
 	 */
 	private static final String DEFAULT_OUTPUT_DIR = "../zap-api-java/subprojects/zap-clientapi/src/main/java/" + TARGET_PACKAGE;
 
-	private File dir; 
-	private boolean optional = false;
-	
-	private final String HEADER = 
+	private static final String HEADER = 
 			"/* Zed Attack Proxy (ZAP) and its related class files.\n" +
 			" *\n" +
 			" * ZAP is an HTTP/HTTPS proxy for assessing web application security.\n" +
@@ -68,11 +61,6 @@ public class JavaAPIGenerator {
 			" */\n" +
 			"\n\n";
 
-	private final String OPTIONAL_MASSAGE = "This component is optional and therefore the API will only work if it is installed"; 
-
-	private ResourceBundle msgs = ResourceBundle.getBundle("lang." + Constant.MESSAGES_PREFIX, Locale.ENGLISH,
-		ResourceBundle.Control.getControl(ResourceBundle.Control.FORMAT_PROPERTIES));
-
 	/**
 	 * Map any names which are reserved in java to something legal
 	 */
@@ -84,20 +72,13 @@ public class JavaAPIGenerator {
     }
     
     public JavaAPIGenerator() {
-    	dir = new File(DEFAULT_OUTPUT_DIR); 
+    	super(DEFAULT_OUTPUT_DIR);
     }
 
     public JavaAPIGenerator(String path, boolean optional) {
-    	dir = new File(path); 
-    	this.optional = optional;
+    	super(path, optional);
     }
 
-	public void generateJavaFiles(List<ApiImplementor> implementors) throws IOException {
-		for (ApiImplementor imp : implementors) {
-			this.generateJavaComponent(imp);
-		}
-	}
-	
 	private void generateJavaElement(ApiElement element, String component, 
 			String type, Writer out) throws IOException {
 		boolean hasParams = false;
@@ -109,29 +90,29 @@ public class JavaAPIGenerator {
 			descTag = component + ".api." + type + "." + element.getName();
 		}
 		try {
-			String desc = msgs.getString(descTag);
+			String desc = getMessages().getString(descTag);
 			out.write("\t/**\n");
 			out.write("\t * " + desc + "\n");
-			if (optional) {
-				out.write("\t * " + OPTIONAL_MASSAGE + "\n");
+			if (isOptional()) {
+				out.write("\t * " + OPTIONAL_MESSAGE + "\n");
 			}
 			out.write("\t */\n");
 		} catch (Exception e) {
 			// Might not be set, so just print out the ones that are missing
 			System.out.println("No i18n for: " + descTag);
-			if (optional) {
+			if (isOptional()) {
 				out.write("\t/**\n");
-				out.write("\t * " + OPTIONAL_MASSAGE + "\n");
+				out.write("\t * " + OPTIONAL_MESSAGE + "\n");
 				out.write("\t */\n");
 			}
 		}
 
-		if (type.equals("other")) {
+		if (type.equals(OTHER_ENDPOINT)) {
 			out.write("\tpublic byte[] " + createMethodName(element.getName()) + "(");
 		} else {
 			out.write("\tpublic ApiResponse " + createMethodName(element.getName()) + "(");
 		}
-		if (type.equals("action") || type.equals("other")) {
+		if (type.equals(ACTION_ENDPOINT) || type.equals(OTHER_ENDPOINT)) {
 			// Always add the API key - we've no way of knowing if it will be required or not
 			hasParams = true;
 			out.write("String ");
@@ -175,12 +156,10 @@ public class JavaAPIGenerator {
 		out.write(") throws ClientApiException {\n");
 
 
-		out.write("\t\tMap<String, String> map = null;\n"); 
-		
 		if (hasParams) {
-			out.write("\t\tmap = new HashMap<String, String>();\n"); 
+			out.write("\t\tMap<String, String> map = new HashMap<>();\n"); 
 			
-			if (type.equals("action") || type.equals("other")) {
+			if (type.equals(ACTION_ENDPOINT) || type.equals(OTHER_ENDPOINT)) {
 				// Always add the API key (if not null) - we've no way of knowing if it will be required or not
 				out.write("\t\tif (apikey != null) {\n");
 				out.write("\t\t\tmap.put(\"apikey\", apikey);\n");
@@ -218,12 +197,16 @@ public class JavaAPIGenerator {
 			}
 		}
 		
-		if (type.equals("other")) {
-			out.write("\t\treturn api.callApiOther(\"" + 
-					component + "\", \"" + type + "\", \"" + element.getName() + "\", map);\n"); 
+		out.write("\t\treturn api.callApi");
+		if (type.equals(OTHER_ENDPOINT)) {
+			out.write("Other"); 
+		}
+		out.write("(\"" + component + "\", \"" + type + "\", \"" + element.getName() + "\"");
+
+		if (hasParams) {
+			out.write(", map);\n");
 		} else {
-			out.write("\t\treturn api.callApi(\"" + 
-					component + "\", \"" + type + "\", \"" + element.getName() + "\", map);\n"); 
+			out.write(", null);\n");
 		}
 		
 		out.write("\t}\n\n");
@@ -241,44 +224,45 @@ public class JavaAPIGenerator {
 		return string.replaceAll("\\.", "");
 	}
 
-	private void generateJavaComponent(ApiImplementor imp) throws IOException {
+	@Override
+	protected void generateAPIFiles(ApiImplementor imp) throws IOException {
 		String className = imp.getPrefix().substring(0, 1).toUpperCase() + imp.getPrefix().substring(1);
 	
-		File f = new File(this.dir, className + ".java");
-		System.out.println("Generating " + f.getAbsolutePath());
-		FileWriter out = new FileWriter(f);
-		out.write(HEADER);
-		out.write("package org.zaproxy.clientapi.gen;\n\n");
-		
-		out.write("import java.util.HashMap;\n");
-		out.write("import java.util.Map;\n");
-		out.write("import org.zaproxy.clientapi.core.ApiResponse;\n");
-		out.write("import org.zaproxy.clientapi.core.ClientApi;\n");
-		out.write("import org.zaproxy.clientapi.core.ClientApiException;\n");
-		out.write("\n");
-		
-		out.write("\n");
-		out.write("/**\n");
-		out.write(" * This file was automatically generated.\n");
-		out.write(" */\n");
-		out.write("public class " + className + " {\n\n");
-		
-		out.write("\tprivate ClientApi api = null;\n\n");
-		out.write("\tpublic " + className + "(ClientApi api) {\n");
-		out.write("\t\tthis.api = api;\n");
-		out.write("\t}\n\n");
-
-		for (ApiElement view : imp.getApiViews()) {
-			this.generateJavaElement(view, imp.getPrefix(), "view", out);
+		Path file = getDirectory().resolve(className + ".java");
+		System.out.println("Generating " + file.toAbsolutePath());
+		try (BufferedWriter out = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
+			out.write(HEADER);
+			out.write("package org.zaproxy.clientapi.gen;\n\n");
+			
+			out.write("import java.util.HashMap;\n");
+			out.write("import java.util.Map;\n");
+			out.write("import org.zaproxy.clientapi.core.ApiResponse;\n");
+			out.write("import org.zaproxy.clientapi.core.ClientApi;\n");
+			out.write("import org.zaproxy.clientapi.core.ClientApiException;\n");
+			out.write("\n");
+			
+			out.write("\n");
+			out.write("/**\n");
+			out.write(" * This file was automatically generated.\n");
+			out.write(" */\n");
+			out.write("public class " + className + " {\n\n");
+			
+			out.write("\tprivate final ClientApi api;\n\n");
+			out.write("\tpublic " + className + "(ClientApi api) {\n");
+			out.write("\t\tthis.api = api;\n");
+			out.write("\t}\n\n");
+	
+			for (ApiElement view : imp.getApiViews()) {
+				this.generateJavaElement(view, imp.getPrefix(), VIEW_ENDPOINT, out);
+			}
+			for (ApiElement action : imp.getApiActions()) {
+				this.generateJavaElement(action, imp.getPrefix(), ACTION_ENDPOINT, out);
+			}
+			for (ApiElement other : imp.getApiOthers()) {
+				this.generateJavaElement(other, imp.getPrefix(), OTHER_ENDPOINT, out);
+			}
+			out.write("}\n");
 		}
-		for (ApiElement action : imp.getApiActions()) {
-			this.generateJavaElement(action, imp.getPrefix(), "action", out);
-		}
-		for (ApiElement other : imp.getApiOthers()) {
-			this.generateJavaElement(other, imp.getPrefix(), "other", out);
-		}
-		out.write("}\n");
-		out.close();
 	}
 
 	public static void main(String[] args) throws Exception {
@@ -290,7 +274,7 @@ public class JavaAPIGenerator {
 		}
 
 		JavaAPIGenerator wapi = new JavaAPIGenerator();
-		wapi.generateJavaFiles(ApiGeneratorUtils.getAllImplementors());
+		wapi.generateCoreAPIFiles();
 		
 	}
 

--- a/src/org/zaproxy/zap/extension/api/PhpAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/PhpAPIGenerator.java
@@ -17,22 +17,17 @@
  */
 package org.zaproxy.zap.extension.api;
 
-import java.io.File;
-import java.io.FileWriter;
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.ResourceBundle;
 
-import org.parosproxy.paros.Constant;
-
-public class PhpAPIGenerator {
-	private File dir;
-	private boolean optional = false;
+public class PhpAPIGenerator extends AbstractAPIGenerator {
 
 	private final String HEADER =
 			"<?php\n" +
@@ -57,11 +52,6 @@ public class PhpAPIGenerator {
 			" */\n" +
 			"\n\n";
 
-	private final String OPTIONAL_MASSAGE = "This component is optional and therefore the API will only work if it is installed"; 
-
-	private ResourceBundle msgs = ResourceBundle.getBundle("lang." + Constant.MESSAGES_PREFIX, Locale.ENGLISH,
-		ResourceBundle.Control.getControl(ResourceBundle.Control.FORMAT_PROPERTIES));
-
 	/**
 	 * Map any names which are reserved in java to something legal
 	 */
@@ -74,19 +64,12 @@ public class PhpAPIGenerator {
     }
 
     public PhpAPIGenerator() {
-    	dir = new File("php/api/zapv2/src/Zap"); 
+    	super("php/api/zapv2/src/Zap");
     }
 
     public PhpAPIGenerator(String path, boolean optional) {
-    	dir = new File(path); 
-    	this.optional = optional;
+    	super(path, optional);
     }
-
-	public void generatePhpFiles(List<ApiImplementor> implementors) throws IOException {
-		for (ApiImplementor imp : implementors) {
-			this.generatePhpComponent(imp);
-		}
-	}
 
 	private void generatePhpElement(ApiElement element, String component, 
 			String type, Writer out) throws IOException {
@@ -104,19 +87,19 @@ public class PhpAPIGenerator {
 		}
 
 		try {
-			String desc = msgs.getString(descTag);
+			String desc = getMessages().getString(descTag);
 			out.write("\t/**\n");
 			out.write("\t * " + desc + "\n");
-			if (optional) {
-				out.write("\t * " + OPTIONAL_MASSAGE + "\n");
+			if (isOptional()) {
+				out.write("\t * " + OPTIONAL_MESSAGE + "\n");
 			}
 			out.write("\t */\n");
 		} catch (Exception e) {
 			// Might not be set, so just print out the ones that are missing
 			System.out.println("No i18n for: " + descTag);
-			if (optional) {
+			if (isOptional()) {
 				out.write("\t/**\n");
-				out.write("\t * " + OPTIONAL_MASSAGE + "\n");
+				out.write("\t * " + OPTIONAL_MESSAGE + "\n");
 				out.write("\t */\n");
 			}
 		}
@@ -144,7 +127,7 @@ public class PhpAPIGenerator {
 			out.write(paramOpt);
 		}
 
-		if (type.equals("action") || type.equals("other")) {
+		if (type.equals(ACTION_ENDPOINT) || type.equals(OTHER_ENDPOINT)) {
 		    if (hasParams) {
 		        out.write(", ");
 		    }
@@ -169,7 +152,7 @@ public class PhpAPIGenerator {
 					reqParams.append("'" + param + "' => $" + param.toLowerCase());
 				}
 			}
-			if (type.equals("action") || type.equals("other")) {
+			if (type.equals(ACTION_ENDPOINT) || type.equals(OTHER_ENDPOINT)) {
 				// Always add the API key - we've no way of knowing if it will be required or not
 				if (!first) {
 					reqParams.append(", ");
@@ -194,7 +177,7 @@ public class PhpAPIGenerator {
 
 		String method = "request";
 		String baseUrl = "base";
-		if (type.equals("other")) {
+		if (type.equals(OTHER_ENDPOINT)) {
 			method += "other";
 			baseUrl += "_other";
 		}
@@ -206,12 +189,12 @@ public class PhpAPIGenerator {
 			out.write(", ");
 			out.write(reqParams.toString());
 			out.write(")");
-			if (type.equals("view")) {
+			if (type.equals(VIEW_ENDPOINT)) {
 				out.write("->{'" + element.getName() + "'};\n");
 			} else {
 			    out.write(";\n");
 			}
-		} else if (!type.equals("other")) {
+		} else if (!type.equals(OTHER_ENDPOINT)) {
 			if (element.getName().startsWith("option")) {
 				out.write(")->{'" + element.getName().substring(6) + "'};\n");
 			} else {
@@ -235,36 +218,37 @@ public class PhpAPIGenerator {
 		return string.replaceAll("\\.", "");
 	}
 
-	private void generatePhpComponent(ApiImplementor imp) throws IOException {
+	@Override
+	protected void generateAPIFiles(ApiImplementor imp) throws IOException {
 		String className = safeName(imp.getPrefix().substring(0, 1).toUpperCase() + imp.getPrefix().substring(1));
 
-		File f = new File(this.dir, className + ".php");
-		System.out.println("Generating " + f.getAbsolutePath());
-		FileWriter out = new FileWriter(f);
-		out.write(HEADER);
-		out.write("namespace Zap;\n\n");
+		Path file = getDirectory().resolve(className + ".php");
+		System.out.println("Generating " + file.toAbsolutePath());
+		try (BufferedWriter out = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
+			out.write(HEADER);
+			out.write("namespace Zap;\n\n");
 
-		out.write("\n");
-		out.write("/**\n");
-		out.write(" * This file was automatically generated.\n");
-		out.write(" */\n");
-		out.write("class " + className + " {\n\n");
+			out.write("\n");
+			out.write("/**\n");
+			out.write(" * This file was automatically generated.\n");
+			out.write(" */\n");
+			out.write("class " + className + " {\n\n");
 
-		out.write("\tpublic function __construct ($zap) {\n");
-		out.write("\t\t$this->zap = $zap;\n");
-		out.write("\t}\n\n");
+			out.write("\tpublic function __construct ($zap) {\n");
+			out.write("\t\t$this->zap = $zap;\n");
+			out.write("\t}\n\n");
 
-		for (ApiElement view : imp.getApiViews()) {
-			this.generatePhpElement(view, imp.getPrefix(), "view", out);
+			for (ApiElement view : imp.getApiViews()) {
+				this.generatePhpElement(view, imp.getPrefix(), VIEW_ENDPOINT, out);
+			}
+			for (ApiElement action : imp.getApiActions()) {
+				this.generatePhpElement(action, imp.getPrefix(), ACTION_ENDPOINT, out);
+			}
+			for (ApiElement other : imp.getApiOthers()) {
+				this.generatePhpElement(other, imp.getPrefix(), OTHER_ENDPOINT, out);
+			}
+			out.write("}\n");
 		}
-		for (ApiElement action : imp.getApiActions()) {
-			this.generatePhpElement(action, imp.getPrefix(), "action", out);
-		}
-		for (ApiElement other : imp.getApiOthers()) {
-			this.generatePhpElement(other, imp.getPrefix(), "other", out);
-		}
-		out.write("}\n");
-		out.close();
 	}
 
 	private static String safeName (String name) {
@@ -276,7 +260,7 @@ public class PhpAPIGenerator {
 
 	public static void main(String[] args) throws Exception {
 		PhpAPIGenerator wapi = new PhpAPIGenerator();
-		wapi.generatePhpFiles(ApiGeneratorUtils.getAllImplementors());
+		wapi.generateCoreAPIFiles();
 	}
 
 }


### PR DESCRIPTION
Move some of the common code/behaviour to an abstract class and change
the API generators to extend/use that class (also, extract constants for
the API end points and the optional message).
Change API client generators to use try-with-resource statements when
handling/opening the files and to use Path instead of File and Files to
create the file.
For the JavaAPIGenerator also change to not create the map variable, for
the API parameters, if there's none and change to not create unnecessary
null initialisation for the map and the instance variable "api".