### PR TITLE
Remove hardcoded names in script scanners

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/ScriptsActiveScanner.java
+++ b/src/org/zaproxy/zap/extension/ascan/ScriptsActiveScanner.java
@@ -56,11 +56,7 @@ public class ScriptsActiveScanner extends AbstractAppParamPlugin {
 
     @Override
     public String getName() {
-    	// TODO this npes due to loading order :(
-    	if (Constant.messages.containsKey("ascan.scripts.activescanner.title")) {
-    		return Constant.messages.getString("ascan.scripts.activescanner.title");
-    	}
-    	return "Script active scan rules";
+    	return Constant.messages.getString("ascan.scripts.activescanner.title");
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
+++ b/src/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
@@ -38,7 +38,6 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
 	
 	private ExtensionScript extension = null;
 	private PassiveScanThread parent = null;
-	private String name = null;
 	
 
 	private int currentHRefId;
@@ -48,14 +47,7 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
 	
 	@Override
 	public String getName() {
-		if (name == null) {
-			// Cache to prevent an NPE when unloaded
-	    	if (Constant.messages.containsKey("pscan.scripts.passivescanner.title")) {
-	    		name = Constant.messages.getString("pscan.scripts.passivescanner.title");
-	    	}
-	    	name = "Script passive scan rules";
-		}
-		return name;
+		return Constant.messages.getString("pscan.scripts.passivescanner.title");
 	}
 
 	private ExtensionScript getExtension() {


### PR DESCRIPTION
Remove hardcoded names in classes ScriptsActiveScanner and
ScriptsPassiveScanner, the resource messages will be loaded/available by
the time the names are required.