### PR TITLE
Update dependencies, Fix license

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ out/
 /build/dist/
 /build/results/
 /bin/
+
+# Node
+node_modules/

--- a/nodejs/api/zapv2/package.json
+++ b/nodejs/api/zapv2/package.json
@@ -1,32 +1,27 @@
 {
   "name": "zaproxy",
   "description": "ZAProxy Client API for Node.js",
-  "version": "0.1.0",
-  "homepage": "https://github.com/TeamPraxis/node-zaproxy",
+  "version": "0.3.0",
+  "homepage": "https://github.com/zaproxy/zaproxy",
   "author": {
     "name": "Keith Hamasaki",
     "email": "khamasaki@teampraxis.com"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/TeamPraxis/node-zaproxy.git"
+    "url": "https://github.com/zaproxy/zaproxy.git"
   },
   "bugs": {
-    "url": "https://github.com/TeamPraxis/node-zaproxy/issues"
+    "url": "https://github.com/zaproxy/zaproxy/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/TeamPraxis/node-zaproxy/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "main": "index.js",
   "engines": {
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "lodash": "~2.4.1",
-    "request": "~2.36.0"
+    "lodash": "~4.16",
+    "request": "~2.75"
   },
   "keywords": [
     "zaproxy",


### PR DESCRIPTION
@khamasaki, @psiinon: As there are no automated tests for the node.js API, please review closely before merging!

I bumped the version to 0.3 because on the old(?) code location @TeamPraxis org the latest version was already 0.2 while still being 0.1 in the @zaproxy org. It seemed that the API code was generated more recently in the @zaproxy repo, so I figured this is the latest.

If everything is fine, please release to npm. And maybe @khamasaki could remove the original repo on @TeamPraxis to avoid confusion? Or at least add a note that the location was changed?
