### PR TITLE
Tidy up JavaDoc of some classes/methods

### DIFF
--- a/src/org/apache/commons/httpclient/HttpMethodBase.java
+++ b/src/org/apache/commons/httpclient/HttpMethodBase.java
@@ -1848,7 +1848,6 @@ public abstract class HttpMethodBase implements HttpMethod {
      * Subclasses may want to override one or more of the above methods to to
      * customize the processing. (Or they may choose to override this method
      * if dramatically different processing is required.)
-     * </p>
      *
      * @param state the {@link HttpState state} information associated with this method
      * @param conn the {@link HttpConnection connection} used to execute

--- a/src/org/parosproxy/paros/CommandLine.java
+++ b/src/org/parosproxy/paros/CommandLine.java
@@ -32,6 +32,7 @@
 // ZAP: 2015/04/02 Issue 321: Support multiple databases and Issue 1582: Low memory option
 // ZAP: 2015/10/06 Issue 1962: Install and update add-ons from the command line
 // ZAP: 2016/08/19 Issue 2782: Support -configfile
+// ZAP: 2016/09/22 JavaDoc tweaks
 
 package org.parosproxy.paros;
 
@@ -361,14 +362,18 @@ public class CommandLine {
     }
 
     /**
-     * @return Returns the noGUI.
+     * Tells whether or not ZAP was started with GUI.
+     * 
+     * @return {@code true} if ZAP was started with GUI, {@code false} otherwise
      */
     public boolean isGUI() {
         return GUI;
     }
 
     /**
-     * @param GUI The noGUI to set.
+     * Sets whether or not ZAP was started with GUI.
+     * 
+     * @param GUI {@code true} if ZAP was started with GUI, {@code false} otherwise
      */
     public void setGUI(boolean GUI) {
         this.GUI = GUI;
@@ -451,10 +456,9 @@ public class CommandLine {
     }
     
     /**
-     * A method for reporting informational messages in CommandLineListener.execute(..) implementations.
-     * It ensures that messages are written to the log file and/or written to stdout as appropriate.
-     * @param str
-     * @see org.parosproxy.paros.extension.CommandLineListener#execute()
+     * A method for reporting informational messages in {@link CommandLineListener#execute(CommandLineArgument[])}
+     * implementations. It ensures that messages are written to the log file and/or written to stdout as appropriate.
+     * @param str the informational message
      */
     public static void info(String str) {
     	switch (ZAP.getProcessType()) {
@@ -466,10 +470,9 @@ public class CommandLine {
     }
     
     /**
-     * A method for reporting error messages in CommandLineListener.execute(..) implementations.
+     * A method for reporting error messages in {@link CommandLineListener#execute(CommandLineArgument[])} implementations.
      * It ensures that messages are written to the log file and/or written to stderr as appropriate.
-     * @param str
-     * @see org.parosproxy.paros.extension.CommandLineListener#execute()
+     * @param str the error message
      */
     public static void error(String str) {
     	switch (ZAP.getProcessType()) {
@@ -481,10 +484,10 @@ public class CommandLine {
     }
     
     /**
-     * A method for reporting error messages in CommandLineListener.execute(..) implementations.
+     * A method for reporting error messages in {@link CommandLineListener#execute(CommandLineArgument[])} implementations.
      * It ensures that messages are written to the log file and/or written to stderr as appropriate.
-     * @param str
-     * @see org.parosproxy.paros.extension.CommandLineListener#execute()
+     * @param str the error message
+     * @param e the cause of the error
      */
     public static void error(String str, Throwable e) {
     	switch (ZAP.getProcessType()) {

--- a/src/org/parosproxy/paros/Constant.java
+++ b/src/org/parosproxy/paros/Constant.java
@@ -66,6 +66,7 @@
 // ZAP: 2016/06/07 Use filter directory in ZAP's home directory
 // ZAP: 2016/06/13 Migrate config option "proxy.modifyAcceptEncoding" 
 // ZAP: 2016/07/07 Convert passive scanners options to new structure
+// ZAP: 2016/09/22 JavaDoc tweaks
 
 package org.parosproxy.paros;
 
@@ -869,13 +870,12 @@ public final class Constant {
 	}
 
     /**
-     * Returns the system's {@code Locale} (as determined by the JVM at startup, {@code Locale#getDefault()}). Should be used to
+     * Returns the system's {@code Locale} (as determined by the JVM at startup, {@link Locale#getDefault()}). Should be used to
      * show locale dependent information in the system's locale.
      * <p>
      * <strong>Note:</strong> The default locale is overridden with the ZAP's user defined locale/language.
      *
      * @return the system's {@code Locale}
-     * @see Locale#getDefault()
      * @see Locale#setDefault(Locale)
      */
     public static Locale getSystemsLocale() {
@@ -1114,7 +1114,9 @@ public final class Constant {
     }
     
     /**
-     * Returns true if running on Kali and not a daily build 
+     * Tells whether or not ZAP is running in Kali (and it's not a daily build).
+     *
+     * @return {@code true} if running in Kali (and it's not daily build), {@code false} otherwise
      */
 	public static boolean isKali() {
 		if (onKali == null) {

--- a/src/org/parosproxy/paros/common/AbstractParam.java
+++ b/src/org/parosproxy/paros/common/AbstractParam.java
@@ -26,6 +26,7 @@
 // ZAP: 2013/05/02 Re-arranged all modifiers into Java coding standard order
 // ZAP: 2014/01/17 Issue 987: Allow arbitrary config file values to be set via the command line
 // ZAP: 2014/02/21 Issue 1043: Custom active scan dialog
+// ZAP: 2016/09/22 JavaDoc tweaks
 
 package org.parosproxy.paros.common;
 
@@ -43,8 +44,9 @@ public abstract class AbstractParam implements Cloneable {
     
     private FileConfiguration config = null;
     /**
-     * Load this param from config
-     * @param config
+     * Loads the configurations from the given configuration file.
+     * 
+     * @param config the configuration file
      */
     public void load(FileConfiguration config) {
         this.config = config;
@@ -56,13 +58,24 @@ public abstract class AbstractParam implements Cloneable {
         }
     }
     
-    public void load(String fileName) {
-    	this.load(fileName, null);
+    /**
+     * Loads the configurations from the file located at the given path.
+     * 
+     * @param filePath the path to the configuration file, might be relative.
+     */
+    public void load(String filePath) {
+    	this.load(filePath, null);
     }
     
-	public void load(String fileName, ControlOverrides overrides) {
+    /**
+     * Loads the configurations from the file located at the given path and using the given overrides
+     *
+     * @param filePath the path to the configuration file, might be relative.
+     * @param overrides the configuration overrides, might be {@code null}.
+     */
+	public void load(String filePath, ControlOverrides overrides) {
         try {
-            config = new ZapXmlConfiguration(fileName);
+            config = new ZapXmlConfiguration(filePath);
             if (overrides != null) {
                 for (Entry<String,String> entry : overrides.getConfigs().entrySet()) {
                 	logger.info("Setting config " + entry.getKey() + " = " + entry.getValue() + 
@@ -76,6 +89,11 @@ public abstract class AbstractParam implements Cloneable {
         }
 	}
 
+    /**
+     * Gets the configuration file, previously loaded.
+     *
+     * @return the configurations file
+     */
     public FileConfiguration getConfig() {
         return config;
     } 
@@ -93,8 +111,11 @@ public abstract class AbstractParam implements Cloneable {
     }
 
     /**
-     * Implement by subclass to parse the config file.
-     *
+     * Parses the configurations.
+     * <p>
+     * Called each time the configurations are loaded.
+     * 
+     * @see #getConfig()
      */
     protected abstract void parse();
 }

--- a/src/org/parosproxy/paros/common/ThreadPool.java
+++ b/src/org/parosproxy/paros/common/ThreadPool.java
@@ -19,6 +19,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 // ZAP: 2014/04/01 Changed to allow to set a name to created threads.
+// ZAP: 2016/09/22 JavaDoc tweaks
 package org.parosproxy.paros.common;
 
 
@@ -37,8 +38,11 @@ public class ThreadPool {
 	}
 
 	/**
-	Get a free thread from thread pool.  If there is no free thread, return null
-	*/
+	 * Gets a free thread from the thread pool. If there is no free thread, returns {@code null}.
+	 * 
+	 * @param runnable the {@code Runnable} to be run in the thread
+	 * @return the {@code Thread}, already started, with the given {@code Runnable}, or {@code null} if none available.
+	 */
 	public synchronized Thread getFreeThreadAndRun(Runnable runnable) {
 	    
 		for (int i=0; i<pool.length; i++) {
@@ -56,9 +60,11 @@ public class ThreadPool {
 	}
 
 	/**
-	Wait until all thread completed tasks (at most some time for each).
-	If not completed yet, do not wait.  Each thread should kill itself.
-	*/
+	 * Waits until all threads finish its tasks (at most some time for each).
+	 * <p>
+	 * If not completed yet, do not wait. Each thread should kill itself.
+	 * @param waitInMillis the number of milliseconds to wait for the threads
+	 */
 	public void waitAllThreadComplete(int waitInMillis) {
 		for (int i=0; i<pool.length; i++) {
 			if (pool[i] != null && pool[i].isAlive()) {

--- a/src/org/parosproxy/paros/core/proxy/OverrideMessageProxyListener.java
+++ b/src/org/parosproxy/paros/core/proxy/OverrideMessageProxyListener.java
@@ -49,7 +49,6 @@ public interface OverrideMessageProxyListener extends ArrangeableProxyListener {
      * <li>the message will really be forwarded to the server, even if the return value is {@code false}, as the following
      * {@code ProxyListener}s may drop it.</li>
      * </ul>
-     * </p>
      * 
      * @param msg the {@code HttpMessage} that may be overridden and not forwarded to the server
      * @return {@code true} if the message should be overridden and not forward to the server, {@code false} otherwise
@@ -70,7 +69,6 @@ public interface OverrideMessageProxyListener extends ArrangeableProxyListener {
      * <li>the message will really be forwarded to the client, even if the return value is {@code false}, as the following
      * {@code ProxyListener}s may drop it.</li>
      * </ul>
-     * </p>
      * 
      * @param msg the {@code HttpMessage} that may be forwarded to the client
      * @return {@code true} if the message should be forwarded to the client, {@code false} otherwise

--- a/src/org/parosproxy/paros/core/proxy/ProxyListener.java
+++ b/src/org/parosproxy/paros/core/proxy/ProxyListener.java
@@ -22,6 +22,7 @@
 // ZAP: 2012/03/15 Added the method getProxyListenerOrder.
 // ZAP: 2012/06/17 Documented the interface.
 // ZAP: 2012/12/27 Extend from ArrangeableListener.
+// ZAP: 2016/09/22 JavaDoc tweaks
 package org.parosproxy.paros.core.proxy;
 
 import org.parosproxy.paros.network.HttpMessage;
@@ -46,8 +47,6 @@ public interface ProxyListener extends ArrangeableProxyListener {
      * the value is {@code false} the message <i>will not</i> be forwarded and
      * no more listeners will be notified.
      * <p>
-     * 
-     * <p>
      * <strong>Note:</strong> In the presence of more than one listener there
      * are <i>no</i> guarantees that:
      * <ul>
@@ -57,7 +56,6 @@ public interface ProxyListener extends ArrangeableProxyListener {
      * return value is {@code true}, as the following listeners may return
      * {@code false}.</li>
      * </ul>
-     * </p>
      * 
      * @param msg
      *            the {@code HttpMessage} that may be forwarded to the server
@@ -77,8 +75,6 @@ public interface ProxyListener extends ArrangeableProxyListener {
      * the value is {@code false} the message <i>will not</i> be forwarded and
      * no more listeners will be notified.
      * <p>
-     * 
-     * <p>
      * <strong>Note:</strong> In the presence of more than one listener there
      * are <i>no</i> guarantees that:
      * <ul>
@@ -88,7 +84,6 @@ public interface ProxyListener extends ArrangeableProxyListener {
      * return value is {@code true}, as the following listeners may return
      * {@code false}.</li>
      * </ul>
-     * </p>
      * 
      * @param msg
      *            the {@code HttpMessage} that may be forwarded to the client

--- a/src/org/parosproxy/paros/core/proxy/ProxyServer.java
+++ b/src/org/parosproxy/paros/core/proxy/ProxyServer.java
@@ -31,6 +31,7 @@
 // ZAP: 2014/08/14 Issue 1312: Misleading error message when unable to bind the local proxy to specified address
 // ZAP: 2015/11/04 Issue 1920: Report the host:port ZAP is listening on in daemon mode, or exit if it cant
 // ZAP: 2016/05/30 Issue 2494: ZAP Proxy is not showing the HTTP CONNECT Request in history tab
+// ZAP: 2016/09/22 JavaDoc tweaks
 
 package org.parosproxy.paros.core.proxy;
 
@@ -122,8 +123,15 @@ public class ProxyServer implements Runnable {
     }
 
     /**
-     *
-     * @return	true = the server is started successfully.
+     * Starts the proxy server.
+     * <p>
+     * If the proxy server was already running it's stopped first.
+     * 
+     * @param ip the IP/address the server should bind to
+     * @param port the port
+     * @param isDynamicPort {@code true} if it should use another port if the given one is already in use, {@code false}
+     *            otherwise.
+     * @return the port the server is listening to, or {@code -1} if not able to start
      */
     public synchronized int startServer(String ip, int port, boolean isDynamicPort) {
 
@@ -203,9 +211,9 @@ public class ProxyServer implements Runnable {
     }
 
     /**
-     * Stop this server
+     * Stops the proxy server.
      *
-     * @return true if server can be stopped.
+     * @return {@code true} if the proxy server was stopped, {@code false} if it was not running.
      */
     public synchronized boolean stopServer() {
 

--- a/src/org/parosproxy/paros/core/proxy/ProxyThread.java
+++ b/src/org/parosproxy/paros/core/proxy/ProxyThread.java
@@ -61,6 +61,7 @@
 // ZAP: 2016/04/29 Adjust exception logging levels and log when timeouts happen
 // ZAP: 2016/05/30 Issue 2494: ZAP Proxy is not showing the HTTP CONNECT Request in history tab
 // ZAP: 2016/06/13 Remove all unsupported encodings (instead of just some)
+// ZAP: 2016/09/22 JavaDoc tweaks
 
 package org.parosproxy.paros.core.proxy;
 
@@ -164,7 +165,7 @@ class ProxyThread implements Runnable {
 	
 	/**
 	 * @param targethost the host where you want to connect to
-	 * @throws IOException
+	 * @throws IOException if an error occurred while establishing the SSL/TLS connection
 	 */
 	private void beginSSL(String targethost) throws IOException {
 		// ZAP: added parameter 'targethost'
@@ -553,7 +554,8 @@ class ProxyThread implements Runnable {
 	/**
 	 * Go through each observers to process a request in each observers.
 	 * The method can be modified in each observers.
-	 * @param httpMessage
+	 * @param httpMessage the request that was received from the client and may be forwarded to the server
+	 * @return {@code true} if the message should be forwarded to the server, {@code false} otherwise
 	 */
 	private boolean notifyListenerRequestSend(HttpMessage httpMessage) {
 		if (parentServer.excludeUrl(httpMessage.getRequestHeader().getURI())) {
@@ -577,7 +579,8 @@ class ProxyThread implements Runnable {
 	/**
 	 * Go thru each observers and process the http message in each observers.
 	 * The msg can be changed by each observers.
-	 * @param msg
+	 * @param httpMessage the response that was received from the server and may be forwarded to the client
+	 * @return {@code true} if the message should be forwarded to the client, {@code false} otherwise
 	 */
 	private boolean notifyListenerResponseReceive(HttpMessage httpMessage) {
 		if (parentServer.excludeUrl(httpMessage.getRequestHeader().getURI())) {
@@ -628,7 +631,7 @@ class ProxyThread implements Runnable {
 	 * Go thru each listener and offer him to take over the connection. The
 	 * first observer that returns true gets exclusive rights.
 	 * 
-	 * @param httpMessage Contains HTTP request & response.
+	 * @param httpMessage Contains HTTP request &amp; response.
 	 * @param inSocket Encapsulates the TCP connection to the browser.
 	 * @param method Provides more power to process response.
 	 * 

--- a/src/org/parosproxy/paros/db/TableHistory.java
+++ b/src/org/parosproxy/paros/db/TableHistory.java
@@ -119,16 +119,10 @@ public interface TableHistory extends DatabaseListener {
 			throws DatabaseException;
 
 	/**
-	 * Deletes all records whose history type was marked as temporary (by calling {@code setHistoryTypeTemporary(int)}).
-	 * <p>
-	 * By default the only temporary history types are {@code HistoryReference#TYPE_TEMPORARY} and
-	 * {@code HistoryReference#TYPE_SCANNER_TEMPORARY}.
+	 * Deletes all records whose history type was marked as temporary.
 	 *
 	 * @throws DatabaseException if an error occurred while deleting the temporary history records
-	 * @see #setHistoryTypeAsTemporary(int)
-	 * @see #unsetHistoryTypeAsTemporary(int)
-	 * @see HistoryReference#TYPE_TEMPORARY
-	 * @see HistoryReference#TYPE_SCANNER_TEMPORARY
+	 * @see HistoryReference#getTemporaryTypes()
 	 */
 	void deleteTemporary() throws DatabaseException;
 

--- a/src/org/parosproxy/paros/extension/CommandLineListener.java
+++ b/src/org/parosproxy/paros/extension/CommandLineListener.java
@@ -32,6 +32,7 @@ import java.util.List;
 public interface CommandLineListener {
     /**
      * execute the command line using the argument provided.
+     * @param args the command line arguments
      */
     void execute(CommandLineArgument[] args);
     
@@ -39,14 +40,14 @@ public interface CommandLineListener {
      * Handle the specified file (in whatever way is appropriate).
      * This will only be called for files specified on the command line without switches 
      * and which match one of the extensions returned by getHandledExtensions() 
-     * @param file
+     * @param file the file provided through the command line
      * @return true if the listener handled the file, false otherwise
      */
     boolean handleFile (File file);
     
     /**
      * Get the list of extensions this listener can handle
-     * @return
+     * @return a {@code List} with the handled extensions
      */
     List<String> getHandledExtensions();
 

--- a/src/org/parosproxy/paros/extension/SessionChangedListener.java
+++ b/src/org/parosproxy/paros/extension/SessionChangedListener.java
@@ -22,6 +22,7 @@
 // ZAP: 2012/07/29 Issue 43: added sessionScopeChanged event
 // ZAP: 2012/08/01 Issue 332: added support for Modes
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
+// ZAP: 2016/09/22 JavaDoc tweaks
 
 package org.parosproxy.paros.extension;
 
@@ -33,16 +34,16 @@ public interface SessionChangedListener {
      * Called just after the session has changed.
      * sessionChanged may be called by non-event thread.  Should handle with care in
      * all the listener.  Use EventThread for each GUI event.
-     * @param session
+     * @param session the new session
      */
     void sessionChanged(Session session);
     
     /**
      * Called just prior to the session changing.
-     * Listeners should close down any resources associaited with this session. 
+     * Listeners should close down any resources associated with this session. 
      * sessionAboutToChange may be called by non-event thread.  Should handle with care in
      * all the listener.  Use EventThread for each GUI event.
-     * @param session
+     * @param session the session about to be closed
      */
     void sessionAboutToChange(Session session);
     
@@ -50,7 +51,7 @@ public interface SessionChangedListener {
      * Called when the user has changes the session scope.
      * sessionScopeChanged may be called by non-event thread.  Should handle with care in
      * all the listener.  Use EventThread for each GUI event.
-     * @param session
+     * @param session the current session
      */
     void sessionScopeChanged(Session session);
     
@@ -58,7 +59,7 @@ public interface SessionChangedListener {
      * Called when the user changes the mode.
      * sessionModeChanged may be called by non-event thread.  Should handle with care in
      * all the listener.  Use EventThread for each GUI event.
-     * @param mode
+     * @param mode the new mode
      */
     void sessionModeChanged(Mode mode);
     

--- a/src/org/parosproxy/paros/security/SslCertificateServiceImpl.java
+++ b/src/org/parosproxy/paros/security/SslCertificateServiceImpl.java
@@ -69,7 +69,6 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
  * At least, Firefox v3.x does.
  *
  * @author MaWoKi
- * @see org.bouncycastle.x509.examples.AttrCertExample how to manage CAs and stuff
  * @see CachedSslCertifificateServiceImpl for a cached SslCertificateService
  */
 public final class SslCertificateServiceImpl implements SslCertificateService {
@@ -164,8 +163,8 @@ public final class SslCertificateServiceImpl implements SslCertificateService {
 	/**
 	 * Generates a 2048 bit RSA key pair using SHA1PRNG.
 	 *
-	 * @return
-	 * @throws NoSuchAlgorithmException
+	 * @return the key pair
+	 * @throws NoSuchAlgorithmException if no provider supports the used algorithms.
 	 */
 	private KeyPair createKeyPair() throws NoSuchAlgorithmException {
 		final KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");

--- a/src/org/zaproxy/zap/GuiBootstrap.java
+++ b/src/org/zaproxy/zap/GuiBootstrap.java
@@ -393,11 +393,11 @@ public class GuiBootstrap extends ZapBootstrap {
     /**
      * Determines the {@link Locale} of the current user's system.
      * <p>
-     * It will match the {@link Constant#getSystemsLocale()} with the available locales from ZAPs translation files.
+     * It will match the {@link Constant#getSystemsLocale()} with the available locales from ZAP's translation files.
      * <p>
-     * It may return {@code null}, if the users system locale is not in the list of available translations of ZAP.
+     * It may return {@code null}, if the user's system locale is not in the list of available translations of ZAP.
      *
-     * @return
+     * @return the {@code Locale} that best matches the user's locale, or {@code null} if none found
      */
     private static Locale determineUsersSystemLocale() {
         Locale userloc = null;

--- a/src/org/zaproxy/zap/ZapGetMethod.java
+++ b/src/org/zaproxy/zap/ZapGetMethod.java
@@ -33,7 +33,7 @@ import org.apache.commons.logging.LogFactory;
 import org.zaproxy.zap.network.ZapHttpParser;
 
 /**
- * Do not ignore HTTP status code of 101 and keep {@link Socket} &
+ * Do not ignore HTTP status code of 101 and keep {@link Socket} &amp;
  * {@link InputStream} open, as 101 states a protocol switch.
  * 
  * Is essential for the WebSockets extension.
@@ -66,7 +66,7 @@ public class ZapGetMethod extends GetMethod {
 	/**
 	 * Constructor.
 	 * 
-	 * @param uri
+	 * @param uri the request URI
 	 */
 	public ZapGetMethod(String uri) {
 		super(uri);

--- a/src/org/zaproxy/zap/ZapHttpConnection.java
+++ b/src/org/zaproxy/zap/ZapHttpConnection.java
@@ -50,7 +50,7 @@ public class ZapHttpConnection extends HttpConnection {
 	}
 	
 	/**
-	 * Avoid closing in- & output stream as that would close the underlying
+	 * Avoid closing in- &amp; output stream as that would close the underlying
 	 * socket also. We have to keep it for our WebSocket connection.
 	 */
 	@Override

--- a/src/org/zaproxy/zap/control/AddOnLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnLoader.java
@@ -812,8 +812,10 @@ public class AddOnLoader extends URLClassLoader {
 	}
 
     /**
-     * Check local jar (paros.jar) or related package if any target file is found.
-     *
+     * Check local jar (zap.jar) or related package if any target file is found.
+     * 
+     * @param packageName the package name that the class must belong too
+     * @return a {@code List} with all the classes belonging to the given package
      */
     private List<ClassNameWrapper> getLocalClassNames (String packageName) {
     

--- a/src/org/zaproxy/zap/control/ExtensionFactory.java
+++ b/src/org/zaproxy/zap/control/ExtensionFactory.java
@@ -286,6 +286,7 @@ public class ExtensionFactory {
     /**
      * If there are help files within the extension, they are loaded and merged
      * with existing help files if the core help was correctly loaded.
+     * @param ext the extension being initialised
      */
     private static void intitializeHelpSet(Extension ext) {
         HelpBroker hb = ExtensionHelp.getHelpBroker();
@@ -417,7 +418,6 @@ public class ExtensionFactory {
      * </pre>
      *
      * The URL of the first existent resource is returned.
-     * </p>
      *
      * @param cl the class loader that will be used to get the resource,
      * {@code null} the system class loader is used.

--- a/src/org/zaproxy/zap/extension/ExtensionPopupMenu.java
+++ b/src/org/zaproxy/zap/extension/ExtensionPopupMenu.java
@@ -114,7 +114,6 @@ public class ExtensionPopupMenu extends JMenu implements ExtensionPopupMenuCompo
 	 * {@code true};</li>
 	 * </ul>
 	 * The separators will be dynamically added and removed as needed when the pop up menu is shown.
-	 * </p>
 	 * <p>
 	 * <strong>Implementation Note:</strong> The method {@code isEnableForComponent(Component)} is called on all child
 	 * {@code ExtensionPopupMenuComponent}s, even if a previous child has returned {@code true}, as it allows to notify all the
@@ -151,7 +150,6 @@ public class ExtensionPopupMenu extends JMenu implements ExtensionPopupMenuCompo
 	 * {@code true};</li>
 	 * </ul>
 	 * The separators will be dynamically added and removed as needed when the pop up menu is shown.
-	 * </p>
 	 * 
 	 * @param invokerWrapper the wrapped invoker
 	 * @return {@code true} if at least one of the child items is enable, {@code false} otherwise.

--- a/src/org/zaproxy/zap/extension/XmlReporterExtension.java
+++ b/src/org/zaproxy/zap/extension/XmlReporterExtension.java
@@ -9,7 +9,7 @@ import org.parosproxy.paros.model.SiteNode;
 /**
  * This interface should be implemented by extensions that wish to write data to 
  * XML report. getXML() method should return well-formed XML fragment (without the
- * <?xml> declaration) . This method is called by ReportLastScan class
+ * {@code <?xml>} declaration) . This method is called by ReportLastScan class
  * @author alla
  */
 public interface XmlReporterExtension {

--- a/src/org/zaproxy/zap/extension/alert/AlertParam.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertParam.java
@@ -83,6 +83,7 @@ public class AlertParam extends AbstractParam {
 
     /**
      * Sets the maximum instances of an alert to include in a report.
+     * @param maximumInstances the maximum number of instances for each alert
      */
     public void setMaximumInstances(int maximumInstances) {
         if (this.maximumInstances != maximumInstances) {
@@ -94,6 +95,7 @@ public class AlertParam extends AbstractParam {
 
     /**
      * Returns the maximum instances of an alert to include in a report.
+     * @return the maximum number of instances for each alert
      */
     public int getMaximumInstances() {
         return maximumInstances;

--- a/src/org/zaproxy/zap/extension/alert/OptionsAlertPanel.java
+++ b/src/org/zaproxy/zap/extension/alert/OptionsAlertPanel.java
@@ -49,7 +49,6 @@ import org.zaproxy.zap.view.LayoutHelper;
  * <ul>
  * <li>The number of maximum instances of each vulnerability included in a report.</li>
  * </ul>
- * </p>
  */
 public class OptionsAlertPanel extends AbstractParamPanel {
 

--- a/src/org/zaproxy/zap/extension/alert/PopupMenuShowAlerts.java
+++ b/src/org/zaproxy/zap/extension/alert/PopupMenuShowAlerts.java
@@ -37,7 +37,9 @@ public class PopupMenuShowAlerts extends PopupMenuHistoryReferenceContainer {
 	private static final long serialVersionUID = 1L;
 
     /**
-     * @param label
+     * Constructs a {@code PopupMenuShowAlerts} with the given label.
+     * 
+     * @param label the text shown in the pop up menu
      */
     public PopupMenuShowAlerts(String label) {
         super(label);

--- a/src/org/zaproxy/zap/extension/anticsrf/PopupMenuGenerateForm.java
+++ b/src/org/zaproxy/zap/extension/anticsrf/PopupMenuGenerateForm.java
@@ -30,7 +30,9 @@ public class PopupMenuGenerateForm extends PopupMenuItemHistoryReferenceContaine
 	private static final long serialVersionUID = 1L;
 	
     /**
-     * @param label
+     * Constructs a {@code PopupMenuGenerateForm} with the given label.
+     * 
+     * @param label the text shown in the pop up menu
      */
     public PopupMenuGenerateForm(String label) {
     	super(label);

--- a/src/org/zaproxy/zap/extension/ascan/AttackModeScanner.java
+++ b/src/org/zaproxy/zap/extension/ascan/AttackModeScanner.java
@@ -337,8 +337,8 @@ public class AttackModeScanner implements EventConsumer {
 		}
 		
 		/**
-		 * Returns true if any of the scan threads are currently active
-		 * @return
+		 * Tells whether or not any of the scan threads are currently active.
+		 * @return {@code true} if there's at least one scan active, {@code false} otherwise
 		 */
 		public boolean isActive() {
 			synchronized (this.scanners) {

--- a/src/org/zaproxy/zap/extension/ascan/CustomScanPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/CustomScanPanel.java
@@ -31,32 +31,33 @@ public interface CustomScanPanel {
 	
 	/**
 	 * The i18n label to use for the panel title
-	 * @return
+	 * @return the title of the panel
 	 */
 	String getLabel();
 
 	/**
 	 * The panel to add to the custom active scan dialog
-	 * @return
+	 * @param init {@code true} if the panel should be (re)initialised, {@code false} otherwise
+	 * @return the panel that will be shown
 	 */
 	AbstractParamPanel getPanel(boolean init);
 	
 	/**
 	 * The target to use if (and only if) the user has not specified a target
 	 * Return null if a target just for the information specified in this panel does not make sense
-	 * @return
+	 * @return the target built from the panel
 	 */
 	Target getTarget();
 
 	/**
 	 * A translated error message to display if the information the user has provided in incorrect or incomplete
-	 * @return
+	 * @return a message indicating the error, {@code null} if none.
 	 */
 	String validateFields();
 	
 	/**
 	 * Any context specific objects to add to the scan - return null for none.
-	 * @return
+	 * @return an array containing custom scan objects
 	 */
 	Object[] getContextSpecificObjects();
 

--- a/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -207,6 +207,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
     /**
      * Start the scanning process beginning to a specific node 
      * @param startNode the start node where the scanning should begin to work
+     * @return the ID of the scan
      */
     public int startScan(SiteNode startNode) {
     	return this.startScan(new Target(startNode, true));

--- a/src/org/zaproxy/zap/extension/ascan/OptionsScannerPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/OptionsScannerPanel.java
@@ -65,8 +65,9 @@ public class OptionsScannerPanel extends AbstractParamPanel {
     private ExtensionActiveScan extension;
     
     /**
-     * General Constructor
-     * @param extensionn 
+     * Constructs an {@code OptionsScannerPanel} with the given active scan extension.
+     * 
+     * @param extension the active scan extension, to obtain scan policy names
      */
     public OptionsScannerPanel(ExtensionActiveScan extension) {
         super();

--- a/src/org/zaproxy/zap/extension/ascan/PolicyDialog.java
+++ b/src/org/zaproxy/zap/extension/ascan/PolicyDialog.java
@@ -67,8 +67,9 @@ public class PolicyDialog extends AbstractParamDialog {
     }
 
     /**
-     * 
-     * @param panel 
+     * Adds the given panel, positioned under the root node and in alphabetic order.
+     *
+     * @param panel the panel to add, must not be {@code null}.
      */
     public void addPolicyPanel(AbstractParamPanel panel) {
         this.additionalPanels.add(panel);

--- a/src/org/zaproxy/zap/extension/ascan/ScanProgressActionIcon.java
+++ b/src/org/zaproxy/zap/extension/ascan/ScanProgressActionIcon.java
@@ -48,8 +48,9 @@ public class ScanProgressActionIcon extends JLabel {
     private ScanProgressItem item;
 
     /**
+     * Constructs a {@code ScanProgressActionIcon} for the given scan progress item.
      *
-     * @param plugin
+     * @param item the scan progress item
      */
     public ScanProgressActionIcon(ScanProgressItem item) {
         this.item = item;
@@ -60,8 +61,9 @@ public class ScanProgressActionIcon extends JLabel {
     }
 
     /**
+     * Updates this action icon with the given scan progress item.
      * 
-     * @param item 
+     * @param item new the scan progress item
      */
     public void updateStatus(ScanProgressItem item) {
         this.item = item;


### PR DESCRIPTION
Fix typos, remove unnecessary HTML closing tags, add description to
methods and its parameters, use HTML entities and fix/remove references
to methods/classes that no longer exist.