### PR TITLE
Replace template JavaDoc comments

### DIFF
--- a/src/org/zaproxy/zap/extension/script/ScriptNode.java
+++ b/src/org/zaproxy/zap/extension/script/ScriptNode.java
@@ -24,9 +24,10 @@ import javax.swing.tree.DefaultMutableTreeNode;
 import org.parosproxy.paros.Constant;
 
 /**
- *
- * To change the template for this generated type comment go to
- * Window - Preferences - Java - Code Generation - Code and Comments
+ * A {@link javax.swing.tree.MutableTreeNode MutableTreeNode} for model of scripts tree.
+ * 
+ * @since 2.2.0
+ * @see ScriptTreeModel
  */
 public class ScriptNode extends DefaultMutableTreeNode {
 	private static final long serialVersionUID = 1L;

--- a/src/org/zaproxy/zap/extension/script/ScriptTreeModel.java
+++ b/src/org/zaproxy/zap/extension/script/ScriptTreeModel.java
@@ -28,9 +28,13 @@ import java.util.Map;
 import javax.swing.tree.DefaultTreeModel;
 
 /**
- *
- * To change the template for this generated type comment go to
- * Window - Preferences - Java - Code Generation - Code and Comments
+ * A {@link javax.swing.tree.TreeModel TreeModel} of (user created) scripts and script templates.
+ * <p>
+ * The nodes of the tree model are of the type {@link ScriptNode}.
+ * 
+ * @since 2.2.0
+ * @see #addScript(ScriptWrapper)
+ * @see #addTemplate(ScriptWrapper)
  */
 public class ScriptTreeModel extends DefaultTreeModel {
 


### PR DESCRIPTION
Replace template JavaDoc comments with description of the classes in
ScriptNode and ScriptTreeModel.