### PR TITLE
Remove fragment from form's action for all methods

### DIFF
--- a/src/org/zaproxy/zap/spider/parser/SpiderHtmlFormParser.java
+++ b/src/org/zaproxy/zap/spider/parser/SpiderHtmlFormParser.java
@@ -122,6 +122,12 @@ public class SpiderHtmlFormParser extends SpiderParser {
 				continue;
 			}
 
+			// Clear the fragment, if any, as it does not have any relevance for the server
+			if (action.contains("#")) {
+				int fs = action.lastIndexOf("#");
+				action = action.substring(0, fs);
+			}
+
 			FormData formData = prepareFormDataSet(form.getFormFields());
 
 			// Process the case of a POST method
@@ -155,11 +161,6 @@ public class SpiderHtmlFormParser extends SpiderParser {
 
 			} // Process anything else as a GET method
 			else {
-				// Clear the fragment, if any, as it does not have any relevance for the server
-				if (action.contains("#")) {
-					int fs = action.lastIndexOf("#");
-					action = action.substring(0, fs);
-				}
 
 				// Process the final URL
 				if (action.contains("?")) {

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/FormActionWithFragment.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/FormActionWithFragment.html
@@ -2,11 +2,11 @@
 <html>
 <head>
 <meta charset="UTF-8">
-<title>GET Form Action With Fragment - Spider HTML Form Parser</title>
+<title>Form Action With Fragment - Spider HTML Form Parser</title>
 </head>
 <body>
 
-<form action="http://example.org#fragment" method="GET">
+<form action="http://example.org#fragment" method="%%METHOD%%">
 <input type="text" name="field1" value="Text 1" />
 <input type="text" name="field2" value="Text 2" />
 <input type="submit" name="submit" value="Submit" />


### PR DESCRIPTION
Change SpiderHtmlFormParser to remove the fragment from form's action
for all methods (POST forms should not include the fragment either).
Add tests to assert the expected behaviour.