### PR TITLE
Allow to configure TTL of successful DNS queries

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -724,6 +724,13 @@ cmp.report.header.method       = Method
 cmp.report.header.url          = URL
 
 conn.options.defaultUserAgent	 = Default User Agent:
+conn.options.dns.title = DNS
+conn.options.dns.ttlSuccessfulQueries.label = TTL Successful Queries (in seconds):
+conn.options.dns.ttlSuccessfulQueries.toolTip = <html>Defines for how long the successful DNS queries should be cached:<ul>\
+<li>Negative number, cache forever;</li>\
+<li>Zero, disables caching;</li>\
+<li>Positive number, the number of seconds the queries will be cached.</li></ul>\
+<strong>Note:</strong> Changes are applied after a restart.</html>
 conn.options.general             = General Configuration
 conn.options.proxy.address       = Address/Domain Name:
 conn.options.proxy.address.empty = Empty proxy chain name.
@@ -866,6 +873,7 @@ core.api.action.newSession = Creates a new session, optionally overwriting exist
 core.api.action.saveSession = Saves the session with the name supplied, optionally overwriting existing files. If a relative path is specified it will be resolved against the "session" directory in ZAP "home" dir.
 core.api.action.sendRequest = Sends the HTTP request, optionally following redirections. Returns the request sent and response received and followed redirections, if any. The Mode is enforced when sending the request (and following redirections), custom manual requests are now allowed in 'Safe' mode nor in 'Protected' mode if out of scope.
 core.api.action.setMode = Sets the mode, which may be one of [safe, protect, standard, attack]
+core.api.action.setOptionDnsTtlSuccessfulQueries = Sets the TTL (in seconds) of successful DNS queries (applies after ZAP restart).
 core.api.action.shutdown = Shuts down ZAP
 core.api.other.messagesHar = Gets the HTTP messages sent through/by ZAP, in HAR format, optionally filtered by URL and paginated with 'start' position and 'count' of messages
 core.api.other.sendHarRequest = Sends the first HAR request entry, optionally following redirections. Returns, in HAR format, the request sent and response received and followed redirections, if any. The Mode is enforced when sending the request (and following redirections), custom manual requests are now allowed in 'Safe' mode nor in 'Protected' mode if out of scope.
@@ -882,6 +890,7 @@ core.api.view.message = Gets the HTTP message with the given ID. Returns the ID,
 core.api.view.messages = Gets the HTTP messages sent by ZAP, request and response, optionally filtered by URL and paginated with 'start' position and 'count' of messages
 core.api.view.mode = Gets the mode
 core.api.view.numberOfMessages = Gets the number of messages, optionally filtering by URL
+core.api.view.optionDnsTtlSuccessfulQueries = Gets the TTL (in seconds) of successful DNS queries.
 core.api.view.version = Gets ZAP version
 core.api.view.excludedFromProxy = Gets the regular expressions, applied to URLs, to exclude from the Proxy
 core.api.view.stats = Gets the global stats

--- a/src/org/parosproxy/paros/extension/option/OptionsConnectionPanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsConnectionPanel.java
@@ -32,6 +32,7 @@
 // ZAP: 2015/08/07 Issue 1768: Update to use a more recent default user agent
 // ZAP: 2016/03/08 Issue 646: Outgoing proxy password as JPasswordField (pips) instead of ZapTextField
 // ZAP: 2016/03/18 Add checkbox to allow showing of the password
+// ZAP: 2016/08/08 Issue 2742: Allow for override/customization of Java's "networkaddress.cache.ttl" value
 
 package org.parosproxy.paros.extension.option;
 
@@ -47,6 +48,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 
 import javax.swing.BorderFactory;
+import javax.swing.GroupLayout;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
@@ -65,6 +67,7 @@ import org.parosproxy.paros.view.AbstractParamPanel;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.model.CommonUserAgents;
 import org.zaproxy.zap.utils.FontUtils;
+import org.zaproxy.zap.utils.ZapNumberSpinner;
 import org.zaproxy.zap.utils.ZapPortNumberSpinner;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTablePanel;
