### PR TITLE
Extract correct selected value from combined view

### DIFF
--- a/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/all/request/HttpRequestAllPanelSyntaxHighlightTextView.java
+++ b/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/all/request/HttpRequestAllPanelSyntaxHighlightTextView.java
@@ -130,6 +130,7 @@ public class HttpRequestAllPanelSyntaxHighlightTextView extends HttpPanelSyntaxH
             int end = getSelectionEnd();
             HttpMessageLocation.Location location;
 
+            String value;
             int headerLen = header.length();
             if (start + tHeader < headerLen) {
                 try {
@@ -152,20 +153,16 @@ public class HttpRequestAllPanelSyntaxHighlightTextView extends HttpPanelSyntaxH
                     end = headerLen;
                 }
                 location = HttpMessageLocation.Location.REQUEST_HEADER;
+                value = header.substring(start, end);
             } else {
                 start += tHeader - headerLen;
                 end += tHeader - headerLen;
 
                 location = HttpMessageLocation.Location.REQUEST_BODY;
+                value = httpMessage.getRequestBody().toString().substring(start, end);
             }
 
-            try {
-                return new DefaultTextHttpMessageLocation(location, start, end, getText(start, end - start));
-            } catch (BadLocationException e) {
-                // Shouldn't happen, but in case it does log it and return...
-                log.error(e.getMessage(), e);
-                return new DefaultTextHttpMessageLocation(HttpMessageLocation.Location.REQUEST_HEADER, 0);
-            }
+            return new DefaultTextHttpMessageLocation(location, start, end, value);
 		}
 
 		protected MessageLocationHighlightsManager create() {


### PR DESCRIPTION
Change class HttpRequestAllPanelSyntaxHighlightTextArea to return the
correct selected value, extracted directly from the request header or
the request body (instead of extracting the text from the text area,
which was using relative positions resulting in wrong text being
extracted).

Fix #2774 - Wrong value shown in fuzz location for body text when
selected through combined view