### PR TITLE
Fix exception when getting sessions through ZAP API

### DIFF
--- a/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsAPI.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsAPI.java
@@ -250,7 +250,7 @@ public class HttpSessionsAPI extends ApiImplementor {
 			}
 
 			ApiResponseList response = new ApiResponseList(name);
-			String vsName = params.getString(VIEW_PARAM_SESSION);
+			String vsName = getParam(params, VIEW_PARAM_SESSION, "");
 			// If a session name was not provided
 			if (vsName == null || vsName.isEmpty()) {
 				Set<HttpSession> sessions = site.getHttpSessions();


### PR DESCRIPTION
Change HttpSessionsAPI to obtain the optional parameter "session" with a
default value, otherwise it would lead to a JSONException if it was not
present in the API request.

Fix #2977 - HTTP500 from JSON/httpSessions/view/sessions/?site=FOO