### PR TITLE
Change API JS script to check if method is defined

### DIFF
--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -167,7 +167,9 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 			"  var url = '/' + format + '/' + component + '/' + type + '/' + name + '/'\n" +
 			"  var form=document.getElementById('zapform');\n" +
 			"  form.action = url;\n" +
-			"  form.method = form.elements[\"formMethod\"].value;\n" +
+			"  if (form.elements[\"formMethod\"]) {\n" +
+			"    form.method = form.elements[\"formMethod\"].value;\n" +
+			"  }\n" +
 			"  form.submit();\n" +
 			"}\n" +
 			"document.addEventListener('DOMContentLoaded', function () {\n" +


### PR DESCRIPTION
Change CoreAPI JavaScript script to check if the formMethod field is
defined before using it as not all the API calls (e.g. views) use/define
it, leading to errors.