### PR TITLE
Disable scan menus if ZAP is started in Safe mode

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -346,6 +346,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
         if (menuItemCustomScan == null) {
             menuItemCustomScan = new ZapMenuItem("menu.tools.ascanadv",
                     KeyStroke.getKeyStroke(KeyEvent.VK_A, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK, false));
+            menuItemCustomScan.setEnabled(Control.getSingleton().getMode() != Mode.safe);
 
             menuItemCustomScan.addActionListener(new java.awt.event.ActionListener() {
                 @Override

--- a/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
+++ b/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
@@ -692,6 +692,7 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
         if (menuItemCustomScan  == null) {
             menuItemCustomScan = new ZapMenuItem("menu.tools.spider",
                     KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK, false));
+            menuItemCustomScan.setEnabled(Control.getSingleton().getMode() != Mode.safe);
 
             menuItemCustomScan.addActionListener(new java.awt.event.ActionListener() {
                 @Override


### PR DESCRIPTION
Change classes ExtensionActiveScan and ExtensionSpider to disable the
scan menu items, "Tools" > "Active Scan..." and "Spider...", if ZAP is
started in Safe mode.