### PR TITLE
Allow to passive scan just HTTP messages in scope

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1629,6 +1629,7 @@ proxy.error.generic = An error occurred while starting the proxy:\n
 proxy.error.readtimeout = Failed to read {0} within {1} seconds, check to see if the site is available and if so consider adjusting ZAP''s read time out in the Connection options panel.
 
 pscan.api.action.setEnabled = Sets whether or not the passive scanning is enabled
+pscan.api.action.setScanOnlyInScope = Sets whether or not the passive scan should be performed only on messages that are in scope.
 pscan.api.action.enableAllScanners = Enables all passive scanners
 pscan.api.action.disableAllScanners = Disables all passive scanners
 pscan.api.action.enableScanners = Enables all passive scanners with the given IDs (comma separated list of IDs)
@@ -1636,6 +1637,7 @@ pscan.api.action.disableScanners = Disables all passive scanners with the given 
 pscan.api.action.setScannerAlertThreshold = Sets the alert threshold of the passive scanner with the given ID, accepted values for alert threshold: OFF, DEFAULT, LOW, MEDIUM and HIGH
 pscan.api.view.scanners = Lists all passive scanners with its ID, name, enabled state and alert threshold.
 pscan.api.view.recordsToScan	= The number of records the passive scanner still has to scan
+pscan.api.view.scanOnlyInScope = Tells whether or not the passive scan should be performed only on messages that are in scope.
 pscan.desc                                  = Passive scanner
 pscan.options.header                        = <html><body><p>The following passive scan rules have been defined.</p><p>New or changed rules only apply to new requests, not existing ones.</p></body></html>
 
@@ -1649,6 +1651,8 @@ pscan.options.dialog.scanner.field.label.editResponseHeaderRegex = Response Head
 pscan.options.dialog.scanner.field.label.enabled                 = Enabled:
 pscan.options.dialog.scanner.field.label.name                    = Name:
 pscan.options.dialog.scanner.field.label.type                    = Type:
+pscan.options.main.name = Passive Scanner
+pscan.options.main.label.scanOnlyInScope = Scan messages only in scope:
 pscan.options.name                          = Passive Scan Tags
 pscan.options.table.header.enabled                 = Enabled
 pscan.options.table.header.name                    = Name

--- a/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -72,6 +72,8 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
         DEPENDENCIES = Collections.unmodifiableList(dep);
     }
 
+    private PassiveScannerOptionsPanel passiveScannerOptionsPanel;
+
     public ExtensionPassiveScan() {
         super();
         initialize();
@@ -98,6 +100,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
         extensionHook.addProxyListener(getPassiveScanThread());
         extensionHook.addSessionListener(this);
         if (getView() != null) {
+            extensionHook.getHookView().addOptionPanel(getPassiveScannerOptionsPanel());
             extensionHook.getHookView().addOptionPanel(getOptionsPassiveScan(getPassiveScanThread()));
             extensionHook.getHookView().addOptionPanel(getPolicyPanel());
         }
@@ -406,18 +409,25 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
             final ExtensionHistory extHist = (ExtensionHistory) extensionLoader.getExtension(ExtensionHistory.NAME);
             final ExtensionAlert extAlert = (ExtensionAlert) extensionLoader.getExtension(ExtensionAlert.NAME);
 
-            pst = new PassiveScanThread(getPassiveScannerList(), extHist, extAlert);
+            pst = new PassiveScanThread(getPassiveScannerList(), extHist, extAlert, getPassiveScanParam());
 
             pst.start();
         }
         return pst;
     }
 
