### PR TITLE
Tweak log in SpiderTask to include more info

### DIFF
--- a/src/org/zaproxy/zap/spider/SpiderTask.java
+++ b/src/org/zaproxy/zap/spider/SpiderTask.java
@@ -194,24 +194,8 @@ public class SpiderTask implements Runnable {
 		HttpMessage msg = null;
 		try {
 			msg = fetchResource();
-		} catch (ConnectException e) {
-			// This will have been logged at debug level with the URL (which we dont have here)
-			parent.postTaskExecution();
-			return;
-		} catch (SocketTimeoutException e) {
-			// This will have been logged at debug level with the URL (which we dont have here)
-			parent.postTaskExecution();
-			return;
-		} catch (SocketException e) {
-			// This will have been logged at debug level with the URL (which we dont have here)
-			parent.postTaskExecution();
-			return;
-		} catch (UnknownHostException e) {
-			// This will have been logged at debug level with the URL (which we dont have here)
-			parent.postTaskExecution();
-			return;
 		} catch (Exception e) {
-			log.error("An error occured while fetching the resource: " + e.getMessage(), e);
+			// The exception was already logged, in fetchResource, with the URL (which we dont have here)
 			parent.postTaskExecution();
 			return;
 		}
@@ -367,6 +351,10 @@ public class SpiderTask implements Runnable {
 				throw e;
 			} catch (UnknownHostException e) {
 				log.debug("Unknown host: " + msg.getRequestHeader().getURI(), e);
+				throw e;
+			} catch (Exception e) {
+				log.error("An error occurred while fetching the resource [" + msg.getRequestHeader().getURI() + "]: "
+							+ e.getMessage(), e);
 				throw e;
 			}
 		}


### PR DESCRIPTION
Change SpiderTask to include the URL of the resource being fetched when
logging the Exception.