### PR TITLE
Additional Commentary for JS templates

### DIFF
--- a/src/scripts/templates/active/Active default template.js
+++ b/src/scripts/templates/active/Active default template.js
@@ -1,10 +1,15 @@
-// The scanNode function will typically be called once for every page 
-// The scan function will typically be called for every parameter in every URL and Form for every page 
-
 // Note that new active scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"  
 
-
+/**
+ * Scans a "node", i.e. an individual entry in the Sites Tree.
+ * The scanNode function will typically be called once for every page. 
+ * 
+ * @param as - the ActiveScan parent object that will do all the core interface tasks 
+ *     (i.e.: sending and receiving messages, providing access to Strength and Threshold settings,
+ *     raising alerts, etc.). This is an ScriptsActiveScanner object.
+ * @param msg - the HTTP Message being scanned. This is an HttpMessage object.
+ */
 function scanNode(as, msg) {
 	// Debugging can be done using println like this
 	println('scan called for url=' + msg.getRequestHeader().getURI().toString());
@@ -36,6 +41,17 @@ function scanNode(as, msg) {
 	}
 }
 
+/**
+ * Scans a specific parameter in an HTTP message.
+ * The scan function will typically be called for every parameter in every URL and Form for every page.
+ * 
+ * @param as - the ActiveScan parent object that will do all the core interface tasks 
+ *     (i.e.: sending and receiving messages, providing access to Strength and Threshold settings,
+ *     raising alerts, etc.). This is an ScriptsActiveScanner object.
+ * @param msg - the HTTP Message being scanned. This is an HttpMessage object.
+ * @param {string} param - the name of the parameter being manipulated for this test/scan.
+ * @param {string} value - the original parameter value.
+ */
 function scan(as, msg, param, value) {
 	// Debugging can be done using println like this
 	println('scan called for url=' + msg.getRequestHeader().getURI().toString() + 

--- a/src/scripts/templates/passive/Passive default template.js
+++ b/src/scripts/templates/passive/Passive default template.js
@@ -1,9 +1,18 @@
-// The scan function will be called for request/response made via ZAP, excluding some of the automated tools
 // Passive scan rules should not make any requests 
 
 // Note that new passive scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"  
 
+/**
+ * Passively scans an HTTP message. The scan function will be called for 
+ * request/response made via ZAP, excluding some of the automated tools.
+ * 
+ * @param ps - the PassiveScan parent object that will do all the core interface tasks 
+ *     (i.e.: providing access to Threshold settings, raising alerts, etc.). 
+ *     This is an ScriptsPassiveScanner object.
+ * @param msg - the HTTP Message being scanned. This is an HttpMessage object.
+ * @param src - the Jericho Source representation of the message being scanned.
+ */
 function scan(ps, msg, src) {
 	// Test the request and/or response here
 	if (true) {	// Change to a test which detects the vulnerability

--- a/src/scripts/templates/proxy/Proxy default template.js
+++ b/src/scripts/templates/proxy/Proxy default template.js
@@ -6,6 +6,11 @@
 // Note that new proxy scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"  
 
+/**
+ * This function allows interaction with proxy requests (i.e.: outbound from the browser/client to the server).
+ * 
+ * @param msg - the HTTP request being proxied. This is an HttpMessage object.
+ */
 function proxyRequest(msg) {
 	// Debugging can be done using println like this
 	println('proxyRequest called for url=' + msg.getRequestHeader().getURI().toString())
@@ -13,6 +18,11 @@ function proxyRequest(msg) {
 	return true
 }
 
+/**
+ * This function allows interaction with proxy responses (i.e.: inbound from the server to the browser/client).
+ * 
+ * @param msg - the HTTP response being proxied. This is an HttpMessage object.
+ */
 function proxyResponse(msg) {
 	// Debugging can be done using println like this
 	println('proxyResponse called for url=' + msg.getRequestHeader().getURI().toString())

--- a/src/scripts/templates/targeted/Targeted default template.js
+++ b/src/scripts/templates/targeted/Targeted default template.js
@@ -1,5 +1,10 @@
 // Targeted scripts can only be invoked by you, the user, eg via a right-click option on the Sites or History tabs
 
+/**
+ * A function which will be invoked against a specific "targeted" message.
+ *
+ * @param msg - the HTTP message being acted upon. This is an HttpMessage object.
+ */
 function invokeWith(msg) {
 	// Debugging can be done using println like this
 	println('invokeWith called for url=' + msg.getRequestHeader().getURI().toString()); 


### PR DESCRIPTION
Add JSDoc style comments to base functions in:

Active default template.js
Passive default template.js
Proxy default template.js
Targeted default template.js

Other script types seemed to have sufficiently complete commentary.

Fixes zaproxy/zaproxy#1107