### PR TITLE
Handle parsing errors in VariantAbstractRPCQuery

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/VariantAbstractRPCQuery.java
+++ b/src/org/parosproxy/paros/core/scanner/VariantAbstractRPCQuery.java
@@ -23,6 +23,8 @@ package org.parosproxy.paros.core.scanner;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import org.apache.log4j.Logger;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 
@@ -32,6 +34,8 @@ import org.parosproxy.paros.network.HttpMessage;
  * @author andy
  */
 public abstract class VariantAbstractRPCQuery implements Variant {
+    
+    private final Logger logger = Logger.getLogger(this.getClass());
     
     private final List<RPCParameter> listParam = new ArrayList<>();
     private final List<NameValuePair> params = new ArrayList<>();
@@ -43,7 +47,11 @@ public abstract class VariantAbstractRPCQuery implements Variant {
         // Otherwise give back an empty param list
         String contentType = msg.getRequestHeader().getHeader(HttpHeader.CONTENT_TYPE);
         if (contentType != null && isValidContentType(contentType)) {
-            setRequestContent(msg.getRequestBody().toString());
+            try {
+                setRequestContent(msg.getRequestBody().toString());
+            } catch (Exception e) {
+                logger.warn("Failed to parse the request body: " + e.getMessage(), e);
+            }
         }
     }
 


### PR DESCRIPTION
Change class VariantAbstractRPCQuery to handle the exceptions thrown by
custom implementations when parsing the request body. Log the exceptions
with WARN level (instead of ERROR) as that's not caused (most likely) by
a programming error but a faulty/malformed content.
 ---
Related to discussion in OWASP ZAP User Group: https://groups.google.com/d/topic/zaproxy-users/uVZx3UvHG3Y/discussion