### PR TITLE
Delay init of attack mode scanner to prevent NPE

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -121,7 +121,6 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
         this.setOrder(28);
         policyManager = new PolicyManager(this);
         ascanController = new ActiveScanController(this);
-        attackModeScanner = new AttackModeScanner(this);
 
     }
     
@@ -143,6 +142,8 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
     @Override
     public void hook(ExtensionHook extensionHook) {
         super.hook(extensionHook);
+
+        attackModeScanner = new AttackModeScanner(this);
 
         if (getView() != null) {
             extensionHook.getHookMenu().addAnalyseMenuItem(getMenuItemPolicy());


### PR DESCRIPTION
Change ExtensionActiveScan to delay the initialisation of
AttackModeScanner to allow it to properly check if the view is
initialised, using the extension.

Caused by #2972 - Init status label in attack scanner only with view