### PR TITLE
Use request method to differentiate alerts

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/Alert.java
+++ b/src/org/parosproxy/paros/core/scanner/Alert.java
@@ -42,6 +42,7 @@
 // ZAP: 2015/11/16 Issue 1555: Rework inclusion of HTML tags in reports 
 // ZAP: 2016/02/26 Deprecate alert as an element of Alert in favour of name
 // ZAP: 2016/05/25 Normalise equals/hashCode/compareTo
+// ZAP: 2016/08/10 Issue 2757: Alerts with different request method are considered the same
 
 package org.parosproxy.paros.core.scanner;
 
@@ -324,6 +325,11 @@ public class Alert implements Comparable<Alert>  {
 		if (result != 0) {
 			return result;
 		}
+
+		result = method.compareToIgnoreCase(alert2.method);
+		if (result != 0) {
+			return result;
+		}
 		
 		// ZAP: changed to compare the field uri with alert2.uri
 		result = uri.compareToIgnoreCase(alert2.uri);
@@ -391,6 +397,9 @@ public class Alert implements Comparable<Alert>  {
 		if (!name.equals(item.name)) {
 			return false;
 		}
+		if (!method.equalsIgnoreCase(item.method)) {
+			return false;
+		}
 		if (!uri.equalsIgnoreCase(item.uri)) {
 			return false;
 		}
@@ -428,6 +437,7 @@ public class Alert implements Comparable<Alert>  {
 		result = prime * result + otherInfo.hashCode();
 		result = prime * result + param.hashCode();
 		result = prime * result + pluginId;
+		result = prime * result + method.hashCode();
 		result = prime * result + uri.hashCode();
 		result = prime * result + ((attack == null) ? 0 : attack.hashCode());
 		return result;
@@ -617,6 +627,7 @@ public class Alert implements Comparable<Alert>  {
     public String getUrlParamXML() {
     	StringBuilder sb = new StringBuilder(200); // ZAP: Changed the type to StringBuilder.
         sb.append("  <uri>").append(replaceEntity(uri)).append("</uri>\r\n");
+        sb.append("  <method>").append(replaceEntity(method)).append("</method>\r\n");
         if (param != null && param.length() > 0) {
         	sb.append("  <param>").append(replaceEntity(param)).append("</param>\r\n");
         }

--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -1094,6 +1094,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 		map.put("risk", Alert.MSG_RISK[alert.getRisk()]);
 		map.put("confidence", Alert.MSG_CONFIDENCE[alert.getConfidence()]);
 		map.put("url", alert.getUri());
+		map.put("method", alert.getMethod());
 		map.put("other", alert.getOtherInfo());
 		map.put("param", alert.getParam());
 		map.put("attack", alert.getAttack());

--- a/src/xml/report.html.xsl
+++ b/src/xml/report.html.xsl
@@ -70,7 +70,7 @@
   <xsl:template match="alertitem">
 <p></p>
 <table width="100%" border="0">
-<xsl:apply-templates select="text()|name|desc|uri|param|attack|evidence|instances|count|otherinfo|solution|reference|cweid|wascid|p|br|wbr|ul|li"/>
+<xsl:apply-templates select="text()|name|desc|uri|method|param|attack|evidence|instances|count|otherinfo|solution|reference|cweid|wascid|p|br|wbr|ul|li"/>
 </table>
   </xsl:template>
 
@@ -162,6 +162,16 @@
   </tr>
   </xsl:template>
 
+  <xsl:template match="method">
+  <tr bgcolor="#e8e8e8" valign="top"> 
+    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif"><p>Method</p></font></blockquote></td>
+    <td width="80%">
+    <font size="2" face="Arial, Helvetica, sans-serif">
+    <p><xsl:apply-templates select="text()|*"/></p>
+    </font></td>
+  </tr>
+  </xsl:template>
+
   <xsl:template match="param">
   <xsl:if test="text() !=''">
   <tr bgcolor="#e8e8e8" valign="top"> 
@@ -201,6 +211,16 @@
   <xsl:template match="instances/instance/uri">
   <tr bgcolor="#e8e8e8" valign="top"> 
     <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif"><p>URL</p></font></blockquote></td>
+    <td width="80%">
+    <font size="2" face="Arial, Helvetica, sans-serif">
+    <p><xsl:apply-templates select="text()|*"/></p>
+    </font></td>
+  </tr>
+  </xsl:template>
+
+  <xsl:template match="instances/instance/method">
+  <tr bgcolor="#e8e8e8" valign="top"> 
+    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif"><p>&#160;&#160;&#160;&#160;Method</p></font></blockquote></td>
     <td width="80%">
     <font size="2" face="Arial, Helvetica, sans-serif">
     <p><xsl:apply-templates select="text()|*"/></p>


### PR DESCRIPTION
Change Alert class to use the request method to differentiate the alerts
(in equals/hashCode/compareTo) and to include the request method when
converting to XML (which is included in the XML report).
Change CoreAPI to include the request method in the details of the
alerts.
Change HTML XSL (used for HTML report) to include the request method for
each alert.

Fix #2757 - Alerts with different request method are considered the same