### PR TITLE
Correctly identify fuzzer tab in HTTP pop up menus

### DIFF
--- a/src/org/zaproxy/zap/view/popup/PopupMenuHttpMessageContainer.java
+++ b/src/org/zaproxy/zap/view/popup/PopupMenuHttpMessageContainer.java
@@ -363,7 +363,7 @@ public class PopupMenuHttpMessageContainer extends ExtensionPopupMenuMessageCont
         case ActiveScanPanel.MESSAGE_CONTAINER_NAME:
             invoker = Invoker.ACTIVE_SCANNER_PANEL;
             break;
-        case "HttpFuzzerResultsContentPanel":
+        case "fuzz.httpfuzzerResultsContentPanel":
             invoker = Invoker.FUZZER_PANEL;
             break;
         case "ForcedBrowseMessageContainer":

--- a/src/org/zaproxy/zap/view/popup/PopupMenuItemHttpMessageContainer.java
+++ b/src/org/zaproxy/zap/view/popup/PopupMenuItemHttpMessageContainer.java
@@ -291,6 +291,9 @@ public abstract class PopupMenuItemHttpMessageContainer extends ExtensionPopupMe
         case "ForcedBrowseMessageContainer":
             invoker = Invoker.FORCED_BROWSE_PANEL;
             break;
+        case "fuzz.httpfuzzerResultsContentPanel":
+            invoker = Invoker.FUZZER_PANEL;
+            break;
         default:
             invoker = Invoker.UNKNOWN;
         }


### PR DESCRIPTION
Change classes PopupMenuItemHttpMessageContainer and
PopupMenuHttpMessageContainer to correctly identify the Fuzzer tab, so
custom pop up menus can be correctly shown (or not) in that tab.