### PR TITLE
Add tests for SpiderSitemapXMLParser

### DIFF
--- a/src/org/zaproxy/zap/spider/parser/SpiderSitemapXMLParser.java
+++ b/src/org/zaproxy/zap/spider/parser/SpiderSitemapXMLParser.java
@@ -79,9 +79,13 @@ public class SpiderSitemapXMLParser extends SpiderParser {
 	 * Instantiates a new sitemap.xml parser.
 	 * 
 	 * @param params the params
+	 * @throws IllegalArgumentException if {@code params} is null.
 	 */
 	public SpiderSitemapXMLParser(SpiderParam params) {
 		super();
+		if (params == null) {
+			throw new IllegalArgumentException("Parameter params must not be null.");
+		}
 		this.params = params;
 	}
 
@@ -109,9 +113,7 @@ public class SpiderSitemapXMLParser extends SpiderParser {
 				Document xmldoc = dBuilder.parse(new InputSource(new ByteArrayInputStream(response)));
 				NodeList locationNodes = (NodeList) xpathLocationExpression.evaluate(xmldoc, XPathConstants.NODESET);
 			    for (int i = 0; i < locationNodes.getLength(); i++) {
-			    	String location = locationNodes.item(i).getNodeValue();			    	
-			    	if ( location != null ) 
-			    		processURL(message, depth, location, baseURL); 
+			    	processURL(message, depth, locationNodes.item(i).getNodeValue(), baseURL); 
 			    }
 			} 
 			catch (Exception e) {

--- a/test/org/zaproxy/zap/spider/parser/SpiderSitemapXMLParserUnitTest.java
+++ b/test/org/zaproxy/zap/spider/parser/SpiderSitemapXMLParserUnitTest.java
@@ -1,0 +1,300 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.spider.parser;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.log4j.Logger;
+import org.apache.log4j.varia.NullAppender;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.spider.SpiderParam;
+
+import net.htmlparser.jericho.Source;
+
+/**
+ * Unit test for {@link SpiderSitemapXMLParser}.
+ */
+public class SpiderSitemapXMLParserUnitTest extends SpiderParserTestUtils {
+
+    private static final String ROOT_PATH = "/";
+    private static final int BASE_DEPTH = 0;
+
+    private static final Path BASE_DIR_TEST_FILES = Paths.get("test/resources/org/zaproxy/zap/spider/parser/sitemapxml");
+
+    @BeforeClass
+    public static void suppressLogging() {
+        Logger.getRootLogger().addAppender(new NullAppender());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToCreateParserWithUndefinedSpiderOptions() {
+        // Given
+        SpiderParam undefinedSpiderOptions = null;
+        // When
+        new SpiderSitemapXMLParser(undefinedSpiderOptions);
+        // Then = IllegalArgumentException
+    }
+
+    @Test
+    public void shouldNotFailToEvaluateAnUndefinedMessage() {
+        // Given
+        HttpMessage undefinedMessage = null;
+        SpiderSitemapXMLParser spiderParser = createSpiderSitemapXMLParser();
+        // When
+        boolean canParse = spiderParser.canParseResource(undefinedMessage, ROOT_PATH, false);
+        // Then
+        assertThat(canParse, is(equalTo(false)));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldFailToEvaluateAnUndefinedPath() {
+        // Given
+        String undefinedPath = null;
+        SpiderSitemapXMLParser spiderParser = createSpiderSitemapXMLParser();
+        // When
+        spiderParser.canParseResource(new HttpMessage(), undefinedPath, false);
+        // Then = NullPointerException
+    }
+
+    @Test
+    public void shouldParsePathThatEndsWithSitemapXml() {
+        // Given
+        SpiderSitemapXMLParser spiderParser = createSpiderSitemapXMLParser();
+        boolean parsed = false;
+        // When
+        boolean canParse = spiderParser.canParseResource(new HttpMessage(), "/sitemap.xml", parsed);
+        // Then
+        assertThat(canParse, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldParseMessageEvenIfAlreadyParsed() {
+        // Given
+        SpiderSitemapXMLParser spiderParser = createSpiderSitemapXMLParser();
+        boolean parsed = true;
+        // When
+        boolean canParse = spiderParser.canParseResource(new HttpMessage(), "/sitemap.xml", parsed);
+        // Then
+        assertThat(canParse, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldNotParseAnUndefinedMessage() {
+        // Given
+        HttpMessage undefinedMessage = null;
+        SpiderSitemapXMLParser spiderParser = createSpiderSitemapXMLParser();
+        // When
+        boolean completelyParsed = spiderParser.parseResource(undefinedMessage, new Source(""), BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotRequireSourceToParseMessage() {
+        // Given
+        Source undefinedSource = null;
+        SpiderSitemapXMLParser spiderParser = createSpiderSitemapXMLParser();
+        HttpMessage message = createMessageWith("NoUrlsSitemap.xml");
+        // When
+        boolean completelyParsed = spiderParser.parseResource(message, undefinedSource, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldNotParseMessageIfParseOfSitemapXmlIsDisabled() {
+        // Given
+        SpiderParam params = createSpiderParamWithConfig();
+        params.setParseSitemapXml(false);
+        SpiderSitemapXMLParser spiderParser = new SpiderSitemapXMLParser(params);
+        HttpMessage message = createMessageWith("NoUrlsSitemap.xml");
+        // When
+        boolean completelyParsed = spiderParser.parseResource(message, null, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotParseNonXmlMessage() {
+        // Given
+        SpiderSitemapXMLParser spiderParser = createSpiderSitemapXMLParser();
+        HttpMessage message = createMessageWith("text/html", "NoUrlsSitemap.xml");
+        // When
+        boolean completelyParsed = spiderParser.parseResource(message, null, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotParseXmlMessageIfClientError() {
+        // Given
+        SpiderSitemapXMLParser spiderParser = createSpiderSitemapXMLParser();
+        HttpMessage message = createMessageWith("404 Not Found", "text/xml", "NoUrlsSitemap.xml");
+        // When
+        boolean completelyParsed = spiderParser.parseResource(message, null, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotParseXmlMessageIfServerError() {
+        // Given
+        SpiderSitemapXMLParser spiderParser = createSpiderSitemapXMLParser();
+        HttpMessage message = createMessageWith("500 Internal Server Error", "text/xml", "NoUrlsSitemap.xml");
+        // When
+        boolean completelyParsed = spiderParser.parseResource(message, null, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotParseEmptyXmlMessage() {
+        // Given
+        SpiderSitemapXMLParser spiderParser = createSpiderSitemapXMLParser();
+        HttpMessage message = createMessageWith("EmptyFile.xml");
+        // When
+        boolean completelyParsed = spiderParser.parseResource(message, null, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotParseMalformedXmlMessage() {
+        // Given
+        SpiderSitemapXMLParser spiderParser = createSpiderSitemapXMLParser();
+        HttpMessage message = createMessageWith("MalformedSitemap.xml");
+        // When
+        boolean completelyParsed = spiderParser.parseResource(message, null, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotParseXmlMessageWithDoctype() {
+        // Given
+        SpiderSitemapXMLParser spiderParser = createSpiderSitemapXMLParser();
+        HttpMessage message = createMessageWith("DoctypeSitemap.xml");
+        // When
+        boolean completelyParsed = spiderParser.parseResource(message, null, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotFindUrlsIfNoneDefinedInSitemap() {
+        // Given
+        SpiderSitemapXMLParser spiderParser = createSpiderSitemapXMLParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        spiderParser.addSpiderParserListener(listener);
+        HttpMessage message = createMessageWith("NoUrlsSitemap.xml");
+        // When
+        boolean completelyParsed = spiderParser.parseResource(message, null, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(true)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(0)));
+    }
+
+    @Test
+    public void shouldNotFindUrlsIfUrlHasNoLocationIsEmptyInSitemap() {
+        // Given
+        SpiderSitemapXMLParser spiderParser = createSpiderSitemapXMLParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        spiderParser.addSpiderParserListener(listener);
+        HttpMessage message = createMessageWith("UrlNoLocationSitemap.xml");
+        // When
+        boolean completelyParsed = spiderParser.parseResource(message, null, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(true)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(0)));
+    }
+
+    @Test
+    public void shouldNotFindUrlsIfUrlLocationIsEmptyInSitemap() {
+        // Given
+        SpiderSitemapXMLParser spiderParser = createSpiderSitemapXMLParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        spiderParser.addSpiderParserListener(listener);
+        HttpMessage message = createMessageWith("UrlEmptyLocationSitemap.xml");
+        // When
+        boolean completelyParsed = spiderParser.parseResource(message, null, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(true)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(0)));
+    }
+
+    @Test
+    public void shouldFindUrlsInValidSitemapXml() throws Exception {
+        // Given
+        SpiderSitemapXMLParser spiderParser = createSpiderSitemapXMLParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        spiderParser.addSpiderParserListener(listener);
+        HttpMessage message = createMessageWith("MultipleUrlsSitemap.xml");
+        // When
+        boolean completelyParsed = spiderParser.parseResource(message, null, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(true)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(5)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "https://example.org/",
+                        "http://subdomain.example.com/",
+                        "http://example.com/relative",
+                        "ftp://example.com/",
+                        "http://www.example.com/%C7"));
+    }
+
+    private static SpiderSitemapXMLParser createSpiderSitemapXMLParser() {
+        SpiderParam params = createSpiderParamWithConfig();
+        params.setParseSitemapXml(true);
+        return new SpiderSitemapXMLParser(params);
+    }
+
+    private static HttpMessage createMessageWith(String filename) {
+        return createMessageWith("text/xml", filename);
+    }
+
+    private static HttpMessage createMessageWith(String contentType, String filename) {
+        return createMessageWith("200 OK", contentType, filename);
+    }
+
+    private static HttpMessage createMessageWith(String statusCodeMessage, String contentType, String filename) {
+        HttpMessage message = new HttpMessage();
+        try {
+            String fileContents = readFile(BASE_DIR_TEST_FILES.resolve(filename));
+            message.setRequestHeader("GET / HTTP/1.1\r\nHost: example.com\r\n");
+            message.setResponseHeader(
+                    "HTTP/1.1 " + statusCodeMessage + "\r\n" + "Content-Type: " + contentType + "; charset=UTF-8\r\n"
+                            + "Content-Length: " + fileContents.length());
+            message.setResponseBody(fileContents);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return message;
+    }
+}

--- a/test/resources/org/zaproxy/zap/spider/parser/sitemapxml/DoctypeSitemap.xml
+++ b/test/resources/org/zaproxy/zap/spider/parser/sitemapxml/DoctypeSitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://doctype.example.org/</loc>
+    </url>
+</urlset>

--- a/test/resources/org/zaproxy/zap/spider/parser/sitemapxml/MalformedSitemap.xml
+++ b/test/resources/org/zaproxy/zap/spider/parser/sitemapxml/MalformedSitemap.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://malformed.example.org/</loc>
+</urlset>

--- a/test/resources/org/zaproxy/zap/spider/parser/sitemapxml/MultipleUrlsSitemap.xml
+++ b/test/resources/org/zaproxy/zap/spider/parser/sitemapxml/MultipleUrlsSitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://example.org/</loc>
+    </url>
+    <url>
+        <loc>http://subdomain.example.com/</loc>
+    </url>
+    <url>
+        <loc>relative</loc>
+    </url>
+    <url>
+        <loc>ftp://example.com</loc>
+    </url>
+    <url>
+        <loc>http://www.example.com/%C7</loc>
+    </url>
+</urlset>

--- a/test/resources/org/zaproxy/zap/spider/parser/sitemapxml/NoUrlsSitemap.xml
+++ b/test/resources/org/zaproxy/zap/spider/parser/sitemapxml/NoUrlsSitemap.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+</urlset>

--- a/test/resources/org/zaproxy/zap/spider/parser/sitemapxml/UrlEmptyLocationSitemap.xml
+++ b/test/resources/org/zaproxy/zap/spider/parser/sitemapxml/UrlEmptyLocationSitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc></loc>
+    </url>
+</urlset>

--- a/test/resources/org/zaproxy/zap/spider/parser/sitemapxml/UrlNoLocationSitemap.xml
+++ b/test/resources/org/zaproxy/zap/spider/parser/sitemapxml/UrlNoLocationSitemap.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+    </url>
+</urlset>


### PR DESCRIPTION
Add tests to assert the expected behaviour of SpiderSitemapXMLParser.
Other minor changes were done to class SpiderSitemapXMLParser:
 - Throw an exception when creating an instance with null SpiderParam,
 it's required to check if sitemap.xml files should be parsed;
 - Do not check if the value of the node (of the URL location) is non
 null, the value is guaranteed to be non null (per tests and JavaDoc).