### PR TITLE
Reserve plugin ID for Absence of Anti-CSRF Tokens

### DIFF
--- a/src/doc/alerts.xml
+++ b/src/doc/alerts.xml
@@ -115,6 +115,8 @@ This list the alerts
 10200	Beast (via HTTPS Info Extension)
 10201	Crime (via HTTPS Info Extension)
 
+10202	Absence of Anti-CSRF Tokens
+
 20000	Cold Fusion default file (Depreciated)
 20001	Lotus Domino default files (Depreciated)
 20002	IIS default file (Depreciated)


### PR DESCRIPTION
Reserve the plugin ID for passive scanner Absence of Anti-CSRF Tokens,
which is using the ID of another scanner (40014, Persistent XSS Attack).
 ---
Issue reported in IRC, the two scanners using the same ID were/are causing interoperability problems.