### PR TITLE
Check all nodes when restructuring Sites tree

### DIFF
--- a/src/org/zaproxy/zap/model/Context.java
+++ b/src/org/zaproxy/zap/model/Context.java
@@ -551,8 +551,8 @@ public class Context {
 		// log.debug("checkNode " + sn.getHierarchicNodeName());		// Useful for debugging
 		int origChildren = sn.getChildCount();
 		int movedChildren = 0;
-		for (int i=origChildren; i > 0; i--) {
-			if (checkNode((SiteNode)sn.getChildAt(i-1))) {
+		for (SiteNode childNode : getChildren(sn)) {
+			if (checkNode(childNode)) {
 				movedChildren++;
 			}
 		}
@@ -592,6 +592,25 @@ public class Context {
 		}
 		return false;
 		
+	}
+
+	/**
+	 * Gets the child nodes of the given site node.
+	 *
+	 * @param siteNode the site node that will be used, must not be {@code null}
+	 * @return a {@code List} with the child nodes, never {@code null}
+	 */
+	private List<SiteNode> getChildren(SiteNode siteNode) {
+		int childCount = siteNode.getChildCount();
+		if (childCount == 0) {
+			return Collections.emptyList();
+		}
+
+		List<SiteNode> children = new ArrayList<>(childCount);
+		for (int i = 0; i < childCount; i++) {
+			children.add((SiteNode) siteNode.getChildAt(i));
+		}
+		return children;
 	}
 
 	private void moveNode (SiteMap sitesTree, SiteNode sn) {


### PR DESCRIPTION
Change the method Context.checkNode(SiteNode) to obtain all the child
nodes of the node being checked prior checking them, as the check might
shuffle them (by adding or removing some of nodes) causing some child
nodes to not being checked (its index would no longer be the expected).

Fix #2608 - Removing a DDN from a Context Does Not Appear to Trigger an
Update to the Sites Tab