### PR TITLE
Replace unused parameter in AllCategoryTableModel

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/AllCategoryTableModel.java
+++ b/src/org/zaproxy/zap/extension/ascan/AllCategoryTableModel.java
@@ -23,6 +23,7 @@
 // ZAP: 2012/05/03 Moved a statement in the method setValueAt(Object, int , int).
 // ZAP: 2013/11/28 Issue 923: Allow individual rule thresholds and strengths to be set via GUI
 // ZAP: 2014/05/20 Issue 377: Unfulfilled dependencies hang the active scan
+// ZAP: 2016/07/25 Change constructor's parameter to PluginFactory
 package org.zaproxy.zap.extension.ascan;
 
 import java.util.HashMap;
@@ -49,10 +50,13 @@ public class AllCategoryTableModel extends DefaultTableModel {
     private PluginFactory pluginFactory;
 
     /**
-     * @param policyAllCategoryPanel 
+     * Constructs an {@code AllCategoryTableModel} with the given plugin factory.
      *
+     * @param pluginFactory the plugin factory
+     * @see #setPluginFactory(PluginFactory)
      */
-    public AllCategoryTableModel(PolicyAllCategoryPanel policyAllCategoryPanel) {
+    public AllCategoryTableModel(PluginFactory pluginFactory) {
+        this.pluginFactory = pluginFactory;
     }
 
     

--- a/src/org/zaproxy/zap/extension/ascan/PolicyAllCategoryPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/PolicyAllCategoryPanel.java
@@ -22,6 +22,7 @@
 // ZAP: 2013/11/28 Issue 923: Allow individual rule thresholds and strengths to be set via GUI
 // ZAP: 2016/01/19 Allow to obtain the ScanPolicy
 // ZAP: 2016/04/04 Use StatusUI in scanners' dialogues
+// ZAP: 2016/07/25 Use new AllCategoryTableModel's constructor
 package org.zaproxy.zap.extension.ascan;
 
 import java.awt.GridBagConstraints;
@@ -494,8 +495,7 @@ public class PolicyAllCategoryPanel extends AbstractParamPanel {
      */
     private AllCategoryTableModel getAllCategoryTableModel() {
         if (allCategoryTableModel == null) {
-            allCategoryTableModel = new AllCategoryTableModel(this);
-            allCategoryTableModel.setPluginFactory(this.policy.getPluginFactory());
+            allCategoryTableModel = new AllCategoryTableModel(policy.getPluginFactory());
         }
         
         return allCategoryTableModel;


### PR DESCRIPTION
Change AllCategoryTableModel's constructor to have another parameter
type (PluginFactory) which is used to initialise the model.
Change class PolicyAllCategoryPanel to use the new constructor.

Though the changes are not binary compatible the class is not expected
to be used by non-core code.