### PR TITLE
Active scanners' alerts persisted twice when with GUI

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/ActiveScanPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScanPanel.java
@@ -37,13 +37,11 @@ import javax.swing.KeyStroke;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.HostProcess;
 import org.parosproxy.paros.core.scanner.ScannerListener;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.model.ScanController;
 import org.zaproxy.zap.model.ScanListenner2;
 import org.zaproxy.zap.utils.DisplayUtils;
@@ -255,10 +253,7 @@ public class ActiveScanPanel extends ScanPanel2<ActiveScan, ScanController<Activ
 
 	@Override
 	public void alertFound(Alert alert) {
-		ExtensionAlert extAlert = (ExtensionAlert) Control.getSingleton().getExtensionLoader().getExtension(ExtensionAlert.NAME);
-		if (extAlert != null) {
-			extAlert.alertFound(alert, alert.getHistoryRef());
-		}
+		// Nothing to do, ActiveScanController (through ActiveScan) already raises the alerts.
 	}
 
 


### PR DESCRIPTION
From discussion/research, in IRC channel, for #1211.

Steps to reproduce the issue:
1. Run ZAP;
2. Active scan a target website, for example, bodgeit;
3. View all alerts through the ZAP API;
4. Note that some alert IDs are missing (are shown only 0, 2, 4...);
5. View the missing alerts ("alert" view), comparing the ones shown with the missing ones they are exactly the same (e.g. 0 is equal to 1, 2 with 3...).

Remarks:
 - The issue only happens when running ZAP with GUI.
 - The duplicated alerts are not reflected in the reports or in UI components (e.g. Alerts tree).

ZAP:
Versions >= 2.4.0