### PR TITLE
Remove non-default constructors from AboutPanel

### DIFF
--- a/src/org/zaproxy/zap/view/AboutPanel.java
+++ b/src/org/zaproxy/zap/view/AboutPanel.java
@@ -24,7 +24,6 @@ import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-import java.awt.LayoutManager;
 import java.util.Calendar;
 
 import javax.swing.BorderFactory;
@@ -63,43 +62,12 @@ public class AboutPanel extends JPanel {
 	
 	private static final String HOMEPAGE = "<html><body><p><a>https://www.owasp.org/index.php/ZAP</a></p></body></html>";
 
-
+	/**
+	 * Constructs an {@code AboutPanel}.
+	 */
 	public AboutPanel() {
-		super();
-		initialize();
-	}
+		super(new GridBagLayout(), true);
 
-	/**
-	 * @param arg0
-	 */
-	public AboutPanel(boolean arg0) {
-		super(arg0);
-		initialize();
-	}
-
-	/**
-	 * @param arg0
-	 */
-	public AboutPanel(LayoutManager arg0) {
-		super(arg0);
-		initialize();
-	}
-
-	/**
-	 * @param arg0
-	 * @param arg1
-	 */
-	public AboutPanel(LayoutManager arg0, boolean arg1) {
-		super(arg0, arg1);
-		initialize();
-	}
-
-	/**
-	 * This method initializes this
-	 * 
-	 */
-	private void initialize() {
-		
 		GridBagConstraints gbcOtherCopyright = new GridBagConstraints();
 		GridBagConstraints gbcCopyrightDetail = new GridBagConstraints();
 		GridBagConstraints gbcDisclaimer = new GridBagConstraints();
@@ -109,7 +77,6 @@ public class AboutPanel extends JPanel {
 		GridBagConstraints gbcProgramName = new GridBagConstraints();
 		GridBagConstraints gbcLogo = new GridBagConstraints();
 		
-		this.setLayout(new GridBagLayout());
 		this.setPreferredSize(new Dimension(420, 460));
 		this.setBackground(Color.white);
 		this.setBorder(BorderFactory.createEtchedBorder(javax.swing.border.EtchedBorder.RAISED));


### PR DESCRIPTION
Remove all constructors except default constructor as they are not used
(nor they would work correctly, the LayoutManager would be overridden by
the initialize method which sets another LayoutManager again).
Remove initialize method, merged with default constructor.

Though the changes are not binary compatible the class is not expected
to be used by non-core code.