### PR TITLE
Fix overlapping of text locations with same start

### DIFF
--- a/src/org/zaproxy/zap/model/DefaultTextHttpMessageLocation.java
+++ b/src/org/zaproxy/zap/model/DefaultTextHttpMessageLocation.java
@@ -136,7 +136,10 @@ public class DefaultTextHttpMessageLocation implements TextHttpMessageLocation {
 
         TextHttpMessageLocation otherTextLocation = (TextHttpMessageLocation) otherHttpMessageLocation;
         if (start == otherTextLocation.getStart()) {
-            return (start == end) ? end == otherTextLocation.getEnd() : false;
+            if (start == end) {
+                return end == otherTextLocation.getEnd();
+            }
+            return otherTextLocation.getStart() != otherTextLocation.getEnd();
         }
         if (start < otherTextLocation.getStart()) {
             return end > otherTextLocation.getStart();


### PR DESCRIPTION
Change DefaultTextHttpMessageLocation to check if the new text location
is (or not) an insertion point, when the existing text location has the
same start and different end. If it's not an insertion point it's
overlapping the existing location.

Fix #2792 - Able to overlap fuzz (HTTP) locations