### PR TITLE
Provide skip reason for Script Active Scan Rules

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -295,6 +295,7 @@ ascan.progress.table.status		= Status
 ascan.progress.title            = {0} Scan Progress
 ascan.scripts.activescanner.title	= Script Active Scan Rules
 ascan.scripts.interface.active.error = The provided Active Rules script ({0}) does not implement the required interface.\nPlease refer to the provided templates for examples.
+ascan.scripts.skip.reason = no scripts enabled
 ascan.scripts.type.active		= Active Rules
 ascan.scripts.type.active.desc	= Active Rules scripts run when you run the Active Scanner.\n\n\
 You must enable them before they will be used.

--- a/src/org/zaproxy/zap/extension/ascan/ScriptsActiveScanner.java
+++ b/src/org/zaproxy/zap/extension/ascan/ScriptsActiveScanner.java
@@ -91,7 +91,7 @@ public class ScriptsActiveScanner extends AbstractAppParamPlugin {
     @Override
     public void init() {
         if (shouldSkipScan()) {
-            getParent().pluginSkipped(this);
+            getParent().pluginSkipped(this, Constant.messages.getString("ascan.scripts.skip.reason"));
         }
     }
 


### PR DESCRIPTION
Change class ScriptsActiveScanner to provide the reason why the scanner
is skipped (simply, when there are no Script Rules enabled).

Related to issues:
 - #2221 - Skip "Script Active Scan Rules" scanner if there are no
 scripts enabled;
 - #2415 - Show the reason why an active scanner was skipped.