### PR TITLE
Correct charset determination in HttpResponseBody

### DIFF
--- a/src/org/zaproxy/zap/network/HttpResponseBody.java
+++ b/src/org/zaproxy/zap/network/HttpResponseBody.java
@@ -90,10 +90,14 @@ public class HttpResponseBody extends HttpBody {
 			} catch (IllegalArgumentException e) {
 				log.warn("Unable to determine (valid) charset with the (X)HTML meta charset: " + e.getMessage());
 			}
-		} else if (contents.getBytes(StandardCharsets.UTF_8).length == contents.getBytes().length) {
+		} else if (isUtf8String(contents)) {
 			return StandardCharsets.UTF_8;
 		}
 		return null;
+	}
+
+	private static boolean isUtf8String(String string) {
+		return new String(string.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8).length() == string.length();
 	}
 
 	@Override


### PR DESCRIPTION
Remove use of platform's default charset when determining if the charset
of the string is UTF-8, which was leading to wrong results if the
platform's default charset was not UTF-8.

Related to:
 - #2935 - Wrong charset used in response body if no charset set
 - #2941 - Attempt to determine (String) body's charset