-    private PassiveScanParam getPassiveScanParam() {
+    PassiveScanParam getPassiveScanParam() {
         if (passiveScanParam == null) {
             passiveScanParam = new PassiveScanParam();
         }
         return passiveScanParam;
+    }
+
+    private PassiveScannerOptionsPanel getPassiveScannerOptionsPanel() {
+        if (passiveScannerOptionsPanel == null) {
+            passiveScannerOptionsPanel = new PassiveScannerOptionsPanel(Constant.messages);
+        }
+        return passiveScannerOptionsPanel;
     }
 
     private OptionsPassiveScan getOptionsPassiveScan(PassiveScanThread passiveScanThread) {

--- a/src/org/zaproxy/zap/extension/pscan/PassiveScanAPI.java
+++ b/src/org/zaproxy/zap/extension/pscan/PassiveScanAPI.java
@@ -40,10 +40,12 @@ public class PassiveScanAPI extends ApiImplementor {
 
 	private static final String PREFIX = "pscan";
 	
+	private static final String VIEW_SCAN_ONLY_IN_SCOPE = "scanOnlyInScope";
 	private static final String VIEW_RECORDS_TO_SCAN = "recordsToScan";
 	private static final String VIEW_SCANNERS = "scanners";
 
 	private static final String ACTION_SET_ENABLED = "setEnabled";
+	private static final String ACTION_SET_SCAN_ONLY_IN_SCOPE = "setScanOnlyInScope";
 	private static final String ACTION_ENABLE_ALL_SCANNERS = "enableAllScanners";
 	private static final String ACTION_DISABLE_ALL_SCANNERS = "disableAllScanners";
 	private static final String ACTION_ENABLE_SCANNERS = "enableScanners";
@@ -51,6 +53,7 @@ public class PassiveScanAPI extends ApiImplementor {
 	private static final String ACTION_SET_SCANNER_ALERT_THRESHOLD = "setScannerAlertThreshold";
 
 	private static final String PARAM_ENABLED = "enabled";
+	private static final String PARAM_ONLY_IN_SCOPE = "onlyInScope";
 	private static final String PARAM_IDS = "ids";
 	private static final String PARAM_ID = "id";
 	private static final String PARAM_ALERT_THRESHOLD = "alertThreshold";
@@ -61,12 +64,14 @@ public class PassiveScanAPI extends ApiImplementor {
 		this.extension = extension;
 
 		this.addApiAction(new ApiAction(ACTION_SET_ENABLED, new String[] {PARAM_ENABLED}));
+		this.addApiAction(new ApiAction(ACTION_SET_SCAN_ONLY_IN_SCOPE, new String[] { PARAM_ONLY_IN_SCOPE }));
 		this.addApiAction(new ApiAction(ACTION_ENABLE_ALL_SCANNERS));
 		this.addApiAction(new ApiAction(ACTION_DISABLE_ALL_SCANNERS));
 		this.addApiAction(new ApiAction(ACTION_ENABLE_SCANNERS, new String[] {PARAM_IDS}));
 		this.addApiAction(new ApiAction(ACTION_DISABLE_SCANNERS, new String[] {PARAM_IDS}));
 		this.addApiAction(new ApiAction(ACTION_SET_SCANNER_ALERT_THRESHOLD, new String[] {PARAM_ID, PARAM_ALERT_THRESHOLD}));
 
+		this.addApiView(new ApiView(VIEW_SCAN_ONLY_IN_SCOPE));
 		this.addApiView(new ApiView(VIEW_RECORDS_TO_SCAN));
 		this.addApiView(new ApiView(VIEW_SCANNERS));
 
@@ -84,6 +89,9 @@ public class PassiveScanAPI extends ApiImplementor {
 			boolean enabled = getParam(params, PARAM_ENABLED, false);
 			
 			extension.setPassiveScanEnabled(enabled);
+			break;
+		case ACTION_SET_SCAN_ONLY_IN_SCOPE:
+			extension.getPassiveScanParam().setScanOnlyInScope(params.getBoolean(PARAM_ONLY_IN_SCOPE));
 			break;
 		case ACTION_ENABLE_ALL_SCANNERS:
 			extension.setAllPluginPassiveScannersEnabled(true);
@@ -150,6 +158,9 @@ public class PassiveScanAPI extends ApiImplementor {
 		ApiResponse result;
 
 		switch (name) {
+		case VIEW_SCAN_ONLY_IN_SCOPE:
+			result = new ApiResponseElement(name, Boolean.toString(extension.getPassiveScanParam().isScanOnlyInScope()));
+			break;
 		case VIEW_RECORDS_TO_SCAN:
 			result = new ApiResponseElement(name, String.valueOf(extension.getRecordsToScan()));
 			break;

--- a/src/org/zaproxy/zap/extension/pscan/PassiveScanParam.java
+++ b/src/org/zaproxy/zap/extension/pscan/PassiveScanParam.java
@@ -48,9 +48,18 @@ public class PassiveScanParam extends AbstractParam {
     
     private static final String CONFIRM_REMOVE_AUTO_TAG_SCANNER_KEY = PASSIVE_SCANS_BASE_KEY + ".confirmRemoveAutoTagScanner";
 
+    private static final String SCAN_ONLY_IN_SCOPE_KEY = PASSIVE_SCANS_BASE_KEY + ".scanOnlyInScope";
+
     private List<RegexAutoTagScanner> autoTagScanners = new ArrayList<>(0);
     
     private boolean confirmRemoveAutoTagScanner = true;
+
+    /**
+     * Flag that indicates whether or not the passive scan should be performed only on messages that are in scope.
+     * <p>
+     * Default is {@code false}, all messages are scanned.
+     */
+    private boolean scanOnlyInScope;
     
     public PassiveScanParam() {
     }
@@ -87,6 +96,12 @@ public class PassiveScanParam extends AbstractParam {
             this.confirmRemoveAutoTagScanner = getConfig().getBoolean(CONFIRM_REMOVE_AUTO_TAG_SCANNER_KEY, true);
         } catch (ConversionException e) {
             logger.error("Error while loading the confirm remove option: " + e.getMessage(), e);
+        }
+
+        try {
+            this.scanOnlyInScope = getConfig().getBoolean(SCAN_ONLY_IN_SCOPE_KEY, false);
+        } catch (ConversionException e) {
+            logger.error("Error while loading \"scanOnlyInScope\" option: " + e.getMessage(), e);
         }
     }
 
@@ -125,4 +140,28 @@ public class PassiveScanParam extends AbstractParam {
         getConfig().setProperty(CONFIRM_REMOVE_AUTO_TAG_SCANNER_KEY, Boolean.valueOf(confirmRemoveAutoTagScanner));
     }
     
+    /**
+     * Sets whether or not the passive scan should be performed only on messages that are in scope.
+     *
+     * @param scanOnlyInScope {@code true} if the scan should be performed only on messages that are in scope, {@code false}
+     *            otherwise.
+     * @since TODO add version
+     * @see #isScanOnlyInScope()
+     * @see org.parosproxy.paros.model.Session#isInScope(String) Session.isInScope(String)
+     */
+    public void setScanOnlyInScope(boolean scanOnlyInScope) {
+        this.scanOnlyInScope = scanOnlyInScope;
+        getConfig().setProperty(SCAN_ONLY_IN_SCOPE_KEY, Boolean.valueOf(scanOnlyInScope));
+    }
+
+    /**
+     * Tells whether or not the passive scan should be performed only on messages that are in scope.
+     *
+     * @return {@code true} if the scan should be performed only on messages that are in scope, {@code false} otherwise.
+     * @since TODO add version
+     * @see #setScanOnlyInScope(boolean)
+     */
+    public boolean isScanOnlyInScope() {
+        return scanOnlyInScope;
+    }
 }

--- a/src/org/zaproxy/zap/extension/pscan/PassiveScannerOptionsPanel.java
+++ b/src/org/zaproxy/zap/extension/pscan/PassiveScannerOptionsPanel.java
@@ -1,0 +1,93 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscan;
+
+import javax.swing.GroupLayout;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+
+import org.parosproxy.paros.model.OptionsParam;
+import org.parosproxy.paros.view.AbstractParamPanel;
+import org.zaproxy.zap.utils.I18N;
+
+/**
+ * The GUI panel for options of the passive scanner.
+ * <p>
+ * It allows to change the following options:
+ * <ul>
+ * <li>Scan only in scope - allows to set if the passive scan should be performed only on messages that are in scope.</li>
+ * </ul>
+ * 
+ * @since TODO add version
+ */
+class PassiveScannerOptionsPanel extends AbstractParamPanel {
+
+    private static final long serialVersionUID = 1L;
+
+    private final JCheckBox scanOnlyInScopeCheckBox;
+
+    public PassiveScannerOptionsPanel(I18N messages) {
+        setName(messages.getString("pscan.options.main.name"));
+
+        GroupLayout layout = new GroupLayout(this);
+        setLayout(layout);
+
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
+
+        scanOnlyInScopeCheckBox = new JCheckBox();
+        JLabel scanOnlyInScopeLabel = new JLabel(messages.getString("pscan.options.main.label.scanOnlyInScope"));
+        scanOnlyInScopeLabel.setLabelFor(scanOnlyInScopeCheckBox);
+
+        layout.setHorizontalGroup(
+                layout.createSequentialGroup().addComponent(scanOnlyInScopeLabel).addComponent(scanOnlyInScopeCheckBox));
+
+        layout.setVerticalGroup(
+                layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                        .addComponent(scanOnlyInScopeLabel)
+                        .addComponent(scanOnlyInScopeCheckBox));
+    }
+
+    @Override
+    public void initParam(Object obj) {
+        OptionsParam optionsParam = (OptionsParam) obj;
+        PassiveScanParam pscanOptions = optionsParam.getParamSet(PassiveScanParam.class);
+
+        scanOnlyInScopeCheckBox.setSelected(pscanOptions.isScanOnlyInScope());
+    }
+
+    @Override
+    public void validateParam(Object obj) throws Exception {
+        // Nothing to validate.
+    }
+
+    @Override
+    public void saveParam(Object obj) throws Exception {
+        OptionsParam optionsParam = (OptionsParam) obj;
+        PassiveScanParam pscanOptions = optionsParam.getParamSet(PassiveScanParam.class);
+
+        pscanOptions.setScanOnlyInScope(scanOnlyInScopeCheckBox.isSelected());
+    }
+
+    @Override
+    public String getHelpIndex() {
+        return "ui.dialogs.options.pscan.main";
+    }
+}


### PR DESCRIPTION
Add an option disabled by default, to GUI and API, that allows to set
the passive scanner to scan only messages that are in scope.

Fix #3004 - Allow to passive scan just HTTP messages in scope