### PR TITLE
Set a name to spider threads

### DIFF
--- a/src/org/zaproxy/zap/extension/spider/SpiderScan.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderScan.java
@@ -107,9 +107,39 @@ public class SpiderScan implements ScanListenner, SpiderListener, GenericScanner
 	 */
 	private SpiderMessagesTableModel messagesTableModel;
 
+	/**
+	 * Constructs a {@code SpiderScan} with the given data.
+	 *
+	 * @param extension the extension to obtain configurations and notify the view
+	 * @param spiderParams the spider options
+	 * @param target the spider target
+	 * @param spiderURI the starting URI, may be {@code null}.
+	 * @param scanUser the user to be used in the scan, may be {@code null}.
+	 * @param scanId the ID of the scan
+	 * @deprecated (TODO add version) Use {@link #SpiderScan(ExtensionSpider, SpiderParam, Target, URI, User, int, String)}
+	 *             instead.
+	 */
+	@Deprecated
 	public SpiderScan(ExtensionSpider extension, SpiderParam spiderParams, Target target, URI spiderURI, User scanUser, int scanId) {
+		this(extension, spiderParams, target, spiderURI, scanUser, scanId, "SpiderScan" + scanId);
+	}
+
+	/**
+	 * Constructs a {@code SpiderScan} with the given data.
+	 *
+	 * @param extension the extension to obtain configurations and notify the view
+	 * @param spiderParams the spider options
+	 * @param target the spider target
+	 * @param spiderURI the starting URI, may be {@code null}.
+	 * @param scanUser the user to be used in the scan, may be {@code null}.
+	 * @param scanId the ID of the scan
+	 * @param name the name that identifies the target
+	 * @since TODO add version
+	 */
+	public SpiderScan(ExtensionSpider extension, SpiderParam spiderParams, Target target, URI spiderURI, User scanUser, int scanId, String name) {
 		lock = new ReentrantLock();
 		this.scanId = scanId;
+		setDisplayName(name);
 
 		numberOfURIsFound = new AtomicInteger();
 		foundURIs = Collections.synchronizedSet(new HashSet<String>());
@@ -118,7 +148,7 @@ public class SpiderScan implements ScanListenner, SpiderListener, GenericScanner
 
 		state = State.NOT_STARTED;
 
-		spiderThread = new SpiderThread(extension, spiderParams, "SpiderApi-" + scanId, this);
+		spiderThread = new SpiderThread(Integer.toString(scanId), extension, spiderParams, name, this);
 
 		spiderThread.setStartURI(spiderURI);
 		spiderThread.setStartNode(target.getStartNode());

--- a/src/org/zaproxy/zap/extension/spider/SpiderScanController.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderScanController.java
@@ -120,8 +120,7 @@ public class SpiderScanController implements ScanController<SpiderScan> {
 				}
 			}
 			
-			SpiderScan scan = new SpiderScan(extension, spiderParams, target, startUri, user, id);
-			scan.setDisplayName(name);
+			SpiderScan scan = new SpiderScan(extension, spiderParams, target, startUri, user, id, name);
 			scan.setCustomSpiderParsers(customSpiderParsers);
 			scan.setCustomFetchFilters(customFetchFilters);
 			scan.setCustomParseFilters(customParseFilters);

--- a/src/org/zaproxy/zap/extension/spider/SpiderThread.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderThread.java
@@ -108,21 +108,43 @@ public class SpiderThread extends ScanThread implements SpiderListener {
 
 	private List<ParseFilter> customParseFilters = null;
 
+	private final String id;
+
 	/**
-	 * Instantiates a new spider thread.
+	 * Constructs a {@code SpiderThread} with the given data.
 	 * 
-	 * @param extension the extension
-	 * @param site the site
+	 * @param extension the extension to obtain configurations and notify the view
+	 * @param spiderParams the spider options
+	 * @param site the name that identifies the target site
 	 * @param listenner the scan listener
+	 * @deprecated (TODO add version) Use {@link #SpiderThread(String, ExtensionSpider, SpiderParam, String, ScanListenner)}
 	 */
+	@Deprecated
 	public SpiderThread(ExtensionSpider extension, SpiderParam spiderParams, String site, ScanListenner listenner) {
+		this("?", extension, spiderParams, site, listenner);
+	}
+
+	/**
+	 * Constructs a {@code SpiderThread} with the given data.
+	 * 
+	 * @param id the ID of the spider, usually a unique integer
+	 * @param extension the extension to obtain configurations and notify the view
+	 * @param spiderParams the spider options
+	 * @param site the name that identifies the target site
+	 * @param listenner the scan listener
+	 * @since TODO add version
+	 */
+	public SpiderThread(String id, ExtensionSpider extension, SpiderParam spiderParams, String site, ScanListenner listenner) {
 		super(site, listenner);
 		log.debug("Initializing spider thread for site: " + site);
+		this.id = id;
 		this.extension = extension;
 		this.site = site;
 		this.pendingSpiderListeners = new LinkedList<>();
 		this.resultsModel = new SpiderPanelTableModel();
 		this.spiderParams = spiderParams;
+
+		setName("ZAP-SpiderInitThread-"+ id);
 	}
 
 	@Override
@@ -199,7 +221,7 @@ public class SpiderThread extends ScanThread implements SpiderListener {
 	 */
 	private void startSpider() {
 
-		spider = new Spider(extension, spiderParams, extension.getModel().getOptionsParam()
+		spider = new Spider(id, extension, spiderParams, extension.getModel().getOptionsParam()
 				.getConnectionParam(), extension.getModel(), this.scanContext);
 
 		// Register this thread as a Spider Listener, so it gets notified of events and is able


### PR DESCRIPTION
Initialise the spider threads with custom name as it makes it easier to
identify that are threads created by ZAP, know it's purpose and to know
to which spider scan they belong. Also, correct the site/name show when
starting the spider.