### PR TITLE
Sort (main) help add-on TOC entries

### DIFF
--- a/src/org/zaproxy/zap/extension/help/ZapTocMerger.java
+++ b/src/org/zaproxy/zap/extension/help/ZapTocMerger.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import javax.help.MergeHelpUtilities;
 import javax.help.NavigatorView;
+import javax.help.SortMerge;
 import javax.help.TreeItem;
 import javax.help.UniteAppendMerge;
 import javax.swing.tree.DefaultMutableTreeNode;
@@ -67,6 +68,8 @@ public class ZapTocMerger extends UniteAppendMerge {
 
     private static final String DEFAULT_MERGE_TYPE = ZapTocMerger.class.getCanonicalName();
 
+    private static final String ADDONS_TOC_ID = "addons";
+
     /**
      * A map containing the requirements to do forced merging.
      * <p>
@@ -80,7 +83,7 @@ public class ZapTocMerger extends UniteAppendMerge {
         // Note: The attribute "tocid" should match the ones defined in the toc.xml file.
         // Note 2: the TOC tree node names are hard coded because the "older" add-ons use the same (hard coded) names.
         tempMap.put("toplevelitem", new ForceMergeRequirement(1, "ZAP User Guide"));
-        tempMap.put("addons", new ForceMergeRequirement(2, "Add Ons"));
+        tempMap.put(ADDONS_TOC_ID, new ForceMergeRequirement(2, "Add Ons"));
         TOC_IDS_FORCE_MERGE_MAP = Collections.unmodifiableMap(tempMap);
     }
 
@@ -180,6 +183,9 @@ public class ZapTocMerger extends UniteAppendMerge {
         if (isSameTOCID(masterAtM, slaveNodeChild) || isForceMerge(masterAtM, slaveNodeChild)) {
             MergeHelpUtilities.mergeNodes(DEFAULT_MERGE_TYPE, masterAtM, slaveNodeChild);
             slaveNodeChild.removeFromParent();
+            if (ADDONS_TOC_ID.equals(getTOCID(masterAtM))) {
+                SortMerge.sortNode(masterAtM, MergeHelpUtilities.getLocale(masterAtM));
+            }
             return true;
         }
         return false;


### PR DESCRIPTION
Change class ZapTocMerger to sort the entries under the "Add Ons" TOC
entry, so the add-ons are shown in alphabetic order (instead of the
order they were added/loaded).