### PR TITLE
Document constructors of ZAP text components

### DIFF
--- a/src/org/zaproxy/zap/utils/ZapTextArea.java
+++ b/src/org/zaproxy/zap/utils/ZapTextArea.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.utils.ZapTextComponentUndoManager.UndoManagerPolicy;
  * If you do not need undoable edits consider using a {@code JTextArea} instead.
  * </p>
  * 
+ * @since 1.3.0
  * @see #discardAllEdits()
  * @see #setUndoManagerPolicy
  * @see #setEditsLimit(int)
@@ -49,42 +50,60 @@ public class ZapTextArea extends JTextArea {
 	private ZapTextComponentUndoManager undoManager;
 
 	/**
-	 * @see JTextArea#JTextArea()
+	 * Constructs a {@code ZapTextArea}, with a default {@code Document}, {@code null} text and zero rows/columns.
 	 */
 	public ZapTextArea() {
 		this(null, null, 0, 0);
 	}
 
 	/**
-	 * @see JTextArea#JTextArea(Document)
+	 * Constructs a {@code ZapTextArea}, with the given {@code Document}, {@code null} text and zero rows/columns.
+	 * 
+	 * @param doc the document of the text area
 	 */
 	public ZapTextArea(Document doc) {
 		this(doc, null, 0, 0);
 	}
 
 	/**
-	 * @see JTextArea#JTextArea(String)
+	 * Constructs a {@code ZapTextArea}, with a default {@code Document}, the given {@code text} and zero rows/columns.
+	 * 
+	 * @param text the initial text of the text area
 	 */
 	public ZapTextArea(String text) {
 		this(null, text, 0, 0);
 	}
 
 	/**
-	 * @see JTextArea#JTextArea(int, int)
+	 * Constructs a {@code ZapTextArea}, with a default {@code Document}, {@code null} {@code text} and the given number of rows
+	 * and columns.
+	 * 
+	 * @param rows the number of rows of the text area
+	 * @param columns the number of columns of the text area
 	 */
 	public ZapTextArea(int rows, int columns) {
 		this(null, null, rows, columns);
 	}
 
 	/**
-	 * @see JTextArea#JTextArea(String, int, int)
+	 * Constructs a {@code ZapTextArea}, with a default {@code Document}, the given {@code text} and the given number of rows
+	 * and columns.
+	 * 
+	 * @param text the initial text of the text area
+	 * @param rows the number of rows of the text area
+	 * @param columns the number of columns of the text area
 	 */
 	public ZapTextArea(String text, int rows, int columns) {
 		this(null, text, rows, columns);
 	}
 
 	/**
-	 * @see JTextArea#JTextArea(Document, String, int, int)
+	 * Constructs a {@code ZapTextArea}, with the given {@code Document}, {@code text} and number of rows and columns.
+	 * 
+	 * @param doc the document of the text area
+	 * @param text the initial text of the text area
+	 * @param rows the number of rows of the text area
+	 * @param columns the number of columns of the text area
 	 */
 	public ZapTextArea(Document doc, String text, int rows, int columns) {
 		super(doc, text, rows, columns);

--- a/src/org/zaproxy/zap/utils/ZapTextComponentUndoManager.java
+++ b/src/org/zaproxy/zap/utils/ZapTextComponentUndoManager.java
@@ -51,7 +51,6 @@ import org.parosproxy.paros.Constant;
  * <li>{@code UndoManagerPolicy.ALWAYS_DISABLED}</li>
  * </ul>
  * The policy can be changed with the method {@code setUndoManagerPolicy}.
- * </p>
  * <p>
  * The {@code ZapTextComponentUndoManager} listens to changes to the
  * {@code Document} of the {@code JTextComponent} used with the
@@ -59,6 +58,7 @@ import org.parosproxy.paros.Constant;
  * the document is changed.
  * </p>
  * 
+ * @since 1.4.1
  * @see #setLimit(int)
  * @see #setUndoManagerPolicy(UndoManagerPolicy)
  * @see UndoManagerPolicy

--- a/src/org/zaproxy/zap/utils/ZapTextField.java
+++ b/src/org/zaproxy/zap/utils/ZapTextField.java
@@ -38,6 +38,7 @@ import org.zaproxy.zap.utils.ZapTextComponentUndoManager.UndoManagerPolicy;
  * instead.
  * </p>
  * 
+ * @since 1.3.0
  * @see #discardAllEdits()
  * @see #setEditsLimit(int)
  * @see #setUndoManagerPolicy
@@ -50,35 +51,47 @@ public class ZapTextField extends JTextField {
 	private ZapTextComponentUndoManager undoManager;
 
 	/**
-	 * @see JTextField#JTextField()
+	 * Constructs a {@code ZapTextField}, with a default {@code Document}, {@code null} text and zero columns.
 	 */
 	public ZapTextField() {
 		this(null, null, 0);
 	}
 
 	/**
-	 * @see JTextField#JTextField(int)
+	 * Constructs a {@code ZapTextField}, with a default {@code Document}, {@code null} {@code text} and the given number of
+	 * columns.
+	 * 
+	 * @param columns the number of columns of the text area
 	 */
 	public ZapTextField(int columns) {
 		this(null, null, columns);
 	}
 
 	/**
-	 * @see JTextField#JTextField(String)
+	 * Constructs a {@code ZapTextField}, with a default {@code Document}, the given {@code text} and zero columns.
+	 * 
+	 * @param text the initial text of the text area
 	 */
 	public ZapTextField(String text) {
 		this(null, text, 0);
 	}
 
 	/**
-	 * @see JTextField#JTextField(String, int)
+	 * Constructs a {@code ZapTextField}, with a default {@code Document}, the given {@code text} and the given number columns.
+	 * 
+	 * @param text the initial text of the text area
+	 * @param columns the number of columns of the text area
 	 */
 	public ZapTextField(String text, int columns) {
 		this(null, text, columns);
 	}
 
 	/**
-	 * @see JTextField#JTextField(Document, String, int)
+	 * Constructs a {@code ZapTextField}, with the given {@code Document}, {@code text} and number of columns.
+	 * 
+	 * @param doc the document of the text area
+	 * @param text the initial text of the text area
+	 * @param columns the number of columns of the text area
 	 */
 	public ZapTextField(Document doc, String text, int columns) {
 		super(doc, text, columns);


### PR DESCRIPTION
Document the constructors of ZapTextArea and ZapTextField. Also, add
"since" JavaDoc tags to those classes and ZapTextComponentUndoManager
and for the latter class remove unnecessary closing paragraph tag in
class doc.