### PR TITLE
Add ZAP Comment

### DIFF
--- a/src/org/parosproxy/paros/db/paros/ParosTableHistory.java
+++ b/src/org/parosproxy/paros/db/paros/ParosTableHistory.java
@@ -36,6 +36,7 @@
 // ZAP: 2015/02/09 Issue 1525: Introduce a database interface layer to allow for alternative implementations
 // ZAP: 2016/05/26 Delete temporary history types sequentially
 // ZAP: 2016/05/27 Change to use HistoryReference to obtain the temporary types
+// ZAP: 2016/08/30 Issue 2836: Change to delete temporary history types in batches to prevent out-of-memory-exception(s)
 
 package org.parosproxy.paros.db.paros;
 


### PR DESCRIPTION
Pull https://github.com/zaproxy/zaproxy/pull/2838 was merged, missing
the fact that a ZAP comment hadn't been added. This commit addresses
that oversight.