@@ -95,6 +98,9 @@ public class OptionsConnectionPanel extends AbstractParamPanel {
     private JCheckBox checkBoxSingleCookieRequestHeader;
     private JComboBox<String> commonUserAgents = null;
 	private ZapTextField defaultUserAgent = null;
+
+	private JPanel dnsPanel;
+	private ZapNumberSpinner dnsTtlSuccessfulQueriesNumberSpinner;
 
     private SecurityProtocolsPanel securityProtocolsPanel;
 
@@ -372,34 +378,19 @@ public class OptionsConnectionPanel extends AbstractParamPanel {
 			panelProxyChain.setName("ProxyChain");
 			JPanel innerPanel = new JPanel(new GridBagLayout());
 
-			java.awt.GridBagConstraints gridBagConstraints72 = new GridBagConstraints();
-			java.awt.GridBagConstraints gridBagConstraints82 = new GridBagConstraints();
-			java.awt.GridBagConstraints gridBagConstraints92 = new GridBagConstraints();
+			GridBagConstraints gbc = new GridBagConstraints();
 
-			gridBagConstraints72.gridx = 0;
-			gridBagConstraints72.gridy = 0;
-			gridBagConstraints72.insets = new java.awt.Insets(2,2,2,2);
-			gridBagConstraints72.anchor = java.awt.GridBagConstraints.NORTHWEST;
-			gridBagConstraints72.fill = java.awt.GridBagConstraints.HORIZONTAL;
+			gbc.gridx = 0;
+			gbc.insets = new java.awt.Insets(2,2,2,2);
+			gbc.anchor = java.awt.GridBagConstraints.NORTHWEST;
+			gbc.fill = java.awt.GridBagConstraints.HORIZONTAL;
+			gbc.weightx = 1.0D;
 
-			gridBagConstraints82.gridx = 0;
-			gridBagConstraints82.gridy = 2;
-			gridBagConstraints82.insets = new java.awt.Insets(2,2,2,2);
-			gridBagConstraints82.anchor = java.awt.GridBagConstraints.NORTHWEST;
-			gridBagConstraints82.fill = java.awt.GridBagConstraints.HORIZONTAL;
-			gridBagConstraints82.weightx = 1.0D;
-			
-			gridBagConstraints92.gridx = 0;
-			gridBagConstraints92.gridy = 3;
-			gridBagConstraints92.insets = new java.awt.Insets(2,2,2,2);
-			gridBagConstraints92.anchor = java.awt.GridBagConstraints.NORTHWEST;
-			gridBagConstraints92.fill = java.awt.GridBagConstraints.HORIZONTAL;
-
-			innerPanel.add(getPanelGeneral(), gridBagConstraints72);
-			gridBagConstraints72.gridy = 1;
-			innerPanel.add(getSecurityProtocolsPanel(), gridBagConstraints72);
-			innerPanel.add(getJPanel(), gridBagConstraints82);
-			innerPanel.add(getPanelProxyAuth(), gridBagConstraints92);
+			innerPanel.add(getPanelGeneral(), gbc);
+			innerPanel.add(getDnsPanel(), gbc);
+			innerPanel.add(getSecurityProtocolsPanel(), gbc);
+			innerPanel.add(getJPanel(), gbc);
+			innerPanel.add(getPanelProxyAuth(), gbc);
 			
 			JScrollPane scrollPane = new JScrollPane(innerPanel);
 			scrollPane.setBorder(BorderFactory.createEmptyBorder());
@@ -408,6 +399,48 @@ public class OptionsConnectionPanel extends AbstractParamPanel {
 		}
 		return panelProxyChain;
 	}
+
+	private JPanel getDnsPanel() {
+		if (dnsPanel == null) {
+			dnsPanel = new JPanel();
+			dnsPanel.setBorder(
+					javax.swing.BorderFactory.createTitledBorder(
+							null,
+							Constant.messages.getString("conn.options.dns.title"),
+							javax.swing.border.TitledBorder.DEFAULT_JUSTIFICATION,
+							javax.swing.border.TitledBorder.DEFAULT_POSITION,
+							FontUtils.getFont(FontUtils.Size.standard),
+							Color.black));
+
+			GroupLayout layout = new GroupLayout(dnsPanel);
+			dnsPanel.setLayout(layout);
+			layout.setAutoCreateGaps(true);
+
+			JLabel valueLabel = new JLabel(Constant.messages.getString("conn.options.dns.ttlSuccessfulQueries.label"));
+			valueLabel.setToolTipText(Constant.messages.getString("conn.options.dns.ttlSuccessfulQueries.toolTip"));
+			valueLabel.setLabelFor(getDnsTtlSuccessfulQueriesNumberSpinner());
+
+			layout.setHorizontalGroup(layout.createSequentialGroup()
+					.addComponent(valueLabel)
+					.addComponent(getDnsTtlSuccessfulQueriesNumberSpinner()));
+
+			layout.setVerticalGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+					.addComponent(valueLabel)
+					.addComponent(getDnsTtlSuccessfulQueriesNumberSpinner()));
+		}
+		return dnsPanel;
+	}
+
+	private ZapNumberSpinner getDnsTtlSuccessfulQueriesNumberSpinner() {
+		if (dnsTtlSuccessfulQueriesNumberSpinner == null) {
+			dnsTtlSuccessfulQueriesNumberSpinner = new ZapNumberSpinner(
+					-1,
+					ConnectionParam.DNS_DEFAULT_TTL_SUCCESSFUL_QUERIES,
+					Integer.MAX_VALUE);
+		}
+		return dnsTtlSuccessfulQueriesNumberSpinner;
+	}
+
 	/**
 	 * This method initializes txtProxyChainName	
 	 * 	
@@ -536,6 +569,8 @@ public class OptionsConnectionPanel extends AbstractParamPanel {
 	        txtProxyChainPassword.setText(connectionParam.getProxyChainPassword());
         }
 
+        dnsTtlSuccessfulQueriesNumberSpinner.setValue(connectionParam.getDnsTtlSuccessfulQueries());
+
         securityProtocolsPanel.setSecurityProtocolsEnabled(connectionParam.getSecurityProtocolsEnabled());
         
         defaultUserAgent.setText(connectionParam.getDefaultUserAgent());
@@ -663,6 +698,8 @@ public class OptionsConnectionPanel extends AbstractParamPanel {
 
         connectionParam.setUseProxyChain(chkUseProxyChain.isSelected());
         connectionParam.setUseProxyChainAuth(chkProxyChainAuth.isSelected());
+
+        connectionParam.setDnsTtlSuccessfulQueries(dnsTtlSuccessfulQueriesNumberSpinner.getValue());
 
         connectionParam.setSecurityProtocolsEnabled(securityProtocolsPanel.getSelectedProtocols());
         

--- a/src/org/zaproxy/zap/GuiBootstrap.java
+++ b/src/org/zaproxy/zap/GuiBootstrap.java
@@ -71,6 +71,13 @@ public class GuiBootstrap extends ZapBootstrap {
 
     private final Logger logger = Logger.getLogger(GuiBootstrap.class);
 
+    /**
+     * Flag that indicates whether or not the look and feel was already set.
+     * 
+     * @see #setupLookAndFeel()
+     */
+    private boolean lookAndFeelSet;
+
     public GuiBootstrap(CommandLine cmdLineArgs) {
         super(cmdLineArgs);
     }
