### PR TITLE
Use PopupMenuItemAlert in core classes

### DIFF
--- a/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -406,7 +406,6 @@ public class ExtensionAlert extends ExtensionAdaptor implements SessionChangedLi
     private PopupMenuAlertEdit getPopupMenuAlertEdit() {
         if (popupMenuAlertEdit == null) {
             popupMenuAlertEdit = new PopupMenuAlertEdit();
-            popupMenuAlertEdit.setExtension(this);
         }
         return popupMenuAlertEdit;
     }
@@ -414,7 +413,6 @@ public class ExtensionAlert extends ExtensionAdaptor implements SessionChangedLi
     private PopupMenuAlertDelete getPopupMenuAlertDelete() {
         if (popupMenuAlertDelete == null) {
             popupMenuAlertDelete = new PopupMenuAlertDelete();
-            popupMenuAlertDelete.setExtension(this);
         }
         return popupMenuAlertDelete;
     }
@@ -422,7 +420,6 @@ public class ExtensionAlert extends ExtensionAdaptor implements SessionChangedLi
     private PopupMenuAlertsRefresh getPopupMenuAlertsRefresh() {
         if (popupMenuAlertsRefresh == null) {
             popupMenuAlertsRefresh = new PopupMenuAlertsRefresh();
-            popupMenuAlertsRefresh.setExtension(this);
         }
         return popupMenuAlertsRefresh;
     }

--- a/src/org/zaproxy/zap/extension/alert/PopupMenuAlertDelete.java
+++ b/src/org/zaproxy/zap/extension/alert/PopupMenuAlertDelete.java
@@ -19,82 +19,40 @@
  */
 package org.zaproxy.zap.extension.alert;
 
-import java.awt.Component;
+import java.util.Set;
 
 import javax.swing.JOptionPane;
-import javax.swing.JTree;
-import javax.swing.tree.DefaultMutableTreeNode;
-import javax.swing.tree.TreePath;
 
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
-import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.parosproxy.paros.view.View;
 
 
 /**
- * ZAP: New Popup Menu Alert Delete
+ * A {@link PopupMenuItemAlert} that allows to delete {@link Alert alerts}.
+ * 
+ * @since 1.4.0
  */
