### PR TITLE
Add HTML base element tests for HTML form parser

### DIFF
--- a/src/org/zaproxy/zap/spider/parser/SpiderHtmlFormParser.java
+++ b/src/org/zaproxy/zap/spider/parser/SpiderHtmlFormParser.java
@@ -95,8 +95,9 @@ public class SpiderHtmlFormParser extends SpiderParser {
 			if (log.isDebugEnabled()) {
 				log.debug("Base tag was found in HTML: " + base.getDebugInfo());
 			}
-			if (base.getAttributeValue("href") != null) {
-				baseURL = base.getAttributeValue("href");
+			String href = base.getAttributeValue("href");
+			if (href != null && !href.isEmpty()) {
+				baseURL = href;
 			}
 		}
 

--- a/test/org/zaproxy/zap/spider/parser/SpiderHtmlFormParserUnitTest.java
+++ b/test/org/zaproxy/zap/spider/parser/SpiderHtmlFormParserUnitTest.java
@@ -539,6 +539,142 @@ public class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
         assertThat(listener.getUrlsFound(), contains("http://example.org/?a=b&field1=Text+1&field2=Text+2&submit=Submit"));
     }
 
+    @Test
+    public void shouldUseBaseHtmlUrlWhenParsingGetForm() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage msg = createMessageWith("GetFormWithHtmlBase.html");
+        Source source = createSource(msg);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(msg, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(listener.getUrlsFound(), contains("http://base.example.com/search?q=Search&submit=Submit"));
+    }
+
+    @Test
+    public void shouldIgnoreBaseHtmlIfEmptyHrefWhenParsingGetForm() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage msg = createMessageWith("GetFormWithHtmlBaseWithEmptyHref.html");
+        Source source = createSource(msg);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(msg, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(listener.getUrlsFound(), contains("http://example.com/search?q=Search&submit=Submit"));
+    }
+
+    @Test
+    public void shouldIgnoreBaseHtmlWithNoHrefWhenParsingGetForm() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage msg = createMessageWith("GetFormWithHtmlBaseWithoutHref.html");
+        Source source = createSource(msg);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(msg, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(listener.getUrlsFound(), contains("http://example.com/search?q=Search&submit=Submit"));
+    }
+
+    @Test
+    public void shouldIgnoreBaseHtmlIfActionIsAbsoluteWhenParsingGetForm() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage msg = createMessageWith("GetFormWithHtmlBaseAndAbsoluteAction.html");
+        Source source = createSource(msg);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(msg, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(1)));
+        assertThat(listener.getUrlsFound(), contains("https://example.com/search?q=Search&submit=Submit"));
+    }
+
+    @Test
+    public void shouldUseBaseHtmlUrlWhenParsingPostForm() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage msg = createMessageWith("PostFormWithHtmlBase.html");
+        Source source = createSource(msg);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(msg, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfResourcesFound(), is(equalTo(1)));
+        assertThat(
+                listener.getResourcesFound(),
+                contains(postResource(msg, 1, "http://base.example.com/search", "q=Search&submit=Submit")));
+    }
+
+    @Test
+    public void shouldIgnoreBaseHtmlIfEmptyHrefWhenParsingPostForm() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage msg = createMessageWith("PostFormWithHtmlBaseWithEmptyHref.html");
+        Source source = createSource(msg);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(msg, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfResourcesFound(), is(equalTo(1)));
+        assertThat(
+                listener.getResourcesFound(),
+                contains(postResource(msg, 1, "http://example.com/search", "q=Search&submit=Submit")));
+    }
+
+    @Test
+    public void shouldIgnoreBaseHtmlWithNoHrefWhenParsingPostForm() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage msg = createMessageWith("PostFormWithHtmlBaseWithoutHref.html");
+        Source source = createSource(msg);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(msg, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfResourcesFound(), is(equalTo(1)));
+        assertThat(
+                listener.getResourcesFound(),
+                contains(postResource(msg, 1, "http://example.com/search", "q=Search&submit=Submit")));
+    }
+
+    @Test
+    public void shouldIgnoreBaseHtmlIfActionIsAbsoluteWhenParsingPostForm() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage msg = createMessageWith("PostFormWithHtmlBaseAndAbsoluteAction.html");
+        Source source = createSource(msg);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(msg, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfResourcesFound(), is(equalTo(1)));
+        assertThat(
+                listener.getResourcesFound(),
+                contains(postResource(msg, 1, "https://example.com/search", "q=Search&submit=Submit")));
+    }
+
     private SpiderHtmlFormParser createSpiderHtmlFormParser() {
         SpiderParam spiderOptions = createSpiderParamWithConfig();
         spiderOptions.setProcessForm(true);

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormWithHtmlBase.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormWithHtmlBase.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://base.example.com/">
+<meta charset="UTF-8">
+<title>GET Form With HTML Base - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="search" method="GET">
+<input type="text" name="q" value="Search" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormWithHtmlBaseAndAbsoluteAction.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormWithHtmlBaseAndAbsoluteAction.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://base.example.com/">
+<meta charset="UTF-8">
+<title>GET Form With HTML Base And Absolute Action - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="https://example.com/search" method="GET">
+<input type="text" name="q" value="Search" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormWithHtmlBaseWithEmptyHref.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormWithHtmlBaseWithEmptyHref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="">
+<meta charset="UTF-8">
+<title>GET Form With HTML Base With Empty href - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="search" method="GET">
+<input type="text" name="q" value="Search" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormWithHtmlBaseWithoutHref.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/GetFormWithHtmlBaseWithoutHref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base>
+<meta charset="UTF-8">
+<title>GET Form With HTML Base Without href - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="search" method="GET">
+<input type="text" name="q" value="Search" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/PostFormWithHtmlBase.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/PostFormWithHtmlBase.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://base.example.com/">
+<meta charset="UTF-8">
+<title>POST Form With HTML Base - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="search" method="POST">
+<input type="text" name="q" value="Search" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/PostFormWithHtmlBaseAndAbsoluteAction.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/PostFormWithHtmlBaseAndAbsoluteAction.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://base.example.com/">
+<meta charset="UTF-8">
+<title>POST Form With HTML Base And Absolute Action - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="https://example.com/search" method="POST">
+<input type="text" name="q" value="Search" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/PostFormWithHtmlBaseWithEmptyHref.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/PostFormWithHtmlBaseWithEmptyHref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="">
+<meta charset="UTF-8">
+<title>POST Form With HTML Base With Empty href - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="search" method="POST">
+<input type="text" name="q" value="Search" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/PostFormWithHtmlBaseWithoutHref.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/PostFormWithHtmlBaseWithoutHref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base>
+<meta charset="UTF-8">
+<title>POST Form With HTML Base Without href - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="search" method="POST">
+<input type="text" name="q" value="Search" />
+<input type="submit" name="submit" value="Submit" />
+</form>
+
+</body>
+</html>


### PR DESCRIPTION
Change class SpiderHtmlFormParser to require a non empty value in HTML
base element to be used.
Add tests to assert the expected behaviour when handling the HTML base
element for GET and POST forms.
 ---
From https://github.com/zaproxy/zaproxy/pull/2779#issuecomment-242163412.