### PR TITLE
Persist the default context on new sessions

### DIFF
--- a/src/org/parosproxy/paros/model/Model.java
+++ b/src/org/parosproxy/paros/model/Model.java
@@ -39,6 +39,7 @@
 // ZAP: 2016/03/22 Allow to remove ContextDataFactory
 // ZAP: 2016/03/23 Issue 2331: Custom Context Panels not show in existing contexts after installation of add-on
 // ZAP: 2016/06/10 Do not clean up the database if the current session does not require it
+// ZAP: 2016/07/05 Issue 2218: Persisted Sessions don't save unconfigured Default Context
 
 package org.parosproxy.paros.model;
 
@@ -125,6 +126,8 @@ public class Model {
 	 */
 	public Session newSession() {
 		session = new Session(this);
+		// Always start with one context
+		session.saveContext(session.getNewContext(Constant.messages.getString("context.default.name")));
 		return session;
 	}
 

--- a/src/org/parosproxy/paros/model/Session.java
+++ b/src/org/parosproxy/paros/model/Session.java
@@ -60,6 +60,7 @@
 // ZAP: 2016/05/10 Use empty String for (URL) parameters with no value
 // ZAP: 2016/05/24 Call Database.discardSession(long) in Session.discard()
 // ZAP: 2016/06/10 Do not clean up the database if the current session does not require it
+// ZAP: 2016/07/05 Issue 2218: Persisted Sessions don't save unconfigured Default Context
 
 package org.parosproxy.paros.model;
 
@@ -159,8 +160,6 @@ public class Session {
 		this.model = model;
 		
 		discardContexts();
-		// Always start with one context
-	    getNewContext(Constant.messages.getString("context.default.name"));
 	    
 	    Stats.clearAll();
 


### PR DESCRIPTION
Move the creation/addition of the default context from the constructor
Session(Model) to the method Model.newSession() and change to persist
the context, in the method it's guaranteed that the initialisation of
the Session is complete (a database exists) and the context can be
persisted.

Fix #2218 - Persisted Sessions don't save unconfigured Default Context