### PR TITLE
Correct API error message on missing script params

### DIFF
--- a/src/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
@@ -782,6 +782,8 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
 					if (log.isDebugEnabled())
 						log.debug("Loaded authentication script parameters:" + paramValues);
 
+				} catch (ApiException e) {
+					throw e;
 				} catch (Exception e) {
 					getScriptsExtension().handleScriptException(script, e);
 					log.error("Unable to load Script Based Authentication method. The script "


### PR DESCRIPTION
Change ScriptBasedAuthenticationMethodType to catch and re-throw the
ApiException caused by missing parameters, so the error shown is, for
example:
 Missing Parameter (missing_parameter) : LoginURL

instead of:
 An error has occurred when loading the provided script
  (bad_script_format) : missing_parameter

which happened because the ApiException was being treated as an error
in the script.

Related to issue jenkinsci/zaproxy-plugin#31.