### PR TITLE
Address JavaDoc issues in session/auth packages

### DIFF
--- a/src/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
@@ -104,17 +104,15 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
 		/**
 		 * Load a script and fills in the method's filled according to the values specified by the
 		 * script.
-		 * 
-		 * If an error occurs while loading the script, an {@link IllegalArgumentException} is
-		 * thrown.
-		 * 
+		 * <p>
 		 * If the method already had a loaded script and a set of values for the parameters, it
 		 * tries to provide new values for the new parameters if they match any previous parameter
 		 * names.
 		 * 
 		 * @param scriptW the script wrapper
+		 * @throws IllegalArgumentException if an error occurs while loading the script.
 		 */
-		public void loadScript(ScriptWrapper scriptW) throws IllegalArgumentException {
+		public void loadScript(ScriptWrapper scriptW) {
 			AuthenticationScript script = getScriptInterfaceV2(scriptW);
 			if (script == null) {
 				script = getScriptInterface(scriptW);

--- a/src/org/zaproxy/zap/extension/authentication/ContextAuthenticationPanel.java
+++ b/src/org/zaproxy/zap/extension/authentication/ContextAuthenticationPanel.java
@@ -151,9 +151,7 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
 	 * a parameter, nothing is shown. If the provided method type does not require configuration, a
 	 * simple message is shown stating that no configuration is needed.
 	 * 
-	 * @param newMethodType the new method type. If null, nothing is shown. If does not require
-	 *            config, a message is shown, on a panel returned by
-	 *            {@link ContextAuthenticationPanel#getNoMethodConfigurationPanel()}).
+	 * @param newMethodType the new method type. If null, nothing is shown.
 	 */
 	private void changeMethodConfigPanel(AuthenticationMethodType newMethodType) {
 		// If there's no new method, don't display anything

--- a/src/org/zaproxy/zap/extension/sessions/ContextSessionManagementPanel.java
+++ b/src/org/zaproxy/zap/extension/sessions/ContextSessionManagementPanel.java
@@ -118,9 +118,7 @@ public class ContextSessionManagementPanel extends AbstractContextPropertiesPane
 	 * a parameter, nothing is shown. If the provided method type does not require configuration, a
 	 * simple message is shown stating that no configuration is needed.
 	 * 
-	 * @param newMethodType the new method type. If null, nothing is shown. If does not require
-	 *            config, a message is shown, on a panel returned by
-	 *            {@link #getNoMethodConfigurationPanel()}).
+	 * @param newMethodType the new method type. If null, nothing is shown.
 	 */
 	private void changeMethodConfigPanel(SessionManagementMethodType newMethodType) {
 		// If there's no new method, don't display anything

--- a/src/org/zaproxy/zap/session/AbstractSessionManagementMethodOptionsPanel.java
+++ b/src/org/zaproxy/zap/session/AbstractSessionManagementMethodOptionsPanel.java
@@ -25,8 +25,8 @@ import org.zaproxy.zap.session.SessionManagementMethodType.UnsupportedSessionMan
 
 /**
  * An Options Panel that is used to configure all the settings corresponding to an
- * {@link SessionManagementMethod}.<br/>
- * <br/>
+ * {@link SessionManagementMethod}.
+ * <p>
  * This panel will be displayed to users in a separate dialog.
  */
 public abstract class AbstractSessionManagementMethodOptionsPanel extends JPanel {
@@ -44,6 +44,7 @@ public abstract class AbstractSessionManagementMethodOptionsPanel extends JPanel
 	 * (if {@link #saveMethod()} was called).
 	 * 
 	 * @param method the method to be loaded/shown in the panel.
+	 * @throws UnsupportedSessionManagementMethodException if the given method is not supported.
 	 */
 	public abstract void bindMethod(SessionManagementMethod method)
 			throws UnsupportedSessionManagementMethodException;

--- a/src/org/zaproxy/zap/session/SessionManagementMethod.java
+++ b/src/org/zaproxy/zap/session/SessionManagementMethod.java
@@ -55,25 +55,8 @@ public interface SessionManagementMethod {
 	public SessionManagementMethod clone();
 
 	/**
-	 * Identifies the web session, from a list of existing sessions, which matches the given
-	 * HttpMesage. The callers of this method <b>must</b> make sure that the provided list contains
-	 * sessions that are the same type and are adequate.
-	 * 
-	 * @param sessions the list of existing sessions for this Session Management method.
-	 * @param msg the http message
-	 * @return the matching Web Session, if any, or {@code null} otherwise
-	 * @throws UnsupportedWebSessionException if the web session type is unsupported
-	 */
-	// public WebSession identifyMatchingWebSession(List<WebSession> sessions, HttpMessage msg)
-	// throws UnsupportedWebSessionException;
-
-	/**
 	 * Extracts the web session information from a Http Message, creating a {@link WebSession}
 	 * object corresponding to the Session Management Method.
-	 * <p>
-	 * This method should not store the extracted web session. Future calls to
-	 * {@link SessionManagementMethod#setWebSession(WebSession)} will be made.
-	 * </p>
 	 * 
 	 * @param msg the msg
 	 * @return the web session

--- a/src/org/zaproxy/zap/session/SessionManagementMethodType.java
+++ b/src/org/zaproxy/zap/session/SessionManagementMethodType.java
@@ -40,12 +40,12 @@ import org.zaproxy.zap.model.Context;
 public abstract class SessionManagementMethodType {
 
 	/**
-	 * Builds a new, empty, session management method. The session mangement method should then be
+	 * Builds a new, empty, session management method. The session management method should then be
 	 * configured through its corresponding Options panel.
 	 * 
 	 * @param contextId the context id
 	 * @return the session management method
-	 * @see SessionManagementMethodType#buildOptionsPanel(SessionManagementMethod, int)
+	 * @see #buildOptionsPanel(Context)
 	 */
 	public abstract SessionManagementMethod createSessionManagementMethod(int contextId);
 
@@ -69,7 +69,7 @@ public abstract class SessionManagementMethodType {
 	 * 
 	 * @param uiSharedContext the ui shared context on which the panel should work
 	 * @return the abstract session method options panel
-	 * @see SessionManagementMethodType#hasOptionsPanel
+	 * @see #hasOptionsPanel()
 	 */
 	public abstract AbstractSessionManagementMethodOptionsPanel buildOptionsPanel(Context uiSharedContext);
 
@@ -77,7 +77,7 @@ public abstract class SessionManagementMethodType {
 	 * Checks if the corresponding {@link SessionManagementMethod} has an options panel that can be
 	 * used for configuration.
 	 * 
-	 * @see SessionManagementMethodType#buildOptionsPanel
+	 * @see #buildOptionsPanel(Context)
 	 * 
 	 * @return true, if successful
 	 */
@@ -86,7 +86,7 @@ public abstract class SessionManagementMethodType {
 	/**
 	 * Checks if is this the type for the Session Management Method provided as parameter.
 	 * 
-	 * @param methodClass the method class
+	 * @param method the method
 	 * @return true, if is type for method
 	 */
 	public abstract boolean isTypeForMethod(SessionManagementMethod method);
@@ -112,8 +112,9 @@ public abstract class SessionManagementMethodType {
 	 * session management method type.
 	 * 
 	 * @param session the session
-	 * @param context the context
+	 * @param contextId the context ID
 	 * @return the session management method
+	 * @throws DatabaseException if an error occurred while loading the authentication method
 	 */
 	public abstract SessionManagementMethod loadMethodFromSession(Session session, int contextId)
 			throws DatabaseException;
@@ -126,23 +127,23 @@ public abstract class SessionManagementMethodType {
 	 * @param method the session management method to persist
 	 * @throws UnsupportedSessionManagementMethodException the unsupported session management method
 	 *             exception
-	 * @throws DatabaseException the sQL exception
+	 * @throws DatabaseException if an error occurred while persisting the authentication method
 	 */
 	public abstract void persistMethodToSession(Session session, int contextId, SessionManagementMethod method)
-			throws UnsupportedSessionManagementMethodException, DatabaseException;
+			throws DatabaseException;
 
 	/**
 	 * Export the method to the configuration
-	 * @param config
-	 * @param sessionMethod
+	 * @param config the configurations where to export/save the session management method
+	 * @param sessionMethod the session management method to be exported
 	 */
 	public abstract void exportData(Configuration config, SessionManagementMethod sessionMethod);
 
 	/**
 	 * Import the method from the configuration
-	 * @param config
-	 * @param sessionMethod
-	 * @throws ConfigurationException
+	 * @param config the configurations from where to import/load the session management method
+	 * @param sessionMethod where to set the imported session management method data
+	 * @throws ConfigurationException if an error occurred while reading the session management method data 
 	 */
 	public abstract void importData(Configuration config, SessionManagementMethod sessionMethod) throws ConfigurationException;
 


### PR DESCRIPTION
Address JavaDoc issues in session/authentication packages, typo,
inexistent method references, commented method, missing docs on
parameters and exceptions.