-public class PopupMenuAlertDelete extends ExtensionPopupMenuItem {
+public class PopupMenuAlertDelete extends PopupMenuItemAlert {
 
 	private static final long serialVersionUID = 1L;
 
-	private ExtensionAlert extension = null;
-
     public PopupMenuAlertDelete() {
-        super(Constant.messages.getString("scanner.delete.popup"));
-
-        this.addActionListener(new java.awt.event.ActionListener() { 
-
-        	@Override
-        	public void actionPerformed(java.awt.event.ActionEvent e) {
-			    TreePath[] paths = extension.getAlertPanel().getTreeAlert().getSelectionPaths();
-			    if (paths != null) {
-			    	if (View.getSingleton().showConfirmDialog(Constant.messages.getString("scanner.delete.confirm")) 
-			    			!= JOptionPane.OK_OPTION) {
-			    		return;
-			    	}
-			    	for (TreePath path : paths) {
-			    		DefaultMutableTreeNode node = (DefaultMutableTreeNode)  path.getLastPathComponent();
-			    		deleteNode(node);
-			    	}
-			    }
-        	}
-        });
-			
-	}
-	
-	private void deleteNode(DefaultMutableTreeNode node) {
-		while (node.getChildCount() > 0) {
-			deleteNode((DefaultMutableTreeNode)node.getChildAt(0));
-		}
-	    if (node.getUserObject() != null) {
-	        Object obj = node.getUserObject();
-	        if (obj instanceof Alert) {
-	            extension.deleteAlert((Alert) obj);
-	        }
-	    }
+        super(Constant.messages.getString("scanner.delete.popup"), true);
 	}
 	
     @Override
-    public boolean isEnableForComponent(Component invoker) {
-        if (invoker.getName() != null && invoker.getName().equals("treeAlert")) {
-            try {
-                JTree tree = (JTree) invoker;
-                if (tree.getLastSelectedPathComponent() != null) {
-                    DefaultMutableTreeNode node = (DefaultMutableTreeNode) tree.getLastSelectedPathComponent();
-                    if (!node.isRoot()) {
-                        return true;
-                    }
-                }
-            } catch (Exception e) {}
-            
+    protected void performActions(Set<Alert> alerts) {
+        if (View.getSingleton()
+                .showConfirmDialog(Constant.messages.getString("scanner.delete.confirm")) != JOptionPane.OK_OPTION) {
+            return;
         }
-        return false;
+        super.performActions(alerts);
     }
-    
-    void setExtension(ExtensionAlert extension) {
-        this.extension = extension;
+
+    @Override
+    protected void performAction(Alert alert) {
+        getExtensionAlert().deleteAlert(alert);
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/alert/PopupMenuAlertEdit.java
+++ b/src/org/zaproxy/zap/extension/alert/PopupMenuAlertEdit.java
@@ -19,76 +19,35 @@
  */
 package org.zaproxy.zap.extension.alert;
 
-import java.awt.Component;
-
-import javax.swing.JTree;
-import javax.swing.tree.DefaultMutableTreeNode;
-
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
-import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
 
 
 /**
- * ZAP: New Popup Menu Alert Edit
+ * A {@link PopupMenuItemAlert} that allows to edit an {@link Alert alert}.
+ * 
+ * @since 1.4.0
  */
-public class PopupMenuAlertEdit extends ExtensionPopupMenuItem {
+public class PopupMenuAlertEdit extends PopupMenuItemAlert {
 
 	private static final long serialVersionUID = 1L;
-
-	private ExtensionAlert extension = null;
 
 	private ExtensionHistory extHist = null; 
 
     public PopupMenuAlertEdit() {
         super(Constant.messages.getString("scanner.edit.popup"));
-
-        this.addActionListener(new java.awt.event.ActionListener() { 
-
-        	@Override
-        	public void actionPerformed(java.awt.event.ActionEvent e) {
-        	    
-			    DefaultMutableTreeNode node = (DefaultMutableTreeNode) extension.getAlertPanel().getTreeAlert().getLastSelectedPathComponent();
-			    if (node != null && node.getUserObject() != null) {
-			        Object obj = node.getUserObject();
-			        if (obj instanceof Alert) {
-			            Alert alert = (Alert) obj;
-			            
-						if (extHist == null) {
-							extHist = (ExtensionHistory) Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.NAME);
-						}
-						if (extHist != null) {
-							extHist.showAlertAddDialog(alert);
-						}
-			        }
-			    }
-        	    
-        	}
-        });
-			
 	}
 	
     @Override
-    public boolean isEnableForComponent(Component invoker) {
-        if (invoker.getName() != null && invoker.getName().equals("treeAlert")) {
-            try {
-                JTree tree = (JTree) invoker;
-                if (tree.getLastSelectedPathComponent() != null) {
-                    DefaultMutableTreeNode node = (DefaultMutableTreeNode) tree.getLastSelectedPathComponent();
-                    if (!node.isRoot() && node.getUserObject() != null) {
-                        return true;
-                    }
-                }
-            } catch (Exception e) {}
-            
+    protected void performAction(Alert alert) {
+        if (extHist == null) {
+            extHist = (ExtensionHistory) Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.NAME);
         }
-        return false;
-    }
-    
-    void setExtension(ExtensionAlert extension) {
-        this.extension = extension;
+        if (extHist != null) {
+            extHist.showAlertAddDialog(alert);
+        }
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/alert/PopupMenuAlertsRefresh.java
+++ b/src/org/zaproxy/zap/extension/alert/PopupMenuAlertsRefresh.java
@@ -20,45 +20,44 @@
 package org.zaproxy.zap.extension.alert;
 
 import java.awt.Component;
+import java.util.Set;
 
 import javax.swing.tree.DefaultTreeModel;
 
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
+import org.parosproxy.paros.core.scanner.Alert;
 
 
 /**
- * ZAP: New Popup Menu Alert Delete
+ * A {@link PopupMenuItemAlert} that allows to refresh the Alerts tree (the UI tree is rebuilt from the model already set).
+ * 
+ * @since 1.4.0
  */
-public class PopupMenuAlertsRefresh extends ExtensionPopupMenuItem {
+public class PopupMenuAlertsRefresh extends PopupMenuItemAlert {
 
 	private static final long serialVersionUID = 1L;
 
-	private ExtensionAlert extension = null;
-
     public PopupMenuAlertsRefresh() {
-        super(Constant.messages.getString("alerts.refresh.popup"));
-
-        this.addActionListener(new java.awt.event.ActionListener() { 
-
-        	@Override
-        	public void actionPerformed(java.awt.event.ActionEvent e) {
-			    ((DefaultTreeModel)extension.getAlertPanel().getTreeAlert().getModel()).reload();
-        	}
-        });
-			
+        super(Constant.messages.getString("alerts.refresh.popup"), true);
 	}
 	
     @Override
+    protected void performActions(Set<Alert> alerts) {
+        ((DefaultTreeModel) getExtensionAlert().getAlertPanel().getTreeAlert().getModel()).reload();
+    }
+
+    @Override
     public boolean isEnableForComponent(Component invoker) {
-        if (invoker.getName() != null && invoker.getName().equals("treeAlert")) {
-        	return true;
+        if (super.isEnableForComponent(invoker)) {
+            setEnabled(true);
+            return true;
         }
         return false;
     }
     
-    void setExtension(ExtensionAlert extension) {
-        this.extension = extension;
+    @Override
+    protected void performAction(Alert alert) {
+        // Nothing to do.
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/alert/PopupMenuItemAlert.java
+++ b/src/org/zaproxy/zap/extension/alert/PopupMenuItemAlert.java
@@ -23,9 +23,11 @@ package org.zaproxy.zap.extension.alert;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.Component;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.swing.JTree;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreePath;
 
@@ -35,7 +37,12 @@ import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
 
-
+/**
+ * An {@link ExtensionPopupMenuItem} that exposes the selected {@link Alert alerts} of the Alerts tree.
+ * 
+ * @since TODO add version
+ * @see #performAction(Alert)
+ */
 public abstract class PopupMenuItemAlert extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;
@@ -44,10 +51,25 @@ public abstract class PopupMenuItemAlert extends ExtensionPopupMenuItem {
 
     private static final Logger log = Logger.getLogger(PopupMenuItemAlert.class);
 
+    /**
+     * Constructs a {@code PopupMenuItemAlert} with the given label and with no support for multiple selected alerts (the menu
+     * button will not be enabled when the Alerts tree has multiple selected alerts).
+     * 
+     * @param label the label of the menu item
+     * @see #isEnableForComponent(Component)
+     */
     public PopupMenuItemAlert(String label) {
         this(label, false);
     }
 
+    /**
+     * Constructs a {@code PopupMenuItemAlert} with the given label and whether or not the menu item supports multiple selected
+     * alerts (if {@code false} the menu button will not be enabled when the Alerts tree has multiple selected alerts).
+     * 
+     * @param label the label of the menu item
+     * @param multiSelect {@code true} if the menu item supports multiple selected alerts, {@code false} otherwise.
+     * @see #isEnableForComponent(Component)
+     */
     public PopupMenuItemAlert(String label, boolean multiSelect) {
         super(label);
         this.multiSelect = multiSelect;
@@ -55,13 +77,30 @@ public abstract class PopupMenuItemAlert extends ExtensionPopupMenuItem {
         this.extAlert = Control.getSingleton().getExtensionLoader().getExtension(ExtensionAlert.class);
 	}
 
+    /**
+     * Tells whether or not the menu item supports multiple selected alerts. If {@code false} the menu button will not be
+     * enabled when the Alerts tree has multiple selected alerts.
+     * 
+     * @return {@code true} if the menu item supports multiple selected alerts, {@code false} otherwise.
+     * @see #isButtonEnabledForNumberOfSelectedAlerts(int)
+     */
     public final boolean isMultiSelect() {
         return multiSelect;
     }
 
     private Set<Alert> getAlertNodes() {
         TreePath[] paths = this.extAlert.getAlertPanel().getTreeAlert().getSelectionPaths();
+        if (paths == null || paths.length == 0) {
+            return Collections.emptySet();
+        }
+
         HashSet<Alert> alertNodes = new HashSet<Alert>();
+        if (!isMultiSelect()) {
+            DefaultMutableTreeNode alertNode = (DefaultMutableTreeNode) paths[0].getLastPathComponent();
+            alertNodes.add((Alert) alertNode.getUserObject());
+            return alertNodes;
+        }
+
         for(int i = 0; i < paths.length; i++ ) {
             DefaultMutableTreeNode alertNode = (DefaultMutableTreeNode)paths[i].getLastPathComponent();
             if(alertNode.getChildCount() == 0) {
@@ -76,14 +115,46 @@ public abstract class PopupMenuItemAlert extends ExtensionPopupMenuItem {
         return alertNodes;
     }
 
+    /**
+     * Performs the action of the menu item for the given selected alert.
+     * <p>
+     * By default, it's called for each selected alert.
+     *
+     * @param alert the selected alert, never {@code null}
+     * @see #performActions(Set)
+     */
     protected abstract void performAction(Alert alert);
 
+    /**
+     * Performs the action of the menu item for each of the given selected alerts.
+     * <p>
+     * Called when the pop up menu item is chosen.
+     * 
+     * @param alerts the selected alerts, never {@code null}
+     * @see #performAction(Alert)
+     */
     protected void performActions(Set<Alert> alerts) {
         for(Alert alert: alerts) {
             performAction(alert);
         }
     }
 
+    /**
+     * Tells whether or not the button should be enabled for the given number of selected alerts.
+     * <p>
+     * If multiple alert nodes are selected the {@code count} corresponds to the number of selected alerts. If just a middle
+     * alert node (that is, the nodes that show the alert name) is selected the {@code count} is only one alert when
+     * {@link #isMultiSelect() multiple selection} is not supported, otherwise it is the number of child nodes (which is one
+     * alert per node).
+     * <p>
+     * By default the button is only enabled if at least one alert is selected. For menu items that do not support multiple
+     * selection it's only enabled if just one alert is selected.
+     * <p>
+     * <strong>Note:</strong> This method is only called if the invoker is the Alerts tree and the root node is not selected.
+     * 
+     * @param count the number of selected alerts
+     * @return {@code true} if the button should be enabled, {@code false} otherwise
+     */
     protected boolean isButtonEnabledForNumberOfSelectedAlerts(int count) {
         if(count == 0 ) {
             return false;
@@ -93,17 +164,63 @@ public abstract class PopupMenuItemAlert extends ExtensionPopupMenuItem {
         return true;
     }
 
+    /**
+     * @see #isButtonEnabledForNumberOfSelectedAlerts(int)
+     */
     @Override
     public boolean isEnableForComponent(Component invoker) {
         if(this.extAlert == null) {
             return false;
         }
         if ("treeAlert".equals(invoker.getName())) {
-            int count = this.extAlert.getAlertPanel().getTreeAlert().getSelectionCount();
-            setEnabled(!this.extAlert.getAlertPanel().getTreeAlert().isRowSelected(0) && isButtonEnabledForNumberOfSelectedAlerts(count));
+            setEnabled(!this.extAlert.getAlertPanel().getTreeAlert().isRowSelected(0) && 
+                    isButtonEnabledForNumberOfSelectedAlerts(getNumberOfSelectedAlerts()));
             return true;
         }
         return false;
+    }
+
+    /**
+     * Gets the number of selected alerts in the Alerts tree.
+     * <p>
+     * If multiple alert nodes are selected it returns the corresponding number of alerts. If just a middle alert node (that is,
+     * the nodes that show the alert name) is selected it returns only one selected alert when {@link #isMultiSelect() multiple
+     * selection} is not supported, otherwise it returns the number of child nodes (which is one alert per node).
+     * 
+     * @return the number of selected nodes
+     */
+    private int getNumberOfSelectedAlerts() {
+        JTree treeAlert = this.extAlert.getAlertPanel().getTreeAlert();
+        int count = treeAlert.getSelectionCount();
+        if (count == 0) {
+            return 0;
+        }
+
+        if (count == 1) {
+            DefaultMutableTreeNode alertNode = (DefaultMutableTreeNode) treeAlert.getSelectionPath().getLastPathComponent();
+            if (alertNode.getChildCount() == 0 || !isMultiSelect()) {
+                return 1;
+            }
+            return alertNode.getChildCount();
+        }
+
+        count = 0;
+        TreePath[] paths = treeAlert.getSelectionPaths();
+        for (int i = 0; i < paths.length; i++) {
+            TreePath nodePath = paths[i];
+            int childCount = ((DefaultMutableTreeNode) nodePath.getLastPathComponent()).getChildCount();
+            count += childCount != 0 ? childCount : (treeAlert.isPathSelected(nodePath.getParentPath()) ? 0 : 1);
+        }
+        return count;
+    }
+
+    /**
+     * Gets the {@code ExtensionAlert}.
+     *
+     * @return the {@code ExtensionAlert}, or {@code null} if the extension is not enabled.
+     */
+    protected ExtensionAlert getExtensionAlert() {
+        return extAlert;
     }
 
     private class PerformActionsActionListener implements ActionListener {


### PR DESCRIPTION
Change classes PopupMenuAlertDelete, PopupMenuAlertEdit and
PopupMenuAlertsRefresh to use PopupMenuItemAlert, instead of "manually"
accessing the Alerts tree.
Change class PopupMenuItemAlert to return just one alert selected if the
menu item does not support multiple selected alerts when a middle alert
node (one that shows the alert name) is selected, instead of returning
all child alerts or the number of all child alerts when checking if the
button of the menu item is enabled for the number of selected alerts.
The change allows menu items that do not support multiple selection to
still be used when the middle alerts are selected (for example, the
edit menu item).
Add some JavaDocs to the classes.