### PR TITLE
Show correct error for wrong regex in ContextAPI

### DIFF
--- a/src/org/zaproxy/zap/extension/api/ContextAPI.java
+++ b/src/org/zaproxy/zap/extension/api/ContextAPI.java
@@ -122,12 +122,16 @@ public class ContextAPI extends ApiImplementor {
         case EXCLUDE_FROM_CONTEXT_REGEX:
         	try {
 				addExcludeToContext(getContext(params), params.getString(REGEX_PARAM));
-			} catch (Exception e) {
-	            throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
+			} catch (IllegalArgumentException e) {
+	            throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, REGEX_PARAM, e);
 			}
         	break;
         case INCLUDE_IN_CONTEXT_REGEX:
-        	addIncludeToContext(getContext(params), params.getString(REGEX_PARAM));
+            try {
+                addIncludeToContext(getContext(params), params.getString(REGEX_PARAM));
+            } catch (IllegalArgumentException e) {
+                throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, REGEX_PARAM, e);
+            }
         	break;
         case ACTION_NEW_CONTEXT:
             context = Model.getSingleton().getSession().getNewContext(params.getString(CONTEXT_NAME));
@@ -219,7 +223,7 @@ public class ContextAPI extends ApiImplementor {
         return ApiResponseElement.OK;
     }
 
-    private void addExcludeToContext(Context context, String regex) throws Exception {
+    private void addExcludeToContext(Context context, String regex) {
     	List<String> incRegexes = new ArrayList<String>(context.getIncludeInContextRegexs());
     	if (incRegexes.remove(regex)) {
     		// Its already explicitly included, removing it from the include list is safer and more useful

--- a/src/org/zaproxy/zap/model/Context.java
+++ b/src/org/zaproxy/zap/model/Context.java
@@ -26,6 +26,7 @@ import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -319,18 +320,45 @@ public class Context {
 		return Collections.unmodifiableList(includeInRegexs);
 	}
 
-	private void checkRegexs(List<String> regexs) throws Exception {
-		for (String url : regexs) {
-			url = url.trim();
-			if (url.length() > 0) {
-				Pattern.compile(url, Pattern.CASE_INSENSITIVE);
-			}
+	/**
+	 * Validates that the given regular expressions are not {@code null} nor invalid.
+	 *
+	 * @param regexs the regular expressions to be validated, must not be {@code null}
+	 * @throws IllegalArgumentException if one of the regular expressions is {@code null}.
+	 * @throws PatternSyntaxException if one of the regular expressions is invalid.
+	 */
+	private static void validateRegexs(List<String> regexs) {
+		for (String regex : regexs) {
+			validateRegex(regex);
 		}
 	}
 
-	public void setIncludeInContextRegexs(List<String> includeRegexs) throws Exception {
-		// Check they are all valid regexes first
-		checkRegexs(includeRegexs);
+	/**
+	 * Validates that the given regular expression is not {@code null} nor invalid.
+	 *
+	 * @param regex the regular expression to be validated
+	 * @throws IllegalArgumentException if the regular expression is {@code null}.
+	 * @throws PatternSyntaxException if the regular expression is invalid.
+	 */
+	private static void validateRegex(String regex) {
+		if (regex == null) {
+			throw new IllegalArgumentException("The regular expression must not be null.");
+		}
+		String trimmedRegex = regex.trim();
+		if (!trimmedRegex.isEmpty()) {
+			Pattern.compile(trimmedRegex, Pattern.CASE_INSENSITIVE);
+		}
+	}
+
+	/**
+	 * Sets the regular expressions used to include a URL in context.
+	 *
+	 * @param includeRegexs the regular expressions
+	 * @throws IllegalArgumentException if one of the regular expressions is {@code null}.
+	 * @throws PatternSyntaxException if one of the regular expressions is invalid.
+	 */
+	public void setIncludeInContextRegexs(List<String> includeRegexs) {
+		validateRegexs(includeRegexs);
 		// Check if theyve been changed
 		if (includeInRegexs.size() == includeRegexs.size()) {
 			boolean changed = false;
@@ -366,8 +394,8 @@ public class Context {
 	}
 
 	public void addIncludeInContextRegex(String includeRegex) {
-		Pattern p = Pattern.compile(includeRegex, Pattern.CASE_INSENSITIVE);
-		includeInPatterns.add(p);
+		validateRegex(includeRegex);
+		includeInPatterns.add(Pattern.compile(includeRegex, Pattern.CASE_INSENSITIVE));
 		includeInRegexs.add(includeRegex);
 	}
 
@@ -375,9 +403,15 @@ public class Context {
 		return Collections.unmodifiableList(excludeFromRegexs);
 	}
 
-	public void setExcludeFromContextRegexs(List<String> excludeRegexs) throws Exception {
-		// Check they are all valid regexes first
-		checkRegexs(excludeRegexs);
+	/**
+	 * Sets the regular expressions used to exclude a URL from the context.
+	 *
+	 * @param excludeRegexs the regular expressions
+	 * @throws IllegalArgumentException if one of the regular expressions is {@code null}.
+	 * @throws PatternSyntaxException if one of the regular expressions is invalid.
+	 */
+	public void setExcludeFromContextRegexs(List<String> excludeRegexs) {
+		validateRegexs(excludeRegexs);
 		// Check if theyve been changed
 		if (excludeFromRegexs.size() == excludeRegexs.size()) {
 			boolean changed = false;
@@ -406,8 +440,8 @@ public class Context {
 	}
 
 	public void addExcludeFromContextRegex(String excludeRegex) {
-		Pattern p = Pattern.compile(excludeRegex, Pattern.CASE_INSENSITIVE);
-		excludeFromPatterns.add(p);
+		validateRegex(excludeRegex);
+		excludeFromPatterns.add(Pattern.compile(excludeRegex, Pattern.CASE_INSENSITIVE));
 		excludeFromRegexs.add(excludeRegex);
 	}
 

--- a/src/org/zaproxy/zap/view/ContextExcludePanel.java
+++ b/src/org/zaproxy/zap/view/ContextExcludePanel.java
@@ -145,11 +145,7 @@ public class ContextExcludePanel extends AbstractContextPropertiesPanel {
 
 	@Override
 	public void saveTemporaryContextData(Context uiSharedContext) {
-		try {
-			uiSharedContext.setExcludeFromContextRegexs(regexesPanel.getRegexes());
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+		uiSharedContext.setExcludeFromContextRegexs(regexesPanel.getRegexes());
 	}
 
 }

--- a/src/org/zaproxy/zap/view/ContextIncludePanel.java
+++ b/src/org/zaproxy/zap/view/ContextIncludePanel.java
@@ -146,11 +146,7 @@ public class ContextIncludePanel extends AbstractContextPropertiesPanel {
 
 	@Override
 	public void saveTemporaryContextData(Context uiSharedContext) {
-		try {
-			uiSharedContext.setIncludeInContextRegexs(regexesPanel.getRegexes());
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+		uiSharedContext.setIncludeInContextRegexs(regexesPanel.getRegexes());
 	}
 
 }


### PR DESCRIPTION
Change ContextAPI to throw ILLEGAL_PARAMETER (instead of INTERNAL_ERROR)
when the regular expression (for context inclusion or exclusion) is
invalid, which better indicates what the problem is.
Change Context class to not throw Exception and document the exceptions
expected to be thrown (PatternSyntaxException if the regular expression
is not valid or IllegalArgumentException if it it's null).
Change ContextExcludePanel and ContextIncludePanel to no longer catch
the exception when setting the (already validated) regular expressions.