### PR TITLE
Allow to hook ApiImplementor

### DIFF
--- a/src/org/parosproxy/paros/extension/ExtensionHook.java
+++ b/src/org/parosproxy/paros/extension/ExtensionHook.java
@@ -28,6 +28,7 @@
 // ZAP: 2016/04/08 Allow to add ContextDataFactory
 // ZAP: 2016/05/30 Allow to add AddOnInstallationStatusListener
 // ZAP: 2016/05/30 Issue 2494: ZAP Proxy is not showing the HTTP CONNECT Request in history tab
+// ZAP: 2016/08/18 Allow to add ApiImplementor
 
 package org.parosproxy.paros.extension;
 
@@ -44,6 +45,7 @@ import org.parosproxy.paros.core.scanner.ScannerHook;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.PersistentConnectionListener;
 import org.zaproxy.zap.extension.AddonFilesChangedListener;
+import org.zaproxy.zap.extension.api.ApiImplementor;
 import org.zaproxy.zap.extension.AddOnInstallationStatusListener;
 import org.zaproxy.zap.model.ContextDataFactory;
 import org.zaproxy.zap.view.SiteMapListener;
@@ -96,6 +98,16 @@ public class ExtensionHook {
      * @see #getAddOnInstallationStatusListeners()
      */
     private List<AddOnInstallationStatusListener> addOnInstallationStatusListeners;
+
+    /**
+     * The {@link ApiImplementor}s added to this extension hook.
+     * <p>
+     * Lazily initialised.
+     * 
+     * @see #addApiImplementor(ApiImplementor)
+     * @see #getApiImplementors()
+     */
+    private List<ApiImplementor> apiImplementors;
     
     private ViewDelegate view = null;
     private CommandLineArgument[] arg = new CommandLineArgument[0];
@@ -320,5 +332,40 @@ public class ExtensionHook {
             return Collections.emptyList();
         }
         return Collections.unmodifiableList(contextDataFactories);
+    }
+
+    /**
+     * Adds the given {@code apiImplementor} to the extension hook, to be later added to the
+     * {@link org.zaproxy.zap.extension.api.API API}.
+     * <p>
+     * By default, the {@code ApiImplementor}s added to this extension hook are removed from the {@code API} when the extension
+     * is unloaded.
+     *
+     * @param apiImplementor the ApiImplementor that will be added to the ZAP API
+     * @throws IllegalArgumentException if the given {@code apiImplementor} is {@code null}.
+     * @since 2.6.0
+     */
+    public void addApiImplementor(ApiImplementor apiImplementor) {
+        if (apiImplementor == null) {
+            throw new IllegalArgumentException("Parameter apiImplementor must not be null.");
+        }
+
+        if (apiImplementors == null) {
+            apiImplementors = new ArrayList<>();
+        }
+        apiImplementors.add(apiImplementor);
+    }
+
+    /**
+     * Gets the {@link ApiImplementor}s added to this hook.
+     *
+     * @return an unmodifiable {@code List} containing the added {@code ApiImplementor}s, never {@code null}.
+     * @since 2.6.0
+     */
+    List<ApiImplementor> getApiImplementors() {
+        if (apiImplementors == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableList(apiImplementors);
     }
 }

--- a/src/org/parosproxy/paros/extension/ExtensionLoader.java
+++ b/src/org/parosproxy/paros/extension/ExtensionLoader.java
@@ -64,6 +64,7 @@
 // ZAP: 2016/04/08 Hook ContextDataFactory/ContextPanelFactory 
 // ZAP: 2016/05/30 Notification of installation status of the add-ons
 // ZAP: 2016/05/30 Issue 2494: ZAP Proxy is not showing the HTTP CONNECT Request in history tab
+// ZAP: 2016/08/18 Hook ApiImplementor
 
 package org.parosproxy.paros.extension;
 
@@ -104,6 +105,8 @@ import org.parosproxy.paros.view.WorkbenchPanel;
 import org.zaproxy.zap.PersistentConnectionListener;
 import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.extension.AddonFilesChangedListener;
+import org.zaproxy.zap.extension.api.API;
+import org.zaproxy.zap.extension.api.ApiImplementor;
 import org.zaproxy.zap.extension.AddOnInstallationStatusListener;
 import org.zaproxy.zap.model.ContextDataFactory;
 import org.zaproxy.zap.view.ContextPanelFactory;
