### PR TITLE
Allow to active scan a Context through the ZAP API

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -134,6 +134,7 @@ api.options.autofillKey		= Autofill API key in the API UI
 api.options.label.testingWarning	= <html>* The following options should only be used for testing as they may make it easier to attack ZAP</html>
 api.options.nokey.error		= You must supply an API key or explicitly disable it.
 ascan.activeActionPrefix = Active scanning: {0}
+ascan.api.action.scan = Runs the active scanner against the given URL and/or Context. Optionally, the 'recurse' parameter can be used to scan URLs under the given URL, the parameter 'inScopeOnly' can be used to constrain the scan to URLs that are in scope (ignored if a Context is specified), the parameter 'scanPolicyName' allows to specify the scan policy (if none is given it uses the default scan policy), the parameters 'method' and 'postData' allow to select a given request in conjunction with the given URL.
 ascan.api.action.scanAsUser = Active Scans from the perspective of a User, obtained using the given Context ID and User ID. See 'scan' action for more details.
 ascan.api.view.optionScanHeadersAllRequests = Tells whether or not the HTTP Headers of all requests should be scanned. Not just requests that send parameters, through the query or request body.
 ascan.api.action.setOptionScanHeadersAllRequests = Sets whether or not the HTTP Headers of all requests should be scanned. Not just requests that send parameters, through the query or request body.

--- a/src/org/zaproxy/zap/extension/api/ApiImplementor.java
+++ b/src/org/zaproxy/zap/extension/api/ApiImplementor.java
@@ -363,6 +363,20 @@ public abstract class ApiImplementor {
 	}
 
 	/**
+	 * Validates that a parameter with the given {@code name} exists (and it has a value) in the given {@code parameters}.
+	 *
+	 * @param parameters the parameters
+	 * @param name the name of the parameter that must exist
+	 * @throws ApiException if the parameter with the given name does not exist or it has no value.
+	 * @since TODO add version
+	 */
+	protected void validateParamExists(JSONObject parameters, String name) throws ApiException {
+		if (!parameters.has(name) || parameters.getString(name).length() == 0) {
+			throw new ApiException(ApiException.Type.MISSING_PARAMETER, name);
+		}
+	}
+	
+	/**
 	 * Override to add custom headers for specific API operations
 	 * @param name	the name of the operation
 	 * @param type the type of the operation


### PR DESCRIPTION
Change ActiveScanAPI to:
 - Allow to specify a context for the "scan" action;
 - Not require the URL, in the actions "scan" and "scanAsUser", if
 the context is specified (for the latter action it is always).

Add helper method to ApiImplementor that validates that an API parameter
exists.

Fix #1853 - Allow to active scan a Context through ZAP API