### PR TITLE
Address JavaDoc errors/warnings in some packages

### DIFF
--- a/src/org/zaproxy/zap/authentication/AuthenticationMethod.java
+++ b/src/org/zaproxy/zap/authentication/AuthenticationMethod.java
@@ -34,8 +34,8 @@ import org.zaproxy.zap.users.User;
 import org.zaproxy.zap.utils.Stats;
 
 /**
- * The AuthenticationMethod represents an authentication method that can be used to authenticate an
- * entity in a particular WebApplication.
+ * The {@code AuthenticationMethod} represents an authentication method that can be used to authenticate an
+ * entity in a particular web application.
  */
 public abstract class AuthenticationMethod {
 
@@ -118,6 +118,7 @@ public abstract class AuthenticationMethod {
 	 * @param sessionManagementMethod the set up session management method is provided so it can be
 	 *            used, if needed, to automatically extract session information from Http Messages.
 	 * @param credentials the credentials
+	 * @param user the user to authenticate
 	 * @return an authenticated web session
 	 * @throws UnsupportedAuthenticationCredentialsException the unsupported authentication
 	 *             credentials exception {@link WebSession}.

--- a/src/org/zaproxy/zap/authentication/AuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/AuthenticationMethodType.java
@@ -50,7 +50,9 @@ public abstract class AuthenticationMethodType {
 	 * Builds a new, empty, authentication method. The authentication method should then be
 	 * configured through the Options panel.
 	 * 
+	 * @param contextId the ID of the context for which the authentication method is being created
 	 * @return the authentication method
+	 * @see #buildOptionsPanel(Context)
 	 */
 	public abstract AuthenticationMethod createAuthenticationMethod(int contextId);
 
@@ -79,7 +81,7 @@ public abstract class AuthenticationMethodType {
 	 * 
 	 * @param uiSharedContext the shared context on which the panel should work
 	 * @return the abstract authentication method options panel
-	 * @see AuthenticationMethodType#hasOptionsPanel()
+	 * @see #hasOptionsPanel()
 	 */
 	public abstract AbstractAuthenticationMethodOptionsPanel buildOptionsPanel(Context uiSharedContext);
 
@@ -87,9 +89,8 @@ public abstract class AuthenticationMethodType {
 	 * Checks if the corresponding {@link AuthenticationMethod} has an options panel that can be
 	 * used for configuration.
 	 * 
-	 * @see #buildOptionsPanel(Context)
-	 * 
 	 * @return true, if it needs one
+	 * @see #buildOptionsPanel(Context)
 	 */
 	public abstract boolean hasOptionsPanel();
 
@@ -137,6 +138,7 @@ public abstract class AuthenticationMethodType {
 	 * @param session the session
 	 * @param contextId the ID of the context
 	 * @return the authentication method
+	 * @throws DatabaseException if an error occurred while loading the authentication method
 	 */
 	public abstract AuthenticationMethod loadMethodFromSession(Session session, int contextId)
 			throws DatabaseException;
@@ -149,22 +151,23 @@ public abstract class AuthenticationMethodType {
 	 * @param authMethod the auth method to persist
 	 * @throws UnsupportedAuthenticationMethodException the unsupported authentication method
 	 *             exception
+	 * @throws DatabaseException if an error occurred while persisting the authentication method
 	 */
 	public abstract void persistMethodToSession(Session session, int contextId,
-			AuthenticationMethod authMethod) throws UnsupportedAuthenticationMethodException, DatabaseException;
+			AuthenticationMethod authMethod) throws DatabaseException;
 
 	/**
 	 * Export the specified method to the configuration
-	 * @param config
-	 * @param authMethod
+	 * @param config the {@code Configuration} where to export/save the authentication method
+	 * @param authMethod the authentication method to be exported
 	 */
 	public abstract void exportData(Configuration config, AuthenticationMethod authMethod);
 
 	/**
-	 * Import the method from the confuguration
-	 * @param config
-	 * @param authMethod
-	 * @throws ConfigurationException
+	 * Import the method from the configuration
+	 * @param config the {@code Configuration} from where to import/load the authentication method
+	 * @param authMethod where to set the imported authentication method data
+	 * @throws ConfigurationException if an error occurred while reading the authentication method data 
 	 */
 	public abstract void importData(Configuration config, AuthenticationMethod authMethod) throws ConfigurationException;
 

--- a/src/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
@@ -28,7 +28,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-import java.sql.SQLException;
 import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.List;
@@ -155,11 +154,13 @@ public class FormBasedAuthenticationMethodType extends AuthenticationMethodType 
 		 * in the request URI and the POST data, if any.
 		 * 
 		 * @param credentials the credentials
-		 * @throws SQLException
-		 * @throws HttpMalformedHeaderException
+		 * @return the HTTP message prepared for authentication
+		 * @throws URIException if failed to create the request URI
+		 * @throws HttpMalformedHeaderException if the constructed HTTP request is malformed
+		 * @throws DatabaseException if an error occurred while reading the request from database
 		 */
 		private HttpMessage prepareRequestMessage(UsernamePasswordAuthenticationCredentials credentials)
-				throws URIException, NullPointerException, HttpMalformedHeaderException, DatabaseException {
+				throws URIException, HttpMalformedHeaderException, DatabaseException {
 
 			// Replace the username and password in the uri
 			String requestURL = loginRequestURL.replace(MSG_USER_PATTERN,
@@ -273,6 +274,7 @@ public class FormBasedAuthenticationMethodType extends AuthenticationMethodType 
 		 * Sets the login request as being an existing SiteNode.
 		 * 
 		 * @param loginSiteNode the new login request
+		 * @throws Exception if an error occurred while obtaining the message from the node
 		 */
 		public void setLoginRequest(SiteNode loginSiteNode) throws Exception {
 			this.loginSiteNode = loginSiteNode;

--- a/src/org/zaproxy/zap/spider/Spider.java
+++ b/src/org/zaproxy/zap/spider/Spider.java
@@ -760,6 +760,8 @@ public class Spider {
 
 	/**
 	 * Notifies the listeners that the spider is complete.
+	 * 
+	 * @param successful {@code true} if the spider completed successfully (e.g. was not stopped), {@code false} otherwise
 	 */
 	protected synchronized void notifyListenersSpiderComplete(boolean successful) {
 		for (SpiderListener l : listeners) {

--- a/src/org/zaproxy/zap/spider/SpiderController.java
+++ b/src/org/zaproxy/zap/spider/SpiderController.java
@@ -83,6 +83,7 @@ public class SpiderController implements SpiderParserListener {
 	 * Instantiates a new spider controller.
 	 * 
 	 * @param spider the spider
+	 * @param customParsers the custom spider parsers
 	 */
 	protected SpiderController(Spider spider, List<SpiderParser> customParsers) {
 		super();

--- a/src/org/zaproxy/zap/spider/SpiderParam.java
+++ b/src/org/zaproxy/zap/spider/SpiderParam.java
@@ -696,8 +696,9 @@ public class SpiderParam extends AbstractParam {
 	 * {@code "USE_ALL"}, {@code "IGNORE_VALUE"}, {@code "IGNORE_COMPLETELY"}.
 	 * 
 	 * @param handleParametersVisited the new handle parameters visited value
+	 * @throws IllegalArgumentException if the given parameter is not a value of {@code HandleParametersOption}.
 	 */
-	public void setHandleParameters(String handleParametersVisited) throws IllegalArgumentException {
+	public void setHandleParameters(String handleParametersVisited) {
 		this.handleParametersVisited = HandleParametersOption.valueOf(handleParametersVisited);
 		getConfig().setProperty(SPIDER_HANDLE_PARAMETERS, this.handleParametersVisited.toString());
 	}
@@ -894,7 +895,7 @@ public class SpiderParam extends AbstractParam {
 
 	/**
 	 * Returns the maximum duration in minutes that the spider should run for. Zero means no limit.
-	 * @return
+	 * @return the maximum time, in minutes, that the spider should run
 	 */
     public int getMaxDuration() {
     	return maxDuration; 
@@ -902,7 +903,7 @@ public class SpiderParam extends AbstractParam {
 
     /**
      * Sets the maximum duration in minutes that the spider should run for. Zero means no limit.
-     * @param maxDuration
+     * @param maxDuration the maximum time, in minutes, that the spider should run
      */
     public void setMaxDuration(int maxDuration) {
         this.maxDuration = maxDuration;

--- a/src/org/zaproxy/zap/spider/SpiderTask.java
+++ b/src/org/zaproxy/zap/spider/SpiderTask.java
@@ -311,9 +311,9 @@ public class SpiderTask implements Runnable {
 	 * @return the response http message
 	 * @throws HttpException the http exception
 	 * @throws IOException Signals that an I/O exception has occurred.
-	 * @throws DatabaseException
+	 * @throws DatabaseException if an error occurred while reading the HTTP message
 	 */
-	private HttpMessage fetchResource() throws HttpException, IOException, DatabaseException {
+	private HttpMessage fetchResource() throws IOException, DatabaseException {
 
 		// Build fetch the request message from the database
 		HttpMessage msg;

--- a/src/org/zaproxy/zap/spider/URLCanonicalizer.java
+++ b/src/org/zaproxy/zap/spider/URLCanonicalizer.java
@@ -38,9 +38,8 @@ import org.zaproxy.zap.spider.SpiderParam.HandleParametersOption;
 
 /**
  * The URLCanonicalizer is used for the process of converting an URL into a canonical (normalized) form. See
- * <a href="http://en.wikipedia.org/wiki/URL_normalization">URL Normalization</a> for a reference. <br/>
- * <br/>
- * 
+ * <a href="http://en.wikipedia.org/wiki/URL_normalization">URL Normalization</a> for a reference.
+ * <p>
  * Note: some parts of the code are adapted from: <a
  * href="http://stackoverflow.com/a/4057470/405418">stackoverflow</a>
  * 

--- a/src/org/zaproxy/zap/spider/URLResolver.java
+++ b/src/org/zaproxy/zap/spider/URLResolver.java
@@ -71,19 +71,16 @@ public final class URLResolver {
 
 	/**
 	 * Parses a given specification using the algorithm depicted in <a
-	 * href="http://www.faqs.org/rfcs/rfc1808.html">RFC1808</a>:<br/>
-	 * <br/>
-	 * 
-	 * <p>
-	 * Section 2.4: Parsing a URL
-	 * </p>
-	 * 
+	 * href="https://tools.ietf.org/html/rfc1808#section-2.4">RFC1808 - Section 2.4</a>:
+	 * <blockquote>
+	 * <h3>Section 2.4: Parsing a URL</h3>
 	 * An accepted method for parsing URLs is useful to clarify the generic-RL syntax of Section 2.2
 	 * and to describe the algorithm for resolving relative URLs presented in Section 4. This
 	 * section describes the parsing rules for breaking down a URL (relative or absolute) into the
 	 * component parts described in Section 2.1. The rules assume that the URL has already been
 	 * separated from any surrounding text and copied to a "parse string". The rules are listed in
 	 * the order in which they would be applied by the parser.
+	 * </blockquote>
 	 * 
 	 * @param spec The specification to parse.
 	 * @return the parsed specification.

--- a/src/org/zaproxy/zap/spider/filters/DefaultFetchFilter.java
+++ b/src/org/zaproxy/zap/spider/filters/DefaultFetchFilter.java
@@ -29,7 +29,7 @@ import org.zaproxy.zap.spider.DomainAlwaysInScopeMatcher;
 
 /**
  * The DefaultFetchFilter is an implementation of a FetchFilter that is default for spidering process. Its
- * filter rules are the following:<br/>
+ * filter rules are the following:
  * <ul>
  * <li>the resource protocol/scheme must be 'HTTP' or 'HTTPs'.</li>
  * <li>the resource must be found in the scope (domain) of the spidering process.</li>

--- a/src/org/zaproxy/zap/spider/filters/DefaultParseFilter.java
+++ b/src/org/zaproxy/zap/spider/filters/DefaultParseFilter.java
@@ -26,7 +26,7 @@ import org.parosproxy.paros.network.HttpStatusCode;
 
 /**
  * The DefaultParseFilter is an implementation of a {@link ParseFilter} that is default for
- * spidering process. Its filter rules are the following:<br/>
+ * spidering process. Its filter rules are the following:
  * <ul>
  * <li>the resource body should be under MAX_RESPONSE_BODY_SIZE bytes, otherwise it's probably a
  * binary resource.</li>

--- a/src/org/zaproxy/zap/spider/filters/MaxChildrenFetchFilter.java
+++ b/src/org/zaproxy/zap/spider/filters/MaxChildrenFetchFilter.java
@@ -50,6 +50,8 @@ public class MaxChildrenFetchFilter extends FetchFilter {
 
 	/**
 	 * Sets the model
+	 * 
+	 * @param model the model used to check the number of children of a node
 	 */
 	public void setModel(Model model) {
 		this.model = model;

--- a/src/org/zaproxy/zap/spider/filters/MaxChildrenParseFilter.java
+++ b/src/org/zaproxy/zap/spider/filters/MaxChildrenParseFilter.java
@@ -49,6 +49,8 @@ public class MaxChildrenParseFilter extends ParseFilter {
 
 	/**
 	 * Sets the model
+	 * 
+	 * @param model the model used to check the number of children of a node
 	 */
 	public void setModel(Model model) {
 		this.model = model;

--- a/src/org/zaproxy/zap/spider/parser/SpiderHtmlFormParser.java
+++ b/src/org/zaproxy/zap/spider/parser/SpiderHtmlFormParser.java
@@ -179,12 +179,10 @@ public class SpiderHtmlFormParser extends SpiderParser {
 	 * Prepares the form data set. A form data set is a sequence of control-name/current-value pairs
 	 * constructed from successful controls, which will be sent with a GET/POST request for a form.
 	 * 
-	 * <br/>
-	 * Also see:
-	 * http://whatwg.org/specs/web-apps/current-work/multipage/association-of-controls-and-forms.
-	 * html
-	 * 
-	 * @see http://www.w3.org/TR/REC-html40/interact/forms.html#form-data-set
+	 * @see <a href="https://www.w3.org/TR/REC-html40/interact/forms.html#form-data-set">HTML 4.01 Specification - 17.13.3
+	 *      Processing form data</a>
+	 * @see <a href="https://html.spec.whatwg.org/multipage/forms.html#association-of-controls-and-forms">HTML 5 - 4.10.18.3
+	 *      Association of controls and forms</a>
 	 * @param form the form
 	 * @return the list
 	 */
@@ -343,8 +341,8 @@ public class SpiderHtmlFormParser extends SpiderParser {
 	/**
 	 * Builds the query, encoded with "application/x-www-form-urlencoded".
 	 * 
-	 * 
-	 * @see http://www.w3.org/TR/REC-html40/interact/forms.html#form-content-type
+	 * @see <a href="https://www.w3.org/TR/REC-html40/interact/forms.html#form-content-type">HTML 4.01 Specification - 17.13.4
+	 *      Form content types</a>
 	 * @param formDataSet the form data set
 	 * @return the query
 	 */

--- a/src/org/zaproxy/zap/spider/parser/SpiderHtmlParser.java
+++ b/src/org/zaproxy/zap/spider/parser/SpiderHtmlParser.java
@@ -31,12 +31,9 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.spider.SpiderParam;
 
 /**
- * The Class SpiderHtmlParser is used for parsing of HTML files, gathering resource urls from them.<br/>
- * 
+ * The Class SpiderHtmlParser is used for parsing of HTML files, gathering resource urls from them.
  * <p>
- * NOTE: Handling of HTML Forms is not done in this Parser. Instead see {@link SpiderHtmlFormParser}
- * </p>
- * .
+ * <strong>NOTE:</strong> Handling of HTML Forms is not done in this Parser. Instead see {@link SpiderHtmlFormParser}.
  */
 public class SpiderHtmlParser extends SpiderParser {
 

--- a/src/org/zaproxy/zap/spider/parser/SpiderODataAtomParser.java
+++ b/src/org/zaproxy/zap/spider/parser/SpiderODataAtomParser.java
@@ -26,9 +26,8 @@ import org.apache.commons.lang.StringEscapeUtils;
 import org.parosproxy.paros.network.HttpMessage;
 
 /**
- * Used to parse OData content in Atom format<br/>
- * It's derived from the SpiderTextParser</br>
- * Even if the format of the file is XML  we will process it as a simple text file
+ * Used to parse OData content in Atom format.<p>
+ * It's derived from the SpiderTextParser. Even if the format of the file is XML we will process it as a simple text file
  */
 public class SpiderODataAtomParser extends SpiderParser {
 

--- a/src/org/zaproxy/zap/spider/parser/SpiderParser.java
+++ b/src/org/zaproxy/zap/spider/parser/SpiderParser.java
@@ -108,12 +108,12 @@ public abstract class SpiderParser {
 	/**
 	 * Parses the resource. The HTTP message containing the request and the response is given. Also,
 	 * if possible, a Jericho source with the Response Body is provided.
-	 * <p/>
+	 * <p>
 	 * When a link is encountered, implementations can use
 	 * {@link #processURL(HttpMessage, int, String, String)},
 	 * {@link #notifyListenersPostResourceFound(HttpMessage, int, String, String)} and
 	 * {@link #notifyListenersResourceFound(HttpMessage, int, String)} to announce the found URIs.
-	 * <p/>
+	 * <p>
 	 * The return value specifies whether the resource should be considered 'completely
 	 * processed'/consumed and should be treated accordingly by subsequent parsers. For example, any
 	 * parsers which are meant to be 'fall-back' parsers should skip messages already processed by
@@ -129,11 +129,11 @@ public abstract class SpiderParser {
 
 	/**
 	 * Checks whether the parser should be called to parse the given HttpMessage.
-	 * <p/>
+	 * <p>
 	 * Based on the specifics of the HttpMessage and whether this message was already processed by
 	 * another Parser, this method should decide whether the
 	 * {@link #parseResource(HttpMessage, Source, int)} should be invoked.
-	 * <p/>
+	 * <p>
 	 * The {@code wasAlreadyConsumed} could be used by parsers which represent a 'fall-back' parser
 	 * to check whether any other parser has processed the message before.
 	 * 

--- a/src/org/zaproxy/zap/spider/parser/SpiderParserListener.java
+++ b/src/org/zaproxy/zap/spider/parser/SpiderParserListener.java
@@ -41,8 +41,8 @@ public interface SpiderParserListener {
 
 	/**
 	 * Event triggered when a new resource URI is found. The responseMessage contains all the
-	 * required information regarding the page which contains the URI.<br/>
-	 * <br/>
+	 * required information regarding the page which contains the URI.
+	 * <p>
 	 * Also provides a {@code shouldIgnore} boolean that states that this resourceURI should be
 	 * ignored in the fetching process, as it's probably a dead end (e.g. binary data, image, etc).
 	 * 

--- a/src/org/zaproxy/zap/users/User.java
+++ b/src/org/zaproxy/zap/users/User.java
@@ -226,7 +226,7 @@ public class User extends Enableable {
 	/**
 	 * Gets the last successful auth time.
 	 * 
-	 * @param lastSuccessfulAuthTime the new last successful auth time
+	 * @return the time of last successful authentication
 	 */
 	protected long getLastSuccessfulAuthTime() {
 		return lastSuccessfulAuthTime;
@@ -297,6 +297,7 @@ public class User extends Enableable {
 	 * Decodes an User from an encoded string. The string provided as input should have been
 	 * obtained through calls to {@link #encode(User)}.
 	 * 
+	 * @param contextId the ID of the context the user belongs to
 	 * @param encodedString the encoded string
 	 * @return the user
 	 */
@@ -306,8 +307,9 @@ public class User extends Enableable {
 	}
 
 	/**
-	 * Helper method for decoding an user from an encoded string. See {@link #decode(String)}.
+	 * Helper method for decoding an user from an encoded string. See {@link #decode(int, String)}.
 	 * 
+	 * @param contextId the ID of the context the user belongs to
 	 * @param encodedString the encoded string
 	 * @param authenticationExtension the authentication extension
 	 * @return the user

--- a/src/org/zaproxy/zap/utils/ApiUtils.java
+++ b/src/org/zaproxy/zap/utils/ApiUtils.java
@@ -89,6 +89,7 @@ public final class ApiUtils {
 	/**
 	 * Gets an optional enum param, returning <code>null</code> if the parameter was not found.
 	 *
+	 * @param <E> the type of the enum that will be returned
 	 * @param params the params
 	 * @param paramName the param name
 	 * @return the enum, or <code>null</code>

--- a/src/org/zaproxy/zap/utils/ContentMatcher.java
+++ b/src/org/zaproxy/zap/utils/ContentMatcher.java
@@ -50,7 +50,7 @@ public class ContentMatcher {
      * Direct method for a complete ContentMatcher instance creation.
      * Use the ClassLoader for the resource detection and loading, be careful regarding the 
      * relative file name use (this class is in another package).
-     * @param xmlfileName the name of the XML file that need to be used for initialization
+     * @param xmlFileName the name of the XML file that need to be used for initialization
      * @return a ContentMatcher instance
      */
     public static ContentMatcher getInstance(String xmlFileName) {
@@ -88,9 +88,12 @@ public class ContentMatcher {
     
     /**
      * Load a pattern list from an XML formatted file.
-     * Pattern should be enclosed around a <Patterns> tag and should be
-     * defined as <Pattern type="xxx"></Pattern>. Use "regex" to define
+     * Pattern should be enclosed around a {@code <Patterns>} tag and should be
+     * defined as {@code <Pattern type="xxx"></Pattern>}. Use "regex" to define
      * a Regex formatted pattern or "string" for an exact matching pattern.
+     * @param xmlInputStream the {@code InputStream} used to read the patterns
+     * @throws JDOMException if an error occurred while parsing
+     * @throws IOException if an I/O error occurred while reading the {@code InputStream}
      */
     protected void loadXMLPatternDefinitions(InputStream xmlInputStream) throws JDOMException, IOException {
         strings = new ArrayList<BoyerMooreMatcher>();

--- a/src/org/zaproxy/zap/utils/HirshbergMatcher.java
+++ b/src/org/zaproxy/zap/utils/HirshbergMatcher.java
@@ -26,8 +26,8 @@ package org.zaproxy.zap.utils;
  * or the similarity ratio between two strings.
  * This implementation is using Hirschber's algorithm B and algorithm C.
  *
- * @see <a href="http://code.google.com/p/algorithm800/source/browse/trunk/src/Hirschberg.java">Hirschberg&apos;s algorithm
- *      implementation of project algorithm800</a>
+ * @see <a href="https://code.google.com/archive/p/algorithm800/source/default/source">Hirschberg's algorithm implementation of
+ *      project algorithm800</a>
  *
  * @author Valentinos Georgiades
  * @author Minh Nguyen
@@ -41,15 +41,6 @@ public class HirshbergMatcher {
     // Maximum value for comparison ratio
     public static final double MAX_RATIO = 1.0;
     
-    /**
-     * Algorithm B as described by Hirschberg
-     *
-     * @param m
-     * @param n
-     * @param a
-     * @param b
-     * @return
-     */
     private static int[] algB(int m, int n, String a, String b) {
         // Step 1
         int[][] k = new int[2][n + 1];
@@ -79,15 +70,6 @@ public class HirshbergMatcher {
 
     }
 
-    /**
-     * Algorithm C as described by Hirschberg
-     *
-     * @param m
-     * @param n
-     * @param a
-     * @param b
-     * @return
-     */
     private static void algC(StringBuilder sb, int m, int n, String a, String b) {
         int i;
         int j;
@@ -123,23 +105,14 @@ public class HirshbergMatcher {
     /**
      * This method takes a string as input reverses it and returns the result
      * 
-     * @param in
-     * @return
+     * @param in the string to be reversed
+     * @return the reversed string
      */
     private static String reverseString(String in) {
         StringBuilder out = new StringBuilder(in).reverse();
         return out.toString();
     }
 
-    /**
-     * This method finds the index of the maximum sum of L1 and L2, as described
-     * by Hirschberg
-     *
-     * @param l1
-     * @param l2
-     * @param n
-     * @return
-     */
     private static int findK(int[] l1, int[] l2, int n) {
         int m = 0;
         int k = 0;

--- a/src/org/zaproxy/zap/utils/HttpUserAgent.java
+++ b/src/org/zaproxy/zap/utils/HttpUserAgent.java
@@ -75,14 +75,15 @@ public final class HttpUserAgent {
 	
 	/**
 	 * Return what type of browser is used based on the user-agent
-	 * @param userAgent
-	 * @return Returns the following values for Firefox, Internet Explorer, Chrome, and Safari:<br/>
-	 * - firefox<br/>
-	 * - internet explorer<br/>
-	 * - chrome<br/>
-	 * - safari<br/>
-	 * <br/>
-	 * If the browser is not know, the error string "-1" will be returned
+	 * @param userAgent the value of the {@code User-Agent} header
+	 * @return a {@code String} with one of the following values depending on the browser:
+	 *         <ul>
+	 *         <li>Firefox - firefox</li>
+	 *         <li>Internet Explorer - internet explorer</li>
+	 *         <li>Chrome - chrome</li>
+	 *         <li>Safari - safari</li>
+	 *         </ul>
+	 *         Or, if not a known browser the error string {@code -1}.
 	 */
 	public static String getBrowser(String userAgent) {
 		if (userAgent.toLowerCase().contains(FireFox)){
@@ -99,10 +100,8 @@ public final class HttpUserAgent {
 	
 	/**
 	 * Return the version of the browser used based on the user-agent
-	 * @param userAgent
-	 * @return Returns the browser version<br/>
-	 * <br/>
-	 * If the browser is not know, the error string "-1" will be returned
+	 * @param userAgent the value of the {@code User-Agent} header
+	 * @return a {@code String} with the browser version, or if not a known browser the error string {@code -1}.
 	 */
 	public static String getBrowserVersion(String userAgent) {
 		if (userAgent.toLowerCase().contains(FireFox)){

--- a/src/org/zaproxy/zap/utils/I18N.java
+++ b/src/org/zaproxy/zap/utils/I18N.java
@@ -60,7 +60,9 @@ public class I18N {
     }
 
     /**
-     * Gets the String with the given key surrounded by <i>&lt;html&gt;&lt;p&gt; tags.
+     * Gets the String with the given key surrounded by {@code <html><p>} tags.
+     * @param key the key of the string
+     * @return the string read wrapped in HTML and paragraph tags
      */
 	public String getHtmlWrappedString(String key) {
 		String values = getString(key);
@@ -72,8 +74,8 @@ public class I18N {
     /**
      * Returns the specified char from the language file. 
      * As these are typically used for mnemnoics the 'null' char is returned if the key is not defined 
-     * @param key
-     * @return
+     * @param key the key of the char
+     * @return the char read, or null char if not found
      */
     public char getChar(String key) {
     	try {

--- a/src/org/zaproxy/zap/utils/LocaleUtils.java
+++ b/src/org/zaproxy/zap/utils/LocaleUtils.java
@@ -223,7 +223,9 @@ public final class LocaleUtils {
 	}
 	
 	/**
-	 * @param locale
+	 * Gets the name of the language of and for the given locale.
+	 * 
+	 * @param locale the locale whose language name will be returned
 	 * @return the name of the language
 	 */
 	public static String getLocalDisplayName(String locale) {

--- a/src/org/zaproxy/zap/utils/PagingTableModel.java
+++ b/src/org/zaproxy/zap/utils/PagingTableModel.java
@@ -215,14 +215,16 @@ public abstract class PagingTableModel<T> extends AbstractTableModel {
 	 * Called by {@link PagingTableModel#getValueAt(int, int)} when requested
 	 * row is already loaded.
 	 * 
-	 * @param rowObject
-	 * @param columnIndex
+	 * @param rowObject the row object
+	 * @param columnIndex the column index
 	 * @return value from requested column
 	 */
 	protected abstract Object getRealValueAt(T rowObject, int columnIndex);
 
 	/**
-	 * @param columnIndex
+	 * Gets the placeholder value that should be shown for the given column, until the actual values are ready to be shown.
+	 * 
+	 * @param columnIndex the column index
 	 * @return Value is used to display while loading entry
 	 */
 	protected abstract Object getPlaceholderValueAt(int columnIndex);
@@ -255,7 +257,9 @@ public abstract class PagingTableModel<T> extends AbstractTableModel {
 	}
 
 	/**
-	 * @param rowIndex
+	 * Gets the object at the given row.
+	 * 
+	 * @param rowIndex the index of the row
 	 * @return {@code null} if object is not in the current page
 	 */
 	protected T getRowObject(int rowIndex) {
@@ -270,7 +274,7 @@ public abstract class PagingTableModel<T> extends AbstractTableModel {
 	 * Schedule the loading of the neighborhood around offset (if not already
 	 * scheduled).
 	 * 
-	 * @param offset
+	 * @param offset the offset row 
 	 */
 	private void schedule(int offset) {
 		if (isPending(offset)) {

--- a/src/org/zaproxy/zap/utils/Pair.java
+++ b/src/org/zaproxy/zap/utils/Pair.java
@@ -20,8 +20,8 @@ package org.zaproxy.zap.utils;
 /**
  * Simple class that represents a tuple.
  * 
- * @param <X>
- * @param <Y>
+ * @param <X> the type of the first element
+ * @param <Y> the type of the second element
  */
 public class Pair<X, Y> {
 	public final X first;

--- a/src/org/zaproxy/zap/utils/TableColumnManager.java
+++ b/src/org/zaproxy/zap/utils/TableColumnManager.java
@@ -32,8 +32,7 @@ import javax.swing.table.TableColumnModel;
  * added to the table header of the table. The TableColumnModel is still used to
  * control the view for the table. The manager will invoke the appropriate
  * methods of the TableColumnModel to hide/show columns as required. <br>
- * Code taken from {@link http
- * ://tips4java.wordpress.com/2011/05/08/table-column-manager/}. Written by Rob
+ * Code taken from <a href="http://tips4java.wordpress.com/2011/05/08/table-column-manager/">tips4java</a>. Written by Rob
  * Camick, which states free usage: You are free to use and/or modify any or all
  * code posted on the Java Tips Weblog without restriction. A credit in the code
  * comments would be nice, but not in any way mandatory.
@@ -99,7 +98,7 @@ public class TableColumnManager implements MouseListener, ActionListener,
 	/**
 	 * Get the popup support.
 	 * 
-	 * @returns the popup support
+	 * @return the popup support
 	 */
 	public boolean isMenuPopup() {
 		return menuPopup;
@@ -109,7 +108,7 @@ public class TableColumnManager implements MouseListener, ActionListener,
 	 * Add/remove support for a popup menu to the table header. The popup menu
 	 * will give the user control over which columns are visible.
 	 * 
-	 * @param menuPopop
+	 * @param menuPopup
 	 *            when true support for displaying a popup menu is added
 	 *            otherwise the popup menu is removed.
 	 */

--- a/src/org/zaproxy/zap/utils/ThreadUtils.java
+++ b/src/org/zaproxy/zap/utils/ThreadUtils.java
@@ -10,9 +10,9 @@ public class ThreadUtils {
 	 * like {@link EventQueue#invokeAndWait(Runnable)}, but can be called from the main thread as
 	 * well.
 	 * 
-	 * @param runnable
-	 * @throws InterruptedException
-	 * @throws InvocationTargetException
+	 * @param runnable the {@code Runnable} to be run in the EDT
+	 * @throws InterruptedException if the current thread was interrupted while waiting for the EDT
+	 * @throws InvocationTargetException if an exception occurred while running the {@code Runnable}
 	 */
 	public static void invokeAndWait(Runnable runnable) throws InvocationTargetException,
 			InterruptedException {

--- a/src/org/zaproxy/zap/utils/TimeStampUtils.java
+++ b/src/org/zaproxy/zap/utils/TimeStampUtils.java
@@ -66,7 +66,7 @@ public final class TimeStampUtils {
     * {@code format} fails a default format is used. 
     * The DEFAULT is defined in Messages.properties.
     * @see SimpleDateFormat
-    * @param a {@code String} representing the date format
+    * @param format a {@code String} representing the date format
     * @return current formatted time stamp as {@code String}
     */
 	public static String currentFormattedTimeStamp(String format) {
@@ -88,7 +88,7 @@ public final class TimeStampUtils {
     * If application of the provided {@code format} fails a default format is used. 
     * The DEFAULT format is defined in Messages.properties.
     * @param message the message to be time stamped
-    * @param the format to be used in creating the time stamp
+    * @param format the format to be used in creating the time stamp
     * @return a time stamp in the designated format along with the original message
     * 
     * @see SimpleDateFormat

--- a/src/org/zaproxy/zap/utils/ViewState.java
+++ b/src/org/zaproxy/zap/utils/ViewState.java
@@ -56,6 +56,7 @@ public class ViewState {
         /** 
          * encode a object to a base64 string
          * @param o is a implemented java.io.Serializable object
+         * @return the encoded object
          */
         public static String encode(Serializable o) {
                 ByteArrayOutputStream bos = new ByteArrayOutputStream(); 
@@ -75,7 +76,9 @@ public class ViewState {
         
         /**
          * decode a base64 string to a object
+         * @param <T> the type of the object
          * @param base64 a encoded string by ViewState.encode method
+         * @return the decoded object
          */
         @SuppressWarnings("unchecked")
         public static <T> T decode(String base64) {


### PR DESCRIPTION
Address JavaDoc errors/warnings (Java 7 and 8) in packages "utils",
"authentication", "spider" and "users", for example:
 - warning: no description for `@param`;
 - warning: no description for `@throws`;
 - warning: no `@return`;
 - warning: no `@param` for ...;
 - error: self-closing element not allowed;
 - error: unexpected text (in see tags);
 - error: reference not found;
 - error: unknown tag: ...;
 - error: `@param` ... not found.