### PR TITLE
Remove redundant test in SpiderHtmlParserUnitTest

### DIFF
--- a/test/org/zaproxy/zap/spider/parser/SpiderHtmlParserUnitTest.java
+++ b/test/org/zaproxy/zap/spider/parser/SpiderHtmlParserUnitTest.java
@@ -72,17 +72,6 @@ public class SpiderHtmlParserUnitTest extends SpiderParserTestUtils {
     }
 
     @Test
-    public void shouldNotParseMessageIfAlreadyParsed() {
-        // Given
-        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
-        boolean parsed = false;
-        // When
-        boolean canParse = htmlParser.canParseResource(new HttpMessage(), ROOT_PATH, parsed);
-        // Then
-        assertThat(canParse, is(equalTo(false)));
-    }
-
-    @Test
     public void shouldParseHtmlResponse() {
         // Given
         SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());


### PR DESCRIPTION
Remove redundant test (and incorrect, "parsed" should be true)
"shouldNotParseMessageIfAlreadyParsed". The behaviour is already being
asserted with "shouldNotParseHtmlResponseIfAlreadyParsed".