### PR TITLE
Use all technologies by default in active scans

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/src/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -51,6 +51,7 @@
 // ZAP: 2016/04/21 Include Plugin itself when notifying of a new message sent
 // ZAP: 2016/05/03 Remove exceptions' stack trace prints
 // ZAP: 2016/06/10 Honour scan's scope when following redirections
+// ZAP: 2016/07/12 Do not allow techSet to be null
 
 package org.parosproxy.paros.core.scanner;
 
@@ -104,7 +105,7 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
     private static final AlertThreshold[] alertThresholdsSupported = new AlertThreshold[]{AlertThreshold.MEDIUM};
     private AttackStrength defaultAttackStrength = AttackStrength.MEDIUM;
     private static final AttackStrength[] attackStrengthsSupported = new AttackStrength[]{AttackStrength.MEDIUM};
-    private TechSet techSet = null;
+    private TechSet techSet;
     private Date started = null;
     private Date finished = null;
     private AddOn.Status status = AddOn.Status.unknown;
@@ -122,6 +123,7 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
      * Default Constructor
      */
     public AbstractPlugin() {
+        this.techSet = TechSet.AllTech;
     }
 
     @Override
@@ -926,18 +928,22 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
 
     @Override
     public boolean inScope(Tech tech) {
-        return this.techSet == null || this.techSet.includes(tech);
+        return this.techSet.includes(tech);
     }
 
     @Override
     public void setTechSet(TechSet ts) {
+        if (ts == null) {
+            throw new IllegalArgumentException("Parameter ts must not be null.");
+        }
         this.techSet = ts;
     }
     
     /**
      * Returns the technologies enabled for the scan.
      *
-     * @return a {@code TechSet} with the technologies enabled for the scan.
+     * @return a {@code TechSet} with the technologies enabled for the scan, never {@code null} (since TODO add version).
+     * @since 2.4.0
      * @see #inScope(Tech)
      * @see #targets(TechSet)
      */
@@ -948,6 +954,7 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
     /**
      * Returns {@code true} by default.
      * 
+     * @since 2.4.1
      * @see #getTechSet()
      */
     @Override

--- a/src/org/parosproxy/paros/core/scanner/HostProcess.java
+++ b/src/org/parosproxy/paros/core/scanner/HostProcess.java
@@ -57,6 +57,7 @@
 // ZAP: 2016/01/27 Prevent HostProcess from reporting progress higher than 100%
 // ZAP: 2016/04/21 Allow scanners to notify of messages sent (and tweak the progress and request count of each plugin)
 // ZAP: 2016/06/29 Allow to specify and obtain the reason why a scanner was skipped
+// ZAP: 2016/07/12 Do not allow techSet to be null
 
 package org.parosproxy.paros.core.scanner;
 
