### PR TITLE
Upgrade to use ubuntu:16.04

### DIFF
--- a/build/docker/Dockerfile-weekly
+++ b/build/docker/Dockerfile-weekly
@@ -1,5 +1,5 @@
 # This dockerfile builds the zap weekly release
-FROM ubuntu:15.04
+FROM ubuntu:16.04
 MAINTAINER Simon Bennetts "psiinon@gmail.com"
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
 
-
+RUN pip install --upgrade pip
 RUN gem install zapr
 RUN pip install zapcli
 # Install latest dev version of the python API


### PR DESCRIPTION
Fixes #2903 
The pip upgrade is required - the pip install of the API fails otherwise