@@ -106,9 +113,9 @@ public class GuiBootstrap extends ZapBootstrap {
     private void startImpl() {
         setX11AwtAppClassName();
         setDefaultViewLocale(Constant.getLocale());
-        setupLookAndFeel();
 
         if (isFirstTime()) {
+            setupLookAndFeel();
             showLicense();
         } else {
             init(false);
@@ -140,7 +147,9 @@ public class GuiBootstrap extends ZapBootstrap {
     private void init(final boolean firstTime) {
         try {
             initModel();
+            setupLookAndFeel();
         } catch (Exception e) {
+            setupLookAndFeel();
             if (e instanceof FileNotFoundException) {
                 JOptionPane.showMessageDialog(
                         null,
@@ -308,8 +317,17 @@ public class GuiBootstrap extends ZapBootstrap {
 
     /**
      * Setups Swing's look and feel.
+     * <p>
+     * <strong>Note:</strong> Should be called only after calling {@link #initModel()}, if not initialising ZAP for the
+     * {@link #isFirstTime() first time}. The look and feel set up might initialise some network classes (e.g.
+     * {@link java.net.InetAddress InetAddress}) preventing some ZAP options from being correctly applied.
      */
     private void setupLookAndFeel() {
+        if (lookAndFeelSet) {
+            return;
+        }
+        lookAndFeelSet = true;
+
         try {
             // Set the systems Look and Feel
             UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());


### PR DESCRIPTION
Add an option to Connection options panel that allows to configure the
TTL of successful DNS queries (that is, GUI option for security property
"networkaddress.cache.ttl").

Fix #2742 - Allow for override/customization of Java's
"networkaddress.cache.ttl" value