### PR TITLE
Fix typo in resource message key

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -2029,7 +2029,7 @@ timestamp.format.timeonly = HH:mm:ss
 # The following delimiter is used between timestamps and messages that are being stamped
 timestamp.format.delimiter = :
 
-uituils.desc = Core UI related functionality.
+uiutils.desc = Core UI related functionality.
 
 users.panel.title 							= Users
 users.panel.description						= Users which can be used for various operations for this context.

--- a/src/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
+++ b/src/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
@@ -106,7 +106,7 @@ public class ExtensionUiUtils extends ExtensionAdaptor implements SessionChanged
 
 	@Override
 	public String getDescription() {
-		return Constant.messages.getString("uituils.desc");
+		return Constant.messages.getString("uiutils.desc");
 	}
 
 	@Override


### PR DESCRIPTION
Change the name of the resource message key to match the name of the
package of the extension ("uiutils").