@@ -99,7 +100,7 @@ public class HostProcess implements Runnable {
     private Analyser analyser = null;
     private Kb kb = null;
     private User user = null;
-    private TechSet techSet = null;
+    private TechSet techSet;
 
     /**
      * A {@code Map} from plugin IDs to corresponding {@link PluginStats}.
@@ -146,6 +147,7 @@ public class HostProcess implements Runnable {
         }
         
         threadPool = new ThreadPool(maxNumberOfThreads, "ZAP-ActiveScanner-");
+        this.techSet = TechSet.AllTech;
     }
 
     /**
@@ -224,7 +226,7 @@ public class HostProcess implements Runnable {
             mapPluginStats.put(plugin.getId(), new PluginStats());
         }
 
-        if (techSet != null && !plugin.targets(techSet)) {
+        if (!plugin.targets(techSet)) {
             pluginSkipped(plugin, Constant.messages.getString("ascan.progress.label.skipped.reason.techs"));
             pluginCompleted(plugin);
             return;
@@ -699,11 +701,27 @@ public class HostProcess implements Runnable {
 		}
 	}
 
+	/**
+	 * Gets the technologies to be used in the scan.
+	 *
+	 * @return the technologies, never {@code null} (since TODO add version)
+	 * @since 2.4.0
+	 */
 	public TechSet getTechSet() {
 		return techSet;
 	}
 
+	/**
+	 * Sets the technologies to be used in the scan.
+	 *
+	 * @param techSet the technologies to be used during the scan
+	 * @since 2.4.0
+	 * @throws IllegalArgumentException (since TODO add version) if the given parameter is {@code null}.
+	 */
 	public void setTechSet(TechSet techSet) {
+		if (techSet == null) {
+			throw new IllegalArgumentException("Parameter techSet must not be null.");
+		}
 		this.techSet = techSet;
 	}
 	

--- a/src/org/parosproxy/paros/core/scanner/Plugin.java
+++ b/src/org/parosproxy/paros/core/scanner/Plugin.java
@@ -267,9 +267,11 @@ public interface Plugin extends Runnable {
     AttackStrength[] getAttackStrengthsSupported();
 
     /**
-     * Sets the technologies enabled for the scan. Might be {@code null} when all technologies are enabled.
+     * Sets the technologies enabled for the scan.
      *
      * @param ts the technologies enabled for the scan
+     * @throws IllegalArgumentException (since TODO add version) if the given parameter is {@code null}.
+     * @since 2.0.0
      * @see #targets(TechSet)
      */
     void setTechSet(TechSet ts);
@@ -281,6 +283,7 @@ public interface Plugin extends Runnable {
      *
      * @param tech the technology that will be checked
      * @return {@code true} if the technology is enabled for the scan, {@code false} otherwise
+     * @since 2.0.0
      * @see #targets(TechSet)
      */
     boolean inScope(Tech tech);
@@ -294,6 +297,7 @@ public interface Plugin extends Runnable {
      *
      * @param technologies the technologies that are enabled for the scan, never {@code null}
      * @return {@code true} if the scanner is targeting the given technologies (or none at all), {@code false} otherwise
+     * @since 2.4.1
      * @see #setTechSet(TechSet)
      * @see #inScope(Tech)
      */

--- a/src/org/parosproxy/paros/core/scanner/Scanner.java
+++ b/src/org/parosproxy/paros/core/scanner/Scanner.java
@@ -38,6 +38,7 @@
 // ZAP: 2015/04/02 Issue 1582: Low memory option
 // ZAP: 2015/10/21 Issue 1576: Removed SiteNode cast no longer needed
 // ZAP: 2015/12/14 Prevent scans from becoming in undefined state
+// ZAP: 2016/07/12 Do not allow techSet to be null
 
 package org.parosproxy.paros.core.scanner;
 
@@ -92,7 +93,7 @@ public class Scanner implements Runnable {
 	private boolean justScanInScope = false;
 	private boolean scanChildren = true;
 	private User user = null;
-    private TechSet techSet = null;
+    private TechSet techSet;
     private Set<ScriptCollection> scriptCollections = new HashSet<ScriptCollection>();
 	private int id;
 
@@ -109,6 +110,8 @@ public class Scanner implements Runnable {
 	    
 	  //ZAP: Load all scanner hooks from extensionloader. 
 	    Control.getSingleton().getExtensionLoader().hookScannerHook(this);
+
+		techSet = TechSet.AllTech;
     }
     
     
@@ -473,11 +476,27 @@ public class Scanner implements Runnable {
 		this.user = user;
 	}
 	
+	/**
+	 * Gets the technologies used in the scan.
+	 *
+	 * @return the technologies, never {@code null} (since TODO add version)
+	 * @since 2.4.0
+	 */
 	public TechSet getTechSet() {
 		return techSet;
 	}
 
+	/**
+	 * Sets the technologies to be used in the scan.
+	 *
+	 * @param techSet the technologies to be used during the scan
+	 * @since 2.4.0
+	 * @throws IllegalArgumentException (since TODO add version) if the given parameter is {@code null}
+	 */
 	public void setTechSet(TechSet techSet) {
+		if (techSet == null) {
+			throw new IllegalArgumentException("Parameter techSet must not be null.");
+		}
 		this.techSet = techSet;
 	}
 

--- a/test/org/parosproxy/paros/core/scanner/AbstractPluginUnitTest.java
+++ b/test/org/parosproxy/paros/core/scanner/AbstractPluginUnitTest.java
@@ -36,6 +36,23 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
  */
 public class AbstractPluginUnitTest extends PluginTestUtils {
 
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToSetNullTechSet() {
+        // Given
+        AbstractPlugin plugin = createAbstractPlugin();
+        // When
+        plugin.setTechSet(null);
+        // Then = IllegalArgumentException.class
+    }
+
+    @Test
+    public void shouldHaveAllTechSetByDefault() {
+        // Given / When
+        AbstractPlugin plugin = createAbstractPlugin();
+        // Then
+        assertThat(plugin.getTechSet(), is(equalTo(TechSet.AllTech)));
+    }
+
     @Test
     public void shouldNotHaveConfigByDefault() {
         // Given / When


### PR DESCRIPTION
Change classes HostProcess, Plugin, AbtractPlugin and Scanner to not
allow to set a null TechSet and to use all technologies by default
(TechSet.AllTech instead of null).
The change ensures that the TechSet being used in the active scans is
never null (thus preventing NullPointerException in scanners).
Add tests to AbtractPluginUnitTest to assert the expected behaviour.
Update JavaDoc with the new behaviour (and add since tags to technology
related methods).