@@ -650,6 +653,7 @@ public class ExtensionLoader {
             extensionHooks.put(ext, extHook);
 
             hookContextDataFactories(ext, extHook);
+            hookApiImplementors(ext, extHook);
 
             if (view != null) {
                 // no need to hook view if no GUI
@@ -726,6 +730,7 @@ public class ExtensionLoader {
                 extensionHooks.put(ext, extHook);
 
                 hookContextDataFactories(ext, extHook);
+                hookApiImplementors(ext, extHook);
 
                 if (view != null) {
                     EventQueue.invokeAndWait(new Runnable() {
@@ -770,6 +775,16 @@ public class ExtensionLoader {
                 model.addContextDataFactory(contextDataFactory);
             } catch (Exception e) {
                 logger.error("Error while adding a ContextDataFactory from " + extension.getClass().getCanonicalName(), e);
+            }
+        }
+    }
+
+    private void hookApiImplementors(Extension extension, ExtensionHook extHook) {
+        for (ApiImplementor apiImplementor : extHook.getApiImplementors()) {
+            try {
+                API.getInstance().registerApiImplementor(apiImplementor);
+            } catch (Exception e) {
+                logger.error("Error while adding an ApiImplementor from " + extension.getClass().getCanonicalName(), e);
             }
         }
     }
@@ -1210,6 +1225,14 @@ public class ExtensionLoader {
                 model.removeContextDataFactory(contextDataFactory);
             } catch (Exception e) {
                 logger.error("Error while removing a ContextDataFactory from " + extension.getClass().getCanonicalName(), e);
+            }
+        }
+
+        for (ApiImplementor apiImplementor : hook.getApiImplementors()) {
+            try {
+                API.getInstance().removeApiImplementor(apiImplementor);
+            } catch (Exception e) {
+                logger.error("Error while removing an ApiImplementor from " + extension.getClass().getCanonicalName(), e);
             }
         }
 

--- a/src/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRF.java
+++ b/src/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRF.java
@@ -54,7 +54,6 @@ import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
 
 public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChangedListener {
@@ -132,7 +131,7 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
 
 	    AntiCsrfAPI api = new AntiCsrfAPI(this);
         api.addApiOptions(getParam());
-        API.getInstance().registerApiImplementor(api);
+        extensionHook.addApiImplementor(api);
 
 	}
 	

--- a/src/org/zaproxy/zap/extension/api/API.java
+++ b/src/org/zaproxy/zap/extension/api/API.java
@@ -92,6 +92,20 @@ public class API {
 		return api;
 	}
 
+	/**
+	 * Registers the given {@code ApiImplementor} to the ZAP API.
+	 * <p>
+	 * The implementor is not registed if the {@link ApiImplementor#getPrefix() API implementor prefix} is already in use.
+	 * <p>
+	 * <strong>Note:</strong> The preferred method to add an {@code ApiImplementor} is through the method
+	 * {@link org.parosproxy.paros.extension.ExtensionHook#addApiImplementor(ApiImplementor)
+	 * ExtensionHook.addApiImplementor(ApiImplementor)} when the corresponding
+	 * {@link org.parosproxy.paros.extension.Extension#hook(org.parosproxy.paros.extension.ExtensionHook) extension is hooked}.
+	 * Only use this method if really necessary.
+	 *
+	 * @param impl the implementor that will be registered
+	 * @see #removeApiImplementor(ApiImplementor)
+	 */
 	public void registerApiImplementor (ApiImplementor impl) {
 		if (implementors.get(impl.getPrefix()) != null) {
 			logger.error("Second attempt to register API implementor with prefix of " + impl.getPrefix());
@@ -107,6 +121,13 @@ public class API {
 		}
 	}
 	
+	/**
+	 * Removes the given {@code ApiImplementor} from the ZAP API.
+	 *
+	 * @param impl the implementor that will be removed
+	 * @since 2.1.0
+	 * @see #registerApiImplementor(ApiImplementor)
+	 */
 	public void removeApiImplementor(ApiImplementor impl) {
 		if (!implementors.containsKey(impl.getPrefix())) {
 			logger.warn("Attempting to remove an API implementor not registered, with prefix: " + impl.getPrefix());

--- a/src/org/zaproxy/zap/extension/api/ExtensionAPI.java
+++ b/src/org/zaproxy/zap/extension/api/ExtensionAPI.java
@@ -56,10 +56,9 @@ public class ExtensionAPI extends ExtensionAdaptor {
         
         coreApi = new CoreAPI();
         coreApi.addApiOptions(extensionHook.getModel().getOptionsParam().getConnectionParam());
-        API.getInstance().registerApiImplementor(coreApi);
 
-        API.getInstance().registerApiImplementor(new ContextAPI());
-
+        extensionHook.addApiImplementor(coreApi);
+        extensionHook.addApiImplementor(new ContextAPI());
 
 	}
 

--- a/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -58,7 +58,6 @@ import org.parosproxy.paros.view.AbstractParamPanel;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.extension.script.ScriptType;
@@ -175,7 +174,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
         this.ascanController.setExtAlert((ExtensionAlert) Control.getSingleton().getExtensionLoader().getExtension(ExtensionAlert.NAME));
         this.activeScanApi = new ActiveScanAPI(this);
         this.activeScanApi.addApiOptions(getScannerParam());
-        API.getInstance().registerApiImplementor(activeScanApi);
+        extensionHook.addApiImplementor(activeScanApi);
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/authentication/ExtensionAuthentication.java
+++ b/src/org/zaproxy/zap/extension/authentication/ExtensionAuthentication.java
@@ -46,7 +46,6 @@ import org.zaproxy.zap.authentication.FormBasedAuthenticationMethodType.FormBase
 import org.zaproxy.zap.authentication.HttpAuthenticationMethodType;
 import org.zaproxy.zap.authentication.ManualAuthenticationMethodType;
 import org.zaproxy.zap.authentication.ScriptBasedAuthenticationMethodType;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.stdmenus.PopupContextMenuItemFactory;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.ContextDataFactory;
@@ -111,7 +110,7 @@ public class ExtensionAuthentication extends ExtensionAdaptor implements Context
 
 		// Register the api
 		this.api = new AuthenticationAPI(this);
-		API.getInstance().registerApiImplementor(api);
+		extensionHook.addApiImplementor(api);
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/authorization/ExtensionAuthorization.java
+++ b/src/org/zaproxy/zap/extension/authorization/ExtensionAuthorization.java
@@ -35,8 +35,6 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
-import org.zaproxy.zap.extension.api.API;
-import org.zaproxy.zap.extension.api.ApiImplementor;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.ContextDataFactory;
 import org.zaproxy.zap.view.AbstractContextPropertiesPanel;
@@ -86,9 +84,7 @@ public class ExtensionAuthorization extends ExtensionAdaptor implements ContextP
 			getView().addContextPanelFactory(this);
 		}
 
-		// Register the api
-		ApiImplementor api = new AuthorizationAPI();
-		API.getInstance().registerApiImplementor(api);
+		extensionHook.addApiImplementor(new AuthorizationAPI());
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -82,7 +82,6 @@ import org.zaproxy.zap.control.AddOnRunIssuesUtils;
 import org.zaproxy.zap.control.AddOnUninstallationProgressCallback;
 import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.control.ZapRelease;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.autoupdate.AddOnDependencyChecker.AddOnChangesResult;
 import org.zaproxy.zap.extension.autoupdate.AddOnDependencyChecker.UninstallationResult;
 import org.zaproxy.zap.extension.autoupdate.UninstallationProgressDialogue.AddOnUninstallListener;
@@ -537,7 +536,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 	    extensionHook.addCommandLine(getCommandLineArguments());
         this.api = new AutoUpdateAPI(this);
         this.api.addApiOptions(getModel().getOptionsParam().getCheckForUpdatesParam());
-        API.getInstance().registerApiImplementor(this.api);
+        extensionHook.addApiImplementor(this.api);
 	}
 	
 	private ScanStatus getScanStatus() {

--- a/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
+++ b/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
@@ -52,7 +52,6 @@ import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.brk.impl.http.HttpBreakpointMessage;
 import org.zaproxy.zap.extension.brk.impl.http.HttpBreakpointMessage.Location;
 import org.zaproxy.zap.extension.brk.impl.http.HttpBreakpointMessage.Match;
@@ -158,7 +157,7 @@ public class ExtensionBreak extends ExtensionAdaptor implements SessionChangedLi
 
             // APIs are usually loaded even if the view is null, as they are specifically for daemon mode
             // However in this case the API isnt really of any use unless the UI is available
-    		API.getInstance().registerApiImplementor(api);
+            extensionHook.addApiImplementor(api);
 
             extensionHook.addSessionListener(this);
             extensionHook.addOptionsChangedListener(this);

--- a/src/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
+++ b/src/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
@@ -43,7 +43,6 @@ import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.users.ExtensionUserManagement;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.ContextDataFactory;
@@ -131,7 +130,7 @@ public class ExtensionForcedUser extends ExtensionAdaptor implements ContextPane
 
 		// Prepare API
 		this.api = new ForcedUserAPI(this);
-		API.getInstance().registerApiImplementor(api);
+		extensionHook.addApiImplementor(api);
 	}
 
 	private void updateForcedUserModeToggleButtonEnabledState() {

--- a/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
@@ -39,7 +39,6 @@ import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.network.HttpSenderListener;
 import org.zaproxy.zap.view.ScanPanel;
@@ -176,8 +175,7 @@ public class ExtensionHttpSessions extends ExtensionAdaptor implements SessionCh
 		}
 
 		// Register as an API implementor
-		HttpSessionsAPI httpSessionsApi = new HttpSessionsAPI(this);
-		API.getInstance().registerApiImplementor(httpSessionsApi);
+		extensionHook.addApiImplementor(new HttpSessionsAPI(this));
 	}
 
 	/**

--- a/src/org/zaproxy/zap/extension/keyboard/ExtensionKeyboard.java
+++ b/src/org/zaproxy/zap/extension/keyboard/ExtensionKeyboard.java
@@ -33,7 +33,6 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.utils.DesktopUtils;
 import org.zaproxy.zap.view.ZapMenuItem;
 
@@ -67,7 +66,7 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
 	        
 	        // Ditto the API
 	        api = new KeyboardAPI(this);
-	        API.getInstance().registerApiImplementor(api);
+	        extensionHook.addApiImplementor(api);
 	    }
 	}
 	

--- a/src/org/zaproxy/zap/extension/params/ExtensionParams.java
+++ b/src/org/zaproxy/zap/extension/params/ExtensionParams.java
@@ -48,7 +48,6 @@ import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.anticsrf.ExtensionAntiCSRF;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
 import org.zaproxy.zap.extension.httpsessions.ExtensionHttpSessions;
 import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
@@ -76,13 +75,12 @@ public class ExtensionParams extends ExtensionAdaptor
     public ExtensionParams() {
         super(NAME);
         this.setOrder(58);
-
-        API.getInstance().registerApiImplementor(new ParamsAPI(this));
 	}
 	
 	@Override
 	public void hook(ExtensionHook extensionHook) {
 	    super.hook(extensionHook);
+        extensionHook.addApiImplementor(new ParamsAPI(this));
 	    extensionHook.addSessionListener(this);
         extensionHook.addSiteMapListener(this);
 	    

--- a/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -46,7 +46,6 @@ import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.control.CoreFunctionality;
 import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.extension.script.ScriptType;
@@ -109,7 +108,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
         }
 
 
-        API.getInstance().registerApiImplementor(new PassiveScanAPI(this));
+        extensionHook.addApiImplementor(new PassiveScanAPI(this));
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/ruleconfig/ExtensionRuleConfig.java
+++ b/src/org/zaproxy/zap/extension/ruleconfig/ExtensionRuleConfig.java
@@ -26,7 +26,6 @@ import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
-import org.zaproxy.zap.extension.api.API;
 
 public class ExtensionRuleConfig extends ExtensionAdaptor {
 
@@ -50,7 +49,7 @@ public class ExtensionRuleConfig extends ExtensionAdaptor {
             extensionHook.getHookView().addOptionPanel(getOptionsRuleConfigPanel());
         }
         
-        API.getInstance().registerApiImplementor(new RuleConfigAPI(this));
+        extensionHook.addApiImplementor(new RuleConfigAPI(this));
     }
     
     public RuleConfigParam getRuleConfigParam() {

--- a/src/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/src/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -69,7 +69,6 @@ import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.control.ExtensionFactory;
-import org.zaproxy.zap.extension.api.API;
 
 public class ExtensionScript extends ExtensionAdaptor implements CommandLineListener {
 	
@@ -166,7 +165,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
         	this.addWriter(new PrintWriter(System.out));
 		}
 
-        API.getInstance().registerApiImplementor(new ScriptAPI(this));
+		extensionHook.addApiImplementor(new ScriptAPI(this));
 
 	}
 	

--- a/src/org/zaproxy/zap/extension/search/ExtensionSearch.java
+++ b/src/org/zaproxy/zap/extension/search/ExtensionSearch.java
@@ -36,7 +36,6 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.SessionChangedListener;
 import org.parosproxy.paros.model.Session;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
 import org.zaproxy.zap.view.ZapMenuItem;
 
@@ -83,7 +82,7 @@ public class ExtensionSearch extends ExtensionAdaptor implements SessionChangedL
 	        
 	        ExtensionHelp.enableHelpKey(getSearchPanel(), "ui.tabs.search");
 	    }
-        API.getInstance().registerApiImplementor(new SearchAPI(this));
+	    extensionHook.addApiImplementor(new SearchAPI(this));
 	}
 	
 	SearchParam getSearchParam() {

--- a/src/org/zaproxy/zap/extension/sessions/ExtensionSessionManagement.java
+++ b/src/org/zaproxy/zap/extension/sessions/ExtensionSessionManagement.java
@@ -36,7 +36,6 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.ContextDataFactory;
 import org.zaproxy.zap.session.CookieBasedSessionManagementMethodType;
@@ -98,7 +97,7 @@ public class ExtensionSessionManagement extends ExtensionAdaptor implements Cont
 
 		// Register the api
 		this.api = new SessionManagementAPI(this);
-		API.getInstance().registerApiImplementor(api);
+		extensionHook.addApiImplementor(api);
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
+++ b/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
@@ -47,7 +47,6 @@ import org.parosproxy.paros.extension.SessionChangedListener;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.ScanController;
@@ -141,7 +140,7 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
 		// Register as an API implementor
 		spiderApi = new SpiderAPI(this);
 		spiderApi.addApiOptions(getSpiderParam());
-		API.getInstance().registerApiImplementor(spiderApi);
+		extensionHook.addApiImplementor(spiderApi);
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/stats/ExtensionStats.java
+++ b/src/org/zaproxy/zap/extension/stats/ExtensionStats.java
@@ -31,7 +31,6 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.OptionsChangedListener;
 import org.parosproxy.paros.model.OptionsParam;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.utils.Stats;
 
 public class ExtensionStats extends ExtensionAdaptor implements OptionsChangedListener {
@@ -41,7 +40,6 @@ public class ExtensionStats extends ExtensionAdaptor implements OptionsChangedLi
 	private InMemoryStats inMemStats;
 	private Statsd statsd;
 	private OptionsStatsPanel optionsStatsPanel;
-	private StatsAPI statsAPI;
 	private StatsParam statsParam;
 
     private static final Logger LOG = Logger.getLogger(ExtensionStats.class);
@@ -53,7 +51,6 @@ public class ExtensionStats extends ExtensionAdaptor implements OptionsChangedLi
 
 	private void initialize() {
         this.setName(NAME);
-    	statsAPI = new StatsAPI(this);
 	}
 
 	@Override
@@ -67,7 +64,8 @@ public class ExtensionStats extends ExtensionAdaptor implements OptionsChangedLi
 	        extensionHook.getHookView().addOptionPanel(getOptionsStatsPanel());
 	    }
 	    
-	    API.getInstance().registerApiImplementor(statsAPI);
+	    StatsAPI statsAPI = new StatsAPI(this);
+	    extensionHook.addApiImplementor(statsAPI);
 	    statsAPI.addApiOptions(getStatsParam());
 
 	}

--- a/src/org/zaproxy/zap/extension/users/ExtensionUserManagement.java
+++ b/src/org/zaproxy/zap/extension/users/ExtensionUserManagement.java
@@ -40,7 +40,6 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.zaproxy.zap.authentication.AuthenticationMethodType;
 import org.zaproxy.zap.control.ExtensionFactory;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.authentication.ExtensionAuthentication;
 import org.zaproxy.zap.extension.httpsessions.ExtensionHttpSessions;
 import org.zaproxy.zap.extension.sessions.ExtensionSessionManagement;
@@ -150,7 +149,7 @@ public class ExtensionUserManagement extends ExtensionAdaptor implements Context
 
 		// Prepare API
 		this.api = new UsersAPI(this);
-		API.getInstance().registerApiImplementor(api);
+		extensionHook.addApiImplementor(api);
 	}
 
 	@Override


### PR DESCRIPTION
Change class ExtensionHook to allow to add ApiImplementor, so it can be
automatically added/removed by core code.
Change ExtensionLoader to add/remove the ApiImplementor when the
extensions are initialised/unloaded.
Change core extensions to use the new method (just removes the coupling
with the API class, as the core extensions are never unloaded).