### PR TITLE
Use the ID to save configs of passive scanners

### DIFF
--- a/src/org/zaproxy/zap/extension/pscan/PassiveScanParam.java
+++ b/src/org/zaproxy/zap/extension/pscan/PassiveScanParam.java
@@ -34,7 +34,7 @@ public class PassiveScanParam extends AbstractParam {
     
     private static final Logger logger = Logger.getLogger(PassiveScanParam.class);
 
-    private static final String PASSIVE_SCANS_BASE_KEY = "pscans";
+    static final String PASSIVE_SCANS_BASE_KEY = "pscans";
     private static final String ALL_AUTO_TAG_SCANNERS_KEY = PASSIVE_SCANS_BASE_KEY + ".autoTagScanners.scanner";
 
     private static final String AUTO_TAG_SCANNER_NAME_KEY = "name";

--- a/src/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
+++ b/src/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
@@ -22,9 +22,11 @@ package org.zaproxy.zap.extension.pscan;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.model.HistoryReference;
 import org.zaproxy.zap.control.AddOn;
@@ -32,6 +34,32 @@ import org.zaproxy.zap.utils.Enableable;
 
 
 public abstract class PluginPassiveScanner extends Enableable implements PassiveScanner {
+
+	/**
+	 * The (base) configuration key used to saved the configurations of a passive scanner, ID, alert threshold and enabled
+	 * state.
+	 */
+	private static final String PSCANS_KEY = PassiveScanParam.PASSIVE_SCANS_BASE_KEY + ".pscanner";
+
+	/**
+	 * The configuration key used to save/load the ID of a passive scanner.
+	 */
+	private static final String ID_KEY = "id";
+
+	/**
+	 * The configuration key used to load the classname of a passive scanner, used only for backwards compatibility.
+	 */
+	private static final String CLASSNAME_KEY = "classname";
+
+	/**
+	 * The configuration key used to save/load the alert threshold of a passive scanner.
+	 */
+	private static final String LEVEL_KEY = "level";
+
+	/**
+	 * The configuration key used to save/load the enabled state of a passive scanner.
+	 */
+	private static final String ENABLED_KEY = "enabled";
 
 	private static final Integer[] DEFAULT_HISTORY_TYPES = new Integer[] {
 		HistoryReference.TYPE_PROXIED, HistoryReference.TYPE_ZAP_USER, 
@@ -45,29 +73,99 @@ public abstract class PluginPassiveScanner extends Enableable implements Passive
 	private Configuration config = null;
 	private AddOn.Status status = AddOn.Status.unknown;
 
+	/**
+	 * Sets the current configuration of the passive scanner.
+	 *
+	 * @param config the configuration of the scanner
+	 * @throws IllegalArgumentException if the given parameter is {@code null}.
+	 * @since 1.4.0
+	 * @see #getConfig()
+	 */
 	public void setConfig(Configuration config) {
+		if (config == null) {
+			throw new IllegalArgumentException("Parameter config must not be null.");
+		}
 	    this.config = config;
 	    this.loadFrom(config);
 	}
 
 	public void loadFrom(Configuration conf) {
-		this.setEnabled(
-				conf.getBoolean("pscans." + getClass().getCanonicalName() + ".enabled", true));
-		this.setLevel(AlertThreshold.valueOf(
-				conf.getString("pscans." + getClass().getCanonicalName() + ".level", AlertThreshold.DEFAULT.name())));
+		List<HierarchicalConfiguration> fields = ((HierarchicalConfiguration) getConfig()).configurationsAt(PSCANS_KEY);
+		for (HierarchicalConfiguration sub : fields) {
+			if (isPluginConfiguration(sub)) {
+				setLevel(AlertThreshold.valueOf(sub.getString(LEVEL_KEY, AlertThreshold.DEFAULT.name())));
+				setEnabled(sub.getBoolean(ENABLED_KEY, true));
+				break;
+			}
+		}
 	}
 
+	/**
+	 * Tells whether or not the given configuration belongs to this passive scanner.
+	 *
+	 * @param configuration the configuration to check
+	 * @return {@code true} if the configuration belongs to this passive scanner, {@code false} otherwise
+	 */
+	private boolean isPluginConfiguration(Configuration configuration) {
+		return (configuration.containsKey(ID_KEY) && getPluginId() == configuration.getInt(ID_KEY))
+				// To keep backwards compatibility check also the classname
+				|| getClass().getCanonicalName().equals(configuration.getString(CLASSNAME_KEY, ""));
+	}
+
+	/**
+	 * Gets the current configuration of the passive scanner.
+	 *
+	 * @return the configuration of the scanner, might be {@code null}
+	 * @since 1.4.0
+	 * @see #setConfig(Configuration)
+	 */
 	public Configuration getConfig() {
 	    return config;
 	}
 	
+	/**
+	 * Saves the configurations of the passive scanner to the current configuration.
+	 * 
+	 * @throws IllegalStateException if no configuration was set.
+	 * @since 1.4.0
+	 * @see #setConfig(Configuration)
+	 * @see #saveTo(Configuration)
+	 */
 	public void save() {
-		this.saveTo(getConfig());
+		Configuration conf = getConfig();
+		if (conf == null) {
+			throw new IllegalStateException("No configuration has been set.");
+		}
+		this.saveTo(conf);
 	}
 
 	public void saveTo(Configuration conf) {
-		conf.setProperty("pscans." + getClass().getCanonicalName() + ".enabled", this.isEnabled());
-		conf.setProperty("pscans." + getClass().getCanonicalName() + ".level", this.getLevel(true).name());
+		boolean removed = false;
+		List<HierarchicalConfiguration> fields = ((HierarchicalConfiguration) getConfig()).configurationsAt(PSCANS_KEY);
+		for (HierarchicalConfiguration sub : fields) {
+			if (isPluginConfiguration(sub)) {
+				sub.getRootNode().getParentNode().removeChild(sub.getRootNode());
+				removed = true;
+				break;
+			}
+		}
+
+		boolean persistId = false;
+		String entryKey = PSCANS_KEY + "(" + (removed ? fields.size() - 1 : fields.size()) + ").";
+
+		if (getLevel() != AlertThreshold.MEDIUM) {
+			conf.setProperty(entryKey + LEVEL_KEY, getLevel().name());
+			persistId = true;
+		}
+
+		if (!isEnabled()) {
+			conf.setProperty(entryKey + ENABLED_KEY, Boolean.FALSE);
+			persistId = true;
+		}
+
+		if (persistId) {
+			conf.setProperty(entryKey + ID_KEY, getPluginId());
+		}
 	}
 
 	@Override
@@ -82,12 +180,30 @@ public abstract class PluginPassiveScanner extends Enableable implements Passive
 		return level;
 	}
 	
+	/**
+	 * @throws IllegalArgumentException if the given parameter is {@code null}.
+	 * @see #getLevel()
+	 */
 	@Override
 	public void setLevel(AlertThreshold level) {
+		if (level == null) {
+			throw new IllegalArgumentException("Parameter level must not be null.");
+		}
 		this.level = level;
 	}
 
+	/**
+	 * Sets the alert threshold that should be returned when set to {@link AlertThreshold#DEFAULT}.
+	 *
+	 * @param level the value of default alert threshold
+	 * @throws IllegalArgumentException if the given parameter is {@code null} or {@codeAlertThreshold.DEFAULT}.
+	 * @since 2.0.0
+	 * @see #setLevel(AlertThreshold)
+	 */
 	public void setDefaultLevel(AlertThreshold level) {
+		if (level == null || level == AlertThreshold.DEFAULT) {
+			throw new IllegalArgumentException("Parameter level must not be null or DEFAULT.");
+		}
 		this.defaultLevel = level;
 	}
 
@@ -101,11 +217,27 @@ public abstract class PluginPassiveScanner extends Enableable implements Passive
 		return -1;
 	}
 
+	/**
+	 * Gets the status of the passive scanner.
+	 *
+	 * @return the status of the scanner, never {@code null}
+	 * @since 2.4.0
+	 */
 	public AddOn.Status getStatus() {
 		return status;
 	}
 
+	/**
+	 * Sets the status of the passive scanner.
+	 *
+	 * @param status the status of the scanner
+	 * @throws IllegalArgumentException if the given parameter is {@code null}.
+	 * @since 2.4.0
+	 */
 	public void setStatus(AddOn.Status status) {
+		if (status == null) {
+			throw new IllegalArgumentException("Parameter status must not be null.");
+		}
 		this.status = status;
 	}
 

--- a/test/org/zaproxy/zap/extension/pscan/PluginPassiveScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscan/PluginPassiveScannerUnitTest.java
@@ -1,28 +1,26 @@
 package org.zaproxy.zap.extension.pscan;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
 import net.htmlparser.jericho.Source;
 import org.apache.commons.configuration.Configuration;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.control.AddOn;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+/**
+ * Unit test for {@link PluginPassiveScanner}.
+ */
 public class PluginPassiveScannerUnitTest {
 
-	@Mock
-	Configuration configuration;
-
-	PluginPassiveScanner scanner;
+	private PluginPassiveScanner scanner;
 
 	@Before
 	public void setUp() throws Exception {
@@ -30,8 +28,100 @@ public class PluginPassiveScannerUnitTest {
 	}
 
 	@Test
+	public void shouldHaveUndefinedPluginIdByDefault() {
+		assertThat(scanner.getPluginId(), is(equalTo(-1)));
+	}
+
+	@Test
+	public void shouldHaveUnkownStatusByDefault() {
+		assertThat(scanner.getStatus(), is(equalTo(AddOn.Status.unknown)));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldFailToSetNullStatus() {
+		// Given
+		AddOn.Status status = null;
+		// When
+		scanner.setStatus(status);
+		// Then = IllegalArgumentException.
+	}
+
+	@Test
+	public void shouldSetValidStatus() {
+		// Given
+		AddOn.Status status = AddOn.Status.beta;
+		// When
+		scanner.setStatus(status);
+		// Then
+		assertThat(scanner.getStatus(), is(equalTo(status)));
+	}
+
+	@Test
+	public void shouldBeDisabledByDefault() {
+		assertThat(scanner.isEnabled(), is(equalTo(false)));
+	}
+
+	@Test
+	public void shouldChangeEnabledState() {
+		// Given
+		boolean enabled = true;
+		// When
+		scanner.setEnabled(enabled);
+		// Then
+		assertThat(scanner.isEnabled(), is(equalTo(enabled)));
+	}
+
+	@Test
 	public void shouldHaveMediumAsDefaultLevel() {
 		assertThat(scanner.getLevel(), is(equalTo(AlertThreshold.MEDIUM)));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldFailToSetNullLevel() {
+		// Given
+		AlertThreshold level = null;
+		// When
+		scanner.setLevel(level);
+		// Then = IllegalArgumentException.
+	}
+
+	@Test
+	public void shouldSetValidLevel() {
+		// Given
+		AlertThreshold level = AlertThreshold.HIGH;
+		// When
+		scanner.setLevel(level);
+		// Then
+		assertThat(scanner.getLevel(), is(equalTo(level)));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldFailToSetNullDefaultLevel() {
+		// Given
+		AlertThreshold level = null;
+		// When
+		scanner.setDefaultLevel(level);
+		// Then = IllegalArgumentException.
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldFailToSetDefaultToDefaultLevel() {
+		// Given
+		AlertThreshold level = AlertThreshold.DEFAULT;
+		// When
+		scanner.setDefaultLevel(level);
+		// Then = IllegalArgumentException.
+	}
+
+	@Test
+	public void shouldSetValidDefaultLevel() {
+		// Given
+		scanner.setLevel(AlertThreshold.DEFAULT);
+		AlertThreshold level = AlertThreshold.HIGH;
+		// When
+		scanner.setDefaultLevel(level);
+		// Then
+		assertThat(scanner.getLevel(), is(equalTo(level)));
 	}
 
 	@Test
@@ -39,11 +129,46 @@ public class PluginPassiveScannerUnitTest {
 		assertThat(scanner.getConfig(), is(nullValue()));
 	}
 
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldFailToSetNullConfiguration() {
+		// Given
+		Configuration configuration = null;
+		// When
+		scanner.setConfig(configuration);
+		// Then = IllegalArgumentException.
+	}
+
 	@Test
-	public void shouldEnableByDefaultIsNotSpecifiedInConfiguration() {
+	public void shouldNotChangeEnabledStateOrLevelIfConfigurationSetIsEmpty() {
+		Configuration configuration = createEmptyConfiguration();
 		// given
-		given(configuration.getBoolean(anyString(), eq(true))).willReturn(true);
-		given(configuration.getString(anyString(), anyString())).willReturn(AlertThreshold.DEFAULT.name());
+		scanner.setEnabled(false);
+		scanner.setLevel(AlertThreshold.HIGH);
+		// when
+		scanner.setConfig(configuration);
+		// then
+		assertThat(scanner.isEnabled(), is(false));
+		assertThat(scanner.getLevel(), is(equalTo(AlertThreshold.HIGH)));
+	}
+
+	@Test
+	public void shouldNotChangeEnabledStateOrLevelIfNoApplicableDataIsPresentInConfigurationSet() {
+		Configuration configuration = createConfiguration(Integer.MIN_VALUE, Boolean.TRUE, AlertThreshold.LOW);
+		// given
+		scanner.setEnabled(false);
+		scanner.setLevel(AlertThreshold.HIGH);
+		// when
+		scanner.setConfig(configuration);
+		// then
+		assertThat(scanner.isEnabled(), is(false));
+		assertThat(scanner.getLevel(), is(equalTo(AlertThreshold.HIGH)));
+	}
+
+	@Test
+	public void shouldEnableByDefaultIfNotSpecifiedInConfigurationSet() {
+		// given
+		Configuration configuration = createConfiguration(TestPluginPassiveScanner.PLUGIN_ID, null, null);
+		scanner.setEnabled(false);
 		// when
 		scanner.setConfig(configuration);
 		// then
@@ -51,10 +176,10 @@ public class PluginPassiveScannerUnitTest {
 	}
 
 	@Test
-	public void shouldDisableIfSpecifiedInConfiguration() {
+	public void shouldDisableIfSpecifiedInConfigurationSet() {
 		// given
-		given(configuration.getBoolean(anyString(), anyBoolean())).willReturn(false);
-		given(configuration.getString(anyString(), anyString())).willReturn(AlertThreshold.DEFAULT.name());
+		Configuration configuration = createConfiguration(TestPluginPassiveScanner.PLUGIN_ID, Boolean.FALSE, null);
+		scanner.setEnabled(true);
 		// when
 		scanner.setConfig(configuration);
 		// then
@@ -62,20 +187,251 @@ public class PluginPassiveScannerUnitTest {
 	}
 
 	@Test
-	public void shouldPersistEnabledStatusInConfigurationOnSave() {
+	public void shouldUseDefaultLevelIfNotSpecifiedInConfigurationSet() {
 		// given
-		given(configuration.getBoolean(anyString(), eq(true))).willReturn(true);
-		given(configuration.getString(anyString(), anyString())).willReturn(AlertThreshold.DEFAULT.name());
+		Configuration configuration = createConfiguration(TestPluginPassiveScanner.PLUGIN_ID, Boolean.TRUE, null);
+		scanner.setDefaultLevel(AlertThreshold.HIGH);
+		scanner.setLevel(AlertThreshold.LOW);
 		// when
 		scanner.setConfig(configuration);
-		scanner.save();
 		// then
-		verify(configuration).setProperty(
-				"pscans." + scanner.getClass().getCanonicalName() + ".enabled",
-				true);
+		assertThat(scanner.getLevel(), is(equalTo(AlertThreshold.HIGH)));
 	}
 
-	private final class TestPluginPassiveScanner extends PluginPassiveScanner {
+	@Test
+	public void shouldUseLevelSpecifiedInConfigurationSet() {
+		// given
+		Configuration configuration = createConfiguration(TestPluginPassiveScanner.PLUGIN_ID, null, AlertThreshold.HIGH);
+		scanner.setLevel(AlertThreshold.LOW);
+		// when
+		scanner.setConfig(configuration);
+		// then
+		assertThat(scanner.getLevel(), is(equalTo(AlertThreshold.HIGH)));
+	}
+
+	@Test
+	public void shouldUseClassnameToReadConfigurationSet() {
+		// given
+		Configuration configuration = createConfiguration(
+				TestPluginPassiveScanner.class.getCanonicalName(),
+				Boolean.FALSE,
+				AlertThreshold.HIGH);
+		scanner.setEnabled(true);
+		scanner.setLevel(AlertThreshold.LOW);
+		// when
+		scanner.setConfig(configuration);
+		// then
+		assertThat(scanner.isEnabled(), is(false));
+		assertThat(scanner.getLevel(), is(equalTo(AlertThreshold.HIGH)));
+	}
+
+	@Test
+	public void shouldReadConfigurationSetEvenIfThereAreMultipleUnrelatedEntries() {
+		// given
+		Configuration configuration = createEmptyConfiguration();
+		addConfiguration(configuration, 0, 10, null, null);
+		addConfiguration(configuration, 1, "TestClassName", Boolean.TRUE, AlertThreshold.HIGH);
+		addConfiguration(configuration, 2, TestPluginPassiveScanner.PLUGIN_ID, Boolean.FALSE, AlertThreshold.MEDIUM);
+		addConfiguration(configuration, 3, 1011, null, AlertThreshold.LOW);
+		addConfiguration(configuration, 4, "OtherTestClassName", Boolean.FALSE, AlertThreshold.OFF);
+		scanner.setEnabled(true);
+		scanner.setLevel(AlertThreshold.LOW);
+		// when
+		scanner.setConfig(configuration);
+		// then
+		assertThat(scanner.isEnabled(), is(false));
+		assertThat(scanner.getLevel(), is(equalTo(AlertThreshold.MEDIUM)));
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void shouldFailToSaveByDefault() {
+		// Given / When
+		scanner.save();
+		// Then = IllegalStateException.
+	}
+
+	@Test
+	public void shouldNotPersistEnabledStateOnSaveIfEnabled() {
+		// given
+		Configuration configuration = createEmptyConfiguration();
+		scanner.setConfig(configuration);
+		scanner.setEnabled(true);
+		// when
+		scanner.save();
+		// then
+		assertThat(configuration.containsKey("pscans.pscanner(0).enabled"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(0).id"), is(false));
+	}
+
+	@Test
+	public void shouldPersistEnabledStateOnSaveIfDisabled() {
+		// Given
+		Configuration configuration = createEmptyConfiguration();
+		scanner.setConfig(configuration);
+		scanner.setEnabled(false);
+		// When
+		scanner.save();
+		// Then
+		assertThat(configuration.containsKey("pscans.pscanner(0).enabled"), is(true));
+		assertThat(configuration.getBoolean("pscans.pscanner(0).enabled"), is(false));
+        assertThat(configuration.containsKey("pscans.pscanner(0).id"), is(true));
+		assertThat(configuration.getInt("pscans.pscanner(0).id"), is(equalTo(TestPluginPassiveScanner.PLUGIN_ID)));
+	}
+
+	@Test
+	public void shouldNotPersistLevelOnSaveIfDefaultValue() {
+		// Given
+		Configuration configuration = createEmptyConfiguration();
+		scanner.setConfig(configuration);
+		scanner.setLevel(AlertThreshold.MEDIUM);
+		scanner.setEnabled(true);
+		// When
+		scanner.save();
+		// Then
+		assertThat(configuration.containsKey("pscans.pscanner(0).level"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(0).id"), is(false));
+	}
+
+	@Test
+	public void shouldPersistLevelOnSaveIfNotDefaultValue() {
+		// Given
+		Configuration configuration = createEmptyConfiguration();
+		scanner.setConfig(configuration);
+		scanner.setLevel(AlertThreshold.HIGH);
+		scanner.setEnabled(true);
+		// When
+		scanner.save();
+		// Then
+		assertThat(configuration.containsKey("pscans.pscanner(0).level"), is(true));
+		assertThat(configuration.getString("pscans.pscanner(0).level"), is(equalTo(AlertThreshold.HIGH.name())));
+		assertThat(configuration.containsKey("pscans.pscanner(0).id"), is(true));
+		assertThat(configuration.getInt("pscans.pscanner(0).id"), is(equalTo(TestPluginPassiveScanner.PLUGIN_ID)));
+	}
+
+	@Test
+	public void shouldRemoveExistingConfigDataOnSaveIfDefaultValues() {
+		// Given
+		Configuration configuration = createConfiguration(
+				TestPluginPassiveScanner.PLUGIN_ID,
+				Boolean.FALSE,
+				AlertThreshold.HIGH);
+		scanner.setConfig(configuration);
+		scanner.setEnabled(true);
+		scanner.setLevel(AlertThreshold.MEDIUM);
+		// When
+		scanner.save();
+		// Then
+		assertThat(configuration.containsKey("pscans.pscanner(0).enabled"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(0).level"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(0).id"), is(false));
+	}
+
+	@Test
+	public void shouldRemoveClassnameConfigEntryOnSave() {
+		// Given
+		Configuration configuration = createConfiguration(
+				TestPluginPassiveScanner.class.getCanonicalName(),
+				Boolean.FALSE,
+				AlertThreshold.HIGH);
+		scanner.setConfig(configuration);
+		scanner.setEnabled(true);
+		scanner.setLevel(AlertThreshold.MEDIUM);
+		// When
+		scanner.save();
+		// Then
+		assertThat(configuration.containsKey("pscans.pscanner(0).classname"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(0).enabled"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(0).level"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(0).id"), is(false));
+	}
+
+	@Test
+	public void shouldPersistConfigsOnSaveEvenIfThereAreMultipleUnrelatedEntries() {
+		// Given
+		Configuration configuration = createEmptyConfiguration();
+		addConfiguration(configuration, 0, 10, null, null);
+		addConfiguration(configuration, 1, "TestClassName", Boolean.TRUE, AlertThreshold.HIGH);
+		addConfiguration(configuration, 2, TestPluginPassiveScanner.PLUGIN_ID, Boolean.FALSE, AlertThreshold.MEDIUM);
+		addConfiguration(configuration, 3, 1011, null, AlertThreshold.LOW);
+		scanner.setConfig(configuration);
+		scanner.setEnabled(false);
+		scanner.setLevel(AlertThreshold.LOW);
+		// When
+		scanner.save();
+		// Then
+		assertThat(configuration.containsKey("pscans.pscanner(0).id"), is(true));
+		assertThat(configuration.getInt("pscans.pscanner(0).id"), is(equalTo(10)));
+		assertThat(configuration.containsKey("pscans.pscanner(0).enabled"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(0).level"), is(false));
+
+		assertThat(configuration.containsKey("pscans.pscanner(1).id"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(1).classname"), is(true));
+		assertThat(configuration.getString("pscans.pscanner(1).classname"), is(equalTo("TestClassName")));
+		assertThat(configuration.containsKey("pscans.pscanner(1).enabled"), is(true));
+		assertThat(configuration.getBoolean("pscans.pscanner(1).enabled"), is(true));
+		assertThat(configuration.containsKey("pscans.pscanner(1).level"), is(true));
+		assertThat(configuration.getString("pscans.pscanner(1).level"), is(equalTo(AlertThreshold.HIGH.name())));
+
+		assertThat(configuration.containsKey("pscans.pscanner(2).id"), is(true));
+		assertThat(configuration.getInt("pscans.pscanner(2).id"), is(equalTo(1011)));
+		assertThat(configuration.containsKey("pscans.pscanner(2).enabled"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(2).level"), is(true));
+		assertThat(configuration.getString("pscans.pscanner(2).level"), is(equalTo(AlertThreshold.LOW.name())));
+
+		assertThat(configuration.containsKey("pscans.pscanner(3).id"), is(true));
+		assertThat(configuration.getInt("pscans.pscanner(3).id"), is(equalTo(TestPluginPassiveScanner.PLUGIN_ID)));
+		assertThat(configuration.containsKey("pscans.pscanner(3).enabled"), is(true));
+		assertThat(configuration.getBoolean("pscans.pscanner(3).enabled"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(3).level"), is(true));
+		assertThat(configuration.getString("pscans.pscanner(3).level"), is(equalTo(AlertThreshold.LOW.name())));
+
+		assertThat(configuration.containsKey("pscans.pscanner(4).enabled"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(4).level"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(5).id"), is(false));
+	}
+
+	@Test
+	public void shouldRemoveExistingConfigDataOnSaveIfDefaultValuesEvenIfThereAreMultipleUnrelatedEntries() {
+		// Given
+		Configuration configuration = createEmptyConfiguration();
+		addConfiguration(configuration, 0, 10, null, null);
+		addConfiguration(configuration, 1, "TestClassName", Boolean.TRUE, AlertThreshold.HIGH);
+		addConfiguration(configuration, 2, TestPluginPassiveScanner.PLUGIN_ID, Boolean.FALSE, AlertThreshold.MEDIUM);
+		addConfiguration(configuration, 3, 1011, null, AlertThreshold.LOW);
+		scanner.setConfig(configuration);
+		scanner.setEnabled(true);
+		scanner.setLevel(AlertThreshold.MEDIUM);
+		// When
+		scanner.save();
+		// Then
+		assertThat(configuration.containsKey("pscans.pscanner(0).id"), is(true));
+		assertThat(configuration.getInt("pscans.pscanner(0).id"), is(equalTo(10)));
+		assertThat(configuration.containsKey("pscans.pscanner(0).enabled"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(0).level"), is(false));
+
+		assertThat(configuration.containsKey("pscans.pscanner(1).id"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(1).classname"), is(true));
+		assertThat(configuration.getString("pscans.pscanner(1).classname"), is(equalTo("TestClassName")));
+		assertThat(configuration.containsKey("pscans.pscanner(1).enabled"), is(true));
+		assertThat(configuration.getBoolean("pscans.pscanner(1).enabled"), is(true));
+		assertThat(configuration.containsKey("pscans.pscanner(1).level"), is(true));
+		assertThat(configuration.getString("pscans.pscanner(1).level"), is(equalTo(AlertThreshold.HIGH.name())));
+
+		assertThat(configuration.containsKey("pscans.pscanner(2).id"), is(true));
+		assertThat(configuration.getInt("pscans.pscanner(2).id"), is(equalTo(1011)));
+		assertThat(configuration.containsKey("pscans.pscanner(2).enabled"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(2).level"), is(true));
+		assertThat(configuration.getString("pscans.pscanner(2).level"), is(equalTo(AlertThreshold.LOW.name())));
+
+		assertThat(configuration.containsKey("pscans.pscanner(3).enabled"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(3).level"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(3).id"), is(false));
+	}
+
+	private static class TestPluginPassiveScanner extends PluginPassiveScanner {
+
+		private static final int PLUGIN_ID = -1;
+
 		@Override
 		public void setParent(PassiveScanThread parent) {
 		}
@@ -93,11 +449,55 @@ public class PluginPassiveScannerUnitTest {
 		public String getName() {
 			return null;
 		}
-
-		@Override
-		public boolean appliesToHistoryType(int historyType) {
-			return true;
-		}
 	}
 
+	private static Configuration createEmptyConfiguration() {
+		return new ZapXmlConfiguration();
+	}
+
+	private static Configuration createConfiguration(String classname, Boolean enabled, AlertThreshold alertThreshold) {
+		ZapXmlConfiguration configuration = new ZapXmlConfiguration();
+		setClassname(configuration, 0, classname);
+		setProperties(configuration, 0, enabled, alertThreshold);
+		return configuration;
+	}
+
+	private static void setClassname(Configuration configuration, int index, String classname) {
+		configuration.setProperty("pscans.pscanner(" + index + ").classname", classname);
+	}
+
+	private static Configuration createConfiguration(int pluginId, Boolean enabled, AlertThreshold alertThreshold) {
+		ZapXmlConfiguration configuration = new ZapXmlConfiguration();
+		addConfiguration(configuration, 0, pluginId, enabled, alertThreshold);
+		return configuration;
+	}
+
+	private static void addConfiguration(
+			Configuration configuration,
+			int index,
+			String classname,
+			Boolean enabled,
+			AlertThreshold alertThreshold) {
+		setClassname(configuration, index, classname);
+		setProperties(configuration, index, enabled, alertThreshold);
+	}
+
+	private static void addConfiguration(
+			Configuration configuration,
+			int index,
+			int pluginId,
+			Boolean enabled,
+			AlertThreshold alertThreshold) {
+		configuration.setProperty("pscans.pscanner(" + index + ").id", pluginId);
+		setProperties(configuration, index, enabled, alertThreshold);
+	}
+
+	private static void setProperties(Configuration configuration, int index, Boolean enabled, AlertThreshold alertThreshold) {
+		if (enabled != null) {
+			configuration.setProperty("pscans.pscanner(" + index + ").enabled", enabled);
+		}
+		if (alertThreshold != null) {
+			configuration.setProperty("pscans.pscanner(" + index + ").level", alertThreshold.name());
+		}
+	}
 }


### PR DESCRIPTION
Change how the configurations of the passive scanners are saved by using
its ID instead of the classname. The ID is used to (uniquely) identify a
scanner so it's more suitable than the classname which gives problems
when the passive scanners are promoted or demoted (since it, usually,
requires a change in the package name).
The configurations now use the elements, "id", "level" and "enabled", to
save the ID, alert threshold and enabled state of a scanner, each one in
its own "pscanner" element (which are all under an "pscan" element).
While the options are migrated some will have an element called
"classname" containing the classname of the scanner, which is removed
once the configurations are saved again (then starting to use the ID).

Change class PluginPassiveScanner to save the configurations with the
new structure, also, document and normalise its behaviour.
Change Constant class to convert to the new options when updating from
version 2.5.0.
Change class PassiveScanParam to expose the root element of the
configurations.
Add tests to assert the expected behaviour of the class
PluginPassiveScanner.