### PR TITLE
Reduce session load time with many alerts

### DIFF
--- a/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -498,9 +498,9 @@ public class ExtensionAlert extends ExtensionAdaptor implements SessionChangedLi
         	this.getFilteredTreeModel().deletePath(alert);
             List<HistoryReference> toDelete = new ArrayList<>();
             for (HistoryReference href : hrefs.values()) {
-                if (href.getAlerts().contains(alert)) {
+                if (href.hasAlert(alert)) {
                     href.deleteAlert(alert);
-                    if (href.getAlerts().size() == 0) {
+                    if (!href.hasAlerts()) {
                         toDelete.add(href);
                     }
                 }

--- a/src/org/zaproxy/zap/extension/alert/PopupMenuShowAlerts.java
+++ b/src/org/zaproxy/zap/extension/alert/PopupMenuShowAlerts.java
@@ -58,9 +58,11 @@ public class PopupMenuShowAlerts extends PopupMenuHistoryReferenceContainer {
 
 	@Override
     public boolean isButtonEnabledForHistoryReference (HistoryReference href) {
-		List<Alert> alerts = href.getAlerts();
+		List<Alert> alerts;
 		if (href.getSiteNode() != null) {
 			alerts = href.getSiteNode().getAlerts();
+		} else {
+			alerts = href.getAlerts();
 		}
 		URI hrefURI = href.getURI();
 		List<PopupMenuShowAlert> alertList = new ArrayList<>(alerts.size()); 


### PR DESCRIPTION
Change SiteNode and HistoryReference to use a Set for the alerts, which
already ensures that there are no duplicates (instead of having to
iterate the Lists to check for duplicates, which was leading to too
much time spent checking that). Also, for SiteNode keep track of the
alert with highest risk instead of iterating the collection each time
the string representation is needed.
Change other classes to reduce the calls to obtain the alerts from the
previously mentioned classes, since they return a copy of the internal
collection.