### PR TITLE
Remove empty plain/JavaDoc comments

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/MultipartFormParser.java
+++ b/src/org/parosproxy/paros/core/scanner/MultipartFormParser.java
@@ -95,9 +95,6 @@ public class MultipartFormParser {
         return boundary;
     }
         
-    /**
-     *
-     */
     public MultipartParam getNextParam() throws IOException {
         MultipartParam param;
         String line;

--- a/src/org/parosproxy/paros/core/scanner/PluginFactory.java
+++ b/src/org/parosproxy/paros/core/scanner/PluginFactory.java
@@ -81,9 +81,6 @@ public class PluginFactory {
     private boolean init = false;
     private Configuration config;
 
-    /**
-     *
-     */
     public PluginFactory() {
         super();
         HierarchicalConfiguration configuration = new HierarchicalConfiguration();

--- a/src/org/parosproxy/paros/core/scanner/VariantJSONQuery.java
+++ b/src/org/parosproxy/paros/core/scanner/VariantJSONQuery.java
@@ -84,9 +84,6 @@ public class VariantJSONQuery extends VariantAbstractRPCQuery {
     private static final int STATE_READ_VALUE = 2;
     private static final int STATE_READ_POST_VALUE = 3;
     
-    /**
-     * 
-     */
     private void parseObject() {
         int state = STATE_READ_START_OBJECT;
         boolean objectRead = false;
@@ -297,9 +294,6 @@ public class VariantJSONQuery extends VariantAbstractRPCQuery {
         }
     }
 
-    /**
-     *
-     */
     protected class SimpleStringReader {
         private static final String WS = " \t\r\n";
         private String str;
@@ -344,9 +338,6 @@ public class VariantJSONQuery extends VariantAbstractRPCQuery {
             return str.charAt(next++);
         }
 
-        /**
-         *
-         */
         public void unreadLastCharacter() {
             next--;
         }

--- a/src/org/parosproxy/paros/db/DatabaseUnsupportedException.java
+++ b/src/org/parosproxy/paros/db/DatabaseUnsupportedException.java
@@ -19,9 +19,6 @@ package org.parosproxy.paros.db;
 
 public class DatabaseUnsupportedException extends Exception {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 
 }

--- a/src/org/parosproxy/paros/db/paros/ParosAbstractTable.java
+++ b/src/org/parosproxy/paros/db/paros/ParosAbstractTable.java
@@ -38,9 +38,6 @@ import org.parosproxy.paros.db.DatabaseUnsupportedException;
     private Connection connection = null;
     private ParosDatabaseServer server = null;
     
-    /**
-     * 
-     */
     public ParosAbstractTable() {
     }
     

--- a/src/org/parosproxy/paros/extension/edit/ExtensionEdit.java
+++ b/src/org/parosproxy/paros/extension/edit/ExtensionEdit.java
@@ -47,9 +47,6 @@ public class ExtensionEdit extends ExtensionAdaptor {
     private ZapMenuItem menuFind = null;
     private PopupFindMenu popupFindMenu = null;
 
-    /**
-     * 
-     */
     public ExtensionEdit() {
         super("ExtensionEdit");
         this.setOrder(4);

--- a/src/org/parosproxy/paros/extension/filter/AllFilterPanel.java
+++ b/src/org/parosproxy/paros/extension/filter/AllFilterPanel.java
@@ -50,9 +50,7 @@ public class AllFilterPanel extends AbstractParamPanel {
 	private static final long serialVersionUID = 1L;
 	private JTable tableFilter = null;
 	private JScrollPane jScrollPane = null;
-    /**
-     * 
-     */
+
     public AllFilterPanel() {
         super();
  		initialize();

--- a/src/org/parosproxy/paros/extension/filter/AllFilterTableModel.java
+++ b/src/org/parosproxy/paros/extension/filter/AllFilterTableModel.java
@@ -51,9 +51,7 @@ public class AllFilterTableModel extends DefaultTableModel {
     private void setAllFilters(List<Filter> allFilters) {
         this.allFilters = allFilters;
     }
-    /**
-     * 
-     */
+
     public AllFilterTableModel() {
         // ZAP: Added the type argument.
         allFilters = new Vector<>();

--- a/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -152,9 +152,6 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
 	private Logger logger = Logger.getLogger(ExtensionHistory.class);
 
 
-    /**
-     * 
-     */
     public ExtensionHistory() {
         super(NAME);
         this.setOrder(16);

--- a/src/org/parosproxy/paros/extension/history/LogPanel.java
+++ b/src/org/parosproxy/paros/extension/history/LogPanel.java
@@ -192,7 +192,6 @@ public class LogPanel extends AbstractPanel implements Runnable {
 		}
 		return historyPanel;
 	}
-	/**/
 
 	private javax.swing.JToolBar getPanelToolbar() {
 		if (panelToolbar == null) {

--- a/src/org/parosproxy/paros/extension/history/PopupMenuEmbeddedBrowser.java
+++ b/src/org/parosproxy/paros/extension/history/PopupMenuEmbeddedBrowser.java
@@ -55,9 +55,6 @@ public class PopupMenuEmbeddedBrowser extends ExtensionPopupMenuItem {
     private BrowserLauncher launcher = null;
     private boolean supported = true;
 
-	/**
-     * 
-     */
     public PopupMenuEmbeddedBrowser() {
         super();
  		initialize();

--- a/src/org/parosproxy/paros/extension/history/PopupMenuExportMessage.java
+++ b/src/org/parosproxy/paros/extension/history/PopupMenuExportMessage.java
@@ -58,9 +58,6 @@ public class PopupMenuExportMessage extends JMenuItem {
     private static final String CRLF = "\r\n";
     private ExtensionHistory extension = null;
     
-    /**
-     * 
-     */
     public PopupMenuExportMessage() {
         super(Constant.messages.getString("history.export.messages.popup"));	// ZAP: i18n
 

--- a/src/org/parosproxy/paros/extension/history/PopupMenuExportResponse.java
+++ b/src/org/parosproxy/paros/extension/history/PopupMenuExportResponse.java
@@ -52,9 +52,6 @@ public class PopupMenuExportResponse extends JMenuItem {
 
     private ExtensionHistory extension = null;
     
-    /**
-     * 
-     */
     public PopupMenuExportResponse() {
         super(Constant.messages.getString("history.export.response.popup"));	// ZAP: i18n
 

--- a/src/org/parosproxy/paros/extension/history/PopupMenuResendSites.java
+++ b/src/org/parosproxy/paros/extension/history/PopupMenuResendSites.java
@@ -48,9 +48,6 @@ public class PopupMenuResendSites extends ExtensionPopupMenuItem {
     
     private ExtensionHistory extension;
 
-	/**
-     * 
-     */
     public PopupMenuResendSites() {
         super();
  		initialize();

--- a/src/org/parosproxy/paros/extension/report/ExtensionReport.java
+++ b/src/org/parosproxy/paros/extension/report/ExtensionReport.java
@@ -50,9 +50,6 @@ public class ExtensionReport extends ExtensionAdaptor implements CommandLineList
 	private ZapMenuItem menuItemXmlReport = null;
 	private CommandLineArgument[] arguments = new CommandLineArgument[1];
 
-    /**
-     * 
-     */
     public ExtensionReport() {
         super("ExtensionReport");
         this.setOrder(14);

--- a/src/org/parosproxy/paros/extension/state/ExtensionState.java
+++ b/src/org/parosproxy/paros/extension/state/ExtensionState.java
@@ -52,9 +52,7 @@ public class ExtensionState extends ExtensionAdaptor implements SessionChangedLi
 	private JCheckBoxMenuItem menuSessionTrackingEnable = null;
 
 	private ZapMenuItem menuResetSessionState = null;
-    /**
-     * 
-     */
+
     public ExtensionState() {
         super("ExtensionState");
         this.setOrder(12);

--- a/src/org/parosproxy/paros/view/LicenseFrame.java
+++ b/src/org/parosproxy/paros/view/LicenseFrame.java
@@ -50,9 +50,7 @@ public class LicenseFrame extends AbstractFrame {
 	private boolean accepted = false;
 
 	private JPanel jPanel2 = null;
-    /**
-     *
-     */
+
     public LicenseFrame() {
         super();
  		initialize();

--- a/src/org/parosproxy/paros/view/MainPopupMenu.java
+++ b/src/org/parosproxy/paros/view/MainPopupMenu.java
@@ -104,9 +104,6 @@ public class MainPopupMenu extends JPopupMenu {
      */
     private MenuElement[] pathSelectedMenu;
 
-    /**
-     * 
-     */
     public MainPopupMenu(View view) {
         super();
  		initialize();

--- a/src/org/parosproxy/paros/view/OutputPanel.java
+++ b/src/org/parosproxy/paros/view/OutputPanel.java
@@ -66,9 +66,6 @@ public class OutputPanel extends AbstractPanel {
 	private JScrollPane jScrollPane = null;
 	private ZapTextArea txtOutput = null;
 
-	/**
-     * 
-     */
     public OutputPanel() {
         super();
  		initialize();

--- a/src/org/zaproxy/zap/ZAP.java
+++ b/src/org/zaproxy/zap/ZAP.java
@@ -36,9 +36,6 @@ import org.zaproxy.zap.eventBus.EventBus;
 import org.zaproxy.zap.eventBus.SimpleEventBus;
 import org.zaproxy.zap.utils.ClassLoaderUtil;
 
-/**
- * 
- */
 public class ZAP {
 
     /**

--- a/src/org/zaproxy/zap/control/ExtensionFactory.java
+++ b/src/org/zaproxy/zap/control/ExtensionFactory.java
@@ -57,9 +57,6 @@ public class ExtensionFactory {
 
     private static AddOnLoader addOnLoader = null;
 
-    /**
-     *
-     */
     public ExtensionFactory() {
         super();
     }

--- a/src/org/zaproxy/zap/db/sql/SqlAbstractTable.java
+++ b/src/org/zaproxy/zap/db/sql/SqlAbstractTable.java
@@ -34,9 +34,6 @@ import org.zaproxy.zap.db.sql.SqlDatabaseServer;
     private Connection connection = null;
     private SqlDatabaseServer sqlServer = null;
     
-    /**
-     * 
-     */
     public SqlAbstractTable() {
     }
     

--- a/src/org/zaproxy/zap/db/sql/SqlTableHistory.java
+++ b/src/org/zaproxy/zap/db/sql/SqlTableHistory.java
@@ -148,7 +148,6 @@ public class SqlTableHistory extends SqlAbstractTable implements TableHistory {
 			    DbUtils.executeAndClose(connection.prepareStatement(DbSQL.getSQL("history.ps.addrespfromtarget")));
 			    DbUtils.executeUpdateAndClose(connection.prepareStatement(DbSQL.getSQL("history.ps.setrespfromtarget")));
 			}
-			/* */
 			
 			int requestbodysizeindb = DbUtils.getColumnSize(connection, TABLE_NAME, REQBODY);
 			int responsebodysizeindb = DbUtils.getColumnSize(connection, TABLE_NAME, RESBODY);

--- a/src/org/zaproxy/zap/extension/alert/AlertPanel.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertPanel.java
@@ -136,9 +136,6 @@ public class AlertPanel extends AbstractPanel {
 	private ExtensionHistory extHist = null; 
 
 	
-    /**
-     * 
-     */
     public AlertPanel(ExtensionAlert extension) {
         super();
         this.extension = extension;

--- a/src/org/zaproxy/zap/extension/alert/AlertViewPanel.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertViewPanel.java
@@ -105,9 +105,6 @@ public class AlertViewPanel extends AbstractPanel {
      */
 	private HttpMessage httpMessage;
 
-	/**
-     * 
-     */
     public AlertViewPanel() {
     	this (false);
     }

--- a/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -76,9 +76,6 @@ public class ExtensionAlert extends ExtensionAdaptor implements SessionChangedLi
 	private AlertParam alertParam = null;
 	private OptionsAlertPanel optionsPanel = null;
 
-    /**
-     *
-     */
     public ExtensionAlert() {
         super(NAME);
         this.setOrder(27);

--- a/src/org/zaproxy/zap/extension/alert/PopupMenuAlertDelete.java
+++ b/src/org/zaproxy/zap/extension/alert/PopupMenuAlertDelete.java
@@ -41,9 +41,6 @@ public class PopupMenuAlertDelete extends ExtensionPopupMenuItem {
 
 	private ExtensionAlert extension = null;
 
-    /**
-     * 
-     */
     public PopupMenuAlertDelete() {
         super(Constant.messages.getString("scanner.delete.popup"));
 

--- a/src/org/zaproxy/zap/extension/alert/PopupMenuAlertEdit.java
+++ b/src/org/zaproxy/zap/extension/alert/PopupMenuAlertEdit.java
@@ -42,9 +42,6 @@ public class PopupMenuAlertEdit extends ExtensionPopupMenuItem {
 
 	private ExtensionHistory extHist = null; 
 
-    /**
-     * 
-     */
     public PopupMenuAlertEdit() {
         super(Constant.messages.getString("scanner.edit.popup"));
 

--- a/src/org/zaproxy/zap/extension/alert/PopupMenuAlertsRefresh.java
+++ b/src/org/zaproxy/zap/extension/alert/PopupMenuAlertsRefresh.java
@@ -36,9 +36,6 @@ public class PopupMenuAlertsRefresh extends ExtensionPopupMenuItem {
 
 	private ExtensionAlert extension = null;
 
-    /**
-     * 
-     */
     public PopupMenuAlertsRefresh() {
         super(Constant.messages.getString("alerts.refresh.popup"));
 

--- a/src/org/zaproxy/zap/extension/anticsrf/OptionsAntiCsrfPanel.java
+++ b/src/org/zaproxy/zap/extension/anticsrf/OptionsAntiCsrfPanel.java
@@ -41,9 +41,6 @@ public class OptionsAntiCsrfPanel extends AbstractParamPanel {
 
 	private OptionsAntiCsrfTableModel antiCsrfModel = null;
 	
-    /**
-     * 
-     */
     public OptionsAntiCsrfPanel() {
         super();
  		initialize();

--- a/src/org/zaproxy/zap/extension/anticsrf/OptionsAntiCsrfTableModel.java
+++ b/src/org/zaproxy/zap/extension/anticsrf/OptionsAntiCsrfTableModel.java
@@ -36,9 +36,6 @@ public class OptionsAntiCsrfTableModel extends AbstractMultipleOptionsTableModel
 	
     private List<AntiCsrfParamToken> tokens = new ArrayList<>(0);
     
-    /**
-     * 
-     */
     public OptionsAntiCsrfTableModel() {
         super();
     }

--- a/src/org/zaproxy/zap/extension/ascan/CategoryTableModel.java
+++ b/src/org/zaproxy/zap/extension/ascan/CategoryTableModel.java
@@ -65,9 +65,6 @@ public class CategoryTableModel extends DefaultTableModel {
     private int category;
     private AlertThreshold defaultThreshold;
     
-    /**
-     * 
-     */
     public CategoryTableModel() {
     }
     

--- a/src/org/zaproxy/zap/extension/ascan/ChallengeCallbackAPI.java
+++ b/src/org/zaproxy/zap/extension/ascan/ChallengeCallbackAPI.java
@@ -180,9 +180,6 @@ public abstract class ChallengeCallbackAPI extends ApiImplementor {
         regCallbacks.put(challenge, new RegisteredCallback(plugin, attack));
     }
     
-    /**
-     * 
-     */
     private static class RegisteredCallback {
         private final ChallengeCallbackPlugin plugin;
         private HistoryReference hRef;

--- a/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -117,9 +117,6 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
     
 	private ActiveScanAPI activeScanApi;
 
-    /**
-     *
-     */
     public ExtensionActiveScan() {
         super(NAME);
         this.setOrder(28);

--- a/src/org/zaproxy/zap/extension/ascan/OptionsVariantPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/OptionsVariantPanel.java
@@ -471,9 +471,6 @@ public class OptionsVariantPanel extends AbstractParamPanel {
         return chkRPCCustom;
     }
 
-    /**
-     * 
-     */
     private static class ExcludedParameterPanel extends AbstractMultipleOptionsBaseTablePanel<ScannerParamFilter> {
 
         private static final long serialVersionUID = 1L;

--- a/src/org/zaproxy/zap/extension/ascan/PolicyAllCategoryPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/PolicyAllCategoryPanel.java
@@ -89,9 +89,6 @@ public class PolicyAllCategoryPanel extends AbstractParamPanel {
     
     private static final int[] width = {300, 100, 100};
 
-    /**
-     *
-     */
     public PolicyAllCategoryPanel(Window parent, ExtensionActiveScan extension, ScanPolicy policy) {
     	this(parent, extension, policy, false);
     }

--- a/src/org/zaproxy/zap/extension/ascan/PolicyCategoryPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/PolicyCategoryPanel.java
@@ -52,9 +52,7 @@ public class PolicyCategoryPanel extends AbstractParamPanel {
 	private CategoryTableModel categoryTableModel = null;  //  @jve:decl-index=0:parse,visual-constraint="294,249"
 	private static final int[] width = {300,100, 100, 200};
 	private int category;
-    /**
-     *
-     */
+
     public PolicyCategoryPanel(int category, PluginFactory pluginFactory, AlertThreshold defaultThreshold) {
         super();
  		this.category = category;

--- a/src/org/zaproxy/zap/extension/ascan/PolicyDialog.java
+++ b/src/org/zaproxy/zap/extension/ascan/PolicyDialog.java
@@ -53,9 +53,6 @@ public class PolicyDialog extends AbstractParamDialog {
         initialize();
     }
 
-    /**
-     * 
-     */
     private void initialize() {
         this.setTitle(POLICY);
         this.setSize(750, 420);

--- a/src/org/zaproxy/zap/extension/ascan/ScanProgressActionIcon.java
+++ b/src/org/zaproxy/zap/extension/ascan/ScanProgressActionIcon.java
@@ -68,9 +68,6 @@ public class ScanProgressActionIcon extends JLabel {
         this.changeIcon();
     }
 
-    /**
-     * 
-     */
     private void changeIcon() {
 
         if (item.isSkipped()) {
@@ -115,25 +112,16 @@ public class ScanProgressActionIcon extends JLabel {
         return Constant.messages.getString("ascan.progress.label.skipped");
     }
 
-    /**
-     * 
-     */
     public void invokeAction() {
         // do the Action
         item.skip();
     }
 
-    /**
-     * 
-     */
     public void setPressed() {
         state = STATE_PRESSED;
         changeIcon();
     }
 
-    /**
-     * 
-     */
     public void setReleased() {
         if (state == STATE_PRESSED) {
             state = STATE_FOCUSED;
@@ -141,9 +129,6 @@ public class ScanProgressActionIcon extends JLabel {
         }
     }
 
-    /**
-     * 
-     */
     public void setOver() {
         if (state == STATE_NORMAL) {
             state = STATE_FOCUSED;

--- a/src/org/zaproxy/zap/extension/ascan/ScanProgressDialog.java
+++ b/src/org/zaproxy/zap/extension/ascan/ScanProgressDialog.java
@@ -127,9 +127,6 @@ public class ScanProgressDialog extends AbstractDialog {
         this.initialize();
     }
 
-    /**
-     * 
-     */
     private void initialize() {
         this.setSize(new Dimension(580, 504));
 

--- a/src/org/zaproxy/zap/extension/ascan/ScanProgressItem.java
+++ b/src/org/zaproxy/zap/extension/ascan/ScanProgressItem.java
@@ -84,9 +84,6 @@ public class ScanProgressItem {
         return "";
     }
 
-    /**
-     *
-     */
     public long getElapsedTime() {
         if ((status == STATUS_PENDING) || (plugin.getTimeStarted() == null)) {
             return -1;
@@ -154,9 +151,6 @@ public class ScanProgressItem {
         return hProcess.getSkippedReason(plugin);
     }
 
-    /**
-     * 
-     */
     public void skip() {
         if (isRunning()) {
             hProcess.pluginSkipped(plugin, Constant.messages.getString("ascan.progress.label.skipped.reason.user"));

--- a/src/org/zaproxy/zap/extension/ascan/ScanProgressTableModel.java
+++ b/src/org/zaproxy/zap/extension/ascan/ScanProgressTableModel.java
@@ -47,9 +47,6 @@ public class ScanProgressTableModel extends AbstractTableModel {
     private String totRequests;
     private String totTime;
 
-    /**
-     *
-     */
     public ScanProgressTableModel() {
         super();
         values = new ArrayList<ScanProgressItem>();

--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -152,9 +152,6 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
     							ARG_CFU_LIST_IDX};
 	private CommandLineArgument[] arguments = new CommandLineArgument[ARG_IDXS.length];
 
-    /**
-     * 
-     */
     public ExtensionAutoUpdate() {
         super();
  		initialize();
@@ -579,9 +576,6 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
     	return (int) (diff / (1000 * 60 * 60 * 24));
     }
     
-    /*
-     * 
-     */
     public void alertIfNewVersions() {
     	// Kicks off a thread and pops up a window if there are new versions.
     	// Depending on the options the user has chosen.

--- a/src/org/zaproxy/zap/extension/autoupdate/OptionsAutoupdateDirsTableModel.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/OptionsAutoupdateDirsTableModel.java
@@ -38,9 +38,6 @@ public class OptionsAutoupdateDirsTableModel extends AbstractMultipleOptionsBase
 	
     private List<File> tokens = new ArrayList<>(0);
     
-    /**
-     * 
-     */
     public OptionsAutoupdateDirsTableModel() {
         super();
     }

--- a/src/org/zaproxy/zap/extension/autoupdate/UninstalledAddOnsTableModel.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/UninstalledAddOnsTableModel.java
@@ -44,9 +44,6 @@ public class UninstalledAddOnsTableModel extends AddOnsTableModel {
     
 	private static final int COLUMN_COUNT = COLUMN_NAMES.length;
 
-    /**
-     * 
-     */
     public UninstalledAddOnsTableModel(AddOnCollection installedAddOns) {
         super(installedAddOns, 4);
     }

--- a/src/org/zaproxy/zap/extension/compare/ExtensionCompare.java
+++ b/src/org/zaproxy/zap/extension/compare/ExtensionCompare.java
@@ -62,9 +62,6 @@ public class ExtensionCompare extends ExtensionAdaptor implements SessionChanged
 
     private static Logger log = Logger.getLogger(ExtensionCompare.class);
 
-	/**
-     * 
-     */
     public ExtensionCompare() {
         super("ExtensionCompare");
         this.setOrder(44);

--- a/src/org/zaproxy/zap/extension/encoder2/ExtensionEncoder2.java
+++ b/src/org/zaproxy/zap/extension/encoder2/ExtensionEncoder2.java
@@ -45,9 +45,6 @@ public class ExtensionEncoder2 extends ExtensionAdaptor implements OptionsChange
 	private EncodeDecodeParamPanel optionsPanel;
 	private EncodeDecodeParam params;
 
-    /**
-     * 
-     */
     public ExtensionEncoder2() {
         super("ExtensionEncode2");
         this.setOrder(22);

--- a/src/org/zaproxy/zap/extension/ext/OptionsExtensionPanel.java
+++ b/src/org/zaproxy/zap/extension/ext/OptionsExtensionPanel.java
@@ -63,9 +63,6 @@ public class OptionsExtensionPanel extends AbstractParamPanel {
 
     private static Logger log = Logger.getLogger(OptionsExtensionPanel.class);
 
-	/**
-     * 
-     */
     public OptionsExtensionPanel(ExtensionExtension ext) {
         super();
  		initialize();

--- a/src/org/zaproxy/zap/extension/ext/OptionsExtensionTableModel.java
+++ b/src/org/zaproxy/zap/extension/ext/OptionsExtensionTableModel.java
@@ -45,9 +45,6 @@ public class OptionsExtensionTableModel extends AbstractTableModel {
     
     private static Logger log = Logger.getLogger(OptionsExtensionTableModel.class);
 
-    /**
-     * 
-     */
     public OptionsExtensionTableModel() {
         super();
         // Sort extensions by name

--- a/src/org/zaproxy/zap/extension/globalexcludeurl/OptionsGlobalExcludeURLPanel.java
+++ b/src/org/zaproxy/zap/extension/globalexcludeurl/OptionsGlobalExcludeURLPanel.java
@@ -47,9 +47,6 @@ public class OptionsGlobalExcludeURLPanel extends AbstractParamPanel {
 
 	private OptionsGlobalExcludeURLTableModel globalExcludeURLModel = null;
 	
-    /**
-     * 
-     */
     public OptionsGlobalExcludeURLPanel() {
         super();
  		initialize();

--- a/src/org/zaproxy/zap/extension/history/PopupMenuExportURLs.java
+++ b/src/org/zaproxy/zap/extension/history/PopupMenuExportURLs.java
@@ -49,9 +49,6 @@ public class PopupMenuExportURLs extends ExtensionPopupMenuItem {
 
     private static Logger log = Logger.getLogger(PopupMenuExportURLs.class);
 
-    /**
-     * 
-     */
     public PopupMenuExportURLs() {
         super(Constant.messages.getString("exportUrls.popup"));
 

--- a/src/org/zaproxy/zap/extension/keyboard/KeyboardShortcutTableModel.java
+++ b/src/org/zaproxy/zap/extension/keyboard/KeyboardShortcutTableModel.java
@@ -38,9 +38,6 @@ public class KeyboardShortcutTableModel extends AbstractTableModel {
 	
     private List<KeyboardShortcut> tokens = new ArrayList<>(0);
     
-    /**
-     * 
-     */
     public KeyboardShortcutTableModel() {
         super();
     }

--- a/src/org/zaproxy/zap/extension/keyboard/OptionsKeyboardShortcutPanel.java
+++ b/src/org/zaproxy/zap/extension/keyboard/OptionsKeyboardShortcutPanel.java
@@ -51,9 +51,6 @@ public class OptionsKeyboardShortcutPanel extends AbstractParamPanel {
 
 	private KeyboardShortcutTableModel keyboardModel = null;
 	
-    /**
-     * 
-     */
     public OptionsKeyboardShortcutPanel(ExtensionKeyboard extension) {
         super();
         this.extension = extension;

--- a/src/org/zaproxy/zap/extension/log4j/ExtensionLog4j.java
+++ b/src/org/zaproxy/zap/extension/log4j/ExtensionLog4j.java
@@ -43,9 +43,6 @@ public class ExtensionLog4j extends ExtensionAdaptor {
 
 	private ScanStatus scanStatus;
 	
-    /**
-     * 
-     */
     public ExtensionLog4j() {
         super("ExtensionLog4j");
         this.setOrder(56);

--- a/src/org/zaproxy/zap/extension/params/ExtensionParams.java
+++ b/src/org/zaproxy/zap/extension/params/ExtensionParams.java
@@ -73,9 +73,6 @@ public class ExtensionParams extends ExtensionAdaptor
     private ExtensionHttpSessions extensionHttpSessions;
     private ParamScanner paramScanner;
     
-	/**
-     * 
-     */
     public ExtensionParams() {
         super(NAME);
         this.setOrder(58);

--- a/src/org/zaproxy/zap/extension/params/ParamsPanel.java
+++ b/src/org/zaproxy/zap/extension/params/ParamsPanel.java
@@ -63,9 +63,6 @@ public class ParamsPanel extends AbstractPanel{
 	
     //private static Log log = LogFactory.getLog(ParamsPanel.class);
     
-    /**
-     * 
-     */
     public ParamsPanel(ExtensionParams extension) {
         super();
         this.extension = extension;
@@ -93,7 +90,6 @@ public class ParamsPanel extends AbstractPanel{
 	 * @return javax.swing.JPanel	
 
 	 */    
-	/**/
 	private javax.swing.JPanel getPanelCommand() {
 		if (panelCommand == null) {
 
@@ -124,7 +120,6 @@ public class ParamsPanel extends AbstractPanel{
 		}
 		return panelCommand;
 	}
-	/**/
 
 	private javax.swing.JToolBar getPanelToolbar() {
 		if (panelToolbar == null) {

--- a/src/org/zaproxy/zap/extension/params/PopupMenuAddAntiCSRF.java
+++ b/src/org/zaproxy/zap/extension/params/PopupMenuAddAntiCSRF.java
@@ -32,9 +32,6 @@ public class PopupMenuAddAntiCSRF extends ExtensionPopupMenuItem {
 
     private ExtensionParams extension;
 
-	/**
-     * 
-     */
     public PopupMenuAddAntiCSRF() {
         super(Constant.messages.getString("params.anticrsf.add.popup"));
         this.addActionListener(new java.awt.event.ActionListener() { 

--- a/src/org/zaproxy/zap/extension/params/PopupMenuAddSession.java
+++ b/src/org/zaproxy/zap/extension/params/PopupMenuAddSession.java
@@ -32,9 +32,6 @@ public class PopupMenuAddSession extends ExtensionPopupMenuItem {
 
     private ExtensionParams extension;
 
-	/**
-     * 
-     */
     public PopupMenuAddSession() {
         super(Constant.messages.getString("params.session.add.popup"));
         this.addActionListener(new java.awt.event.ActionListener() { 

--- a/src/org/zaproxy/zap/extension/params/PopupMenuParamSearch.java
+++ b/src/org/zaproxy/zap/extension/params/PopupMenuParamSearch.java
@@ -31,9 +31,6 @@ public class PopupMenuParamSearch extends ExtensionPopupMenuItem {
 
     private ExtensionParams extension;
 
-	/**
-     * 
-     */
     public PopupMenuParamSearch() {
         super(Constant.messages.getString("params.search.popup"));
         this.addActionListener(new java.awt.event.ActionListener() { 

--- a/src/org/zaproxy/zap/extension/params/PopupMenuRemoveAntiCSRF.java
+++ b/src/org/zaproxy/zap/extension/params/PopupMenuRemoveAntiCSRF.java
@@ -32,9 +32,6 @@ public class PopupMenuRemoveAntiCSRF extends ExtensionPopupMenuItem {
 
     private ExtensionParams extension;
 
-	/**
-     * 
-     */
     public PopupMenuRemoveAntiCSRF() {
         super(Constant.messages.getString("params.anticrsf.remove.popup"));
         this.addActionListener(new java.awt.event.ActionListener() { 

--- a/src/org/zaproxy/zap/extension/params/PopupMenuRemoveSession.java
+++ b/src/org/zaproxy/zap/extension/params/PopupMenuRemoveSession.java
@@ -32,9 +32,6 @@ public class PopupMenuRemoveSession extends ExtensionPopupMenuItem {
 
     private ExtensionParams extension;
 
-	/**
-     * 
-     */
     public PopupMenuRemoveSession() {
         super(Constant.messages.getString("params.session.remove.popup"));
         this.addActionListener(new java.awt.event.ActionListener() { 

--- a/src/org/zaproxy/zap/extension/pscan/OptionsPassiveScanTableModel.java
+++ b/src/org/zaproxy/zap/extension/pscan/OptionsPassiveScanTableModel.java
@@ -41,9 +41,6 @@ public class OptionsPassiveScanTableModel extends AbstractMultipleOptionsTableMo
     
 	private List <RegexAutoTagScanner> defns = new ArrayList<>(5);
     
-    /**
-     * 
-     */
     public OptionsPassiveScanTableModel() {
         super();
     }

--- a/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanPanel.java
+++ b/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanPanel.java
@@ -56,9 +56,6 @@ public class PolicyPassiveScanPanel extends AbstractParamPanel {
     private JComboBox<String> applyToThreshold = null;
     private JComboBox<String> applyToThresholdTarget = null;
 
-    /**
-     *
-     */
     public PolicyPassiveScanPanel() {
         super();
         initialize();

--- a/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanTableModel.java
+++ b/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanTableModel.java
@@ -45,9 +45,6 @@ public class PolicyPassiveScanTableModel extends DefaultTableModel {
     private List<ScannerWrapper> listScanners = new ArrayList<>();
     private Map<String, String> i18nToStr = null;
 
-    /**
-     *
-     */
     public PolicyPassiveScanTableModel() {
     }
     

--- a/src/org/zaproxy/zap/extension/script/OptionsScriptPanel.java
+++ b/src/org/zaproxy/zap/extension/script/OptionsScriptPanel.java
@@ -44,9 +44,6 @@ public class OptionsScriptPanel extends AbstractParamPanel {
 	private AntiCsrfMultipleOptionsPanel tokensOptionsPanel;
 	private OptionsScriptTableModel scriptDirModel = null;
 	
-    /**
-     * 
-     */
     public OptionsScriptPanel(ExtensionScript extension) {
         super();
         this.extension = extension;

--- a/src/org/zaproxy/zap/extension/script/OptionsScriptTableModel.java
+++ b/src/org/zaproxy/zap/extension/script/OptionsScriptTableModel.java
@@ -36,9 +36,6 @@ public class OptionsScriptTableModel extends AbstractMultipleOptionsBaseTableMod
 	
     private List<File> tokens = new ArrayList<>(0);
     
-    /**
-     * 
-     */
     public OptionsScriptTableModel() {
         super();
     }

--- a/src/org/zaproxy/zap/extension/search/ExtensionSearch.java
+++ b/src/org/zaproxy/zap/extension/search/ExtensionSearch.java
@@ -63,9 +63,6 @@ public class ExtensionSearch extends ExtensionAdaptor implements SessionChangedL
 
     private Map<String, HttpSearcher> customSearchers = new HashMap<>();
 
-	/**
-     * 
-     */
     public ExtensionSearch() {
         super(NAME);
         this.setOrder(20);

--- a/src/org/zaproxy/zap/extension/search/SearchPanel.java
+++ b/src/org/zaproxy/zap/extension/search/SearchPanel.java
@@ -156,7 +156,6 @@ public class SearchPanel extends AbstractPanel implements SearchListenner {
 	 * 	
 	 * @return javax.swing.JPanel	
 	 */    
-	/**/
 	private javax.swing.JPanel getPanelCommand() {
 		if (panelCommand == null) {
 
@@ -188,7 +187,6 @@ public class SearchPanel extends AbstractPanel implements SearchListenner {
 		}
 		return panelCommand;
 	}
-	/**/
 
 	private GridBagConstraints newGBC (int gridx) {
 		GridBagConstraints gridBagConstraints = new GridBagConstraints();

--- a/src/org/zaproxy/zap/extension/siterefresh/ExtensionSitesRefresh.java
+++ b/src/org/zaproxy/zap/extension/siterefresh/ExtensionSitesRefresh.java
@@ -27,9 +27,7 @@ import org.parosproxy.paros.extension.ExtensionHook;
 public class ExtensionSitesRefresh extends ExtensionAdaptor {
 
 	private PopupMenuSitesRefresh popupMenuSitesRefresh = null;
-	/**
-     * 
-     */
+
     public ExtensionSitesRefresh() {
         super("ExtensionSitesRefresh");
         this.setOrder(1000);	// Want this to be as low as possible :)

--- a/src/org/zaproxy/zap/extension/siterefresh/PopupMenuSitesRefresh.java
+++ b/src/org/zaproxy/zap/extension/siterefresh/PopupMenuSitesRefresh.java
@@ -31,9 +31,6 @@ public class PopupMenuSitesRefresh extends ExtensionPopupMenuItem {
 
 	private static final long serialVersionUID = 1L;
     
-    /**
-     * 
-     */
     public PopupMenuSitesRefresh() {
         super(Constant.messages.getString("siterefresh.popop"));
         

--- a/src/org/zaproxy/zap/extension/stdmenus/PopupContextMenuItemFactory.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/PopupContextMenuItemFactory.java
@@ -46,7 +46,7 @@ public abstract class PopupContextMenuItemFactory extends ExtensionPopupMenuItem
 		super("ContextMenuFactory");
 		this.parentMenu = parentMenu;
 	}
-	/**/
+
     @Override
     public String getParentMenuName() {
     	return parentMenu;

--- a/src/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
+++ b/src/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
@@ -45,9 +45,6 @@ public class ExtensionUiUtils extends ExtensionAdaptor implements SessionChanged
 	
     private Logger logger = Logger.getLogger(ExtensionUiUtils.class);
     
-	/**
-     * 
-     */
     public ExtensionUiUtils() {
         super(NAME);
         this.setOrder(200);

--- a/src/org/zaproxy/zap/extension/users/ContextUsersPanel.java
+++ b/src/org/zaproxy/zap/extension/users/ContextUsersPanel.java
@@ -79,9 +79,6 @@ public class ContextUsersPanel extends AbstractContextPropertiesPanel {
 
 	public static class UsersMultipleOptionsPanel extends AbstractMultipleOptionsTablePanel<User> {
 
-		/**
-		 * 
-		 */
 		private static final long serialVersionUID = -7216673905642941770L;
 		private static final String REMOVE_DIALOG_TITLE = Constant.messages
 				.getString("users.dialog.remove.title");

--- a/src/org/zaproxy/zap/extension/users/DialogModifyUser.java
+++ b/src/org/zaproxy/zap/extension/users/DialogModifyUser.java
@@ -7,9 +7,6 @@ import org.zaproxy.zap.users.User;
 
 public class DialogModifyUser extends DialogAddUser {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 7828871270310672334L;
 	private static final String DIALOG_TITLE = Constant.messages
 			.getString("users.dialog.modify.title");

--- a/src/org/zaproxy/zap/view/ContextListTableModel.java
+++ b/src/org/zaproxy/zap/view/ContextListTableModel.java
@@ -38,11 +38,6 @@ public class ContextListTableModel extends AbstractTableModel {
     
     private List<Object[]> values = Collections.emptyList();
     
-    //private static Logger log = Logger.getLogger(ContextListTableModel.class);
-
-    /**
-     * 
-     */
     public ContextListTableModel() {
         super();
     }

--- a/src/org/zaproxy/zap/view/LicenseFrame.java
+++ b/src/org/zaproxy/zap/view/LicenseFrame.java
@@ -54,9 +54,6 @@ public class LicenseFrame extends AbstractFrame {
 
 	private Runnable postTask;
 
-    /**
-     *
-     */
     public LicenseFrame() {
         super();
  		initialize();

--- a/src/org/zaproxy/zap/view/SingleColumnTableModel.java
+++ b/src/org/zaproxy/zap/view/SingleColumnTableModel.java
@@ -35,9 +35,6 @@ public class SingleColumnTableModel extends AbstractTableModel {
     private List<String> lines = new ArrayList<>();
     private boolean editable = true;
     
-    /**
-     * 
-     */
     public SingleColumnTableModel(String columnName) {
         super();
         this.columnNames = new String[] {columnName};

--- a/src/org/zaproxy/zap/view/popup/PopupMenuItemContextDataDriven.java
+++ b/src/org/zaproxy/zap/view/popup/PopupMenuItemContextDataDriven.java
@@ -50,7 +50,6 @@ public class PopupMenuItemContextDataDriven extends PopupMenuItemSiteNodeContain
         super("DataDrivenNodeX", true);
     }
 
-    /**/
     @Override
     public String getParentMenuName() {
         return Constant.messages.getString("context.flag.popup");

--- a/src/org/zaproxy/zap/view/popup/PopupMenuItemContextInclude.java
+++ b/src/org/zaproxy/zap/view/popup/PopupMenuItemContextInclude.java
@@ -49,7 +49,6 @@ public class PopupMenuItemContextInclude extends PopupMenuItemSiteNodeContainer 
         super("IncludeInContextX", true);
     }
 
-    /**/
     @Override
     public String getParentMenuName() {
         return Constant.messages.getString("context.include.popup");

--- a/src/org/zaproxy/zap/view/popup/PopupMenuItemSiteNodeContextMenuFactory.java
+++ b/src/org/zaproxy/zap/view/popup/PopupMenuItemSiteNodeContextMenuFactory.java
@@ -50,7 +50,7 @@ public abstract class PopupMenuItemSiteNodeContextMenuFactory extends PopupMenuI
         super("ContextMenuFactory", true);
         this.parentMenu = parentMenu;
     }
-    /**/
+
     @Override
     public String getParentMenuName() {
         return parentMenu;


### PR DESCRIPTION
Remove empty plain/JavaDoc comments (for example, `/* */` and variations
of `/** */`).
Also, in ContextListTableModel remove commented logger declaration.