### PR TITLE
Log an error if a PluginPassiveScanner has no ID

### DIFF
--- a/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -250,6 +250,11 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
             }
             
             logger.info("loaded passive scan rule: " + scanner.getName());
+            if (scanner.getPluginId() == -1) {
+                logger.error(
+                        "The passive scan rule \"" + scanner.getName() + "\" [" + scanner.getClass().getCanonicalName()
+                                + "] does not have a defined ID.");
+            }
             
         } catch (Exception e) {
             logger.error("Failed to load passive scanner " + scanner.getName(), e);


### PR DESCRIPTION
Change ExtensionPassiveScan to log an error if the PluginPassiveScanner
being added does not have a defined ID, that is it has the value -1. The
ID is required to uniquely identify the scanners therefore it should be
used a specific one, always.