### PR TITLE
Clarify passive scanner's enabled state (API)

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1628,7 +1628,7 @@ proxy.error.address = Cannot listen on address
 proxy.error.generic = An error occurred while starting the proxy:\n
 proxy.error.readtimeout = Failed to read {0} within {1} seconds, check to see if the site is available and if so consider adjusting ZAP''s read time out in the Connection options panel.
 
-pscan.api.action.setEnabled = Sets whether or not the passive scanning is enabled
+pscan.api.action.setEnabled = Sets whether or not the passive scanning is enabled (Note: the enabled state is not persisted).
 pscan.api.action.setScanOnlyInScope = Sets whether or not the passive scan should be performed only on messages that are in scope.
 pscan.api.action.enableAllScanners = Enables all passive scanners
 pscan.api.action.disableAllScanners = Disables all passive scanners


### PR DESCRIPTION
Change the description of API endpoint "setEnabled" to clarify that the
enabled state is not persisted (i.e. defaults to passive scan always).