### PR TITLE
Export context's session management data

### DIFF
--- a/src/org/zaproxy/zap/extension/sessions/ExtensionSessionManagement.java
+++ b/src/org/zaproxy/zap/extension/sessions/ExtensionSessionManagement.java
@@ -202,7 +202,9 @@ public class ExtensionSessionManagement extends ExtensionAdaptor implements Cont
 
 	@Override
 	public void exportContextData(Context ctx, Configuration config) {
-		config.setProperty(CONTEXT_CONFIG_SESSION_TYPE, ctx.getSessionManagementMethod().getType().getUniqueIdentifier());
+		SessionManagementMethodType type = ctx.getSessionManagementMethod().getType();
+		config.setProperty(CONTEXT_CONFIG_SESSION_TYPE, type.getUniqueIdentifier());
+		type.exportData(config, ctx.getSessionManagementMethod());
 	}
 
 	@Override


### PR DESCRIPTION
Change ExtensionSessionManagement to also export session management data
when exporting the context (not a problem for core implementations which
do not have any data).