### PR TITLE
Set ExtensionUiUtils to core and other tweaks

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1997,6 +1997,8 @@ timestamp.format.timeonly = HH:mm:ss
 # The following delimiter is used between timestamps and messages that are being stamped
 timestamp.format.delimiter = :
 
+uituils.desc = Core UI related functionality.
+
 users.panel.title 							= Users
 users.panel.description						= Users which can be used for various operations for this context.
 users.table.header.enabled 					= Enabled

--- a/src/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
+++ b/src/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
@@ -43,7 +43,7 @@ public class ExtensionUiUtils extends ExtensionAdaptor implements SessionChanged
 
 	public static final String NAME = "ExtensionUiUtils"; 
 	
-    private Logger logger = Logger.getLogger(ExtensionUiUtils.class);
+    private static final Logger LOGGER = Logger.getLogger(ExtensionUiUtils.class);
     
     public ExtensionUiUtils() {
         super(NAME);
@@ -54,7 +54,10 @@ public class ExtensionUiUtils extends ExtensionAdaptor implements SessionChanged
 	@Override
 	public void hook(ExtensionHook extensionHook) {
 	    super.hook(extensionHook);
-	    extensionHook.addSessionListener(this);
+
+		if (getView() != null) {
+			extensionHook.addSessionListener(this);
+		}
 	}
 	
 	
@@ -72,16 +75,14 @@ public class ExtensionUiUtils extends ExtensionAdaptor implements SessionChanged
 	                }
 	            });
 	        } catch (Exception e) {
-	            logger.error(e.getMessage(), e);
+	            LOGGER.error(e.getMessage(), e);
 	        }
 	    }
 	}
 	
 	private void sessionChangedEventHandler(Session session) {
-		if (View.isInitialised()) {
-			View.getSingleton().getMainFrame().getMainMenuBar().sessionChanged(session);
-			View.getSingleton().getMainFrame().getMainToolbarPanel().sessionChanged(session);
-		}
+		View.getSingleton().getMainFrame().getMainMenuBar().sessionChanged(session);
+		View.getSingleton().getMainFrame().getMainToolbarPanel().sessionChanged(session);
 	}
 
 
@@ -94,14 +95,18 @@ public class ExtensionUiUtils extends ExtensionAdaptor implements SessionChanged
 	}
 
 	@Override
+	public boolean isCore() {
+		return true;
+	}
+
+	@Override
 	public String getAuthor() {
 		return Constant.ZAP_TEAM;
 	}
 
 	@Override
 	public String getDescription() {
-		// TODO
-		return Constant.messages.getString("params.desc");
+		return Constant.messages.getString("uituils.desc");
 	}
 
 	@Override


### PR DESCRIPTION
Change class ExtensionUiUtils to:
 - Be a core extension, to prevent it from being disabled through the UI
 as it has UI functionality that should be always enabled;
 - Correct its description;
 - Have the logger as final static;
 - Add the session changed listener only if there's view and remove a
 (now) redundant view check.