### PR TITLE
Minor tidy up in context related panels

### DIFF
--- a/src/org/zaproxy/zap/view/ContextExcludePanel.java
+++ b/src/org/zaproxy/zap/view/ContextExcludePanel.java
@@ -56,23 +56,25 @@ public class ContextExcludePanel extends AbstractContextPropertiesPanel {
 	}
 	
     /**
+     * Gets the name of the panel for the given context.
+     * 
+     * @param context the context
+     * @return the name of the panel
      * @deprecated (2.2.0) Replaced by {@link #getPanelName(int)}. It will be removed in a future release.
      */
     @Deprecated
-    @SuppressWarnings("javadoc")
     public static String getPanelName(Context context) {
         return getPanelName(context.getIndex());
     }
 
+    /**
+     * Constructs a {@code ContextIncludePanel} for the given context.
+     * 
+     * @param context the target context, must not be {@code null}.
+     */
     public ContextExcludePanel(Context context) {
         super(context.getIndex());
- 		initialize();
-   }
-    
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
+
         regexesPanel = new MultipleRegexesOptionsPanel(View.getSingleton().getSessionDialog());
 
         this.setLayout(new CardLayout());

--- a/src/org/zaproxy/zap/view/ContextGeneralPanel.java
+++ b/src/org/zaproxy/zap/view/ContextGeneralPanel.java
@@ -32,16 +32,16 @@ public class ContextGeneralPanel extends AbstractContextPropertiesPanel {
 		return index + ":" + name;
 	}
 
-	public ContextGeneralPanel(String name, int index) {
-		super(index);
-		this.setName(name);
-		initialize();
-	}
-
 	/**
-	 * This method initializes this
+	 * Constructs a {@code ContextGeneralPanel} for the given context.
+	 * 
+	 * @param name the name of the panel
+	 * @param contextId the context id
 	 */
-	private void initialize() {
+	public ContextGeneralPanel(String name, int contextId) {
+		super(contextId);
+		this.setName(name);
+
 		this.setLayout(new CardLayout());
 		this.add(getPanelSession(), this.getName() + "gen");
 	}

--- a/src/org/zaproxy/zap/view/ContextIncludePanel.java
+++ b/src/org/zaproxy/zap/view/ContextIncludePanel.java
@@ -56,23 +56,25 @@ public class ContextIncludePanel extends AbstractContextPropertiesPanel {
 	}
 
     /**
+     * Gets the name of the panel for the given context.
+     * 
+     * @param context the context
+     * @return the name of the panel
      * @deprecated (2.2.0) Replaced by {@link #getPanelName(int)}. It will be removed in a future release.
      */
     @Deprecated
-    @SuppressWarnings("javadoc")
     public static String getPanelName(Context context) {
         return getPanelName(context.getIndex());
     }
 
+	/**
+	 * Constructs a {@code ContextIncludePanel} for the given context.
+	 * 
+	 * @param context the target context, must not be {@code null}.
+	 */
 	public ContextIncludePanel(Context context) {
 		super(context.getIndex());
-		initialize();
-	}
 
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
 		regexesPanel = new MultipleRegexesOptionsPanel(View.getSingleton().getSessionDialog());
 
 		this.setLayout(new CardLayout());

--- a/src/org/zaproxy/zap/view/ContextStructurePanel.java
+++ b/src/org/zaproxy/zap/view/ContextStructurePanel.java
@@ -60,10 +60,10 @@ public class ContextStructurePanel extends AbstractContextPropertiesPanel {
 	private ZapTextField postKvPairSeparators = null;
 
 	/**
-	 * Returns the name of the panel "Structure" for the given {@code contextIndex}.
+	 * Returns the name of the panel "Structure" for the given context index.
 	 * 
-	 * @param contextIndex the context index that will be used to create the name of the panel
-	 * @return the name of the panel "Include in context" for the given {@code contextIndex}
+	 * @param contextId the context index that will be used to create the name of the panel
+	 * @return the name of the panel "Include in context" for the given context index
 	 * @since 2.2.0
 	 * @see Context#getIndex()
 	 */
@@ -72,15 +72,16 @@ public class ContextStructurePanel extends AbstractContextPropertiesPanel {
 		return contextId + ": " + PANEL_NAME;
 	}
 
+	/**
+	 * Constructs a {@code ContextStructurePanel} for the given context.
+	 * 
+	 * @param context the target context, must not be {@code null}.
+	 */
 	public ContextStructurePanel(Context context) {
 		super(context.getIndex());
-		initialize();
-	}
 
-	private void initialize() {
 		this.setLayout(new CardLayout());
 		this.setName(getPanelName(this.getContextIndex()));
-		//this.add(new JScrollPane(getPanel()), getPanel().getName());
 		this.add(getPanel(), getPanel().getName());
 	}
 
@@ -219,6 +220,8 @@ public class ContextStructurePanel extends AbstractContextPropertiesPanel {
 	 * Save the data from this panel to the provided context.
 	 *
 	 * @param context the context
+	 * @param updateSiteStructure {@code true} if the nodes of the context should be restructured, {@code false} otherwise
+	 * @see Context#restructureSiteTree()
 	 */
 	private void saveToContext(Context context, boolean updateSiteStructure) {
 		ParameterParser urlParamParser = context.getUrlParamParser();


### PR DESCRIPTION
Add JavaDoc to constructors and other undocumented parameters.
Merge "initialize" methods into the constructors (and remove commented
statement).
Correct the name of a parameter.