### PR TITLE
Remove unused menu constructors

### DIFF
--- a/src/org/parosproxy/paros/extension/history/PopupMenuExportMessage.java
+++ b/src/org/parosproxy/paros/extension/history/PopupMenuExportMessage.java
@@ -28,6 +28,7 @@
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
 // ZAP: 2014/03/23 Changed to a JMenuItem.
 // ZAP: 2016/04/05 Issue 2458: Fix xlint warning messages 
+// ZAP: 2016/07/25 Remove String constructor (unused/unnecessary)
 
 package org.parosproxy.paros.extension.history;
 
@@ -61,22 +62,7 @@ public class PopupMenuExportMessage extends JMenuItem {
      * 
      */
     public PopupMenuExportMessage() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param label
-     */
-    public PopupMenuExportMessage(String label) {
-        super(label);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setText(Constant.messages.getString("history.export.messages.popup"));	// ZAP: i18n
+        super(Constant.messages.getString("history.export.messages.popup"));	// ZAP: i18n
 
         this.addActionListener(new java.awt.event.ActionListener() { 
 

--- a/src/org/parosproxy/paros/extension/history/PopupMenuExportResponse.java
+++ b/src/org/parosproxy/paros/extension/history/PopupMenuExportResponse.java
@@ -24,6 +24,7 @@
 // ZAP: 2012/07/29 Issue 43: Cleaned up access to ExtensionHistory UI
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
 // ZAP: 2014/03/23 Changed to a JMenuItem.
+// ZAP: 2016/07/25 Remove String constructor (unused/unnecessary)
 
 package org.parosproxy.paros.extension.history;
 
@@ -55,23 +56,7 @@ public class PopupMenuExportResponse extends JMenuItem {
      * 
      */
     public PopupMenuExportResponse() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param label
-     */
-    public PopupMenuExportResponse(String label) {
-        super(label);
-    }
-
-	/**
-	 * This method initializes this
-	 * 
-	 */
-	private void initialize() {
-        this.setText(Constant.messages.getString("history.export.response.popup"));	// ZAP: i18n
+        super(Constant.messages.getString("history.export.response.popup"));	// ZAP: i18n
 
         this.addActionListener(new java.awt.event.ActionListener() { 
 

--- a/src/org/zaproxy/zap/extension/alert/PopupMenuAlertDelete.java
+++ b/src/org/zaproxy/zap/extension/alert/PopupMenuAlertDelete.java
@@ -45,22 +45,7 @@ public class PopupMenuAlertDelete extends ExtensionPopupMenuItem {
      * 
      */
     public PopupMenuAlertDelete() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param label
-     */
-    public PopupMenuAlertDelete(String label) {
-        super(label);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setText(Constant.messages.getString("scanner.delete.popup"));
+        super(Constant.messages.getString("scanner.delete.popup"));
 
         this.addActionListener(new java.awt.event.ActionListener() { 
 

--- a/src/org/zaproxy/zap/extension/alert/PopupMenuAlertEdit.java
+++ b/src/org/zaproxy/zap/extension/alert/PopupMenuAlertEdit.java
@@ -46,22 +46,7 @@ public class PopupMenuAlertEdit extends ExtensionPopupMenuItem {
      * 
      */
     public PopupMenuAlertEdit() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param label
-     */
-    public PopupMenuAlertEdit(String label) {
-        super(label);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setText(Constant.messages.getString("scanner.edit.popup"));
+        super(Constant.messages.getString("scanner.edit.popup"));
 
         this.addActionListener(new java.awt.event.ActionListener() { 
 

--- a/src/org/zaproxy/zap/extension/alert/PopupMenuAlertsRefresh.java
+++ b/src/org/zaproxy/zap/extension/alert/PopupMenuAlertsRefresh.java
@@ -40,22 +40,7 @@ public class PopupMenuAlertsRefresh extends ExtensionPopupMenuItem {
      * 
      */
     public PopupMenuAlertsRefresh() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param label
-     */
-    public PopupMenuAlertsRefresh(String label) {
-        super(label);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setText(Constant.messages.getString("alerts.refresh.popup"));
+        super(Constant.messages.getString("alerts.refresh.popup"));
 
         this.addActionListener(new java.awt.event.ActionListener() { 
 

--- a/src/org/zaproxy/zap/extension/brk/PopupMenuEditBreak.java
+++ b/src/org/zaproxy/zap/extension/brk/PopupMenuEditBreak.java
@@ -34,22 +34,7 @@ public class PopupMenuEditBreak extends ExtensionPopupMenuItem {
 
 	
     public PopupMenuEditBreak() {
-        super();
- 		initialize();
-    }
-
-    
-    public PopupMenuEditBreak(String label) {
-        super(label);
-    }
-
-	public void setExtension(ExtensionBreak extension) {
-		this.extension = extension;
-	}
-
-    
-	private void initialize() {
-        this.setText(Constant.messages.getString("brk.edit.popup"));
+        super(Constant.messages.getString("brk.edit.popup"));
         this.addActionListener(new java.awt.event.ActionListener() { 
 
         	@Override
@@ -57,6 +42,10 @@ public class PopupMenuEditBreak extends ExtensionPopupMenuItem {
         		extension.editUiSelectedBreakpoint();
         	}
         });
+	}
+
+	public void setExtension(ExtensionBreak extension) {
+		this.extension = extension;
 	}
 
     @Override

--- a/src/org/zaproxy/zap/extension/brk/PopupMenuRemove.java
+++ b/src/org/zaproxy/zap/extension/brk/PopupMenuRemove.java
@@ -33,18 +33,7 @@ public class PopupMenuRemove extends ExtensionPopupMenuItem {
     
     
     public PopupMenuRemove() {
-        super();
- 		initialize();
-    }
-
-    
-    public PopupMenuRemove(String label) {
-        super(label);
-    }
-
-	
-	private void initialize() {
-        this.setText(Constant.messages.getString("brk.remove.popup"));
+        super(Constant.messages.getString("brk.remove.popup"));
 
         this.addActionListener(new java.awt.event.ActionListener() { 
 

--- a/src/org/zaproxy/zap/extension/history/PopupMenuExportURLs.java
+++ b/src/org/zaproxy/zap/extension/history/PopupMenuExportURLs.java
@@ -53,22 +53,7 @@ public class PopupMenuExportURLs extends ExtensionPopupMenuItem {
      * 
      */
     public PopupMenuExportURLs() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param label
-     */
-    public PopupMenuExportURLs(String label) {
-        super(label);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setText(Constant.messages.getString("exportUrls.popup"));
+        super(Constant.messages.getString("exportUrls.popup"));
 
         this.addActionListener(new java.awt.event.ActionListener() { 
 

--- a/src/org/zaproxy/zap/extension/params/PopupMenuAddAntiCSRF.java
+++ b/src/org/zaproxy/zap/extension/params/PopupMenuAddAntiCSRF.java
@@ -36,26 +36,7 @@ public class PopupMenuAddAntiCSRF extends ExtensionPopupMenuItem {
      * 
      */
     public PopupMenuAddAntiCSRF() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param label
-     */
-    public PopupMenuAddAntiCSRF(String label) {
-        super(label);
-    }
-
-	public void setExtension(ExtensionParams extension) {
-		this.extension = extension;
-	}
-
-    /**
-	 * This method initialises this
-	 */
-	private void initialize() {
-        this.setText(Constant.messages.getString("params.anticrsf.add.popup"));
+        super(Constant.messages.getString("params.anticrsf.add.popup"));
         this.addActionListener(new java.awt.event.ActionListener() { 
 
         	@Override
@@ -64,6 +45,10 @@ public class PopupMenuAddAntiCSRF extends ExtensionPopupMenuItem {
         		extension.addAntiCsrfToken();
         	}
         });
+	}
+
+	public void setExtension(ExtensionParams extension) {
+		this.extension = extension;
 	}
 
     @Override

--- a/src/org/zaproxy/zap/extension/params/PopupMenuAddSession.java
+++ b/src/org/zaproxy/zap/extension/params/PopupMenuAddSession.java
@@ -36,26 +36,7 @@ public class PopupMenuAddSession extends ExtensionPopupMenuItem {
      * 
      */
     public PopupMenuAddSession() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param label
-     */
-    public PopupMenuAddSession(String label) {
-        super(label);
-    }
-
-	public void setExtension(ExtensionParams extension) {
-		this.extension = extension;
-	}
-
-    /**
-	 * This method initialises this
-	 */
-	private void initialize() {
-        this.setText(Constant.messages.getString("params.session.add.popup"));
+        super(Constant.messages.getString("params.session.add.popup"));
         this.addActionListener(new java.awt.event.ActionListener() { 
 
         	@Override
@@ -66,6 +47,10 @@ public class PopupMenuAddSession extends ExtensionPopupMenuItem {
         });
 
 			
+	}
+
+	public void setExtension(ExtensionParams extension) {
+		this.extension = extension;
 	}
 
     @Override

--- a/src/org/zaproxy/zap/extension/params/PopupMenuParamSearch.java
+++ b/src/org/zaproxy/zap/extension/params/PopupMenuParamSearch.java
@@ -35,26 +35,7 @@ public class PopupMenuParamSearch extends ExtensionPopupMenuItem {
      * 
      */
     public PopupMenuParamSearch() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param label
-     */
-    public PopupMenuParamSearch(String label) {
-        super(label);
-    }
-
-	public void setExtension(ExtensionParams extension) {
-		this.extension = extension;
-	}
-
-    /**
-	 * This method initialises this
-	 */
-	private void initialize() {
-        this.setText(Constant.messages.getString("params.search.popup"));
+        super(Constant.messages.getString("params.search.popup"));
         this.addActionListener(new java.awt.event.ActionListener() { 
 
         	@Override
@@ -64,6 +45,10 @@ public class PopupMenuParamSearch extends ExtensionPopupMenuItem {
         });
 
 			
+	}
+
+	public void setExtension(ExtensionParams extension) {
+		this.extension = extension;
 	}
 
     @Override

--- a/src/org/zaproxy/zap/extension/params/PopupMenuRemoveAntiCSRF.java
+++ b/src/org/zaproxy/zap/extension/params/PopupMenuRemoveAntiCSRF.java
@@ -36,26 +36,7 @@ public class PopupMenuRemoveAntiCSRF extends ExtensionPopupMenuItem {
      * 
      */
     public PopupMenuRemoveAntiCSRF() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param label
-     */
-    public PopupMenuRemoveAntiCSRF(String label) {
-        super(label);
-    }
-
-	public void setExtension(ExtensionParams extension) {
-		this.extension = extension;
-	}
-
-    /**
-	 * This method initialises this
-	 */
-	private void initialize() {
-        this.setText(Constant.messages.getString("params.anticrsf.remove.popup"));
+        super(Constant.messages.getString("params.anticrsf.remove.popup"));
         this.addActionListener(new java.awt.event.ActionListener() { 
 
         	@Override
@@ -66,6 +47,10 @@ public class PopupMenuRemoveAntiCSRF extends ExtensionPopupMenuItem {
         });
 
 			
+	}
+
+	public void setExtension(ExtensionParams extension) {
+		this.extension = extension;
 	}
 
     @Override

--- a/src/org/zaproxy/zap/extension/params/PopupMenuRemoveSession.java
+++ b/src/org/zaproxy/zap/extension/params/PopupMenuRemoveSession.java
@@ -36,26 +36,7 @@ public class PopupMenuRemoveSession extends ExtensionPopupMenuItem {
      * 
      */
     public PopupMenuRemoveSession() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param label
-     */
-    public PopupMenuRemoveSession(String label) {
-        super(label);
-    }
-
-	public void setExtension(ExtensionParams extension) {
-		this.extension = extension;
-	}
-
-    /**
-	 * This method initialises this
-	 */
-	private void initialize() {
-        this.setText(Constant.messages.getString("params.session.remove.popup"));
+        super(Constant.messages.getString("params.session.remove.popup"));
         this.addActionListener(new java.awt.event.ActionListener() { 
 
         	@Override
@@ -66,6 +47,10 @@ public class PopupMenuRemoveSession extends ExtensionPopupMenuItem {
         });
 
 			
+	}
+
+	public void setExtension(ExtensionParams extension) {
+		this.extension = extension;
 	}
 
     @Override

--- a/src/org/zaproxy/zap/extension/siterefresh/PopupMenuSitesRefresh.java
+++ b/src/org/zaproxy/zap/extension/siterefresh/PopupMenuSitesRefresh.java
@@ -35,22 +35,7 @@ public class PopupMenuSitesRefresh extends ExtensionPopupMenuItem {
      * 
      */
     public PopupMenuSitesRefresh() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param label
-     */
-    public PopupMenuSitesRefresh(String label) {
-        super(label);
-    }
-
-    /**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setText(Constant.messages.getString("siterefresh.popop"));
+        super(Constant.messages.getString("siterefresh.popop"));
         
         this.addActionListener(new java.awt.event.ActionListener() { 
 


### PR DESCRIPTION
Remove unused (String) constructors from pop up and top level menu
classes, the constructors are not being used moreover they would not
work as expected since the action listeners were not being added (thus
not doing anything by default). Also, for pop up menus that have an
"initialize" method, merge it with default constructor.