### PR TITLE
Edit menu allows ZAP mode change this closes zaproxy/zaproxy#2375

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1303,6 +1303,7 @@ menu.edit.resetState          = Reset Session State
 menu.edit.resetState.mnemonic = r
 menu.edit.search              = Search...
 menu.edit.search.mnemonic     = s
+menu.edit.zapmode	       = ZAP Mode
 menu.file                     = File
 menu.file.mnemonic            = f
 menu.file.closeSession        = The current session will be closed.  Create new session?

--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -429,6 +429,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 				Mode mode = Mode.valueOf(params.getString(PARAM_MODE).toLowerCase());
 		    	if (View.isInitialised()) {
 	    			View.getSingleton().getMainFrame().getMainToolbarPanel().setMode(mode);
+	    			View.getSingleton().getMainFrame().getMainMenuBar().setMode(mode);
 		    	} else {
 	    			Control.getSingleton().setMode(mode);
 		    	}

--- a/src/org/zaproxy/zap/view/MainToolbarPanel.java
+++ b/src/org/zaproxy/zap/view/MainToolbarPanel.java
@@ -178,6 +178,9 @@ public class MainToolbarPanel extends JPanel {
 						default: return;	// Not recognised
 					}
 					Control.getSingleton().setMode(mode);
+					if (View.isInitialised()){
+	 		    		    View.getSingleton().getMainFrame().getMainMenuBar().setMode(mode);
+	 				}
 				}
 			});
 		}


### PR DESCRIPTION
- Edit menu now has an option to change ZAP mode. Mode can now be changed even if the main toolbar is hidden.
- Used checkboxes for mode selection instead of a radio box to maintain GUI consistency.
- There's one issue, however. The display in the MainToolBar panel which shows the ZAP mode and allows for user to select from a drop down list doesn't change when the user changes the mode from the Edit menu. I couldn't to do this as I wasn't able to figure out how to get a reference to the [toolbar](https://github.com/zaproxy/zaproxy/blob/96e98a3a73b2ba7fcfc86eb78cf6518937f7eb40/src/org/zaproxy/zap/view/MainToolbarPanel.java) from the [ExtensionState.java](https://github.com/zaproxy/zaproxy/blob/0879ae7de05dcb04b50f71ce4b7551e8b29977cf/src/org/parosproxy/paros/extension/state/ExtensionState.java) class. If anyone could help me out  with that, I am willing to finish that as well.

Please review the PR and suggest changes if any. Thanks.
