### PR TITLE
Restore the enabled state of passive scanners

### DIFF
--- a/src/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
+++ b/src/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
@@ -73,6 +73,10 @@ public abstract class PluginPassiveScanner extends Enableable implements Passive
 	private Configuration config = null;
 	private AddOn.Status status = AddOn.Status.unknown;
 
+	public PluginPassiveScanner() {
+		super(true);
+	}
+
 	/**
 	 * Sets the current configuration of the passive scanner.
 	 *

--- a/test/org/zaproxy/zap/extension/pscan/PluginPassiveScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscan/PluginPassiveScannerUnitTest.java
@@ -57,8 +57,8 @@ public class PluginPassiveScannerUnitTest {
 	}
 
 	@Test
-	public void shouldBeDisabledByDefault() {
-		assertThat(scanner.isEnabled(), is(equalTo(false)));
+	public void shouldBeEnabledByDefault() {
+		assertThat(scanner.isEnabled(), is(equalTo(true)));
 	}
 
 	@Test


### PR DESCRIPTION
The changes done in #2660 ("Use the ID to save configs of passive
scanners") wrongly changed the default state of passive scanners to
disable (as that's the default state of Enableable, which was no longer
being overridden either when instantiating the passive scanners or
when loading from the configurations).

Change PluginPassiveScanner to be enabled by default and update test to
reflect correct behaviour.