### PR TITLE
Include the base URL in SpiderTextParser

### DIFF
--- a/src/org/zaproxy/zap/spider/URLCanonicalizer.java
+++ b/src/org/zaproxy/zap/spider/URLCanonicalizer.java
@@ -127,7 +127,7 @@ public final class URLCanonicalizer {
 			}
 
 			if (canonicalURI.getRawAuthority() == null) {
-				log.debug("Ignoring URI with no authority (host[\":\"port]): " + canonicalURI);
+				log.debug("Ignoring URI with no authority (host[\":\"port]): " + canonicalURI + " (on base " + baseURL + ")");
 				return null;
 			}
 

--- a/src/org/zaproxy/zap/spider/parser/SpiderTextParser.java
+++ b/src/org/zaproxy/zap/spider/parser/SpiderTextParser.java
@@ -38,11 +38,13 @@ public class SpiderTextParser extends SpiderParser {
 	public boolean parseResource(HttpMessage message, Source source, int depth) {
 		log.debug("Parsing a non-HTML text resource.");
 
+		String baseURL = message.getRequestHeader().getURI().toString();
+
 		// Use a simple pattern matcher to find urls
 		Matcher matcher = patternURL.matcher(message.getResponseBody().toString());
 		while (matcher.find()) {
 			String s = matcher.group(1);
-			processURL(message, depth, s, "");
+			processURL(message, depth, s, baseURL);
 		}
 
 		return false;


### PR DESCRIPTION
Change SpiderTextParser to include the base URL when processing the URLs
found in the response so if there's an error in the processing of those
URLs it's included the page were the problematic URL was found. Without
the change it would be logged:
 Error while Processing URL in the spidering process (on base ): Host
 could not be reliably evaluated from: http://example.com)

which does not give any information where the problematic URL was found.
The inclusion of base URL does not affect how the URLs are resolved, the
processed URLs are already absolute.

Tweak the class URLCanonicalizer to include the base URL when debug
logging URLs with no authority, for same reason.
 ---
Issue reported in IRC channel.