### PR TITLE
Enable Copy URLs pop up menu item for all messages

### DIFF
--- a/src/org/zaproxy/zap/extension/stdmenus/PopupMenuCopyUrls.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/PopupMenuCopyUrls.java
@@ -57,6 +57,11 @@ public class PopupMenuCopyUrls extends PopupMenuItemHistoryReferenceContainer im
     }
 
     @Override
+    protected boolean isButtonEnabledForHistoryReference(HistoryReference historyReference) {
+        return true;
+    }
+
+    @Override
     public boolean isSafe() {
     	return true;
     }


### PR DESCRIPTION
Change pop up menu item "Copy URLs to Clipboard" (PopupMenuCopyUrls) to
be enabled for all HTTP message types, so it can be used in all GUI
components that show HTTP messages.
 ---
Issue reported in the IRC channel.