### PR TITLE
Fix elements name in drivers.xml

### DIFF
--- a/src/ch/csnc/extension/util/DriverConfiguration.java
+++ b/src/ch/csnc/extension/util/DriverConfiguration.java
@@ -74,18 +74,10 @@ public class DriverConfiguration extends Observable {
 				paths.add(pathElement.getValue());
 
 				final Element slotElement = ((Element) o).getChild("slot");
-				try {
-					slots.add(Integer.parseInt(slotElement.getValue()));
-				} catch (final Exception e) {
-					slots.add(0); // default value
-				}
+				slots.add(getIntValue(slotElement));
 
 				final Element slotListIndex = ((Element) o).getChild("slotListIndex");
-				try {
-					slotListIndexes.add(Integer.parseInt(slotListIndex.getValue()));
-				} catch (final Exception e) {
-					slotListIndexes.add(0); // default value
-				}
+				slotListIndexes.add(getIntValue(slotListIndex));
 			}
 
 		} catch (final JDOMException e) {
@@ -104,6 +96,25 @@ public class DriverConfiguration extends Observable {
 					JOptionPane.ERROR_MESSAGE);
 			logger.error(e.getMessage(), e);
 		}
+	}
+
+	/**
+	 * Gets an integer from the given element.
+	 * <p>
+	 * If the given element is {@code null} or does not have an integer, zero is returned.
+	 *
+	 * @param element the element with the integer value
+	 * @return an integer
+	 */
+	private int getIntValue(Element element) {
+		if (element != null) {
+			try {
+				return Integer.parseInt(element.getValue());
+			} catch (NumberFormatException e) {
+				logger.error("Failed to extract an integer from: " + element.getValue());
+			}
+		}
+		return 0;
 	}
 
 	public void write() {

--- a/src/xml/drivers.xml
+++ b/src/xml/drivers.xml
@@ -4,96 +4,96 @@
 		<name>ActivIdentity - Windows (x86)</name>
 		<path>C:\WINDOWS\System32\acpks211.dll</path>
 		<slot>0</slot>
-		<slotIndex>0</slotIndex>
+		<slotListIndex>0</slotListIndex>
 	</driver>
 	<driver>
 		<name>Aladdin eToken - Mac OS X</name>
 		<path>/Library/Frameworks/eToken.framework/Versions/Current/libeToken.dylib</path>
 		<slot>1</slot>
-		<slotIndex>0</slotIndex>
+		<slotListIndex>0</slotListIndex>
 	</driver>
 	<driver>
 		<name>Aladdin eToken - Windows (x86)</name>
 		<path>C:\WINDOWS\System32\eTPKCS11.dll</path>
 		<slot>1</slot>
-		<slotIndex>0</slotIndex>
+		<slotListIndex>0</slotListIndex>
 	</driver>
 	<driver>
 		<name>Axalto - Windows</name>
 		<path>C:\Program Files\Axalto\Access Client\v5\xltCk.dll</path>
 		<slot>0</slot>
-		<slotIndex>0</slotIndex>
+		<slotListIndex>0</slotListIndex>
 	</driver>
 	<driver>
 		<name>Belgium eID - Windows (x86)</name>
 		<path>C:\Windows\System32\beidpkcs11.dll</path>
 		<slot>0</slot>
-		<slotIndex>0</slotIndex>
+		<slotListIndex>0</slotListIndex>
 	</driver>
 	<driver>
 		<name>Belgium eID - Linux (x86)</name>
 		<path>/usr/lib/libbeidpkcs11.so</path>
 		<slot>0</slot>
-		<slotIndex>0</slotIndex>
+		<slotListIndex>0</slotListIndex>
 	</driver>
 	<driver>
 		<name>Belgium eID - Linux (x64)</name>
 		<path>/usr/lib64/libbeidpkcs11.so</path>
 		<slot>0</slot>
-		<slotIndex>0</slotIndex>
+		<slotListIndex>0</slotListIndex>
 	</driver>
 	<driver>
 		<name>Portuguese Cartão de Cidadão - Windows (x86)</name>
 		<path>C:\Windows\System32\pteidpkcs11.dll</path>
 		<slot>0</slot>
-		<slotIndex>0</slotIndex>
+		<slotListIndex>0</slotListIndex>
 	</driver>
 	<driver>
 		<name>Portuguese Cartão de Cidadão - Windows (x64)</name>
 		<path>C:\Windows\SysWOW64\pteidpkcs11.dll</path>
 		<slot>0</slot>
-		<slotIndex>0</slotIndex>
+		<slotListIndex>0</slotListIndex>
 	</driver>
 	<driver>
 		<name>Portuguese Cartão de Cidadão - Linux</name>
 		<path>/usr/local/lib/libpteidpkcs11.so</path>
 		<slot>0</slot>
-		<slotIndex>0</slotIndex>
+		<slotListIndex>0</slotListIndex>
 	</driver>
 	<driver>
 		<name>Spanish DNIe - Windows (x86)</name>
 		<path>C:\WINDOWS\System32\UsrPkcs11.dll</path>
 		<slot>1</slot>
-		<slotIndex>0</slotIndex>
+		<slotListIndex>0</slotListIndex>
 	</driver>
 	<driver>
 		<name>Spanish DNIe - Windows (x64)</name>
 		<path>C:\WINDOWS\SysWOW64\UsrPkcs11.dll</path>
 		<slot>1</slot>
-		<slotIndex>0</slotIndex>
+		<slotListIndex>0</slotListIndex>
 	</driver>
 	<driver>
 		<name>Spanish DNIe - Linux (x86)</name>
 		<path>/usr/lib/opensc-pkcs11.so</path>
 		<slot>0</slot>
-		<slotIndex>0</slotIndex>
+		<slotListIndex>0</slotListIndex>
 	</driver>
 	<driver>
 		<name>Spanish DNIe - Linux (x64)</name>
 		<path>/usr/lib64/opensc-pkcs11.so</path>
 		<slot>0</slot>
-		<slotIndex>0</slotIndex>
+		<slotListIndex>0</slotListIndex>
 	</driver>
 	<driver>
 		<name>Spanish DNIe - Mac OS X</name>
 		<path>/Library/OpenSC/lib/opensc-pkcs11.so</path>
 		<slot>0</slot>
-		<slotIndex>0</slotIndex>
+		<slotListIndex>0</slotListIndex>
 	</driver>
 		<driver>
 		<name>Switzerland SuisseID - Windows (x86)</name>
 		<path>C:\WINDOWS\System32\siecap11.dll</path>
 		<slot>3</slot>
-		<slotIndex>0</slotIndex>
+		<slotListIndex>0</slotListIndex>
 	</driver>
 </driverConfiguration>


### PR DESCRIPTION
The code was changed to read the slot list index of the drivers using
the element name "slotListIndex" (instead of "slotList") but the file
was not updated accordingly leading to (silent) NullPointerException
in DriverConfiguration when attempting to read them.
Change class DriverConfiguration to prevent the NullPointerException
when reading the slot or slot list index of the drivers if they were not
provided.