### PR TITLE
Change ZAP API to read/use the request body

### DIFF
--- a/src/org/zaproxy/zap/extension/api/API.java
+++ b/src/org/zaproxy/zap/extension/api/API.java
@@ -201,6 +201,9 @@ public class API {
 
 		HttpMessage msg = new HttpMessage();
 		msg.setRequestHeader(requestHeader);
+		if (requestHeader.getContentLength() > 0) {
+			msg.setRequestBody(httpIn.readRequestBody(requestHeader));
+		}
 		String component = null;
 		ApiImplementor impl = null;
 		RequestType reqType = null;


### PR DESCRIPTION
Change API class to read/use the request body as that might be required
for some API endpoints (e.g. "other" which might use the whole HTTP
request).
 ---
From talks in IRC channel.