### PR TITLE
Remove use of BAD_TYPE in API implementations

### DIFF
--- a/src/org/zaproxy/zap/authentication/GenericAuthenticationCredentials.java
+++ b/src/org/zaproxy/zap/authentication/GenericAuthenticationCredentials.java
@@ -133,7 +133,7 @@ public class GenericAuthenticationCredentials implements AuthenticationCredentia
 				int userId = ApiUtils.getIntParam(params, UsersAPI.PARAM_USER_ID);
 				// Make sure the type of authentication method is compatible
 				if (!methodType.isTypeForMethod(context.getAuthenticationMethod()))
-					throw new ApiException(ApiException.Type.BAD_TYPE,
+					throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER,
 							"User's credentials should match authentication method type of the context: "
 									+ context.getAuthenticationMethod().getType().getName());
 

--- a/src/org/zaproxy/zap/authentication/ManualAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/ManualAuthenticationMethodType.java
@@ -406,7 +406,7 @@ public class ManualAuthenticationMethodType extends AuthenticationMethodType {
 				int userId = ApiUtils.getIntParam(params, UsersAPI.PARAM_USER_ID);
 				// Make sure the type of authentication method is compatible
 				if (!isTypeForMethod(context.getAuthenticationMethod())) {
-					throw new ApiException(ApiException.Type.BAD_TYPE,
+					throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER,
 							"User's credentials should match authentication method type of the context: "
 									+ context.getAuthenticationMethod().getType().getName());
 				}

--- a/src/org/zaproxy/zap/authentication/UsernamePasswordAuthenticationCredentials.java
+++ b/src/org/zaproxy/zap/authentication/UsernamePasswordAuthenticationCredentials.java
@@ -203,7 +203,7 @@ class UsernamePasswordAuthenticationCredentials implements AuthenticationCredent
 				int userId = ApiUtils.getIntParam(params, UsersAPI.PARAM_USER_ID);
 				// Make sure the type of authentication method is compatible
 				if (!methodType.isTypeForMethod(context.getAuthenticationMethod()))
-					throw new ApiException(ApiException.Type.BAD_TYPE,
+					throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER,
 							"User's credentials should match authentication method type of the context: "
 									+ context.getAuthenticationMethod().getType().getName());
 

--- a/src/org/zaproxy/zap/extension/api/ApiException.java
+++ b/src/org/zaproxy/zap/extension/api/ApiException.java
@@ -46,6 +46,11 @@ public class ApiException extends Exception {
 		 * @see API.Format
 		 */
 		BAD_FORMAT,
+		/**
+		 * Indicates that the requested type is not valid.
+		 * 
+		 * @see API.RequestType
+		 */
 		BAD_TYPE, NO_IMPLEMENTOR, BAD_ACTION, BAD_VIEW, BAD_OTHER, INTERNAL_ERROR, MISSING_PARAMETER, 
 		URL_NOT_FOUND, HREF_NOT_FOUND, SCAN_IN_PROGRESS, DISABLED, ALREADY_EXISTS, DOES_NOT_EXIST,
 		/**


### PR DESCRIPTION
Change API implementations to use ILLEGAL_PARAMETER instead of BAD_TYPE,
the latter is used to inform that the requested API type (view, action
or other) is not valid (which should be used only by core API classes).