### PR TITLE
Delete all Alerts at once when deleting a SiteNode

### DIFF
--- a/src/org/zaproxy/zap/model/Context.java
+++ b/src/org/zaproxy/zap/model/Context.java
@@ -631,15 +631,11 @@ public class Context {
 	
 	private void deleteNode (SiteMap sitesTree, SiteNode sn) {
 		log.debug("Deleting node " + sn.getHierarchicNodeName());
-		List<Alert> alerts = sn.getAlerts();
-		HistoryReference href = sn.getHistoryReference();
+		sn.deleteAlerts(sn.getAlerts());
 		
 		// Remove old one
-		for (Alert alert : alerts) {
-			sn.deleteAlert(alert);
-		}
 		sitesTree.removeNodeFromParent(sn);
-		sitesTree.removeHistoryReference(href.getHistoryId());
+		sitesTree.removeHistoryReference(sn.getHistoryReference().getHistoryId());
 	}
 	
 	


### PR DESCRIPTION
Change method Context.deleteNode to delete all alerts at once instead of
one at a time (which generates more change events/tasks).