### PR TITLE
Attempt to determine (String) body's charset

### DIFF
--- a/src/org/parosproxy/paros/network/HttpBody.java
+++ b/src/org/parosproxy/paros/network/HttpBody.java
@@ -22,6 +22,7 @@
 // ZAP: 2012/03/15 Changed to use byte[] instead of StringBuffer.
 // ZAP: 2014/11/26 Issue: 1415 Fixed file uploads > 128k
 // ZAP: 2016/05/18 Always use charset set when changing the HTTP body
+// ZAP: 2016/10/18 Attempt to determine the charset when setting a String with unknown charset
 
 package org.parosproxy.paros.network;
 
@@ -150,10 +151,29 @@ public abstract class HttpBody {
 		}
 		
 		cachedString = null;
+		if (charset == null) {
+			// Attempt to determine the charset to avoid data loss.
+			charset = determineCharset(contents);
+		}
 		
 		body = contents.getBytes(getCharsetImpl());
 		
 		pos = body.length;
+	}
+
+	/**
+	 * Determines the {@code Charset} of the given {@code contents}, that are being set to the body.
+	 * <p>
+	 * An attempt to prevent data loss when {@link #setBody(String) new contents} are set without a {@code Charset}.
+	 * <p>
+	 * By default returns {@code null}.
+	 * 
+	 * @param contents the contents being set to the body
+	 * @return the {@code Charset}, or {@code null} if not known.
+	 * @since TODO add version
+	 */
+	protected Charset determineCharset(String contents) {
+		return null;
 	}
 
 	/**

--- a/src/org/zaproxy/zap/network/HttpResponseBody.java
+++ b/src/org/zaproxy/zap/network/HttpResponseBody.java
@@ -80,6 +80,21 @@ public class HttpResponseBody extends HttpBody {
 	public HttpResponseBody(byte[] contents) {
 		super(contents);
 	}
+	
+	@Override
+	protected Charset determineCharset(String contents) {
+		Matcher matcher = patternCharset.matcher(contents);
+		if (matcher.find()) {
+			try {
+				return Charset.forName(matcher.group(1));
+			} catch (IllegalArgumentException e) {
+				log.warn("Unable to determine (valid) charset with the (X)HTML meta charset: " + e.getMessage());
+			}
+		} else if (contents.getBytes(StandardCharsets.UTF_8).length == contents.getBytes().length) {
+			return StandardCharsets.UTF_8;
+		}
+		return null;
+	}
 
 	@Override
 	protected String createString(Charset currentCharset) {

--- a/test/org/zaproxy/zap/network/HttpResponseBodyUnitTest.java
+++ b/test/org/zaproxy/zap/network/HttpResponseBodyUnitTest.java
@@ -84,13 +84,25 @@ public class HttpResponseBodyUnitTest extends HttpBodyTestUtils {
     @Test
     public void shouldCreateBodyWithStringUsingDefaultCharset() {
         // Given
-        HttpResponseBody httpBody = new HttpResponseBody(BODY_1_STRING);
+        HttpResponseBody httpBody = new HttpResponseBody(BODY_1_BYTES_DEFAULT_CHARSET);
         // When / Then
         assertThat(httpBody.length(), is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET.length)));
         assertThat(httpBody.getBytes(), is(not(nullValue())));
         assertThat(httpBody.getBytes(), is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET)));
         assertThat(httpBody.getBytes().length, is(equalTo(BODY_1_BYTES_DEFAULT_CHARSET.length)));
         assertThat(httpBody.toString(), is(equalTo(BODY_1_STRING_DEFAULT_CHARSET)));
+    }
+
+    @Test
+    public void shouldCreateBodyWithStringDeterminingItsCharset() {
+        // Given
+        HttpResponseBody httpBody = new HttpResponseBody(BODY_1_STRING);
+        // When / Then
+        assertThat(httpBody.length(), is(equalTo(BODY_1_BYTES_UTF_8.length)));
+        assertThat(httpBody.getBytes(), is(not(nullValue())));
+        assertThat(httpBody.getBytes(), is(equalTo(BODY_1_BYTES_UTF_8)));
+        assertThat(httpBody.getBytes().length, is(equalTo(BODY_1_BYTES_UTF_8.length)));
+        assertThat(httpBody.toString(), is(equalTo(BODY_1_STRING_UTF_8)));
     }
 
     @Test


### PR DESCRIPTION
Change HttpBody and HttpResponseBody to attempt to determine the charset
of the contents (String) being set if the charset is unknown (that is,
it was not previously set before the contents are set).
Update tests to reflect the change in the behaviour.

Related to #2487 - Wrong charset used in HTTP body
Fix #2935 - Wrong charset used in response body if no charset set