### PR TITLE
Remove port if scheme's default in canonicalizer

### DIFF
--- a/src/org/zaproxy/zap/spider/URLCanonicalizer.java
+++ b/src/org/zaproxy/zap/spider/URLCanonicalizer.java
@@ -50,6 +50,12 @@ public final class URLCanonicalizer {
 	/** The Constant log. */
 	private static final Logger log = Logger.getLogger(URLCanonicalizer.class);
 
+	private static final String HTTP_SCHEME = "http";
+	private static final int HTTP_DEFAULT_PORT = 80;
+
+	private static final String HTTPS_SCHEME = "https";
+	private static final int HTTPS_DEFAULT_PORT = 443;
+
 	/** The Constant IRRELEVANT_PARAMETERS defining the parameter names which are ignored in the URL. */
 	private static final Set<String> IRRELEVANT_PARAMETERS = new HashSet<>(3);
 	static {
@@ -163,7 +169,7 @@ public final class URLCanonicalizer {
 
 			/* Drop default port: example.com:80 -> example.com */
 			int port = canonicalURI.getPort();
-			if (port == 80) {
+			if (isDefaultPort(canonicalURI.getScheme(), port)) {
 				port = -1;
 			}
 
@@ -180,6 +186,20 @@ public final class URLCanonicalizer {
 					+ ex.getMessage());
 			return null;
 		}
+	}
+
+	/**
+	 * Tells whether or not the given port is the default for the given scheme.
+	 * <p>
+	 * <strong>Note:</strong> Only HTTP and HTTPS schemes are taken into account.
+	 *
+	 * @param scheme the scheme
+	 * @param port the port
+	 * @return {@code true} if given the port is the default port for the given scheme, {@code false} otherwise.
+	 */
+	private static boolean isDefaultPort(String scheme, int port) {
+		return HTTP_SCHEME.equalsIgnoreCase(scheme) && port == HTTP_DEFAULT_PORT
+				|| HTTPS_SCHEME.equalsIgnoreCase(scheme) && port == HTTPS_DEFAULT_PORT;
 	}
 
 	/**

--- a/test/org/zaproxy/zap/spider/URLCanonicalizerUnitTest.java
+++ b/test/org/zaproxy/zap/spider/URLCanonicalizerUnitTest.java
@@ -37,6 +37,36 @@ public class URLCanonicalizerUnitTest {
     }
 
     @Test
+    public void shouldNotRemoveNonDefaultPortOfHttpUriWhenCanonicalizing() {
+        // Given
+        String uri = "http://example.com:443/";
+        // When
+        String canonicalizedUri = URLCanonicalizer.getCanonicalURL(uri);
+        // Then
+        assertThat(canonicalizedUri, is(equalTo("http://example.com:443/")));
+    }
+
+    @Test
+    public void shouldRemoveDefaultPortOfHttpsUriWhenCanonicalizing() {
+        // Given
+        String uri = "https://example.com:443/";
+        // When
+        String canonicalizedUri = URLCanonicalizer.getCanonicalURL(uri);
+        // Then
+        assertThat(canonicalizedUri, is(equalTo("https://example.com/")));
+    }
+
+    @Test
+    public void shouldNotRemoveNonDefaultPortOfHttpsUriWhenCanonicalizing() {
+        // Given
+        String uri = "https://example.com:80/";
+        // When
+        String canonicalizedUri = URLCanonicalizer.getCanonicalURL(uri);
+        // Then
+        assertThat(canonicalizedUri, is(equalTo("https://example.com:80/")));
+    }
+
+    @Test
     public void shouldAddEmptyPathIfUriHasNoPathWhenCanonicalizing() {
         // Given
         String uri = "http://example.com";


### PR DESCRIPTION
Change URLCanonicalizer to only remove the default port if it's the
default port of the scheme (currently checked for HTTP/S).
Add tests to assert the expected behaviour.