### PR TITLE
Correct offset calculation in text header views

### DIFF
--- a/src/org/zaproxy/zap/extension/httppanel/component/all/request/HttpRequestAllPanelTextView.java
+++ b/src/org/zaproxy/zap/extension/httppanel/component/all/request/HttpRequestAllPanelTextView.java
@@ -21,13 +21,12 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.swing.text.BadLocationException;
-
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.request.RequestStringHttpPanelViewModel;
 import org.zaproxy.zap.extension.httppanel.view.text.HttpPanelTextArea;
 import org.zaproxy.zap.extension.httppanel.view.text.HttpPanelTextView;
+import org.zaproxy.zap.extension.httppanel.view.util.HttpTextViewUtils;
 import org.zaproxy.zap.extension.search.SearchMatch;
 
 public class HttpRequestAllPanelTextView extends HttpPanelTextView {
@@ -49,53 +48,19 @@ public class HttpRequestAllPanelTextView extends HttpPanelTextView {
 		
 		@Override
 		public void search(Pattern p, List<SearchMatch> matches) {
-			HttpMessage httpMessage = (HttpMessage)getMessage();
-			//This only happens in the Request/Response Header
-			//As we replace all \r\n with \n we must add one character
-			//for each line until the line where the selection is.
-			int tHeader = 0;
-			String header = httpMessage.getRequestHeader().toString();
-			int pos = 0;
-			while ((pos = header.indexOf("\r\n", pos)) != -1) {
-				pos += 2;
-				++tHeader;
-			}
-			
-			final int headerLen = header.length();
-			final int diff = tHeader - headerLen;
+			String header = ((HttpMessage) getMessage()).getRequestHeader().toString();
 			
 			Matcher m = p.matcher(getText());
-			int start;
-			int end;
 			while (m.find()) {
-				start = m.start();
-				end = m.end();
-				
-				if (start+tHeader < headerLen) {
-					try {
-						start += getLineOfOffset(start);
-					} catch (BadLocationException e) {
-						//Shouldn't happen, but in case it does log it and return.
-						log.error(e.getMessage(), e);
-						return;
-					}
-					try {
-						end += getLineOfOffset(end);
-					} catch (BadLocationException e) {
-						//Shouldn't happen, but in case it does log it and return.
-						log.error(e.getMessage(), e);
-						return;
-					}
-					if (end > headerLen) {
-						end = headerLen;
-					}
-					matches.add(new SearchMatch(SearchMatch.Location.REQUEST_HEAD, start, end));
-				} else {
-					start += diff;
-					end += diff;
-				
-					matches.add(new SearchMatch(SearchMatch.Location.REQUEST_BODY, start, end));
+				int[] position = HttpTextViewUtils.getViewToHeaderBodyPosition(this, header, m.start(), m.end());
+				if (position.length == 0) {
+					return;
 				}
+
+				SearchMatch.Location location = position.length == 2
+						? SearchMatch.Location.REQUEST_HEAD
+						: SearchMatch.Location.REQUEST_BODY;
+				matches.add(new SearchMatch(location, position[0], position[1]));
 			}
 		}
 		
@@ -106,37 +71,26 @@ public class HttpRequestAllPanelTextView extends HttpPanelTextView {
 				return;
 			}
 			
-			final boolean isBody = SearchMatch.Location.REQUEST_BODY.equals(sm.getLocation());
-			
-			//As we replace all \r\n with \n we must subtract one character
-			//for each line until the line where the selection is.
-			int t = 0;
-			String header = sm.getMessage().getRequestHeader().toString();
-			int pos = 0;
-			while ((pos = header.indexOf("\r\n", pos)) != -1) {
-				pos += 2;
-				
-				if (!isBody && pos > sm.getStart()) {
-					break;
-				}
-				
-				++t;
+			int[] pos;
+			if (SearchMatch.Location.REQUEST_HEAD.equals(sm.getLocation())) {
+				pos = HttpTextViewUtils.getHeaderToViewPosition(
+						this,
+						sm.getMessage().getRequestHeader().toString(),
+						sm.getStart(),
+						sm.getEnd());
+			} else {
+				pos = HttpTextViewUtils.getBodyToViewPosition(
+						this,
+						sm.getMessage().getRequestHeader().toString(),
+						sm.getStart(),
+						sm.getEnd());
 			}
-			
-			int start = sm.getStart()-t;
-			int end = sm.getEnd()-t;
-			
-			if (isBody) {
-				start += header.length();
-				end += header.length();
-			}
-			
-			int len = this.getText().length();
-			if (start > len || end > len) {
+
+			if (pos.length == 0) {
 				return;
 			}
 			
-			highlight(start, end);
+			highlight(pos[0], pos[1]);
 		}
 		
 	}

--- a/src/org/zaproxy/zap/extension/httppanel/component/all/response/HttpResponseAllPanelTextView.java
+++ b/src/org/zaproxy/zap/extension/httppanel/component/all/response/HttpResponseAllPanelTextView.java
@@ -21,13 +21,12 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.swing.text.BadLocationException;
-
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.response.ResponseStringHttpPanelViewModel;
 import org.zaproxy.zap.extension.httppanel.view.text.HttpPanelTextArea;
 import org.zaproxy.zap.extension.httppanel.view.text.HttpPanelTextView;
+import org.zaproxy.zap.extension.httppanel.view.util.HttpTextViewUtils;
 import org.zaproxy.zap.extension.search.SearchMatch;
 
 public class HttpResponseAllPanelTextView extends HttpPanelTextView {
@@ -49,53 +48,19 @@ public class HttpResponseAllPanelTextView extends HttpPanelTextView {
 
 		@Override
 		public void search(Pattern p, List<SearchMatch> matches) {
-			HttpMessage httpMessage = (HttpMessage)getMessage();
-			//This only happens in the Request/Response Header
-			//As we replace all \r\n with \n we must add one character
-			//for each line until the line where the selection is.
-			int tHeader = 0;
-			String header = httpMessage.getResponseHeader().toString();
-			int pos = 0;
-			while ((pos = header.indexOf("\r\n", pos)) != -1) {
-				pos += 2;
-				++tHeader;
-			}
-			
-			final int headerLen = header.length();
-			final int diff = tHeader - headerLen;
-			
+			String header = ((HttpMessage) getMessage()).getResponseHeader().toString();
 			Matcher m = p.matcher(getText());
-			int start;
-			int end;
 			while (m.find()) {
-				start = m.start();
-				end = m.end();
-				
-				if (start+tHeader < headerLen) {
-					try {
-						start += getLineOfOffset(start);
-					} catch (BadLocationException e) {
-						//Shouldn't happen, but in case it does log it and return.
-						log.error(e.getMessage(), e);
-						return;
-					}
-					try {
-						end += getLineOfOffset(end);
-					} catch (BadLocationException e) {
-						//Shouldn't happen, but in case it does log it and return.
-						log.error(e.getMessage(), e);
-						return;
-					}
-					if (end > headerLen) {
-						end = headerLen;
-					}
-					matches.add(new SearchMatch(SearchMatch.Location.RESPONSE_HEAD, start, end));
-				} else {
-					start += diff;
-					end += diff;
-				
-					matches.add(new SearchMatch(SearchMatch.Location.RESPONSE_BODY, start, end));
+
+				int[] position = HttpTextViewUtils.getViewToHeaderBodyPosition(this, header, m.start(), m.end());
+				if (position.length == 0) {
+					return;
 				}
+
+				SearchMatch.Location location = position.length == 2
+						? SearchMatch.Location.RESPONSE_HEAD
+						: SearchMatch.Location.RESPONSE_BODY;
+				matches.add(new SearchMatch(location, position[0], position[1]));
 			}
 		}
 		
@@ -106,37 +71,26 @@ public class HttpResponseAllPanelTextView extends HttpPanelTextView {
 				return;
 			}
 			
-			final boolean isBody = SearchMatch.Location.RESPONSE_BODY.equals(sm.getLocation());
-			
-			//As we replace all \r\n with \n we must subtract one character
-			//for each line until the line where the selection is.
-			int t = 0;
-			String header = sm.getMessage().getResponseHeader().toString();
-			int pos = 0;
-			while ((pos = header.indexOf("\r\n", pos)) != -1) {
-				pos += 2;
-				
-				if (!isBody && pos > sm.getStart()) {
-					break;
-				}
-				
-				++t;
+			int[] pos;
+			if (SearchMatch.Location.RESPONSE_HEAD.equals(sm.getLocation())) {
+				pos = HttpTextViewUtils.getHeaderToViewPosition(
+						this,
+						sm.getMessage().getResponseHeader().toString(),
+						sm.getStart(),
+						sm.getEnd());
+			} else {
+				pos = HttpTextViewUtils.getBodyToViewPosition(
+						this,
+						sm.getMessage().getResponseHeader().toString(),
+						sm.getStart(),
+						sm.getEnd());
 			}
-			
-			int start = sm.getStart()-t;
-			int end = sm.getEnd()-t;
-			
-			if (isBody) {
-				start += header.length();
-				end += header.length();
-			}
-			
-			int len = this.getText().length();
-			if (start > len || end > len) {
+
+			if (pos.length == 0) {
 				return;
 			}
 			
-			highlight(start, end);
+			highlight(pos[0], pos[1]);
 		}
 	}
 }

--- a/src/org/zaproxy/zap/extension/httppanel/component/split/request/HttpRequestHeaderPanelTextView.java
+++ b/src/org/zaproxy/zap/extension/httppanel/component/split/request/HttpRequestHeaderPanelTextView.java
@@ -21,18 +21,14 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.swing.text.BadLocationException;
-
-import org.apache.log4j.Logger;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.request.RequestHeaderStringHttpPanelViewModel;
 import org.zaproxy.zap.extension.httppanel.view.text.HttpPanelTextArea;
 import org.zaproxy.zap.extension.httppanel.view.text.HttpPanelTextView;
+import org.zaproxy.zap.extension.httppanel.view.util.HttpTextViewUtils;
 import org.zaproxy.zap.extension.search.SearchMatch;
 
 public class HttpRequestHeaderPanelTextView extends HttpPanelTextView {
 
-	private static final Logger log = Logger.getLogger(HttpRequestHeaderPanelTextView.class);
-	
 	public HttpRequestHeaderPanelTextView(RequestHeaderStringHttpPanelViewModel model) {
 		super(model);
 	}
@@ -48,33 +44,15 @@ public class HttpRequestHeaderPanelTextView extends HttpPanelTextView {
 		
 		@Override
 		public void search(Pattern p, List<SearchMatch> matches) {
-			int start;
-			int end;
 			Matcher m = p.matcher(getText());
 			while (m.find()) {
 
-				//This only happens in the Request/Response Header
-				//As we replace all \r\n with \n we must add one character
-				//for each line until the line where the match is.
-				start = m.start();
-				try {
-					start += getLineOfOffset(start);
-				} catch (BadLocationException e) {
-					//Shouldn't happen, but in case it does log it and return.
-					log.error(e.getMessage(), e);
-					return;
-				}
-
-				end = m.end();
-				try {
-					end += getLineOfOffset(end);
-				} catch (BadLocationException e) {
-					//Shouldn't happen, but in case it does log it and return.
-					log.error(e.getMessage(), e);
+				int[] position = HttpTextViewUtils.getViewToHeaderPosition(this, m.start(), m.end());
+				if (position.length == 0) {
 					return;
 				}
 				
-				matches.add(new SearchMatch(SearchMatch.Location.REQUEST_HEAD, start, end));
+				matches.add(new SearchMatch(SearchMatch.Location.REQUEST_HEAD, position[0], position[1]));
 			}
 		}
 		
@@ -84,23 +62,15 @@ public class HttpRequestHeaderPanelTextView extends HttpPanelTextView {
 				return;
 			}
 			
-			//As we replace all \r\n with \n we must subtract one character
-			//for each line until the line where the selection is.
-			int t = 0;
-			String header = sm.getMessage().getRequestHeader().toString();
-			
-			int pos = 0;
-			while ((pos = header.indexOf("\r\n", pos)) != -1 && pos < sm.getStart()) {
-				pos += 2;
-				++t;
-			}
-			
-			int len = this.getText().length();
-			if (sm.getStart()-t > len || sm.getEnd()-t > len) {
+			int[] pos = HttpTextViewUtils.getHeaderToViewPosition(
+					this,
+					sm.getMessage().getRequestHeader().toString(),
+					sm.getStart(),
+					sm.getEnd());
+			if (pos.length == 0) {
 				return;
 			}
-			
-			highlight(sm.getStart()-t, sm.getEnd()-t);
+			highlight(pos[0], pos[1]);
 		}
 		
 	}

--- a/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/all/request/HttpRequestAllPanelSyntaxHighlightTextView.java
+++ b/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/all/request/HttpRequestAllPanelSyntaxHighlightTextView.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.swing.text.BadLocationException;
-
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
@@ -33,6 +31,7 @@ import org.zaproxy.zap.extension.httppanel.view.impl.models.http.request.Request
 import org.zaproxy.zap.extension.httppanel.view.syntaxhighlight.HttpPanelSyntaxHighlightTextArea;
 import org.zaproxy.zap.extension.httppanel.view.syntaxhighlight.HttpPanelSyntaxHighlightTextView;
 import org.zaproxy.zap.extension.httppanel.view.util.CaretVisibilityEnforcerOnFocusGain;
+import org.zaproxy.zap.extension.httppanel.view.util.HttpTextViewUtils;
 import org.zaproxy.zap.extension.search.SearchMatch;
 import org.zaproxy.zap.model.DefaultTextHttpMessageLocation;
 import org.zaproxy.zap.model.MessageLocation;
@@ -114,52 +113,25 @@ public class HttpRequestAllPanelSyntaxHighlightTextView extends HttpPanelSyntaxH
 		}
 
         protected MessageLocation getSelection() {
-            HttpMessage httpMessage = getMessage();
-            // This only happens in the Request/Response Header
-            // As we replace all \r\n with \n we must add one character
-            // for each line until the line where the selection is.
-            int tHeader = 0;
-            String header = httpMessage.getRequestHeader().toString();
-            int pos = 0;
-            while ((pos = header.indexOf("\r\n", pos)) != -1) {
-                pos += 2;
-                ++tHeader;
+            String header = getMessage().getRequestHeader().toString();
+
+            int[] position = HttpTextViewUtils
+                    .getViewToHeaderBodyPosition(this, header, getSelectionStart(), getSelectionEnd());
+            if (position.length == 0) {
+                return new DefaultTextHttpMessageLocation(HttpMessageLocation.Location.REQUEST_HEADER, 0);
             }
 
-            int start = getSelectionStart();
-            int end = getSelectionEnd();
+            int start = position[0];
+            int end = position[1];
             HttpMessageLocation.Location location;
 
             String value;
-            int headerLen = header.length();
-            if (start + tHeader < headerLen) {
-                try {
-                    start += getLineOfOffset(start);
-                } catch (BadLocationException e) {
-                    // Shouldn't happen, but in case it does log it and return...
-                    log.error(e.getMessage(), e);
-                    return new DefaultTextHttpMessageLocation(HttpMessageLocation.Location.REQUEST_HEADER, 0);
-                }
-
-                try {
-                    end += getLineOfOffset(end);
-                } catch (BadLocationException e) {
-                    // Shouldn't happen, but in case it does log it and return...
-                    log.error(e.getMessage(), e);
-                    return new DefaultTextHttpMessageLocation(HttpMessageLocation.Location.REQUEST_HEADER, 0);
-                }
-
-                if (end > headerLen) {
-                    end = headerLen;
-                }
+            if (position.length == 2) {
                 location = HttpMessageLocation.Location.REQUEST_HEADER;
                 value = header.substring(start, end);
             } else {
-                start += tHeader - headerLen;
-                end += tHeader - headerLen;
-
                 location = HttpMessageLocation.Location.REQUEST_BODY;
-                value = httpMessage.getRequestBody().toString().substring(start, end);
+                value = getMessage().getRequestBody().toString().substring(start, end);
             }
 
             return new DefaultTextHttpMessageLocation(location, start, end, value);
@@ -176,90 +148,45 @@ public class HttpRequestAllPanelSyntaxHighlightTextView extends HttpPanelSyntaxH
                 return null;
             }
 
-            final boolean isBody = TextHttpMessageLocation.Location.REQUEST_BODY.equals(textLocation.getLocation());
-            
-            //As we replace all \r\n with \n we must subtract one character
-            //for each line until the line where the selection is.
-            int t = 0;
-            String header = getMessage().getRequestHeader().toString();
-            int pos = 0;
-            while ((pos = header.indexOf("\r\n", pos)) != -1) {
-                pos += 2;
-                
-                if (!isBody && pos > textLocation.getStart()) {
-                    break;
-                }
-                
-                ++t;
+            int[] pos;
+            if (TextHttpMessageLocation.Location.REQUEST_HEADER.equals(textLocation.getLocation())) {
+                pos = HttpTextViewUtils.getHeaderToViewPosition(
+                        this,
+                        getMessage().getRequestHeader().toString(),
+                        textLocation.getStart(),
+                        textLocation.getEnd());
+            } else {
+                pos = HttpTextViewUtils.getBodyToViewPosition(
+                        this,
+                        getMessage().getRequestHeader().toString(),
+                        textLocation.getStart(),
+                        textLocation.getEnd());
             }
-            
-            int start = textLocation.getStart()-t;
-            int end = textLocation.getEnd()-t;
-            
-            if (isBody) {
-                start += header.length();
-                end += header.length();
-            }
-            
-            int len = this.getText().length();
-            if (start > len || end > len) {
+
+            if (pos.length == 0) {
                 return null;
             }
 
-            textHighlight.setHighlightReference(highlight(start, end, textHighlight));
+            textHighlight.setHighlightReference(highlight(pos[0], pos[1], textHighlight));
 
             return textHighlight;
         }
 
 		@Override
 		public void search(Pattern p, List<SearchMatch> matches) {
-			HttpMessage httpMessage = getMessage();
-			//This only happens in the Request/Response Header
-			//As we replace all \r\n with \n we must add one character
-			//for each line until the line where the selection is.
-			int tHeader = 0;
-			String header = httpMessage.getRequestHeader().toString();
-			int pos = 0;
-			while ((pos = header.indexOf("\r\n", pos)) != -1) {
-				pos += 2;
-				++tHeader;
-			}
-			
-			final int headerLen = header.length();
-			final int diff = tHeader - headerLen;
-			
+			String header = getMessage().getRequestHeader().toString();
 			Matcher m = p.matcher(getText());
-			int start;
-			int end;
 			while (m.find()) {
-				start = m.start();
-				end = m.end();
-				
-				if (start+tHeader < headerLen) {
-					try {
-						start += getLineOfOffset(start);
-					} catch (BadLocationException e) {
-						//Shouldn't happen, but in case it does log it and return.
-						log.error(e.getMessage(), e);
-						return;
-					}
-					try {
-						end += getLineOfOffset(end);
-					} catch (BadLocationException e) {
-						//Shouldn't happen, but in case it does log it and return.
-						log.error(e.getMessage(), e);
-						return;
-					}
-					if (end > headerLen) {
-						end = headerLen;
-					}
-					matches.add(new SearchMatch(SearchMatch.Location.REQUEST_HEAD, start, end));
-				} else {
-					start += diff;
-					end += diff;
-				
-					matches.add(new SearchMatch(SearchMatch.Location.REQUEST_BODY, start, end));
-				}
+
+                int[] position = HttpTextViewUtils.getViewToHeaderBodyPosition(this, header, m.start(), m.end());
+                if (position.length == 0) {
+                    return;
+                }
+
+                SearchMatch.Location location = position.length == 2
+                        ? SearchMatch.Location.REQUEST_HEAD
+                        : SearchMatch.Location.REQUEST_BODY;
+                matches.add(new SearchMatch(location, position[0], position[1]));
 			}
 		}
 		
@@ -270,37 +197,26 @@ public class HttpRequestAllPanelSyntaxHighlightTextView extends HttpPanelSyntaxH
 				return;
 			}
 			
-			final boolean isBody = SearchMatch.Location.REQUEST_BODY.equals(sm.getLocation());
-			
-			//As we replace all \r\n with \n we must subtract one character
-			//for each line until the line where the selection is.
-			int t = 0;
-			String header = sm.getMessage().getRequestHeader().toString();
-			int pos = 0;
-			while ((pos = header.indexOf("\r\n", pos)) != -1) {
-				pos += 2;
-				
-				if (!isBody && pos > sm.getStart()) {
-					break;
-				}
-				
-				++t;
+			int[] pos;
+			if (SearchMatch.Location.REQUEST_HEAD.equals(sm.getLocation())) {
+				pos = HttpTextViewUtils.getHeaderToViewPosition(
+						this,
+						sm.getMessage().getRequestHeader().toString(),
+						sm.getStart(),
+						sm.getEnd());
+			} else {
+				pos = HttpTextViewUtils.getBodyToViewPosition(
+						this,
+						sm.getMessage().getRequestHeader().toString(),
+						sm.getStart(),
+						sm.getEnd());
 			}
-			
-			int start = sm.getStart()-t;
-			int end = sm.getEnd()-t;
-			
-			if (isBody) {
-				start += header.length();
-				end += header.length();
-			}
-			
-			int len = this.getText().length();
-			if (start > len || end > len) {
+
+			if (pos.length == 0) {
 				return;
 			}
 			
-			highlight(start, end);
+			highlight(pos[0], pos[1]);
 		}
 		
 		@Override

--- a/src/org/zaproxy/zap/extension/httppanel/view/util/HttpTextViewUtils.java
+++ b/src/org/zaproxy/zap/extension/httppanel/view/util/HttpTextViewUtils.java
@@ -1,0 +1,318 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.httppanel.view.util;
+
+import javax.swing.JTextArea;
+import javax.swing.text.BadLocationException;
+
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.network.HttpHeader;
+
+/**
+ * Utility methods related to text views of HTTP messages.
+ * 
+ * @since TODO add version
+ */
+public final class HttpTextViewUtils {
+
+    /**
+     * Position returned when the calculated offsets are greater than the length of the view (e.g. contents of the view do not
+     * match the header).
+     */
+    public static final int[] INVALID_POSITION = {};
+
+    private static final Logger LOGGER = Logger.getLogger(HttpTextViewUtils.class);
+
+    private HttpTextViewUtils() {
+    }
+
+    /**
+     * Gets the given {@code start} and {@code end} header positions offset to the given {@code view}.
+     * <p>
+     * The {@code view} is expected to replace the header line endings {@code \r\n} to {@code \n} (e.g. so there's no invisible
+     * newline ({@code \r}) characters when editing), as such the positions of the {@code header} need to be offset to match the
+     * ones in the {@code view}.
+     *
+     * @param view the view that contains the contents of the header
+     * @param header the header shown in the view
+     * @param start the start position
+     * @param end the end position
+     * @return the positions offset for the {@code view}, or {@link #INVALID_POSITION} if the offset positions are greater than
+     *         {@code view}'s length.
+     * @throws IllegalArgumentException if any of the conditions is true:
+     *             <ul>
+     *             <li>the {@code view} is {@code null} or it has no {@link JTextArea#getDocument() Document};</li>
+     *             <li>the {@code header} is {@code null};</li>
+     *             <li>the {@code start} position is negative or greater than the length of the {@code header};</li>
+     *             <li>the {@code end} position is negative or greater than the length of the {@code header};</li>
+     *             <li>the {@code start} position is greater than the {@code end} position.</li>
+     *             </ul>
+     * @see #getViewToHeaderPosition(JTextArea, int, int)
+     * @see #getBodyToViewPosition(JTextArea, String, int, int)
+     */
+    public static int[] getHeaderToViewPosition(JTextArea view, String header, int start, int end) {
+        validateView(view);
+        validateHeader(header);
+        validateStartEnd(start, end, header.length());
+
+        int excessChars = 0;
+
+        int pos = 0;
+        while ((pos = header.indexOf(HttpHeader.CRLF, pos)) != -1 && pos < start) {
+            pos += 2;
+            ++excessChars;
+        }
+
+        int len = view.getDocument().getLength();
+        int finalStartPos = start - excessChars;
+        if (finalStartPos > len) {
+            return INVALID_POSITION;
+        }
+
+        if (pos != -1) {
+            while ((pos = header.indexOf(HttpHeader.CRLF, pos)) != -1 && pos < end) {
+                pos += 2;
+                ++excessChars;
+            }
+        }
+
+        int finalEndPos = end - excessChars;
+        if (finalEndPos > len) {
+            return INVALID_POSITION;
+        }
+
+        return new int[] { finalStartPos, finalEndPos };
+    }
+
+    /**
+     * Validates that the given {@code view} is not {@code null} and has a {@code Document}.
+     *
+     * @param view the view to be validated
+     * @throws IllegalArgumentException if the {@code view} is {@code null} or it has no {@link JTextArea#getDocument()
+     *             Document}.
+     */
+    private static void validateView(JTextArea view) {
+        if (view == null || view.getDocument() == null) {
+            throw new IllegalArgumentException("Parameter view must not be null and must have a Document.");
+        }
+    }
+
+    /**
+     * Validates that the given {@code header} is not {@code null}.
+     *
+     * @param header the header to be validated
+     * @throws IllegalArgumentException if the {@code header} is {@code null}.
+     */
+    private static void validateHeader(String header) {
+        if (header == null) {
+            throw new IllegalArgumentException("Parameter header must not be null.");
+        }
+    }
+
+    /**
+     * Validates the given {@code start} and {@code end} positions.
+     * 
+     * @param start the start position to be validated
+     * @param end the end position to be validated
+     * @param length the length of the contents
+     * @throws IllegalArgumentException if any of the conditions is true:
+     *             <ul>
+     *             <li>the {@code start} position is negative or greater than {@code length};</li>
+     *             <li>the {@code end} position is negative or greater than {@code length};</li>
+     *             <li>the {@code start} position is greater than the {@code end} position.</li>
+     *             </ul>
+     */
+    private static void validateStartEnd(int start, int end, int length) {
+        if (start < 0) {
+            throw new IllegalArgumentException("Parameter start must not be negative.");
+        }
+        if (end < 0) {
+            throw new IllegalArgumentException("Parameter end must not be negative.");
+        }
+        if (start > end) {
+            throw new IllegalArgumentException("Parameter start must not be greater than end.");
+        }
+        if (start > length) {
+            throw new IllegalArgumentException("Parameter start must not be greater than the length.");
+        }
+        if (end > length) {
+            throw new IllegalArgumentException("Parameter end must not be greater than the length.");
+        }
+    }
+
+    /**
+     * Gets the given {@code start} and {@code end} body positions offset to the given {@code view}.
+     * <p>
+     * The {@code view} is expected to replace the header line endings {@code \r\n} to {@code \n} (e.g. so there's no invisible
+     * newline ({@code \r}) characters when editing), as such the positions of the body (shown after the header) need to be
+     * offset to match the ones in the {@code view}.
+     *
+     * @param view the view that contains the contents of the header and the body
+     * @param header the header shown in the view
+     * @param start the start position
+     * @param end the end position
+     * @return the positions offset for the {@code view}, or {@link #INVALID_POSITION} if the start and end positions are
+     *         greater than body's length.
+     * @throws IllegalArgumentException if any of the conditions is true:
+     *             <ul>
+     *             <li>the {@code view} is {@code null} or it has no {@link JTextArea#getDocument() Document};</li>
+     *             <li>the {@code header} is {@code null};</li>
+     *             <li>the {@code start} position is negative;</li>
+     *             <li>the {@code end} position is negative;</li>
+     *             <li>the {@code start} position is greater than the {@code end} position.</li>
+     *             </ul>
+     * @see #getHeaderToViewPosition(JTextArea, String, int, int)
+     * @see #getViewToHeaderBodyPosition(JTextArea, String, int, int)
+     */
+    public static int[] getBodyToViewPosition(JTextArea view, String header, int start, int end) {
+        validateView(view);
+        validateHeader(header);
+        validateStartEnd(start, end, view.getDocument().getLength());
+
+        int excessChars = 0;
+
+        int pos = 0;
+        while ((pos = header.indexOf(HttpHeader.CRLF, pos)) != -1) {
+            pos += 2;
+            ++excessChars;
+        }
+
+        int len = view.getDocument().getLength();
+        int bodyLen = len - header.length() + excessChars;
+        if (bodyLen < 0 || start > bodyLen || end > bodyLen) {
+            return INVALID_POSITION;
+        }
+
+        int finalStartPos = start + header.length() - excessChars;
+        int finalEndPos = end + header.length() - excessChars;
+        return new int[] { finalStartPos, finalEndPos };
+    }
+
+    /**
+     * Gets the given {@code start} and {@code end} view positions offset to a header.
+     * <p>
+     * The {@code view} is expected to replace the header line endings {@code \r\n} to {@code \n} (e.g. so there's no invisible
+     * newline ({@code \r}) characters when editing), as such the positions of the {@code view} need to be offset to match the
+     * ones in the header.
+     *
+     * @param view the view that contains the contents of a header
+     * @param start the start position
+     * @param end the end position
+     * @return the positions offset for the header
+     * @throws IllegalArgumentException if any of the conditions is true:
+     *             <ul>
+     *             <li>the {@code view} is {@code null} or it has no {@link JTextArea#getDocument() Document};</li>
+     *             <li>the {@code start} position is negative or greater than the length of the {@code view};</li>
+     *             <li>the {@code end} position is negative or greater than the length of the {@code view};</li>
+     *             <li>the {@code start} position is greater than the {@code end} position.</li>
+     *             </ul>
+     * @see #getHeaderToViewPosition(JTextArea, String, int, int)
+     * @see #getViewToHeaderBodyPosition(JTextArea, String, int, int)
+     */
+    public static int[] getViewToHeaderPosition(JTextArea view, int start, int end) {
+        validateView(view);
+        validateStartEnd(start, end, view.getDocument().getLength());
+        return getViewToHeaderPositionImpl(view, start, end);
+    }
+
+    /**
+     * Gets the given {@code start} and {@code end} view positions offset to a header.
+     * <p>
+     * The {@code view} is expected to replace the header line endings {@code \r\n} to {@code \n} (e.g. so there's no invisible
+     * newline ({@code \r}) characters when editing), as such the positions of the {@code view} need to be offset to match the
+     * ones in the header.
+     * <p>
+     * <strong>Note:</strong> The {@code view} and {@code start} and {@code end} positions should be validated before calling
+     * this method.
+     *
+     * @param view the view that contains the contents of a header
+     * @param start the start position
+     * @param end the end position
+     * @return the positions offset for the header
+     * @see #validateView(JTextArea)
+     * @see #validateStartEnd(int, int, int)
+     */
+    private static int[] getViewToHeaderPositionImpl(JTextArea view, int start, int end) {
+        int finalStartPos = start;
+        try {
+            finalStartPos += view.getLineOfOffset(finalStartPos);
+        } catch (BadLocationException e) {
+            // Shouldn't happen, position was already validated.
+            LOGGER.error(e.getMessage(), e);
+            return INVALID_POSITION;
+        }
+
+        int finalEndPos = end;
+        try {
+            finalEndPos += view.getLineOfOffset(finalEndPos);
+        } catch (BadLocationException e) {
+            // Shouldn't happen, position was already validated.
+            LOGGER.error(e.getMessage(), e);
+            return INVALID_POSITION;
+        }
+        return new int[] { finalStartPos, finalEndPos };
+    }
+
+    /**
+     * Gets the given {@code start} and {@code end} view positions offset to, or after, the given {@code header}.
+     * <p>
+     * The {@code view} is expected to replace the header line endings {@code \r\n} to {@code \n} (e.g. so there's no invisible
+     * newline ({@code \r}) characters when editing), as such the positions of the {@code view} need to be offset to match the
+     * ones in, or after, the {@code header}.
+     *
+     * @param view the view that contains the contents of the header and body
+     * @param header the header shown in the view
+     * @param start the start position
+     * @param end the end position
+     * @return the positions offset for the header or, 3 positions, for after the body (the third position is just to indicate
+     *         that it's the body, the value is meaningless)
+     * @throws IllegalArgumentException if any of the conditions is true:
+     *             <ul>
+     *             <li>the {@code view} is {@code null} or it has no {@link JTextArea#getDocument() Document};</li>
+     *             <li>the {@code start} position is negative or greater than the length of the {@code view};</li>
+     *             <li>the {@code end} position is negative or greater than the length of the {@code view};</li>
+     *             <li>the {@code start} position is greater than the {@code end} position.</li>
+     *             </ul>
+     */
+    public static int[] getViewToHeaderBodyPosition(JTextArea view, String header, int start, int end) {
+        validateView(view);
+        validateHeader(header);
+        validateStartEnd(start, end, view.getDocument().getLength());
+
+        int excessChars = 0;
+        int pos = 0;
+        while ((pos = header.indexOf("\r\n", pos)) != -1) {
+            pos += 2;
+            ++excessChars;
+        }
+
+        if (start + excessChars < header.length()) {
+            int[] position = getViewToHeaderPositionImpl(view, start, end);
+            if (position[1] > header.length()) {
+                position[1] = header.length();
+            }
+            return position;
+        }
+
+        int finalStartPos = start + excessChars - header.length();
+        int finalEndPos = end + excessChars - header.length();
+        return new int[] { finalStartPos, finalEndPos, 0 };
+    }
+}

--- a/test/org/zaproxy/zap/extension/httppanel/view/util/HttpTextViewUtilsUnitTest.java
+++ b/test/org/zaproxy/zap/extension/httppanel/view/util/HttpTextViewUtilsUnitTest.java
@@ -1,0 +1,554 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.httppanel.view.util;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import javax.swing.JTextArea;
+
+import org.junit.Test;
+
+/**
+ * Unit test for {@link HttpTextViewUtils}.
+ */
+public class HttpTextViewUtilsUnitTest {
+
+    private static final String HEADER = "GET /path HTTP/1.1\r\nHost: example.com\r\nX-SomeHeader: x-some-value\r\n\r\n";
+    private static final int HEADER_LENGTH = HEADER.length();
+    private static final JTextArea VIEW = new JTextArea(HEADER.replace("\r\n", "\n"));
+    private static final int VIEW_LENGTH = VIEW.getDocument().getLength();
+
+    private static final String BODY = "a=b&c=d\r\nXYZ";
+    private static final JTextArea VIEW_WITH_BODY = new JTextArea(VIEW.getText() + BODY);
+    private static final int VIEW_WITH_BODY_LENGTH = VIEW_WITH_BODY.getDocument().getLength();
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowUndefinedHeaderWhenGettingHeaderToViewPosition() {
+        // Given
+        String undefinedHeader = null;
+        // When
+        HttpTextViewUtils.getHeaderToViewPosition(VIEW, undefinedHeader, 0, 0);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowUndefinedViewWhenGettingHeaderToViewPosition() {
+        // Given
+        JTextArea undefinedView = null;
+        // When
+        HttpTextViewUtils.getHeaderToViewPosition(undefinedView, HEADER, 0, 0);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowNegativeStartWhenGettingHeaderToViewPosition() {
+        // Given / When
+        HttpTextViewUtils.getHeaderToViewPosition(VIEW, HEADER, -1, 0);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowStartGreaterThanLengthWhenGettingHeaderToViewPosition() {
+        // Given / When
+        HttpTextViewUtils.getHeaderToViewPosition(VIEW, HEADER, HEADER_LENGTH + 1, HEADER_LENGTH + 2);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowNegativeEndWhenGettingHeaderToViewPosition() {
+        // Given / When
+        HttpTextViewUtils.getHeaderToViewPosition(VIEW, HEADER, 0, -1);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowEndGreaterThanLengthWhenGettingHeaderToViewPosition() {
+        // Given / When
+        HttpTextViewUtils.getHeaderToViewPosition(VIEW, HEADER, 0, HEADER_LENGTH + 1);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowStartGreaterThanEndWhenGettingHeaderToViewPosition() {
+        // Given / When
+        HttpTextViewUtils.getHeaderToViewPosition(VIEW, HEADER, 2, 1);
+        // Then = IllegalArgumentException
+    }
+
+    @Test
+    public void shouldNotOffsetPositionsIfOnFirstHeaderLineWhenGettingHeaderToViewPosition() throws Exception {
+        // Given
+        int start = 10;
+        int end = 18;
+        // When
+        int[] pos = HttpTextViewUtils.getHeaderToViewPosition(VIEW, HEADER, start, end);
+        // Then
+        assertThat(pos.length, is(equalTo(2)));
+        assertThat(pos[0], is(equalTo(10)));
+        assertThat(pos[1], is(equalTo(18)));
+        assertThat(VIEW.getText(pos[0], pos[1] - pos[0]), is(equalTo("HTTP/1.1")));
+    }
+
+    @Test
+    public void shouldOffsetPositionNotOnFirstLineWhenGettingHeaderToViewPosition() throws Exception {
+        // Given
+        int start = 4;
+        int end = 65;
+        // When
+        int[] pos = HttpTextViewUtils.getHeaderToViewPosition(VIEW, HEADER, start, end);
+        // Then
+        assertThat(pos.length, is(equalTo(2)));
+        assertThat(pos[0], is(equalTo(4)));
+        assertThat(pos[1], is(equalTo(63)));
+        assertThat(
+                VIEW.getText(pos[0], pos[1] - pos[0]),
+                is(equalTo("/path HTTP/1.1\nHost: example.com\nX-SomeHeader: x-some-value")));
+    }
+
+    @Test
+    public void shouldOffsetPositionsPerEachLineHeaderWhenGettingHeaderToViewPosition() throws Exception {
+        // Given
+        int start = 20;
+        int end = 52;
+        // When
+        int[] pos = HttpTextViewUtils.getHeaderToViewPosition(VIEW, HEADER, start, end);
+        // Then
+        assertThat(pos.length, is(equalTo(2)));
+        assertThat(pos[0], is(equalTo(19)));
+        assertThat(pos[1], is(equalTo(50)));
+        assertThat(VIEW.getText(pos[0], pos[1] - pos[0]), is(equalTo("Host: example.com\nX-SomeHeader:")));
+    }
+
+    @Test
+    public void shouldOffsetLastLineHeaderWhenGettingHeaderToViewPosition() throws Exception {
+        // Given
+        int start = 0;
+        int end = HEADER_LENGTH;
+        // When
+        int[] pos = HttpTextViewUtils.getHeaderToViewPosition(VIEW, HEADER, start, end);
+        // Then
+        assertThat(pos.length, is(equalTo(2)));
+        assertThat(pos[0], is(equalTo(0)));
+        assertThat(pos[1], is(equalTo(VIEW_LENGTH)));
+        assertThat(
+                VIEW.getText(pos[0], pos[1]),
+                is(equalTo("GET /path HTTP/1.1\nHost: example.com\nX-SomeHeader: x-some-value\n\n")));
+    }
+
+    @Test
+    public void shouldOffsetTillLastLineHeaderWhenGettingHeaderToViewPosition() {
+        // Given
+        int start = HEADER_LENGTH;
+        int end = HEADER_LENGTH;
+        // When
+        int[] pos = HttpTextViewUtils.getHeaderToViewPosition(VIEW, HEADER, start, end);
+        // Then
+        assertThat(pos.length, is(equalTo(2)));
+        assertThat(pos[0], is(equalTo(VIEW_LENGTH)));
+        assertThat(pos[1], is(equalTo(VIEW_LENGTH)));
+    }
+
+    @Test
+    public void shouldReturnInvalidPositionIfOffsetStartIsGreaterThanViewLengthWhenGettingHeaderToViewPosition() {
+        // Given
+        JTextArea view = new JTextArea("ABC");
+        int start = 5;
+        int end = 6;
+        // When
+        int[] pos = HttpTextViewUtils.getHeaderToViewPosition(view, HEADER, start, end);
+        // Then
+        assertThat(pos, is(equalTo(HttpTextViewUtils.INVALID_POSITION)));
+    }
+
+    @Test
+    public void shouldReturnInvalidPositionIfOffsetEndIsGreaterThanViewLengthWhenGettingHeaderToViewPosition() {
+        // Given
+        JTextArea view = new JTextArea("ABC");
+        int start = 2;
+        int end = 6;
+        // When
+        int[] pos = HttpTextViewUtils.getHeaderToViewPosition(view, HEADER, start, end);
+        // Then
+        assertThat(pos, is(equalTo(HttpTextViewUtils.INVALID_POSITION)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowUndefinedViewWhenGettingViewToHeaderPosition() {
+        // Given
+        JTextArea undefinedView = null;
+        // When
+        HttpTextViewUtils.getViewToHeaderPosition(undefinedView, 0, 0);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowNegativeStartWhenGettingViewToHeaderPosition() {
+        // Given / When
+        HttpTextViewUtils.getViewToHeaderPosition(VIEW, -1, 0);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowStartGreaterThanLengthWhenGettingViewToHeaderPosition() {
+        // Given / When
+        HttpTextViewUtils.getViewToHeaderPosition(VIEW, VIEW_LENGTH + 1, VIEW_LENGTH + 2);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowNegativeEndWhenGettingViewToHeaderPosition() {
+        // Given / When
+        HttpTextViewUtils.getViewToHeaderPosition(VIEW, 0, -1);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowEndGreaterThanLengthWhenGettingViewToHeaderPosition() {
+        // Given / When
+        HttpTextViewUtils.getViewToHeaderPosition(VIEW, 0, VIEW_LENGTH + 1);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowStartGreaterThanEndWhenGettingViewToHeaderPosition() {
+        // Given / When
+        HttpTextViewUtils.getViewToHeaderPosition(VIEW, 2, 1);
+        // Then = IllegalArgumentException
+    }
+
+    @Test
+    public void shouldNotOffsetPositionsIfOnFirstHeaderLineWhenGettingViewToHeaderPosition() {
+        // Given
+        int start = 10;
+        int end = 18;
+        // When
+        int[] pos = HttpTextViewUtils.getViewToHeaderPosition(VIEW, start, end);
+        // Then
+        assertThat(pos.length, is(equalTo(2)));
+        assertThat(pos[0], is(equalTo(10)));
+        assertThat(pos[1], is(equalTo(18)));
+        assertThat(HEADER.substring(pos[0], pos[1]), is(equalTo("HTTP/1.1")));
+    }
+
+    @Test
+    public void shouldOffsetPositionNotOnFirstLineWhenGettingViewToHeaderPosition() {
+        // Given
+        int start = 4;
+        int end = 63;
+        // When
+        int[] pos = HttpTextViewUtils.getViewToHeaderPosition(VIEW, start, end);
+        // Then
+        assertThat(pos.length, is(equalTo(2)));
+        assertThat(pos[0], is(equalTo(4)));
+        assertThat(pos[1], is(equalTo(65)));
+        assertThat(
+                HEADER.substring(pos[0], pos[1]),
+                is(equalTo("/path HTTP/1.1\r\nHost: example.com\r\nX-SomeHeader: x-some-value")));
+    }
+
+    @Test
+    public void shouldOffsetPositionsPerEachLineHeaderHeaderWhenGettingViewToHeaderPosition() {
+        // Given
+        int start = 19;
+        int end = 50;
+        // When
+        int[] pos = HttpTextViewUtils.getViewToHeaderPosition(VIEW, start, end);
+        // Then
+        assertThat(pos.length, is(equalTo(2)));
+        assertThat(pos[0], is(equalTo(20)));
+        assertThat(pos[1], is(equalTo(52)));
+        assertThat(HEADER.substring(pos[0], pos[1]), is(equalTo("Host: example.com\r\nX-SomeHeader:")));
+    }
+
+    @Test
+    public void shouldOffsetLastLineHeaderWhenGettingViewToHeaderPosition() {
+        // Given
+        int start = 0;
+        int end = VIEW_LENGTH;
+        // When
+        int[] pos = HttpTextViewUtils.getViewToHeaderPosition(VIEW, start, end);
+        // Then
+        assertThat(pos.length, is(equalTo(2)));
+        assertThat(pos[0], is(equalTo(0)));
+        assertThat(pos[1], is(equalTo(HEADER_LENGTH)));
+        assertThat(
+                HEADER.substring(pos[0], pos[1]),
+                is(equalTo("GET /path HTTP/1.1\r\nHost: example.com\r\nX-SomeHeader: x-some-value\r\n\r\n")));
+    }
+
+    @Test
+    public void shouldOffsetTillLastLineHeaderWhenGettingViewToHeaderPosition() {
+        // Given
+        int start = VIEW_LENGTH;
+        int end = VIEW_LENGTH;
+        // When
+        int[] pos = HttpTextViewUtils.getViewToHeaderPosition(VIEW, start, end);
+        // Then
+        assertThat(pos.length, is(equalTo(2)));
+        assertThat(pos[0], is(equalTo(HEADER_LENGTH)));
+        assertThat(pos[1], is(equalTo(HEADER_LENGTH)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowUndefinedHeaderWhenGettingBodyToViewPosition() {
+        // Given
+        String undefinedHeader = null;
+        // When
+        HttpTextViewUtils.getBodyToViewPosition(VIEW_WITH_BODY, undefinedHeader, 0, 0);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowUndefinedViewWhenGettingBodyToViewPosition() {
+        // Given
+        JTextArea undefinedView = null;
+        // When
+        HttpTextViewUtils.getBodyToViewPosition(undefinedView, HEADER, 0, 0);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowNegativeStartWhenGettingBodyToViewPosition() {
+        // Given / When
+        HttpTextViewUtils.getBodyToViewPosition(VIEW_WITH_BODY, HEADER, -1, 0);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowStartGreaterThanLengthWhenGettingBodyToViewPosition() {
+        // Given / When
+        HttpTextViewUtils.getBodyToViewPosition(VIEW_WITH_BODY, HEADER, VIEW_WITH_BODY_LENGTH + 1, VIEW_WITH_BODY_LENGTH + 2);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowNegativeEndWhenGettingBodyToViewPosition() {
+        // Given / When
+        HttpTextViewUtils.getBodyToViewPosition(VIEW_WITH_BODY, HEADER, 0, -1);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowEndGreaterThanLengthWhenGettingBodyToViewPosition() {
+        // Given / When
+        HttpTextViewUtils.getBodyToViewPosition(VIEW_WITH_BODY, HEADER, 0, VIEW_WITH_BODY_LENGTH + 1);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowStartGreaterThanEndWhenGettingBodyToViewPosition() {
+        // Given / When
+        HttpTextViewUtils.getBodyToViewPosition(VIEW_WITH_BODY, HEADER, 2, 1);
+        // Then = IllegalArgumentException
+    }
+
+    @Test
+    public void shouldOffsetPositionsPerEachLineHeaderWhenGettingBodyToViewPosition() throws Exception {
+        // Given
+        int start = 0;
+        int end = 12;
+        // When
+        int[] pos = HttpTextViewUtils.getBodyToViewPosition(VIEW_WITH_BODY, HEADER, start, end);
+        // Then
+        assertThat(pos.length, is(equalTo(2)));
+        assertThat(pos[0], is(equalTo(65)));
+        assertThat(pos[1], is(equalTo(77)));
+        assertThat(VIEW_WITH_BODY.getText(pos[0], pos[1] - pos[0]), is(equalTo(BODY)));
+    }
+
+    @Test
+    public void shouldReturnInvalidPositionIfViewHasNoHBodyLengthWhenGettingBodyToViewPosition() {
+        // Given
+        JTextArea view = new JTextArea("AB");
+        int start = 0;
+        int end = 0;
+        // When
+        int[] pos = HttpTextViewUtils.getBodyToViewPosition(view, HEADER, start, end);
+        // Then
+        assertThat(pos, is(equalTo(HttpTextViewUtils.INVALID_POSITION)));
+    }
+
+    @Test
+    public void shouldReturnInvalidPositionIfOffsetStartIsGreaterThanViewLengthWhenGettingBodyToViewPosition() {
+        // Given
+        int start = 1;
+        int end = 2;
+        // When
+        int[] pos = HttpTextViewUtils.getBodyToViewPosition(VIEW, HEADER, start, end);
+        // Then
+        assertThat(pos, is(equalTo(HttpTextViewUtils.INVALID_POSITION)));
+    }
+
+    @Test
+    public void shouldReturnInvalidPositionIfOffsetEndIsGreaterThanViewLengthWhenGettingBodyToViewPosition() {
+        // Given
+        int start = 0;
+        int end = 1;
+        // When
+        int[] pos = HttpTextViewUtils.getBodyToViewPosition(VIEW, HEADER, start, end);
+        // Then
+        assertThat(pos, is(equalTo(HttpTextViewUtils.INVALID_POSITION)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowUndefinedHeaderWhenGettingViewToHeaderBodyPosition() {
+        // Given
+        String undefinedHeader = null;
+        // When
+        HttpTextViewUtils.getViewToHeaderBodyPosition(VIEW_WITH_BODY, undefinedHeader, 0, 0);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowUndefinedViewWhenGettingViewToHeaderBodyPosition() {
+        // Given
+        JTextArea undefinedView = null;
+        // When
+        HttpTextViewUtils.getViewToHeaderBodyPosition(undefinedView, HEADER, 0, 0);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowNegativeStartWhenGettingViewToHeaderBodyPosition() {
+        // Given / When
+        HttpTextViewUtils.getViewToHeaderBodyPosition(VIEW_WITH_BODY, HEADER, -1, 0);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowStartGreaterThanLengthWhenGettingViewToHeaderBodyPosition() {
+        // Given / When
+        HttpTextViewUtils
+                .getViewToHeaderBodyPosition(VIEW_WITH_BODY, HEADER, VIEW_WITH_BODY_LENGTH + 1, VIEW_WITH_BODY_LENGTH + 2);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowNegativeEndWhenGettingViewToHeaderBodyPosition() {
+        // Given / When
+        HttpTextViewUtils.getViewToHeaderBodyPosition(VIEW_WITH_BODY, HEADER, 0, -1);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowEndGreaterThanLengthWhenGettingViewToHeaderBodyPosition() {
+        // Given / When
+        HttpTextViewUtils.getViewToHeaderBodyPosition(VIEW_WITH_BODY, HEADER, 0, VIEW_WITH_BODY_LENGTH + 1);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowStartGreaterThanEndWhenGettingViewToHeaderBodyPosition() {
+        // Given / When
+        HttpTextViewUtils.getViewToHeaderBodyPosition(VIEW_WITH_BODY, HEADER, 2, 1);
+        // Then = IllegalArgumentException
+    }
+
+    @Test
+    public void shouldNotOffsetPositionsIfOnFirstHeaderLineWhenGettingViewToHeaderBodyPosition() {
+        // Given
+        int start = 10;
+        int end = 18;
+        // When
+        int[] pos = HttpTextViewUtils.getViewToHeaderBodyPosition(VIEW_WITH_BODY, HEADER, start, end);
+        // Then
+        assertThat(pos.length, is(equalTo(2)));
+        assertThat(pos[0], is(equalTo(10)));
+        assertThat(pos[1], is(equalTo(18)));
+        assertThat(HEADER.substring(pos[0], pos[1]), is(equalTo("HTTP/1.1")));
+    }
+
+    @Test
+    public void shouldOffsetPositionNotOnFirstLineWhenGettingViewToHeaderBodyPosition() {
+        // Given
+        int start = 4;
+        int end = 63;
+        // When
+        int[] pos = HttpTextViewUtils.getViewToHeaderBodyPosition(VIEW_WITH_BODY, HEADER, start, end);
+        // Then
+        assertThat(pos.length, is(equalTo(2)));
+        assertThat(pos[0], is(equalTo(4)));
+        assertThat(pos[1], is(equalTo(65)));
+        assertThat(
+                HEADER.substring(pos[0], pos[1]),
+                is(equalTo("/path HTTP/1.1\r\nHost: example.com\r\nX-SomeHeader: x-some-value")));
+    }
+
+    @Test
+    public void shouldOffsetPositionsPerEachLineHeaderHeaderWhenGettingViewToHeaderBodyPosition() {
+        // Given
+        int start = 19;
+        int end = 50;
+        // When
+        int[] pos = HttpTextViewUtils.getViewToHeaderBodyPosition(VIEW_WITH_BODY, HEADER, start, end);
+        // Then
+        assertThat(pos.length, is(equalTo(2)));
+        assertThat(pos[0], is(equalTo(20)));
+        assertThat(pos[1], is(equalTo(52)));
+        assertThat(HEADER.substring(pos[0], pos[1]), is(equalTo("Host: example.com\r\nX-SomeHeader:")));
+    }
+
+    @Test
+    public void shouldOffsetLastLineHeaderWhenGettingViewToHeaderBodyPosition() {
+        // Given
+        int start = 0;
+        int end = VIEW_LENGTH;
+        // When
+        int[] pos = HttpTextViewUtils.getViewToHeaderBodyPosition(VIEW_WITH_BODY, HEADER, start, end);
+        // Then
+        assertThat(pos.length, is(equalTo(2)));
+        assertThat(pos[0], is(equalTo(0)));
+        assertThat(pos[1], is(equalTo(HEADER_LENGTH)));
+        assertThat(
+                HEADER.substring(pos[0], pos[1]),
+                is(equalTo("GET /path HTTP/1.1\r\nHost: example.com\r\nX-SomeHeader: x-some-value\r\n\r\n")));
+    }
+
+    @Test
+    public void shouldTruncateEndOffsetIfGreaterThanLastLineHeaderWhenGettingViewToHeaderBodyPosition() {
+        // Given
+        int start = 0;
+        int end = VIEW_WITH_BODY_LENGTH;
+        // When
+        int[] pos = HttpTextViewUtils.getViewToHeaderBodyPosition(VIEW_WITH_BODY, HEADER, start, end);
+        // Then
+        assertThat(pos.length, is(equalTo(2)));
+        assertThat(pos[0], is(equalTo(0)));
+        assertThat(pos[1], is(equalTo(HEADER_LENGTH)));
+        assertThat(
+                HEADER.substring(pos[0], pos[1]),
+                is(equalTo("GET /path HTTP/1.1\r\nHost: example.com\r\nX-SomeHeader: x-some-value\r\n\r\n")));
+    }
+
+    @Test
+    public void shouldOffsetToBodyAfterLastLineHeaderWhenGettingViewToHeaderBodyPosition() {
+        // Given
+        int start = VIEW_LENGTH;
+        int end = VIEW_WITH_BODY_LENGTH;
+        // When
+        int[] pos = HttpTextViewUtils.getViewToHeaderBodyPosition(VIEW_WITH_BODY, HEADER, start, end);
+        // Then
+        assertThat(pos.length, is(equalTo(3)));
+        assertThat(pos[0], is(equalTo(0)));
+        assertThat(pos[1], is(equalTo(BODY.length())));
+    }
+}


### PR DESCRIPTION
Extract the calculation of offsets for view to header and header to view
into a class (HttpTextViewUtils) and changed the text views to use it,
reduces code duplication and uses the correct calculations in all cases
(some calculations were already correct).
Add tests to assert the expected behaviour of HttpTextViewUtils.

Fix #2793 - Wrong highlight in combined view with last part of request
header