### PR TITLE
Fix exception while adding script through the API

### DIFF
--- a/src/org/zaproxy/zap/extension/script/ScriptAPI.java
+++ b/src/org/zaproxy/zap/extension/script/ScriptAPI.java
@@ -151,7 +151,7 @@ public class ScriptAPI extends ApiImplementor {
 			
 			ScriptWrapper script = new ScriptWrapper(
 					params.getString(ACTION_PARAM_SCRIPT_NAME),
-					params.getString(ACTION_PARAM_SCRIPT_DESC),
+					getParam(params, ACTION_PARAM_SCRIPT_DESC, ""),
 					engine,
 					type,
 					true,


### PR DESCRIPTION
Change ScriptAPI to obtain the optional parameter "scriptDescription"
with a default value (i.e. empty string), otherwise it would lead to an
exception if it was not present in the API request:
 Exception while handling API request:
  JSONException: JSONObject["scriptDescription"] not found.

(Since the parameter is optional it's likely to happen.)
 ---
From zaproxy/zap-api-python#5.