### PR TITLE
Use L&F specified through JVM args

### DIFF
--- a/src/org/zaproxy/zap/GuiBootstrap.java
+++ b/src/org/zaproxy/zap/GuiBootstrap.java
@@ -328,6 +328,20 @@ public class GuiBootstrap extends ZapBootstrap {
         }
         lookAndFeelSet = true;
 
+        String lookAndFeelClassname = System.getProperty("swing.defaultlaf");
+        if (lookAndFeelClassname != null) {
+            try {
+                UIManager.setLookAndFeel(lookAndFeelClassname);
+                return;
+            } catch (final UnsupportedLookAndFeelException
+                     | ClassNotFoundException
+                     | ClassCastException
+                     | InstantiationException
+                     | IllegalAccessException e) {
+                logger.warn("Failed to set the specified look and feel: " + e.getMessage());
+            }
+        }
+
         try {
             // Set the systems Look and Feel
             UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
@@ -347,7 +361,7 @@ public class GuiBootstrap extends ZapBootstrap {
                  | ClassNotFoundException
                  | InstantiationException
                  | IllegalAccessException e) {
-            // handle exception
+            logger.warn("Failed to set the \"default\" look and feel: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
Change GuiBootstrap to use the look and feel specified through the JVM
arguments if able to find/set it, otherwise fallback to previous/current
behaviour.

Related to #2964 - Allow to select the look and feel