### PR TITLE
Added filterchain to parse out new line characters

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -650,7 +650,11 @@
 
 	<!-- Load the version from version.txt, set ${zap.jar} -->
 	<target name="setup">
-		<loadfile property="version" srcfile="version.txt" />
+		<loadfile property="version" srcfile="version.txt">
+			<filterchain>
+				<striplinebreaks/>
+			</filterchain>
+		</loadfile>
 		<if>
 			<equals arg1="${version}" arg2="Dev Build" />
 			<then>


### PR DESCRIPTION
Many editors automatically append new lines to the end of files.
Without this change, a trailing new line in version.txt causes the
jar created to attempt to have a newline character in the name.