### PR TITLE
Use all form submit fields when spidering

### DIFF
--- a/src/org/zaproxy/zap/spider/parser/SpiderHtmlFormParser.java
+++ b/src/org/zaproxy/zap/spider/parser/SpiderHtmlFormParser.java
@@ -20,6 +20,7 @@ package org.zaproxy.zap.spider.parser;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
@@ -56,15 +57,19 @@ public class SpiderHtmlFormParser extends SpiderParser {
 	private static final String DEFAULT_PASS_VALUE = DEFAULT_TEXT_VALUE;
 
 	/** The spider parameters. */
-	SpiderParam param;
+	private final SpiderParam param;
 
 	/**
 	 * Instantiates a new spider html form parser.
 	 * 
 	 * @param param the parameters for the spider
+	 * @throws IllegalArgumentException if {@code param} is null.
 	 */
 	public SpiderHtmlFormParser(SpiderParam param) {
 		super();
+		if (param == null) {
+			throw new IllegalArgumentException("Parameter param must not be null.");
+		}
 		this.param = param;
 	}
 
@@ -82,12 +87,7 @@ public class SpiderHtmlFormParser extends SpiderParser {
 		}
 
 		// Get the context (base url)
-		String baseURL;
-		if (message == null) {
-			baseURL = "";
-		} else {
-			baseURL = message.getRequestHeader().getURI().toString();
-		}
+		String baseURL = message.getRequestHeader().getURI().toString();
 
 		// Try to see if there's any BASE tag that could change the base URL
 		Element base = source.getFirstElement(HTMLElementName.BASE);
@@ -121,12 +121,16 @@ public class SpiderHtmlFormParser extends SpiderParser {
 				continue;
 			}
 
-			// Prepare data set
-			List<HtmlParameter> formDataSet = prepareFormDataSet(form.getFormFields());
+			FormData formData = prepareFormDataSet(form.getFormFields());
 
 			// Process the case of a POST method
 			if (method != null && method.trim().equalsIgnoreCase(METHOD_POST)) {
-				String query = "";
+				// Build the absolute canonical URL
+				String fullURL = URLCanonicalizer.getCanonicalURL(action, baseURL);
+				if (fullURL == null) {
+					return false;
+				}
+				log.debug("Canonical URL constructed using '" + action + "': " + fullURL);
 
 				/*
 				 * Ignore encoding, as we will not POST files anyway, so using
@@ -134,24 +138,22 @@ public class SpiderHtmlFormParser extends SpiderParser {
 				 */
 				// String encoding = form.getAttributeValue("enctype");
 				// if (encoding != null && encoding.equals("multipart/form-data"))
-				query = buildEncodedUrlQuery(formDataSet);
-				log.debug("Submiting form with POST method and message body with form parameters (normal encoding): "
-						+ query);
-
-				// Build the absolute canonical URL
-				String fullURL = URLCanonicalizer.getCanonicalURL(action, baseURL);
-				if (fullURL == null) {
-					return false;
+				String baseRequestBody = buildEncodedUrlQuery(formData.getFields());
+				if (formData.getSubmitFields().isEmpty()) {
+					notifyPostResourceFound(message, depth, fullURL, baseRequestBody);
+					continue;
 				}
 
-				log.debug("Canonical URL constructed using '" + action + "': " + fullURL);
-				notifyListenersPostResourceFound(message, depth + 1, fullURL, query);
+				for (HtmlParameter submitField : formData.getSubmitFields()) {
+					notifyPostResourceFound(
+							message,
+							depth,
+							fullURL,
+							appendEncodedUrlQueryParameter(baseRequestBody, submitField));
+				}
 
 			} // Process anything else as a GET method
 			else {
-				String query = buildEncodedUrlQuery(formDataSet);
-				log.debug("Submiting form with GET method and query with form parameters: " + query);
-
 				// Clear the fragment, if any, as it does not have any relevance for the server
 				if (action.contains("#")) {
 					int fs = action.lastIndexOf("#");
@@ -161,18 +163,44 @@ public class SpiderHtmlFormParser extends SpiderParser {
 				// Process the final URL
 				if (action.contains("?")) {
 					if (action.endsWith("?")) {
-						processURL(message, depth, action + query, baseURL);
+						processGetForm(message, depth, action, baseURL, formData);
 					} else {
-						processURL(message, depth, action + "&" + query, baseURL);
+						processGetForm(message, depth, action + "&", baseURL, formData);
 					}
 				} else {
-					processURL(message, depth, action + "?" + query, baseURL);
+					processGetForm(message, depth, action + "?", baseURL, formData);
 				}
 			}
 
 		}
 
 		return false;
+	}
+
+	/**
+	 * Processes the given GET form data into, possibly, several URLs.
+	 * <p>
+	 * For each submit field present in the form data is processed one URL, which includes remaining normal fields.
+	 *
+	 * @param message the source message
+	 * @param depth the current depth
+	 * @param action the action
+	 * @param baseURL the base URL
+	 * @param formData the GET form data
+	 * @see #processURL(HttpMessage, int, String, String)
+	 */
+	private void processGetForm(HttpMessage message, int depth, String action, String baseURL, FormData formData) {
+		String baseQuery = buildEncodedUrlQuery(formData.getFields());
+		if (formData.getSubmitFields().isEmpty()) {
+			log.debug("Submiting form with GET method and query with form parameters: " + baseQuery);
+			processURL(message, depth, action + baseQuery, baseURL);
+		} else {
+			for (HtmlParameter submitField : formData.getSubmitFields()) {
+				String query = appendEncodedUrlQueryParameter(baseQuery, submitField);
+				log.debug("Submiting form with GET method and query with form parameters: " + query);
+				processURL(message, depth, action + query, baseURL);
+			}
+		}
 	}
 
 	/**
@@ -186,8 +214,9 @@ public class SpiderHtmlFormParser extends SpiderParser {
 	 * @param form the form
 	 * @return the list
 	 */
-	private List<HtmlParameter> prepareFormDataSet(FormFields form) {
+	private FormData prepareFormDataSet(FormFields form) {
 		List<HtmlParameter> formDataSet = new LinkedList<>();
+		List<HtmlParameter> submitFields = new ArrayList<>();
 
 		// Process each form field
 		Iterator<FormField> it = form.iterator();
@@ -197,55 +226,86 @@ public class SpiderHtmlFormParser extends SpiderParser {
 				log.debug("New form field: " + field.getDebugInfo());
 			}
 
-			// Get its value(s)
-			List<String> values = field.getValues();
-			if (log.isDebugEnabled()) {
-				log.debug("Existing values: " + values);
+			List<HtmlParameter> currentList = formDataSet;
+			if (field.getFormControl().getFormControlType().isSubmit()) {
+				currentList = submitFields;
 			}
-
-			// If there are no values at all or only an empty value
-			if (values.isEmpty() || (values.size() == 1 && values.get(0).isEmpty())) {
-				String finalValue = DEFAULT_EMPTY_VALUE;
-
-				// Check if we can use predefined values
-				Collection<String> predefValues = field.getPredefinedValues();
-				if (!predefValues.isEmpty()) {
-					// Try first elements
-					Iterator<String> iterator = predefValues.iterator();
-					finalValue = iterator.next();
-
-					// If there are more values, don't use the first, as it usually is a "No select"
-					// item
-					if (iterator.hasNext()) {
-						finalValue = iterator.next();
-					}
-				} else {
-					/*
-					 * In all cases, according to Jericho documentation, the only left option is for
-					 * it to be a TEXT field, without any predefined value. We check if it has only
-					 * one userValueCount, and, if so, fill it with a default value.
-					 */
-					if (field.getUserValueCount() > 0) {
-						finalValue = getDefaultTextValue(field);
-					}
-				}
-
-				// Save the finalValue in the FormDataSet
-				log.debug("No existing value for field " + field.getName() + ". Generated: " + finalValue);
-				HtmlParameter p = new HtmlParameter(Type.form, field.getName(), finalValue);
-				formDataSet.add(p);
-			}
-			// If there are preselected values for the fields, use them
-			else {
-				for (String v : values) {
-					// Save the finalValue in the FormDataSet
-					HtmlParameter p = new HtmlParameter(Type.form, field.getName(), v);
-					formDataSet.add(p);
-				}
+			for (String value : getValues(field)) {
+				currentList.add(new HtmlParameter(Type.form, field.getName(), value));
 			}
 		}
 
-		return formDataSet;
+		return new FormData(formDataSet, submitFields);
+	}
+
+	/**
+	 * Gets the values for the given {@code field}.
+	 * <p>
+	 * If the field is of submit type it returns its predefined values.
+	 *
+	 * @param field the field
+	 * @return a list with the values
+	 * @see #getDefaultTextValue(FormField)
+	 */
+	private static List<String> getValues(FormField field) {
+		if (field.getFormControl().getFormControlType().isSubmit()) {
+			return new ArrayList<>(field.getPredefinedValues());
+		}
+
+		// Get its value(s)
+		List<String> values = field.getValues();
+		if (log.isDebugEnabled()) {
+			log.debug("Existing values: " + values);
+		}
+
+		// If there are no values at all or only an empty value
+		if (values.isEmpty() || (values.size() == 1 && values.get(0).isEmpty())) {
+			String finalValue = DEFAULT_EMPTY_VALUE;
+
+			// Check if we can use predefined values
+			Collection<String> predefValues = field.getPredefinedValues();
+			if (!predefValues.isEmpty()) {
+				// Try first elements
+				Iterator<String> iterator = predefValues.iterator();
+				finalValue = iterator.next();
+
+				// If there are more values, don't use the first, as it usually is a "No select"
+				// item
+				if (iterator.hasNext()) {
+					finalValue = iterator.next();
+				}
+			} else {
+				/*
+				 * In all cases, according to Jericho documentation, the only left option is for
+				 * it to be a TEXT field, without any predefined value. We check if it has only
+				 * one userValueCount, and, if so, fill it with a default value.
+				 */
+				if (field.getUserValueCount() > 0) {
+					finalValue = getDefaultTextValue(field);
+				}
+			}
+
+			log.debug("No existing value for field " + field.getName() + ". Generated: " + finalValue);
+
+			values = new ArrayList<>(1);
+			values.add(finalValue);
+		}
+
+		return values;
+	}
+
+	/**
+	 * Notifies listeners that a new POST resource was found.
+	 *
+	 * @param message the source message
+	 * @param depth the current depth
+	 * @param url the URL of the resource
+	 * @param requestBody the request body
+	 * @see #notifyListenersPostResourceFound(HttpMessage, int, String, String)
+	 */
+	private void notifyPostResourceFound(HttpMessage message, int depth, String url, String requestBody) {
+		log.debug("Submiting form with POST method and message body with form parameters (normal encoding): " + requestBody);
+		notifyListenersPostResourceFound(message, depth + 1, url, requestBody);
 	}
 
 	/**
@@ -268,7 +328,7 @@ public class SpiderHtmlFormParser extends SpiderParser {
 	 * @param field the field
 	 * @return the default text value
 	 */
-	private String getDefaultTextValue(FormField field) {
+	private static String getDefaultTextValue(FormField field) {
 		FormControl fc = field.getFormControl();
 		if (fc.getFormControlType() == FormControlType.TEXT) {
 			// If the control type was reduced to a TEXT type by the Jericho library, check the
@@ -370,9 +430,55 @@ public class SpiderHtmlFormParser extends SpiderParser {
 		return request.toString();
 	}
 
+	/**
+	 * Appends the given {@code parameter} into the given {@code query}.
+	 *
+	 * @param query the query
+	 * @param parameter the parameter to append
+	 * @return the query with the parameter appended
+	 */
+	private static String appendEncodedUrlQueryParameter(String query, HtmlParameter parameter) {
+		StringBuilder strBuilder = new StringBuilder(query);
+		if (strBuilder.length() != 0) {
+			strBuilder.append('&');
+		}
+		try {
+			strBuilder.append(URLEncoder.encode(parameter.getName(), ENCODING_TYPE))
+					.append('=')
+					.append(URLEncoder.encode(parameter.getValue(), ENCODING_TYPE));
+		} catch (UnsupportedEncodingException e) {
+			log.warn("Error while encoding query for form.", e);
+		}
+		return strBuilder.toString();
+	}
+
 	@Override
 	public boolean canParseResource(HttpMessage message, String path, boolean wasAlreadyConsumed) {
 		// Fallback parser - if it's a HTML message which has not already been processed		
 		return !wasAlreadyConsumed && message.getResponseHeader().isHtml();
+	}
+
+	/**
+	 * The fields (and its values) of a HTML form.
+	 * <p>
+	 * Normal fields and submit fields are kept apart.
+	 */
+	private static class FormData {
+
+		private final List<HtmlParameter> fields;
+		private final List<HtmlParameter> submitFields;
+
+		public FormData(List<HtmlParameter> fields, List<HtmlParameter> submitFields) {
+			this.fields = fields;
+			this.submitFields = submitFields;
+		}
+
+		public List<HtmlParameter> getFields() {
+			return fields;
+		}
+
+		public List<HtmlParameter> getSubmitFields() {
+			return submitFields;
+		}
 	}
 }

--- a/test/org/zaproxy/zap/spider/parser/SpiderHtmlFormParserUnitTest.java
+++ b/test/org/zaproxy/zap/spider/parser/SpiderHtmlFormParserUnitTest.java
@@ -1,0 +1,563 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.spider.parser;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.log4j.Logger;
+import org.apache.log4j.varia.NullAppender;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.spider.SpiderParam;
+
+import net.htmlparser.jericho.Source;
+
+/**
+ * Unit test for {@link SpiderHtmlFormParser}.
+ */
+public class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
+
+    private static final String ROOT_PATH = "/";
+    private static final int BASE_DEPTH = 0;
+
+    private static final Path BASE_DIR_HTML_FILES = Paths.get("test/resources/org/zaproxy/zap/spider/parser/htmlform");
+
+    @BeforeClass
+    public static void suppressLogging() {
+        Logger.getRootLogger().addAppender(new NullAppender());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToCreateParserWithUndefinedSpiderOptions() {
+        // Given
+        SpiderParam undefinedSpiderOptions = null;
+        // When
+        new SpiderHtmlFormParser(undefinedSpiderOptions);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldFailToEvaluateAnUndefinedMessage() {
+        // Given
+        HttpMessage undefinedMessage = null;
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        // When
+        htmlParser.canParseResource(undefinedMessage, ROOT_PATH, false);
+        // Then = NullPointerException
+    }
+
+    @Test
+    public void shouldNotParseMessageIfAlreadyParsed() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        boolean parsed = true;
+        // When
+        boolean canParse = htmlParser.canParseResource(new HttpMessage(), ROOT_PATH, parsed);
+        // Then
+        assertThat(canParse, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotParseNonHtmlResponse() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        boolean parsed = false;
+        // When
+        boolean canParse = htmlParser.canParseResource(new HttpMessage(), ROOT_PATH, parsed);
+        // Then
+        assertThat(canParse, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldParseHtmlResponse() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        HttpMessage messageHtmlResponse = createMessageWith("NoForms.html");
+        boolean parsed = false;
+        // When
+        boolean canParse = htmlParser.canParseResource(messageHtmlResponse, ROOT_PATH, parsed);
+        // Then
+        assertThat(canParse, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldParseHtmlResponseEvenIfProvidedPathIsNull() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        HttpMessage messageHtmlResponse = createMessageWith("NoForms.html");
+        boolean parsed = false;
+        // When
+        boolean canParse = htmlParser.canParseResource(messageHtmlResponse, null, parsed);
+        // Then
+        assertThat(canParse, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldNotParseHtmlResponseIfAlreadyParsed() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        HttpMessage messageHtmlResponse = createMessageWith("NoForms.html");
+        boolean parsed = true;
+        // When
+        boolean canParse = htmlParser.canParseResource(messageHtmlResponse, ROOT_PATH, parsed);
+        // Then
+        assertThat(canParse, is(equalTo(false)));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldFailToParseAnUndefinedMessage() {
+        // Given
+        HttpMessage undefinedMessage = null;
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        Source source = createSource(createMessageWith("NoForms.html"));
+        // When
+        htmlParser.parseResource(undefinedMessage, source, BASE_DEPTH);
+        // Then = NullPointerException
+    }
+
+    @Test
+    public void shouldNotParseMessageIfFormProcessingIsDisabled() {
+        // Given
+        SpiderParam spiderOptions = createSpiderParamWithConfig();
+        spiderOptions.setProcessForm(false);
+        SpiderHtmlFormParser htmlParser = new SpiderHtmlFormParser(spiderOptions);
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("PostGetForms.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(0)));
+    }
+
+    @Test
+    public void shouldParseMessageEvenWithoutSource() {
+        // Given
+        Source source = null;
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        HttpMessage messageHtmlResponse = createMessageWith("NoForms.html");
+        // When
+        htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then = No exception
+    }
+
+    @Test
+    public void shouldNeverConsiderCompletelyParsed() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        HttpMessage messageHtmlResponse = createMessageWith("NoForms.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldParseSingleGetForm() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("GetForm.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(listener.getUrlsFound(), contains("http://example.org/?field1=Text+1&field2=Text+2&submit=Submit"));
+    }
+
+    @Test
+    public void shouldParseMultipleGetForms() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("GetForms.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(2)));
+        assertThat(listener.getUrlsFound(), contains(
+                "http://example.org/form1?field1=Text+1&field2=Text+2&submit=Submit",
+                "http://example.org/form2?a=x&b=y&c=z"));
+    }
+
+    @Test
+    public void shouldParseGetFormWithMultipleSubmitFields() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("GetFormMultipleSubmitFields.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(5)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "http://example.org/?field1=Text+1&field2=Text+2&submit1=Submit+1",
+                        "http://example.org/?field1=Text+1&field2=Text+2&submit2=Submit+2",
+                        "http://example.org/?field1=Text+1&field2=Text+2&submit3=Submit+3",
+                        "http://example.org/?field1=Text+1&field2=Text+2&submit=Submit+4",
+                        "http://example.org/?field1=Text+1&field2=Text+2&submit=Submit+5"));
+    }
+
+    @Test
+    public void shouldParseSinglePostForm() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage msg = createMessageWith("PostForm.html");
+        Source source = createSource(msg);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(msg, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(
+                listener.getResourcesFound(),
+                contains(postResource(msg, 1, "http://example.org/", "field1=Text+1&field2=Text+2&submit=Submit")));
+    }
+
+    @Test
+    public void shouldParseMultiplePostForms() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage msg = createMessageWith("PostForms.html");
+        Source source = createSource(msg);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(msg, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(2)));
+        assertThat(
+                listener.getResourcesFound(),
+                contains(
+                        postResource(msg, 1, "http://example.org/form1", "field1=Text+1&field2=Text+2&submit=Submit"),
+                        postResource(msg, 1, "http://example.org/form2", "a=x&b=y&c=z")));
+    }
+
+    @Test
+    public void shouldParsePostFormWithMultipleSubmitFields() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage msg = createMessageWith("PostFormMultipleSubmitFields.html");
+        Source source = createSource(msg);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(msg, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(5)));
+        assertThat(
+                listener.getResourcesFound(),
+                contains(
+                        postResource(msg, 1, "http://example.org/", "field1=Text+1&field2=Text+2&submit1=Submit+1"),
+                        postResource(msg, 1, "http://example.org/", "field1=Text+1&field2=Text+2&submit2=Submit+2"),
+                        postResource(msg, 1, "http://example.org/", "field1=Text+1&field2=Text+2&submit3=Submit+3"),
+                        postResource(msg, 1, "http://example.org/", "field1=Text+1&field2=Text+2&submit=Submit+4"),
+                        postResource(msg, 1, "http://example.org/", "field1=Text+1&field2=Text+2&submit=Submit+5")));
+    }
+
+    @Test
+    public void shouldParsePostAndGetForms() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage msg = createMessageWith("PostGetForms.html");
+        Source source = createSource(msg);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(msg, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfResourcesFound(), is(equalTo(6)));
+        assertThat(
+                listener.getResourcesFound(),
+                contains(
+                        postResource(msg, 1, "http://example.org/form1", "field1=Text+1&field2=Text+2&submit=Submit"),
+                        postResource(msg, 1, "http://example.org/form1", "field1=Text+1&field2=Text+2&submit=Submit+2"),
+                        postResource(msg, 1, "http://example.org/form1", "field1=Text+1&field2=Text+2&submit3=Submit+3"),
+                        uriResource(msg, 1, "http://example.org/form2?a=x&b=y&c=z"),
+                        uriResource(msg, 1, "http://example.org/form2?a=x&b=y&submit=Submit+2"),
+                        uriResource(msg, 1, "http://example.org/form2?a=x&b=y&submit3=Submit+3")));
+    }
+
+    @Test
+    public void shouldNotParsePostFormIfPostFormProcessingIsDisabled() {
+        // Given
+        SpiderParam spiderOptions = createSpiderParamWithConfig();
+        spiderOptions.setProcessForm(true);
+        spiderOptions.setPostForm(false);
+        SpiderHtmlFormParser htmlParser = new SpiderHtmlFormParser(spiderOptions);
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("PostForm.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(0)));
+    }
+
+    @Test
+    public void shouldParseNonPostFormIfPostFormProcessingIsDisabled() {
+        // Given
+        SpiderParam spiderOptions = createSpiderParamWithConfig();
+        spiderOptions.setProcessForm(true);
+        spiderOptions.setPostForm(false);
+        SpiderHtmlFormParser htmlParser = new SpiderHtmlFormParser(spiderOptions);
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("GetForm.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(listener.getUrlsFound(), contains("http://example.org/?field1=Text+1&field2=Text+2&submit=Submit"));
+    }
+
+    @Test
+    public void shouldParseFormAsGetIfNeitherGetNorPostForm() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("NonGetPostForm.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(listener.getUrlsFound(), contains("http://example.org/?field1=Text+1&field2=Text+2&submit=Submit"));
+    }
+
+    @Test
+    public void shouldParseFormAsGetIfFormHasNoMethod() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("NoMethodForm.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(listener.getUrlsFound(), contains("http://example.org/?field1=Text+1&field2=Text+2&submit=Submit"));
+    }
+
+    @Test
+    public void shouldParseFormAsGetIfFormHasNoMethodEvenIfPostFormProcessingIsDisabled() {
+        // Given
+        SpiderParam spiderOptions = createSpiderParamWithConfig();
+        spiderOptions.setProcessForm(true);
+        spiderOptions.setPostForm(false);
+        SpiderHtmlFormParser htmlParser = new SpiderHtmlFormParser(spiderOptions);
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("NoMethodForm.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(listener.getUrlsFound(), contains("http://example.org/?field1=Text+1&field2=Text+2&submit=Submit"));
+    }
+
+    @Test
+    public void shouldParseFormAsGetIfFormHasEmptyMethod() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("EmptyMethodForm.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(listener.getUrlsFound(), contains("http://example.org/?field1=Text+1&field2=Text+2&submit=Submit"));
+    }
+
+    @Test
+    public void shouldUseMessageUrlAsActionIfFormHasNoAction() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("NoActionForm.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(listener.getUrlsFound(), contains("http://example.com/?field1=Text+1&field2=Text+2&submit=Submit"));
+    }
+
+    @Test
+    public void shouldParseGetFormWithoutSubmitField() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("GetFormNoSubmitField.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(listener.getUrlsFound(), contains("http://example.org/?field1=Text+1&field2=Text+2"));
+    }
+
+    @Test
+    public void shouldParsePostFormWithoutSubmitField() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage msg = createMessageWith("PostFormNoSubmitField.html");
+        Source source = createSource(msg);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(msg, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(
+                listener.getResourcesFound(),
+                contains(postResource(msg, 1, "http://example.org/", "field1=Text+1&field2=Text+2")));
+    }
+
+    @Test
+    public void shouldRemoveFragmentFromActionWhenParsingGetForm() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("GetFormActionWithFragment.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(listener.getUrlsFound(), contains("http://example.org/?field1=Text+1&field2=Text+2&submit=Submit"));
+    }
+
+    @Test
+    public void shouldAppendToEmptyQueryActionParametersWhenParsingGetForm() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("GetFormActionWithEmptyQuery.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(listener.getUrlsFound(), contains("http://example.org/?field1=Text+1&field2=Text+2&submit=Submit"));
+    }
+
+    @Test
+    public void shouldAppendToQueryActionParametersWhenParsingGetForm() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("GetFormActionWithQuery.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(listener.getUrlsFound(), contains("http://example.org/?a=b&c=d&field1=Text+1&field2=Text+2&submit=Submit"));
+    }
+
+    @Test
+    public void shouldAppendToQueryActionParametersTerminatedWithAmpersandWhenParsingGetForm() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("GetFormActionWithQueryAmpersand.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(listener.getUrlsFound(), contains("http://example.org/?a=b&field1=Text+1&field2=Text+2&submit=Submit"));
+    }
+
+    private SpiderHtmlFormParser createSpiderHtmlFormParser() {
+        SpiderParam spiderOptions = createSpiderParamWithConfig();
+        spiderOptions.setProcessForm(true);
+        spiderOptions.setPostForm(true);
+        return new SpiderHtmlFormParser(spiderOptions);
+    }
+
+    private static HttpMessage createMessageWith(String filename) {
+        HttpMessage message = new HttpMessage();
+        try {
+            String fileContents = readFile(BASE_DIR_HTML_FILES.resolve(filename));
+            message.setRequestHeader("GET / HTTP/1.1\r\nHost: example.com\r\n");
+            message.setResponseHeader(
+                    "HTTP/1.1 200 OK\r\n" + "Content-Type: text/html; charset=UTF-8\r\n" + "Content-Length: "
+                            + fileContents.length());
+            message.setResponseBody(fileContents);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return message;
+    }
+}

--- a/test/org/zaproxy/zap/spider/parser/SpiderParserTestUtils.java
+++ b/test/org/zaproxy/zap/spider/parser/SpiderParserTestUtils.java
@@ -79,27 +79,47 @@ public class SpiderParserTestUtils {
             return urls;
         }
 
+        public int getNumberOfResourcesFound() {
+            return resources.size();
+        }
+
+        public List<SpiderResource> getResourcesFound() {
+            return resources;
+        }
+
         @Override
         public void resourceURIFound(HttpMessage responseMessage, int depth, String uri) {
             urls.add(uri);
-            resources.add(SpiderResource.createUriResource(responseMessage, depth, uri));
+            resources.add(uriResource(responseMessage, depth, uri));
         }
 
         @Override
         public void resourceURIFound(HttpMessage responseMessage, int depth, String uri, boolean shouldIgnore) {
             urls.add(uri);
-            resources.add(SpiderResource.createUriResource(responseMessage, depth, uri, shouldIgnore));
+            resources.add(uriResource(responseMessage, depth, uri, shouldIgnore));
         }
 
         @Override
         public void resourcePostURIFound(HttpMessage responseMessage, int depth, String uri, String requestBody) {
             urls.add(uri);
-            resources.add(SpiderResource.createPostResource(responseMessage, depth, uri, requestBody));
+            resources.add(postResource(responseMessage, depth, uri, requestBody));
         }
 
         public boolean isResourceFound() {
             return false;
         }
+    }
+
+    public static SpiderResource uriResource(HttpMessage message, int depth, String uri) {
+        return new SpiderResource(message, depth, uri);
+    }
+
+    public static SpiderResource uriResource(HttpMessage message, int depth, String uri, boolean shouldIgnore) {
+        return new SpiderResource(message, depth, uri, shouldIgnore);
+    }
+
+    public static SpiderResource postResource(HttpMessage message, int depth, String uri, String requestBody) {
+        return new SpiderResource(message, depth, uri, requestBody);
     }
 
     public static class SpiderResource {
@@ -156,18 +176,6 @@ public class SpiderParserTestUtils {
             return requestBody;
         }
 
-        public static SpiderResource createUriResource(HttpMessage message, int depth, String uri) {
-            return new SpiderResource(message, depth, uri);
-        }
-
-        public static SpiderResource createUriResource(HttpMessage message, int depth, String uri, boolean shouldIgnore) {
-            return new SpiderResource(message, depth, uri, shouldIgnore);
-        }
-
-        public static SpiderResource createPostResource(HttpMessage message, int depth, String uri, String requestBody) {
-            return new SpiderResource(message, depth, uri, requestBody);
-        }
-
         @Override
         public int hashCode() {
             int result = 31 + depth;
@@ -220,5 +228,15 @@ public class SpiderParserTestUtils {
             return true;
         }
 
+        @Override
+        public String toString() {
+            StringBuilder strBuilder = new StringBuilder(250);
+            strBuilder.append("URI=").append(uri);
+            strBuilder.append(", Depth=").append(depth);
+            strBuilder.append(", RequestBody=").append(requestBody);
+            strBuilder.append(", ShouldIgnore=").append(shouldIgnore);
+            strBuilder.append(", Message=").append(message.hashCode());
+            return strBuilder.toString();
+        }
     }
 }

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/EmptyMethodForm.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/EmptyMethodForm.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Empty Method Form - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="http://example.org" method="">
+<input type="text" name="field1" value="Text 1" />
+<input type="text" name="field2" value="Text 2" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetForm.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetForm.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>GET Form - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="http://example.org" method="GET">
+<input type="text" name="field1" value="Text 1" />
+<input type="text" name="field2" value="Text 2" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormActionWithEmptyQuery.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormActionWithEmptyQuery.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>GET Form Action With Empty Query - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="http://example.org?" method="GET">
+<input type="text" name="field1" value="Text 1" />
+<input type="text" name="field2" value="Text 2" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormActionWithFragment.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormActionWithFragment.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>GET Form Action With Fragment - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="http://example.org#fragment" method="GET">
+<input type="text" name="field1" value="Text 1" />
+<input type="text" name="field2" value="Text 2" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormActionWithQuery.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormActionWithQuery.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>GET Form Action With Query - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="http://example.org?a=b&amp;c=d" method="GET">
+<input type="text" name="field1" value="Text 1" />
+<input type="text" name="field2" value="Text 2" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormActionWithQueryAmpersand.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormActionWithQueryAmpersand.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>GET Form Action With Query Terminated With Ampersand - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="http://example.org?a=b&amp;" method="GET">
+<input type="text" name="field1" value="Text 1" />
+<input type="text" name="field2" value="Text 2" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormMultipleSubmitFields.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormMultipleSubmitFields.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>GET Form Multiple Submit Fields - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="http://example.org" method="GET">
+<input type="text" name="field1" value="Text 1" />
+<input type="text" name="field2" value="Text 2" />
+<input type="submit" name="submit1" value="Submit 1" />
+<input type="submit" name="submit2" value="Submit 2" />
+<input type="submit" name="submit3" value="Submit 3" />
+<input type="submit" name="submit" value="Submit 4" />
+<input type="submit" name="submit" value="Submit 5" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormNoSubmitField.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormNoSubmitField.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>GET Form No Submit Field - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="http://example.org" method="GET">
+<input type="text" name="field1" value="Text 1" />
+<input type="text" name="field2" value="Text 2" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetForms.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetForms.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>GET Forms - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="http://example.org/form1" method="GET">
+<input type="text" name="field1" value="Text 1" />
+<input type="text" name="field2" value="Text 2" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+<form action="http://example.org/form2" method="GET">
+<input type="text" name="a" value="x" />
+<input type="text" name="b" value="y" />
+<input type="submit" name="c" value="z" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/NoActionForm.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/NoActionForm.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>No Action Form - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form method="GET">
+<input type="text" name="field1" value="Text 1" />
+<input type="text" name="field2" value="Text 2" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/NoForms.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/NoForms.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>No Forms - Spider HTML Form Parser</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/NoMethodForm.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/NoMethodForm.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>No Method Form - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="http://example.org">
+<input type="text" name="field1" value="Text 1" />
+<input type="text" name="field2" value="Text 2" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/NonGetPostForm.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/NonGetPostForm.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Non GET POST Form - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="http://example.org" method="NeitherGetNorPost">
+<input type="text" name="field1" value="Text 1" />
+<input type="text" name="field2" value="Text 2" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/PostForm.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/PostForm.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>POST Form - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="http://example.org" method="POST">
+<input type="text" name="field1" value="Text 1" />
+<input type="text" name="field2" value="Text 2" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/PostFormMultipleSubmitFields.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/PostFormMultipleSubmitFields.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>POST Form Multiple Submit Fields - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="http://example.org" method="POST">
+<input type="text" name="field1" value="Text 1" />
+<input type="text" name="field2" value="Text 2" />
+<input type="submit" name="submit1" value="Submit 1" />
+<input type="submit" name="submit2" value="Submit 2" />
+<input type="submit" name="submit3" value="Submit 3" />
+<input type="submit" name="submit" value="Submit 4" />
+<input type="submit" name="submit" value="Submit 5" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/PostFormNoSubmitField.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/PostFormNoSubmitField.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>POST Form No Submit Field - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="http://example.org" method="POST">
+<input type="text" name="field1" value="Text 1" />
+<input type="text" name="field2" value="Text 2" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/PostForms.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/PostForms.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>POST Forms - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="http://example.org/form1" method="POST">
+<input type="text" name="field1" value="Text 1" />
+<input type="text" name="field2" value="Text 2" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+<form action="http://example.org/form2" method="POST">
+<input type="text" name="a" value="x" />
+<input type="text" name="b" value="y" />
+<input type="submit" name="c" value="z" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/PostGetForms.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/PostGetForms.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>GET POST Forms - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="http://example.org/form1" method="POST">
+<input type="text" name="field1" value="Text 1" />
+<input type="text" name="field2" value="Text 2" />
+<input type="submit" name="submit" value="Submit" />
+<input type="submit" name="submit" value="Submit 2" />
+<input type="submit" name="submit3" value="Submit 3" />
+</form>
+
+<form action="http://example.org/form2" method="GET">
+<input type="text" name="a" value="x" />
+<input type="text" name="b" value="y" />
+<input type="submit" name="c" value="z" />
+<input type="submit" name="submit" value="Submit 2" />
+<input type="submit" name="submit3" value="Submit 3" />
+</form>
+
+</body>
+</html>


### PR DESCRIPTION
Change class SpiderHtmlFormParser to use all submit fields when
spidering, using each submit field in turn with remaining form fields.
Add some tests to assert the expected behaviour of SpiderHtmlFormParser.
Other minor changes were done to "normalise" the behaviour/expectations
of class SpiderHtmlFormParser:
 - Throw an exception when creating an instance with null SpiderParam,
 it's required to check if HTML POST forms should be parsed;
 - Change the instance variable "param" to private and final.
 - Expect always a message when parsing (letting a NullPointerException
 be thrown if not).

Fix #2748 - ZAP Spidering HTML Forms with multiple submit buttons