### PR TITLE
Initialise panels when added to session dialogue

### DIFF
--- a/src/org/parosproxy/paros/view/View.java
+++ b/src/org/parosproxy/paros/view/View.java
@@ -69,6 +69,7 @@
 // ZAP: 2016/04/04 Do not require a restart to show/hide the tool bar
 // ZAP: 2016/04/06 Fix layouts' issues
 // ZAP: 2016/04/14 Allow to display a message
+// ZAP: 2016/10/26 Create UI shared context in the session dialogue when adding a context
 
 package org.parosproxy.paros.view;
 
@@ -693,6 +694,8 @@ public class View implements ViewDelegate {
     }
 
     public void addContext(Context c) {
+        getSessionDialog().createUISharedContext(c);
+
         String contextsNodeName = Constant.messages.getString("context.list");
         ContextGeneralPanel contextGenPanel = new ContextGeneralPanel(c.getName(), c.getIndex());
         contextGenPanel.setSessionDialog(getSessionDialog());


### PR DESCRIPTION
Initialise the panels when added to session dialogue if it's shown, to
ensure that the panels are in a consistent state. Also, ensure the
session dialogue has a "UI shared context" when adding the panels of the
newly added context.
The change prevents exceptions (caused by the inconsistent state of the
panels) when changes are done to the contexts (e.g. via ZAP API) while
the dialogue is shown.
Change to initialise the "regular" (i.e. non context) panels only once,
when initParam(Object) is called (already done by base class).