### PR TITLE
Do not access EDT in daemon mode in Context class

### DIFF
--- a/src/org/zaproxy/zap/model/Context.java
+++ b/src/org/zaproxy/zap/model/Context.java
@@ -35,6 +35,7 @@ import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteMap;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.authentication.AuthenticationMethod;
 import org.zaproxy.zap.authentication.ManualAuthenticationMethodType.ManualAuthenticationMethod;
 import org.zaproxy.zap.extension.authorization.AuthorizationDetectionMethod;
@@ -556,7 +557,7 @@ public class Context {
 	}
 
 	public void restructureSiteTree() {
-        if (EventQueue.isDispatchThread()) {
+        if (!View.isInitialised() || EventQueue.isDispatchThread()) {
         	restructureSiteTreeEventHandler();
         } else {
             try {


### PR DESCRIPTION
Change Context class to not access the EDT if the view is not
initialised, when restructuring the sites tree.