### PR TITLE
Correctly render all nodes in checkbox tree

### DIFF
--- a/src/org/zaproxy/zap/view/JCheckBoxTree.java
+++ b/src/org/zaproxy/zap/view/JCheckBoxTree.java
@@ -92,8 +92,8 @@ public class JCheckBoxTree extends JTree {
     // Override
     @Override
     public void setModel(TreeModel newModel) {
+        resetCheckingState(newModel != null ? (DefaultMutableTreeNode) newModel.getRoot() : null);
         super.setModel(newModel);
-        resetCheckingState();
     }
 
     // New method that returns only the checked paths (totally ignores original "selection" mechanism)
@@ -112,14 +112,13 @@ public class JCheckBoxTree extends JTree {
         return cn.isSelected && cn.hasChildren && !cn.allChildrenSelected;
     }
 
-    private void resetCheckingState() { 
+    private void resetCheckingState(DefaultMutableTreeNode rootNode) { 
         nodesCheckingState = new HashMap<TreePath, CheckedNode>();
         checkedPaths = new HashSet<TreePath>();
-        DefaultMutableTreeNode node = (DefaultMutableTreeNode)getModel().getRoot();
-        if (node == null) {
+        if (rootNode == null) {
             return;
         }
-        addSubtreeToCheckingStateTracking(node);
+        addSubtreeToCheckingStateTracking(rootNode);
     }
 
     // Creating data structure of the current model for the checking mechanism
@@ -156,18 +155,18 @@ public class JCheckBoxTree extends JTree {
             DefaultMutableTreeNode node = (DefaultMutableTreeNode)value;
             Object obj = node.getUserObject();          
             TreePath tp = new TreePath(node.getPath());
+            altLabel.setText(obj != null ? obj.toString() : "");
+            altLabel.setForeground(UIManager.getColor(selected ? "Tree.selectionForeground" : "Tree.textForeground"));
             CheckedNode cn = nodesCheckingState.get(tp);
             if (cn == null) {
+                checkBox.setVisible(false);
                 return this;
             }
-            String textRepresentation = obj != null ? obj.toString() : "";
             if (cn.isCheckBoxEnabled) {
 	            checkBox.setSelected(cn.isSelected);
 	            checkBox.setOpaque(cn.isSelected && cn.hasChildren && ! cn.allChildrenSelected);
 	        	checkBox.setVisible(true);
 	        	checkBox.setEnabled(true);
-	        	// TODO nasty hack to prevent top level node text being truncated - need a better fix for this :/
-	        	textRepresentation += "          ";
 	        	/* Looks ok, but doesnt work correctly
 	            if (cn.isSelected && cn.hasChildren && ! cn.allChildrenSelected) {
 	                checkBox.getModel().setPressed(true);
@@ -181,8 +180,6 @@ public class JCheckBoxTree extends JTree {
             	checkBox.setVisible(false);
             	checkBox.setEnabled(false);
             }
-            altLabel.setText(textRepresentation);
-            altLabel.setForeground(UIManager.getColor(selected ? "Tree.selectionForeground" : "Tree.textForeground"));
 
             return this;
         }       

--- a/test/org/zaproxy/zap/view/JCheckBoxTreeUnitTest.java
+++ b/test/org/zaproxy/zap/view/JCheckBoxTreeUnitTest.java
@@ -44,14 +44,14 @@ import org.junit.Test;
  */
 public class JCheckBoxTreeUnitTest {
 
-    @Test(expected = NullPointerException.class)
-    public void shouldFailToSetAnUndefinedTreeModel() {
+    @Test
+    public void shouldNotFailToSetAnUndefinedTreeModel() {
         // Given
         TreeModel undefinedTreeModel = null;
         JCheckBoxTree checkBoxTree = new JCheckBoxTree();
         // When
         checkBoxTree.setModel(undefinedTreeModel);
-        // Then = NullPointerException
+        // Then = No exception.
     }
 
     @Test(expected = ClassCastException.class)


### PR DESCRIPTION
Change JCheckBoxTree to correctly render the top level nodes, the
renderer will not show the checkbox if the node has no checkbox state
moreover set the node's text to the label wherever it has or not a
checkbox. Also, change to create the checkbox state of the tree nodes
before the model is set to the base class (as it might be used by base
class for painting calculations, using the custom renderer).
Update test to reflect the change in behaviour (no longer throws a
NullPointerException when setting a null model).