### PR TITLE
Do not initialise dev logger if there's no view

### DIFF
--- a/src/org/zaproxy/zap/extension/log4j/ExtensionLog4j.java
+++ b/src/org/zaproxy/zap/extension/log4j/ExtensionLog4j.java
@@ -47,7 +47,7 @@ public class ExtensionLog4j extends ExtensionAdaptor {
         super("ExtensionLog4j");
         this.setOrder(56);
 
-		if (Constant.isDevBuild()) {
+		if (Constant.isDevBuild() && View.isInitialised()) {
 			// Only enable if this is a developer build, ie build from source
         
 	        scanStatus = new ScanStatus(
@@ -57,9 +57,7 @@ public class ExtensionLog4j extends ExtensionAdaptor {
 	
 	        Logger.getRootLogger().addAppender(new ZapOutputWriter(scanStatus));
 	
-			if (View.isInitialised()) {
-				View.getSingleton().getMainFrame().getMainFooterPanel().addFooterToolbarRightLabel(scanStatus.getCountLabel());
-			}
+			View.getSingleton().getMainFrame().getMainFooterPanel().addFooterToolbarRightLabel(scanStatus.getCountLabel());
 		}
 	}
 	

--- a/src/org/zaproxy/zap/extension/log4j/ZapOutputWriter.java
+++ b/src/org/zaproxy/zap/extension/log4j/ZapOutputWriter.java
@@ -30,22 +30,18 @@ public class ZapOutputWriter extends WriterAppender {
 	private final static char NEWLINE = '\n';
 	private ScanStatus scanStatus = null;
 	
-	public ZapOutputWriter () {
-		System.out.println("ZapOutputWriter constructor");
-		
-	}
-
 	public ZapOutputWriter(ScanStatus scanStatus) {
+		if (!View.isInitialised()) {
+			throw new IllegalStateException("View must be initialised.");
+		}
+		if (scanStatus == null) {
+			throw new IllegalArgumentException("The parameter scanStatus must not be null.");
+		}
 		this.scanStatus = scanStatus;
 	}
 
 	@Override
 	public void append(final LoggingEvent event) {
-		if (! View.isInitialised()) {
-			// Running in daemon mode
-			return;
-		}
-
 		if (event.getLevel().equals(Level.ERROR)) {
 			if (! SwingUtilities.isEventDispatchThread()) {
 				SwingUtilities.invokeLater(new Runnable(){
@@ -56,9 +52,7 @@ public class ZapOutputWriter extends WriterAppender {
 				return;
 			}
 
-			if (scanStatus != null) {
-				scanStatus.incScanCount();
-			}
+			scanStatus.incScanCount();
 			
 			String renderedmessage=event.getRenderedMessage();
 			if (renderedmessage!=null) {


### PR DESCRIPTION
Change ExtensionLog4j to not initialise the "logger" if there's no view,
it was only used if the view was initialised.
Change ZapOutputWriter to require the view initialised and that the scan
status label is provided (and remove view and null checks when logging,
no longer needed per previous changes). Also, remove unused constructor.