### PR TITLE
Include date/time when logging that ZAP started

### DIFF
--- a/src/org/zaproxy/zap/ZapBootstrap.java
+++ b/src/org/zaproxy/zap/ZapBootstrap.java
@@ -19,6 +19,10 @@
  */
 package org.zaproxy.zap;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 import org.apache.commons.configuration.ConfigurationUtils;
 import org.apache.commons.configuration.DefaultFileSystem;
 import org.apache.log4j.Level;
@@ -118,6 +122,11 @@ abstract class ZapBootstrap {
      * @return the starting message
      */
     protected static String getStartingMessage() {
-        return Constant.PROGRAM_NAME + " " + Constant.PROGRAM_VERSION + " started.";
+        DateFormat dateFormat = SimpleDateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM);
+        StringBuilder strBuilder = new StringBuilder(200);
+        strBuilder.append(Constant.PROGRAM_NAME).append(' ').append(Constant.PROGRAM_VERSION);
+        strBuilder.append(" started ");
+        strBuilder.append(dateFormat.format(new Date()));
+        return strBuilder.toString();
     }
 }


### PR DESCRIPTION
The date/time allows to correlate the output logging with other logs
and events more easily.

 ---

From talks in IRC.