### PR TITLE
Increase page size when accessing alerts

### DIFF
--- a/build/docker/zap-baseline.py
+++ b/build/docker/zap-baseline.py
@@ -366,7 +366,7 @@ def main(argv):
         print ('Total of ' + str(len(zap.core.urls)) + ' URLs')
       # Retrieve the alerts using paging in case there are lots of them
       st = 0
-      pg = 100
+      pg = 5000
       alert_dict = {}
       alerts = zap.core.alerts(start=st, count=pg)
       while len(alerts) > 0:


### PR DESCRIPTION
It turns out that the alert API paging is not implemented very efficiently, and
choosing too small a page size can take a very long time.