### PR TITLE
Check older add-ons on manual installations

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -684,6 +684,7 @@ cfu.warn.addon.with.missing.requirements.unknown = Unknown (refer to log file fo
 cfu.warn.addon.with.missing.requirements.javaversion = Minimum Java version: {0} (found: "{1}")
 cfu.warn.addon.with.missing.requirements.javaversion.dependency = Minimum Java version: {0} (found: "{1}") by dependency: "{2}"
 cfu.warn.addon.with.missing.requirements.javaversion.unknown = unknown
+cfu.warn.addOnOlderVersion = Add-on not installed!\n\nA newer (or same) version of the add-on is already installed:\nInstalled: {0} ({1})\nBeing installed: {2} ({3})
 cfu.warn.addOnNotRunnable.message = The add-on will not run until the following requirements are fulfilled:
 cfu.warn.addOnNotRunnable.question = Continue with the installation?
 cfu.warn.cantload      = Can not load the specified add-on\:\nNot before \= {0}\nNot from \= {1}


### PR DESCRIPTION
Change ExtensionAutoUpdate to check if the add-on being manually
installed is a newer or an older version, to correctly inform about
required changes during the installation (for example, if other add-ons
need to be uninstalled, updated or installed). Also, inform with better
message if the same add-on (version and status) is already installed.

Fix #2707 - Manual add-on installation needs more meaningful dialog
messages