### PR TITLE
Restore HostProcess/Scanner constructors

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/HostProcess.java
+++ b/src/org/parosproxy/paros/core/scanner/HostProcess.java
@@ -61,6 +61,7 @@
 // ZAP: 2016/07/01 Issue 2647 Support a/pscan rule configuration 
 // ZAP: 2016/09/20 - Reorder statements to prevent (potential) NullPointerException in scanSingleNode
 //                 - JavaDoc tweaks
+// ZAP: 2016/11/14 Restore and deprecate old constructor, to keep binary compatibility
 
 package org.parosproxy.paros.core.scanner;
 
@@ -121,6 +122,23 @@ public class HostProcess implements Runnable {
     private int percentage = 0;
     
     /**
+     * Constructs a {@code HostProcess}, with no rules' configurations.
+     * 
+     * @param hostAndPort the host:port value of the site that need to be processed
+     * @param parentScanner the scanner instance which instantiated this process
+     * @param scannerParam the session scanner parameters
+     * @param connectionParam the connection parameters
+     * @param scanPolicy the scan policy
+     * @deprecated Use {@link #HostProcess(String, Scanner, ScannerParam, ConnectionParam, ScanPolicy, RuleConfigParam)}
+     *             instead. It will be removed in a future version.
+     */
+    @Deprecated
+    public HostProcess(String hostAndPort, Scanner parentScanner, ScannerParam scannerParam,
+            ConnectionParam connectionParam, ScanPolicy scanPolicy) {
+        this(hostAndPort, parentScanner, scannerParam, connectionParam, scanPolicy, null);
+    }
+    
+    /**
      * Constructs a {@code HostProcess}.
      * 
      * @param hostAndPort the host:port value of the site that need to be processed
@@ -128,7 +146,8 @@ public class HostProcess implements Runnable {
      * @param scannerParam the session scanner parameters
      * @param connectionParam the connection parameters
      * @param scanPolicy the scan policy
-     * @param ruleConfigParam the rules' configurations
+     * @param ruleConfigParam the rules' configurations, might be {@code null}.
+     * @since TODO add version
      */
     public HostProcess(String hostAndPort, Scanner parentScanner, 
     		ScannerParam scannerParam, ConnectionParam connectionParam, 

--- a/src/org/parosproxy/paros/core/scanner/Scanner.java
+++ b/src/org/parosproxy/paros/core/scanner/Scanner.java
@@ -40,6 +40,7 @@
 // ZAP: 2015/12/14 Prevent scans from becoming in undefined state
 // ZAP: 2016/07/12 Do not allow techSet to be null
 // ZAP: 2016/07/01 Issue 2647 Support a/pscan rule configuration 
+// ZAP: 2016/11/14 Restore and deprecate old constructor, to keep binary compatibility
 
 package org.parosproxy.paros.core.scanner;
 
@@ -105,6 +106,29 @@ public class Scanner implements Runnable {
 	
 	private List<HostProcess> hostProcesses = new ArrayList<>();
 
+    /**
+     * Constructs a {@code Scanner}, with no rules' configurations.
+     *
+     * @param scannerParam the scanner parameters
+     * @param param the connection parameters
+     * @param scanPolicy the scan policy
+     * @deprecated Use {@link #Scanner(ScannerParam, ConnectionParam, ScanPolicy, RuleConfigParam)} instead. It will be removed
+     *             in a future version.
+     */
+    @Deprecated
+    public Scanner(ScannerParam scannerParam, ConnectionParam param, ScanPolicy scanPolicy) {
+        this(scannerParam, param, scanPolicy, null);
+    }
+
+    /**
+     * Constructs a {@code Scanner}.
+     * 
+     * @param scannerParam the scanner parameters
+     * @param param the connection parameters
+     * @param scanPolicy the scan policy
+     * @param ruleConfigParam the rules' configurations, might be {@code null}.
+     * @since TODO add version
+     */
     public Scanner(ScannerParam scannerParam, ConnectionParam param, 
     		ScanPolicy scanPolicy, RuleConfigParam ruleConfigParam) {
 	    this.connectionParam = param;


### PR DESCRIPTION
Restore and deprecate HostProcess/Scanner constructors to keep binary
compatibility with current/previous version, eases migration to newer
version as some (add-on) tests use those constructors.