### PR TITLE
Call postInit when starting an extension

### DIFF
--- a/src/org/parosproxy/paros/extension/ExtensionLoader.java
+++ b/src/org/parosproxy/paros/extension/ExtensionLoader.java
@@ -65,6 +65,7 @@
 // ZAP: 2016/05/30 Notification of installation status of the add-ons
 // ZAP: 2016/05/30 Issue 2494: ZAP Proxy is not showing the HTTP CONNECT Request in history tab
 // ZAP: 2016/08/18 Hook ApiImplementor
+// ZAP: 2016/11/23 Call postInit() when starting an extension, startLifeCycle(Extension).
 
 package org.parosproxy.paros.extension;
 
@@ -663,6 +664,7 @@ public class ExtensionLoader {
             
             hookOptions(extHook);
             ext.optionsLoaded();
+            ext.postInit();
         } catch (Exception e) {
             logger.error(e.getMessage(), e);
         }


### PR DESCRIPTION
Change ExtensionLoader to call the method Extension.postInit() when
starting an extension (i.e. installed by an add-on).
The change ensures the extension is properly/fully initialised when it
is started/installed (e.g. sequence extension which adds a custom scan
panel on postInit()).