### PR TITLE
Allow to disable default standard output logging

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -737,6 +737,7 @@ Core options:\n\
 \t-port <port>             Overrides the port used for proxying specified in the configuration file\n\
 \t-lowmem                  Use the database instead of memory as much as possible - this is still experimental\n\
 \t-experimentaldb          Use the experimental generic database code, which is not surprisingly also still experimental\n\
+\t-nostdout                Disables the default logging through standard output\n\
 Add-on options:\n
 
 cmp.desc                       = Compares 2 sessions and generates an HTML file showing the differences

--- a/src/org/parosproxy/paros/CommandLine.java
+++ b/src/org/parosproxy/paros/CommandLine.java
@@ -33,6 +33,7 @@
 // ZAP: 2015/10/06 Issue 1962: Install and update add-ons from the command line
 // ZAP: 2016/08/19 Issue 2782: Support -configfile
 // ZAP: 2016/09/22 JavaDoc tweaks
+// ZAP: 2016/11/07 Allow to disable default standard output logging
 
 package org.parosproxy.paros;
 
@@ -72,6 +73,14 @@ public class CommandLine {
     public static final String LOWMEM = "-lowmem";
     public static final String EXPERIMENTALDB = "-experimentaldb";
 
+    /**
+     * Command line option to disable the default logging through standard output.
+     * 
+     * @see #isNoStdOutLog()
+     * @since TODO add version
+     */
+    public static final String NOSTDOUT = "-nostdout";
+
     static final String NO_USER_AGENT = "-nouseragent";
     static final String SP = "-sp";
 
@@ -86,6 +95,11 @@ public class CommandLine {
     private final Hashtable<String, String> configs = new Hashtable<>();
     private final Hashtable<String, String> keywords = new Hashtable<>();
     private List<CommandLineArgument[]> commandList = null;
+
+    /**
+     * Flag that indicates whether or not the default logging through standard output should be disabled.
+     */
+    private boolean noStdOutLog;
 
     public CommandLine(String[] args) throws Exception {
         this.args = args;
@@ -298,6 +312,8 @@ public class CommandLine {
             reportVersion = true;
             setDaemon(false);
             setGUI(false);
+        } else if (checkSwitch(args, NOSTDOUT, i)) {
+            noStdOutLog = true;
         }
 
         return result;
@@ -425,6 +441,16 @@ public class CommandLine {
 
     public String getHelp() {
     	return CommandLine.getHelp(commandList);
+    }
+
+    /**
+     * Tells whether or not the default logging through standard output should be disabled.
+     *
+     * @return {@code true} if the default logging through standard output should be disabled, {@code false} otherwise.
+     * @since TODO add version
+     */
+    public boolean isNoStdOutLog() {
+        return noStdOutLog;
     }
 
     public static String getHelp(List<CommandLineArgument[]> cmdList) {

--- a/src/org/zaproxy/zap/DaemonBootstrap.java
+++ b/src/org/zaproxy/zap/DaemonBootstrap.java
@@ -52,7 +52,9 @@ class DaemonBootstrap extends HeadlessBootstrap {
 
         View.setDaemon(true); // Prevents the View ever being initialised
 
-        BasicConfigurator.configure();
+        if (!getArgs().isNoStdOutLog()) {
+            BasicConfigurator.configure();
+        }
         logger.info(getStartingMessage());
 
         try {
@@ -93,7 +95,11 @@ class DaemonBootstrap extends HeadlessBootstrap {
                 }
                 
                 ProxyParam proxyParams = Model.getSingleton().getOptionsParam().getProxyParam();
-                logger.info("ZAP is now listening on " + proxyParams.getRawProxyIP() + ":" + proxyParams.getProxyPort());
+                String message = "ZAP is now listening on " + proxyParams.getRawProxyIP() + ":" + proxyParams.getProxyPort();
+                logger.info(message);
+                if (getArgs().isNoStdOutLog()) {
+                    System.out.println(message);
+                }
 
                 // This is the only non-daemon thread, so should keep running
                 // CoreAPI.handleApiAction uses System.exit to shutdown

--- a/src/org/zaproxy/zap/GuiBootstrap.java
+++ b/src/org/zaproxy/zap/GuiBootstrap.java
@@ -89,7 +89,9 @@ public class GuiBootstrap extends ZapBootstrap {
             return rc;
         }
 
-        BasicConfigurator.configure();
+        if (!getArgs().isNoStdOutLog()) {
+            BasicConfigurator.configure();
+        }
 
         logger.info(getStartingMessage());
 

--- a/test/org/parosproxy/paros/CommandLineUnitTest.java
+++ b/test/org/parosproxy/paros/CommandLineUnitTest.java
@@ -50,6 +50,9 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.zaproxy.zap.utils.I18N;
 
+/**
+ * Unit test for {@link CommandLine}.
+ */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(Constant.class)
 public class CommandLineUnitTest {
@@ -182,6 +185,22 @@ public class CommandLineUnitTest {
         cmdLine = new CommandLine(new String[] { CommandLine.HOST, hostname });
         // Then
         assertThat(cmdLine.getHost(), is(equalTo(hostname)));
+    }
+
+    @Test
+    public void shouldHaveNoStdOutArgumentDisabledByDefault() throws Exception {
+        // Given / When
+        cmdLine = new CommandLine(new String[] {});
+        // Then
+        assertThat(cmdLine.isNoStdOutLog(), is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldParseNoStdOutArgument() throws Exception {
+        // Given / When
+        cmdLine = new CommandLine(new String[] { CommandLine.NOSTDOUT });
+        // Then
+        assertThat(cmdLine.isNoStdOutLog(), is(equalTo(true)));
     }
 
     @Test


### PR DESCRIPTION
Add a command line flag to disable the default standard output logging,
allowing to configure/override it using the log4j.properties file.
Add tests to assert the expected behaviour.

 ---
From talks in IRC.