### PR TITLE
Do not warn about non active attack mode scans

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/AttackModeScanner.java
+++ b/src/org/zaproxy/zap/extension/ascan/AttackModeScanner.java
@@ -223,7 +223,7 @@ public class AttackModeScanner implements EventConsumer {
 		return extAlert;
 	}
 
-	private class AttackModeThread implements Runnable, ScannerListener {
+	private class AttackModeThread implements Runnable, ScannerListener, AttackModeScannerThread {
 
 		private int scannerCount = 4; 
 		private List<Scanner> scanners = new ArrayList<Scanner>();
@@ -244,7 +244,7 @@ public class AttackModeScanner implements EventConsumer {
 
 			ascanWrapper = new AttackScan(Constant.messages.getString("ascan.attack.scan"), extension.getScannerParam(), 
 					extension.getModel().getOptionsParam().getConnectionParam(), 
-					extension.getPolicyManager().getAttackScanPolicy(), ruleConfigParam);
+					extension.getPolicyManager().getAttackScanPolicy(), ruleConfigParam, this);
 			extension.registerScan(ascanWrapper);
 			while (running) {
 				if (scanStatus != null && scanStatus.getScanCount() != nodeStack.size()) {
@@ -349,6 +349,7 @@ public class AttackModeScanner implements EventConsumer {
 			this.running = false;
 		}
 		
+		@Override
 		public boolean isRunning() {
 			return this.running;
 		}
@@ -357,6 +358,7 @@ public class AttackModeScanner implements EventConsumer {
 		 * Tells whether or not any of the scan threads are currently active.
 		 * @return {@code true} if there's at least one scan active, {@code false} otherwise
 		 */
+		@Override
 		public boolean isActive() {
 			synchronized (this.scanners) {
 				for (Scanner scanner : this.scanners) {
@@ -367,5 +369,12 @@ public class AttackModeScanner implements EventConsumer {
 			}
 			return false;
 		}
+	}
+
+	interface AttackModeScannerThread {
+
+		boolean isRunning();
+
+		boolean isActive();
 	}
 }

--- a/src/org/zaproxy/zap/extension/ascan/AttackScan.java
+++ b/src/org/zaproxy/zap/extension/ascan/AttackScan.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.ascan;
 
 import org.parosproxy.paros.core.scanner.ScannerParam;
 import org.parosproxy.paros.network.ConnectionParam;
+import org.zaproxy.zap.extension.ascan.AttackModeScanner.AttackModeScannerThread;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.model.Target;
 
@@ -31,9 +32,18 @@ import org.zaproxy.zap.model.Target;
  */
 public class AttackScan extends ActiveScan {
 
+	private final AttackModeScannerThread attackModeScannerThread;
+
 	public AttackScan(String displayName, ScannerParam scannerParam, 
 			ConnectionParam param, ScanPolicy scanPolicy, RuleConfigParam ruleConfigParam) {
+		this(displayName, scannerParam, param, scanPolicy, ruleConfigParam, null);
+	}
+
+	AttackScan(String displayName, ScannerParam scannerParam,
+			ConnectionParam param, ScanPolicy scanPolicy, RuleConfigParam ruleConfigParam,
+			AttackModeScannerThread attackModeScannerThread) {
 		super(displayName, scannerParam, param, scanPolicy, ruleConfigParam);
+		this.attackModeScannerThread = attackModeScannerThread;
 	}
 	
 	@Override
@@ -79,6 +89,13 @@ public class AttackScan extends ActiveScan {
 	@Override
     public boolean isRunning() {
 		return true;
+	}
+
+	boolean isDone() {
+		if (attackModeScannerThread == null) {
+			return false;
+		}
+		return !attackModeScannerThread.isRunning() || !attackModeScannerThread.isActive();
 	}
 
 }

--- a/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -188,6 +188,9 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
         String activeActionPrefix = Constant.messages.getString("ascan.activeActionPrefix");
         List<String> activeActions = new ArrayList<>(activeScans.size());
         for (ActiveScan activeScan : activeScans) {
+            if (activeScan instanceof AttackScan && ((AttackScan) activeScan).isDone()) {
+                continue;
+            }
             activeActions.add(MessageFormat.format(activeActionPrefix, activeScan.getDisplayName()));
         }
         return activeActions;


### PR DESCRIPTION
Change active scanner extension to not warn/show as active actions the
attack mode scans that are not active (i.e. either already stopped or
still running but not scanning any message).