### PR TITLE
Log exceptions' stack trace on class loading error

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnLoader.java
@@ -805,7 +805,7 @@ public class AddOnLoader extends URLClassLoader {
                 }
             } catch (Throwable e) {
             	// Often not an error
-            	logger.debug(e.getMessage());
+            	logger.debug(e.getMessage(), e);
             }
         }
         return listClass;

--- a/src/org/zaproxy/zap/control/AddOnLoaderUtils.java
+++ b/src/org/zaproxy/zap/control/AddOnLoaderUtils.java
@@ -112,7 +112,7 @@ final class AddOnLoaderUtils {
             T instance = c.newInstance();
             return instance;
         } catch (Exception e) {
-            LOGGER.debug(e.getMessage());
+            LOGGER.debug(e.getMessage(), e);
         }
         return null;
     }


### PR DESCRIPTION
Change classes AddOnLoader and AddOnLoaderUtils to also log the
exception stack trace when failed to instantiate the classes (e.g.
extensions, passive/active scanners...). The exception stack trace gives
more clues to what the problem might be since the exception's message
might be empty leading to log just:
 DEBUG org.zaproxy.zap.control.AddOnLoaderUtils  -

which is not helpful.
 ---
Related to discussion in OWASP ZAP Developer Group: https://groups.google.com/d/topic/zaproxy-develop/jEAWmD_Df98/discussion