### PR TITLE
Added ZAP_HOME variable to launch script

### DIFF
--- a/src/zap.sh
+++ b/src/zap.sh
@@ -11,7 +11,7 @@ done
 cd "`dirname "${SCRIPTNAME}"`" > /dev/null
 
 # Base directory where ZAP is installed
-BASEDIR="`pwd -P`"
+BASEDIR="${ZAP_HOME:-`pwd -P`}"
 
 # Switch to the directory where ZAP is installed
 cd "$BASEDIR"


### PR DESCRIPTION
Utilizing the ZAP_HOME variable if set will allow other Linux
distros to easily package ZAP according to their packaging
guidelines, as it will allow zap.sh to be placed somewhere away
from the Java executable.