### PR TITLE
Tidy up ScanPanel2 class

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/ActiveScanPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScanPanel.java
@@ -88,7 +88,7 @@ public class ActiveScanPanel extends ScanPanel2<ActiveScan, ScanController<Activ
      */
     public ActiveScanPanel(ExtensionActiveScan extension) {
     	// 'fire' icon
-        super("ascan", new ImageIcon(ActiveScanPanel.class.getResource("/resource/icon/16/093.png")), extension, null);
+        super("ascan", new ImageIcon(ActiveScanPanel.class.getResource("/resource/icon/16/093.png")), extension);
         this.extension = extension;
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
 				KeyEvent.VK_A, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK | Event.SHIFT_MASK, false));

--- a/src/org/zaproxy/zap/extension/spider/SpiderPanel.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderPanel.java
@@ -168,8 +168,7 @@ public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderSca
 	 * @param spiderScanParam the spider scan parameters
 	 */
 	public SpiderPanel(ExtensionSpider extension, SpiderParam spiderScanParam) {
-		super("spider", new ImageIcon(SpiderPanel.class.getResource("/resource/icon/16/spider.png")), extension,
-				spiderScanParam);
+		super("spider", new ImageIcon(SpiderPanel.class.getResource("/resource/icon/16/spider.png")), extension);
 
 		tabbedPane = new JTabbedPane();
 

--- a/src/org/zaproxy/zap/view/ScanPanel2.java
+++ b/src/org/zaproxy/zap/view/ScanPanel2.java
@@ -60,9 +60,9 @@ public abstract class ScanPanel2<GS extends GenericScanner2, SC extends ScanCont
 	private static final long serialVersionUID = 1L;
 
 	protected enum Location {start, beforeSites, beforeButtons, beforeProgressBar, afterProgressBar};
-	public String prefix;
+	private final String prefix;
 	
-	private SC controller = null;
+	private final SC controller;
 	private JPanel panelCommand = null;
 	private JToolBar panelToolbar = null;
 	private JLabel scannedCountNameLabel = null;
@@ -84,12 +84,28 @@ public abstract class ScanPanel2<GS extends GenericScanner2, SC extends ScanCont
 	private static Logger log = Logger.getLogger(ScanPanel2.class);
     
     /**
-     * @param prefix
-     * @param icon
-     * @param extension
-     * @param scanParam
+     * Constructs a {@code ScanPanel2} with the given message resources prefix, tab icon and scan controller.
+     * 
+     * @param prefix the prefix for the resource messages
+     * @param icon the icon for the tab of the panel
+     * @param controller the scan controller
+     * @param scanParam unused
+     * @deprecated (TODO add version) Use {@link #ScanPanel2(String, ImageIcon, ScanController)} instead.
      */
+    @Deprecated
     public ScanPanel2(String prefix, ImageIcon icon, SC controller, AbstractParam scanParam) {
+        this(prefix, icon, controller);
+    }
+
+    /**
+     * Constructs a {@code ScanPanel2} with the given message resources prefix, tab icon and scan controller.
+     * 
+     * @param prefix the prefix for the resource messages
+     * @param icon the icon for the tab of the panel
+     * @param controller the scan controller
+     * @since TODO add version
+     */
+    public ScanPanel2(String prefix, ImageIcon icon, SC controller) {
         super();
         this.prefix = prefix;
         this.controller = controller;


### PR DESCRIPTION
Class ScanPanel2:
 - Deprecate current constructor, it has more parameters than the ones
 required (AbstractParam);
 - Add a constructor that just has the required parameters;
 - Change visibility of instance variable "prefix" to private (from
 public);
 - Set final modifier to instance variables prefix and controller.

Change classes SpiderPanel and ActiveScanPanel to use the new
constructor.