### PR TITLE
Fix Issue 368 Spider API URL List

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1827,6 +1827,7 @@ sites.showinsites.popup    = Show in Sites Tab
 spider.activeActionPrefix = Spidering: {0}
 spider.api.action.scan = Runs the spider against the given URL (or context). Optionally, the 'maxChildren' parameter can be set to limit the number of children scanned, the 'recurse' parameter can be used to prevent the spider from seeding recursively, the parameter 'contextName' can be used to constrain the scan to a Context and the parameter 'subtreeOnly' allows to restrict the spider under a site's subtree (using the specified 'url').
 spider.api.action.scanAsUser = Runs the spider from the perspective of a User, obtained using the given Context ID and User ID. See 'scan' action for more details.
+spider.api.view.allUrls = Returns a list of unique URLs from the history table based on HTTP messages added by the Spider.
 spider.api.view.optionSendRefererHeader = Sets whether or not the 'Referer' header should be sent while spidering
 spider.custom.button.reset	= Reset
 spider.custom.button.scan	= Start Scan

--- a/src/org/zaproxy/zap/extension/spider/SpiderAPI.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderAPI.java
@@ -18,9 +18,12 @@
 package org.zaproxy.zap.extension.spider;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.PatternSyntaxException;
 
 import net.sf.json.JSONObject;
@@ -30,8 +33,12 @@ import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.db.DatabaseException;
+import org.parosproxy.paros.db.RecordHistory;
+import org.parosproxy.paros.db.TableHistory;
+import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.zaproxy.zap.extension.api.ApiAction;
 import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiException.Type;
@@ -86,6 +93,7 @@ public class SpiderAPI extends ApiImplementor {
 	private static final String VIEW_RESULTS = "results";
 	private static final String VIEW_FULL_RESULTS = "fullResults";
 	private static final String VIEW_SCANS = "scans";
+	private static final String VIEW_ALL_URLS = "allUrls";
 
 	/**
 	 * The Constant PARAM_URL that defines the parameter defining the url of the scan.
@@ -138,6 +146,7 @@ public class SpiderAPI extends ApiImplementor {
 		this.addApiView(new ApiView(VIEW_FULL_RESULTS, new String[] { PARAM_SCAN_ID }));
 		this.addApiView(new ApiView(VIEW_SCANS));
 		this.addApiView(new ApiView(VIEW_EXCLUDED_FROM_SCAN));
+		this.addApiView(new ApiView(VIEW_ALL_URLS));
 
 	}
 
@@ -460,6 +469,36 @@ public class SpiderAPI extends ApiImplementor {
 				resultList.addItem(new ApiResponseSet("scan", map));
 			}
 			result = resultList;
+		} else if (VIEW_ALL_URLS.equals(name)) {
+			ApiResponseList resultUrls = new ApiResponseList(name);
+			Set<String> urlSet=new HashSet<String>();
+			
+			TableHistory tableHistory = extension.getModel().getDb().getTableHistory();
+			List<Integer> ids = Collections.emptyList();
+			
+			try {
+				ids = tableHistory.getHistoryIdsOfHistType(extension.getModel().getSession().getSessionId(),
+						HistoryReference.TYPE_SPIDER, HistoryReference.TYPE_SPIDER_TASK);
+			} catch (DatabaseException e) {
+				throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
+			}
+			
+			String url;
+			for (Integer id : ids) {
+				try {
+					RecordHistory rh = tableHistory.read(id.intValue());
+					if (rh != null) {
+						url = rh.getHttpMessage().getRequestHeader().getURI().toString();
+						if (urlSet.add(url)) {
+							resultUrls.addItem(new ApiResponseElement("url", url));
+						}
+					}
+				} catch (HttpMalformedHeaderException | DatabaseException e) {
+					throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
+				}
+			}
+			
+			result = resultUrls;
 		} else {
 			throw new ApiException(ApiException.Type.BAD_VIEW);
 		}


### PR DESCRIPTION
Added a Spider API end point:
- allUrls: Returns a list of all URLs found by all spider scans (based
on HistoryReferences)

Fixes zaproxy/zaproxy#368