### PR TITLE
Change attack mode thread to daemon

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/AttackModeScanner.java
+++ b/src/org/zaproxy/zap/extension/ascan/AttackModeScanner.java
@@ -89,8 +89,8 @@ public class AttackModeScanner implements EventConsumer {
 			attackModeThread.shutdown();
 		}
 		attackModeThread = new AttackModeThread();
-		Thread t = new Thread(attackModeThread);
-		t.setName("ZAP-AttackMode");
+		Thread t = new Thread(attackModeThread, "ZAP-AttackMode");
+		t.setDaemon(true);
 		t.start();
 		
 	}


### PR DESCRIPTION
Change the thread used for the attack mode to be a daemon thread, to not
prevent ZAP from terminating normally. For example, if the attack mode
was enabled while starting ZAP (in daemon mode) and ZAP was not able to
bind to the address/port it would be kept running instead of
terminating.