### PR TITLE
Remove incorrect JavaDoc tags

### DIFF
--- a/src/org/apache/commons/httpclient/HttpMethodDirector.java
+++ b/src/org/apache/commons/httpclient/HttpMethodDirector.java
@@ -603,9 +603,7 @@ public class HttpMethodDirector {
     /**
      * Fake response
      * @param method
-     * @return
      */
-    
     private void fakeResponse(final HttpMethod method)
         throws IOException, HttpException {
         // What is to follow is an ugly hack.

--- a/src/org/parosproxy/paros/core/scanner/MultipartParam.java
+++ b/src/org/parosproxy/paros/core/scanner/MultipartParam.java
@@ -113,7 +113,6 @@ public class MultipartParam {
       * <code>String<code>
       * array with elements: disposition, name, filename.
       *
-      * @return String[] of elements: disposition, name, filename.
       * @exception IOException if the line is malformatted.
       */
     private void extractDispositionInfo(String line) throws IOException {

--- a/src/org/parosproxy/paros/extension/history/BrowserDialog.java
+++ b/src/org/parosproxy/paros/extension/history/BrowserDialog.java
@@ -298,22 +298,6 @@ public class BrowserDialog extends AbstractDialog {
         return jPanel;
     }
 
-    /**
-     * This method initializes embeddedBrowser	
-     * 	
-     * @return org.parosproxy.paros.extension.history.EmbeddedBrowser	
-     */
-    // ZAP: Disabled the platform specific browser
-    /*
-    EmbeddedBrowser getEmbeddedBrowser() {
-        if (embeddedBrowser == null) {
-            embeddedBrowser = new EmbeddedBrowser();
-            embeddedBrowser.setName("embeddedBrowser");
-        }
-        return embeddedBrowser;
-    }
-    */
-
     void setURLTitle(String url) {
         setTitle(TITLE + url);
     }

--- a/src/org/parosproxy/paros/network/HttpRequestHeader.java
+++ b/src/org/parosproxy/paros/network/HttpRequestHeader.java
@@ -357,7 +357,6 @@ public class HttpRequestHeader extends HttpHeader {
      * Parse this request header.
      *
      * @param isSecure
-     * @return
      * @throws URIException
      * @throws NullPointerException
      */

--- a/src/org/zaproxy/zap/extension/users/ContextUserAuthManager.java
+++ b/src/org/zaproxy/zap/extension/users/ContextUserAuthManager.java
@@ -76,7 +76,6 @@ public class ContextUserAuthManager {
 	 * Sets a new list of users for this context. An internal copy of the provided list is stored.
 	 * 
 	 * @param users the users
-	 * @return the list
 	 */
 	public void setUsers(List<User> users) {
 		this.users = new ArrayList<>(users);

--- a/src/org/zaproxy/zap/session/AbstractSessionManagementMethodOptionsPanel.java
+++ b/src/org/zaproxy/zap/session/AbstractSessionManagementMethodOptionsPanel.java
@@ -28,8 +28,6 @@ import org.zaproxy.zap.session.SessionManagementMethodType.UnsupportedSessionMan
  * {@link SessionManagementMethod}.<br/>
  * <br/>
  * This panel will be displayed to users in a separate dialog.
- * 
- * @param <T> the session management method type
  */
 public abstract class AbstractSessionManagementMethodOptionsPanel extends JPanel {
 

--- a/src/org/zaproxy/zap/session/SessionManagementMethodType.java
+++ b/src/org/zaproxy/zap/session/SessionManagementMethodType.java
@@ -36,9 +36,6 @@ import org.zaproxy.zap.model.Context;
  * The implementors of new Session Management Methods should also implement a corresponding type.
  * The system automatically detects and loads {@link SessionManagementMethodType} classes and,
  * through them, the corresponding session management methods.
- * </p>
- * 
- * @param <T> the corresponding session management method
  */
 public abstract class SessionManagementMethodType {
 

--- a/src/org/zaproxy/zap/view/ContextExcludePanel.java
+++ b/src/org/zaproxy/zap/view/ContextExcludePanel.java
@@ -71,8 +71,6 @@ public class ContextExcludePanel extends AbstractContextPropertiesPanel {
     
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
         regexesPanel = new MultipleRegexesOptionsPanel(View.getSingleton().getSessionDialog());

--- a/src/org/zaproxy/zap/view/ContextGeneralPanel.java
+++ b/src/org/zaproxy/zap/view/ContextGeneralPanel.java
@@ -40,8 +40,6 @@ public class ContextGeneralPanel extends AbstractContextPropertiesPanel {
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		this.setLayout(new CardLayout());

--- a/src/org/zaproxy/zap/view/ContextIncludePanel.java
+++ b/src/org/zaproxy/zap/view/ContextIncludePanel.java
@@ -71,8 +71,6 @@ public class ContextIncludePanel extends AbstractContextPropertiesPanel {
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		regexesPanel = new MultipleRegexesOptionsPanel(View.getSingleton().getSessionDialog());

--- a/src/org/zaproxy/zap/view/ContextListPanel.java
+++ b/src/org/zaproxy/zap/view/ContextListPanel.java
@@ -52,8 +52,6 @@ public class ContextListPanel extends AbstractParamPanel {
     
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
         this.setLayout(new CardLayout());

--- a/src/org/zaproxy/zap/view/ContextTechnologyPanel.java
+++ b/src/org/zaproxy/zap/view/ContextTechnologyPanel.java
@@ -51,8 +51,6 @@ public class ContextTechnologyPanel extends AbstractContextPropertiesPanel {
 
 	/**
 	 * This method initializes this
-	 * 
-	 * @return void
 	 */
 	private void initialize() {
 		this.setLayout(new CardLayout());


### PR DESCRIPTION
Remove incorrect JavaDoc tags, return tag when the method returns void
and param tag of inexistent type parameters.
Remove commented method and corresponding JavaDoc in BrowserDialog.