### PR TITLE
Correct attribute's name in HTML form parser

### DIFF
--- a/src/org/zaproxy/zap/spider/parser/SpiderHtmlFormParser.java
+++ b/src/org/zaproxy/zap/spider/parser/SpiderHtmlFormParser.java
@@ -60,6 +60,15 @@ public class SpiderHtmlFormParser extends SpiderParser {
 	private final SpiderParam param;
 
 	/**
+	 * The default {@code Date} to be used for default values of date fields.
+	 * <p>
+	 * Default is {@code null}.
+	 * 
+	 * @see #setDefaultDate(Date)
+	 */
+	private Date defaultDate;
+
+	/**
 	 * Instantiates a new spider html form parser.
 	 * 
 	 * @param param the parameters for the spider
@@ -249,7 +258,7 @@ public class SpiderHtmlFormParser extends SpiderParser {
 	 * @return a list with the values
 	 * @see #getDefaultTextValue(FormField)
 	 */
-	private static List<String> getValues(FormField field) {
+	private List<String> getValues(FormField field) {
 		if (field.getFormControl().getFormControlType().isSubmit()) {
 			return new ArrayList<>(field.getPredefinedValues());
 		}
@@ -329,8 +338,9 @@ public class SpiderHtmlFormParser extends SpiderParser {
 	 * 
 	 * @param field the field
 	 * @return the default text value
+	 * @see #getDefaultDate()
 	 */
-	private static String getDefaultTextValue(FormField field) {
+	private String getDefaultTextValue(FormField field) {
 		FormControl fc = field.getFormControl();
 		if (fc.getFormControlType() == FormControlType.TEXT) {
 			// If the control type was reduced to a TEXT type by the Jericho library, check the
@@ -345,7 +355,7 @@ public class SpiderHtmlFormParser extends SpiderParser {
 				if (min != null) {
 					return min;
 				}
-				String max = fc.getAttributesMap().get("min");
+				String max = fc.getAttributesMap().get("max");
 				if (max != null) {
 					return max;
 				}
@@ -370,27 +380,27 @@ public class SpiderHtmlFormParser extends SpiderParser {
 
 			if (type.equalsIgnoreCase("datetime")) {
 				SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-				return format.format(new Date());
+				return format.format(getDefaultDate());
 			}
 			if (type.equalsIgnoreCase("datetime-local")) {
 				SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-				return format.format(new Date());
+				return format.format(getDefaultDate());
 			}
 			if (type.equalsIgnoreCase("date")) {
 				SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
-				return format.format(new Date());
+				return format.format(getDefaultDate());
 			}
 			if (type.equalsIgnoreCase("time")) {
 				SimpleDateFormat format = new SimpleDateFormat("HH:mm:ss");
-				return format.format(new Date());
+				return format.format(getDefaultDate());
 			}
 			if (type.equalsIgnoreCase("month")) {
 				SimpleDateFormat format = new SimpleDateFormat("yyyy-MM");
-				return format.format(new Date());
+				return format.format(getDefaultDate());
 			}
 			if (type.equalsIgnoreCase("week")) {
 				SimpleDateFormat format = new SimpleDateFormat("yyyy-'W'ww");
-				return format.format(new Date());
+				return format.format(getDefaultDate());
 			}
 		} else if (fc.getFormControlType() == FormControlType.PASSWORD) {
 			return DEFAULT_PASS_VALUE;
@@ -398,6 +408,31 @@ public class SpiderHtmlFormParser extends SpiderParser {
 			return DEFAULT_FILE_VALUE;
 		}
 		return DEFAULT_EMPTY_VALUE;
+	}
+
+	/**
+	 * Gets the default {@code Date}, to be used for default values of date fields.
+	 *
+	 * @return the date, never {@code null}.
+	 * @see #setDefaultDate(Date)
+	 */
+	private Date getDefaultDate() {
+		if (defaultDate == null) {
+			return new Date();
+		}
+		return defaultDate;
+	}
+
+	/**
+	 * Sets the default {@code Date}, to be used for default values of date fields.
+	 * <p>
+	 * If none ({@code null}) is set it's used the current date when generating the values for the fields.
+	 *
+	 * @param date the default date, might be {@code null}.
+	 * @since TODO add version
+	 */
+	public void setDefaultDate(Date date) {
+		this.defaultDate = date;
 	}
 
 	/**

--- a/test/org/zaproxy/zap/spider/parser/SpiderHtmlFormParserUnitTest.java
+++ b/test/org/zaproxy/zap/spider/parser/SpiderHtmlFormParserUnitTest.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.assertThat;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import org.apache.log4j.Logger;
 import org.apache.log4j.varia.NullAppender;
@@ -708,6 +710,80 @@ public class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
         assertThat(
                 listener.getResourcesFound(),
                 contains(postResource(msg, 1, "https://example.com/search", "q=Search&submit=Submit")));
+    }
+
+    @Test
+    public void shouldSetValuesToFieldsWithNoValueWhenParsingGetForm() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        Date date = new Date(1474370354555L);
+        htmlParser.setDefaultDate(date);
+        HttpMessage msg = createMessageWith("GET", "FormNoDefaultValues.html");
+        Source source = createSource(msg);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(msg, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfResourcesFound(), is(equalTo(9)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "http://example.org/?_file=test_file.txt&_hidden&_no-type=ZAP&_password=ZAP&_text=ZAP&submit=Submit",
+                        "http://example.org/html5/number?_number=1&_number-max=2&_number-min=1&submit=Submit",
+                        "http://example.org/html5/range?_range=1&_range-max=4&_range-min=3&submit=Submit",
+                        "http://example.org/html5/misc?_color=%23ffffff&_email=foo-bar%40example.com&_tel=9999999999&_url=http%3A%2F%2Fwww.example.com&submit=Submit",
+                        "http://example.org/unknown?_unknown&submit=Submit",
+                        "http://example.org/selects?_select-one-option=first-option&_select-selected-option=selected-option&_select-two-options=last-option&submit=Submit",
+                        "http://example.org/radio?_radio=second-radio&submit=Submit",
+                        "http://example.org/checkbox?_checkbox=second-checkbox&submit=Submit",
+                        "http://example.org/html5/date-time?" + params(
+                                param("_date", formattedDate("yyyy-MM-dd", date)),
+                                param("_datetime", formattedDate("yyyy-MM-dd'T'HH:mm:ss'Z'", date)),
+                                param("_datetime-local", formattedDate("yyyy-MM-dd'T'HH:mm:ss", date)),
+                                param("_month", formattedDate("yyyy-MM", date)),
+                                param("_time", formattedDate("HH:mm:ss", date)),
+                                param("_week", formattedDate("yyyy-'W'ww", date)),
+                                param("submit", "Submit"))));
+    }
+
+    @Test
+    public void shouldSetValuesToFieldsWithNoValueWhenParsingPostForm() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        Date date = new Date(1474370354555L);
+        htmlParser.setDefaultDate(date);
+        HttpMessage msg = createMessageWith("POST", "FormNoDefaultValues.html");
+        Source source = createSource(msg);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(msg, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfResourcesFound(), is(equalTo(9)));
+        assertThat(listener.getResourcesFound(), contains(
+                postResource(msg, 1, "http://example.org/", "_hidden=&_no-type=ZAP&_text=ZAP&_password=ZAP&_file=test_file.txt&submit=Submit"),
+                postResource(msg, 1, "http://example.org/html5/number", "_number=1&_number-min=1&_number-max=2&submit=Submit"),
+                postResource(msg, 1, "http://example.org/html5/range", "_range=1&_range-min=3&_range-max=4&submit=Submit"),
+                postResource(msg, 1, "http://example.org/html5/misc", "_url=http%3A%2F%2Fwww.example.com&_email=foo-bar%40example.com&_color=%23ffffff&_tel=9999999999&submit=Submit"),
+                postResource(msg, 1, "http://example.org/unknown", "_unknown=&submit=Submit"),
+                postResource(msg, 1, "http://example.org/selects", "_select-one-option=first-option&_select-two-options=last-option&_select-selected-option=selected-option&submit=Submit"),
+                postResource(msg, 1, "http://example.org/radio", "_radio=second-radio&submit=Submit"),
+                postResource(msg, 1, "http://example.org/checkbox", "_checkbox=second-checkbox&submit=Submit"),
+                postResource(msg, 1, "http://example.org/html5/date-time", params(
+                        param("_datetime", formattedDate("yyyy-MM-dd'T'HH:mm:ss'Z'", date)),
+                        param("_datetime-local", formattedDate("yyyy-MM-dd'T'HH:mm:ss", date)),
+                        param("_date", formattedDate("yyyy-MM-dd", date)),
+                        param("_time", formattedDate("HH:mm:ss", date)),
+                        param("_month", formattedDate("yyyy-MM", date)),
+                        param("_week", formattedDate("yyyy-'W'ww", date)),
+                        param("submit", "Submit")))));
+    }
+
+    private static String formattedDate(String format, Date date) {
+        return new SimpleDateFormat(format).format(date);
     }
 
     private SpiderHtmlFormParser createSpiderHtmlFormParser() {

--- a/test/org/zaproxy/zap/spider/parser/SpiderParserTestUtils.java
+++ b/test/org/zaproxy/zap/spider/parser/SpiderParserTestUtils.java
@@ -20,6 +20,8 @@
 package org.zaproxy.zap.spider.parser;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -120,6 +122,30 @@ public class SpiderParserTestUtils {
 
     public static SpiderResource postResource(HttpMessage message, int depth, String uri, String requestBody) {
         return new SpiderResource(message, depth, uri, requestBody);
+    }
+
+    public static String params(String... params) {
+        if (params == null || params.length == 0) {
+            return "";
+        }
+
+        StringBuilder strBuilder = new StringBuilder();
+        for (String param : params) {
+            if (strBuilder.length() > 0) {
+                strBuilder.append('&');
+            }
+            strBuilder.append(param);
+        }
+        return strBuilder.toString();
+    }
+
+    public static String param(String name, String value) {
+        try {
+            return URLEncoder.encode(name, StandardCharsets.UTF_8.name()) + "="
+                    + URLEncoder.encode(value, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public static class SpiderResource {

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/FormNoDefaultValues.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/FormNoDefaultValues.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Form No Default Values - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<form action="http://example.org" method="%%METHOD%%">
+<input name="_hidden" type="hidden" />
+<input name="_no-type" />
+<input name="_text" type="text" />
+<input name="_password" type="password" />
+<input name="_file" type="file" />
+<input name="submit" type="submit" value="Submit" />
+</form>
+
+<form action="http://example.org/html5/number" method="%%METHOD%%">
+<input name="_number" type="number" />
+<input name="_number-min" type="number" min="1" />
+<input name="_number-max" type="number" max="2" />
+<input name="submit" type="submit" value="Submit" />
+</form>
+
+<form action="http://example.org/html5/range" method="%%METHOD%%">
+<input name="_range" type="range" />
+<input name="_range-min" type="range" min="3" />
+<input name="_range-max" type="range" max="4" />
+<input name="submit" type="submit" value="Submit" />
+</form>
+
+<form action="http://example.org/html5/misc" method="%%METHOD%%">
+<input name="_url" type="url" />
+<input name="_email" type="email" />
+<input name="_color" type="color" />
+<input name="_tel" type="tel" />
+<input name="submit" type="submit" value="Submit" />
+</form>
+
+<form action="http://example.org/unknown" method="%%METHOD%%">
+<input name="_unknown" type="_unknown_" />
+<input name="submit" type="submit" value="Submit" />
+</form>
+
+<form action="http://example.org/selects" method="%%METHOD%%">
+<select name="_select-no-options">
+</select>
+<select name="_select-one-option">
+    <option value="first-option">first-option</option>
+</select>
+<select name="_select-two-options">
+    <option value="first-option">first-option</option>
+    <option value="last-option">last-option</option>
+</select>
+<select name="_select-selected-option">
+    <option value="first-option">first-option</option>
+    <option value="selected-option" selected="selected">selected-option</option>
+    <option value="last-option">last-option</option>
+</select>
+<input name="submit" type="submit" value="Submit" />
+</form>
+
+<form action="http://example.org/radio" method="%%METHOD%%">
+<input name="_radio" type="radio" value="first-radio" />
+<input name="_radio" type="radio" value="second-radio" />
+<input name="submit" type="submit" value="Submit" />
+</form>
+
+<form action="http://example.org/checkbox" method="%%METHOD%%">
+<input name="_checkbox" type="checkbox" value="first-checkbox" />
+<input name="_checkbox" type="checkbox" value="second-checkbox" />
+<input name="submit" type="submit" value="Submit" />
+</form>
+
+<form action="http://example.org/html5/date-time" method="%%METHOD%%">
+<input name="_datetime" type="datetime" />
+<input name="_datetime-local" type="datetime-local" />
+<input name="_date" type="date" />
+<input name="_time" type="time" />
+<input name="_month" type="month" />
+<input name="_week" type="week" />
+<input name="submit" type="submit" value="Submit" />
+</form>
+
+</body>
+</html>


### PR DESCRIPTION
Correct the name of an attribute (max instead of min) for number/range
fields in SpiderHtmlFormParser.
Change SpiderHtmlFormParser to allow to set the date used for default
values of the form fields (easier to test).
Add tests to assert the expected behaviour of the expected values set to
the form fields.