### PR TITLE
Restore API generator methods

### DIFF
--- a/src/org/zaproxy/zap/extension/api/AbstractAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/AbstractAPIGenerator.java
@@ -30,6 +30,8 @@ import org.parosproxy.paros.Constant;
 
 /**
  * The base class for ZAP API client generators.
+ * 
+ * @since TODO add version
  */
 abstract class AbstractAPIGenerator {
 

--- a/src/org/zaproxy/zap/extension/api/DotNetAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/DotNetAPIGenerator.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class DotNetAPIGenerator extends AbstractAPIGenerator {
@@ -69,6 +70,18 @@ public class DotNetAPIGenerator extends AbstractAPIGenerator {
 
     public DotNetAPIGenerator(String path, boolean optional) {
     	super(path, optional);
+    }
+
+    /**
+     * Generates the API client files of the given API implementors.
+     *
+     * @param implementors the implementors
+     * @throws IOException if an error occurred while generating the APIs.
+     * @deprecated (TODO add version) Use {@link #generateAPIFiles(List)} instead.
+     */
+    @Deprecated
+    public void generateCSharpFiles(List<ApiImplementor> implementors) throws IOException {
+        this.generateAPIFiles(implementors);
     }
 
 	private void generateCSharpElement(ApiElement element, String component, 

--- a/src/org/zaproxy/zap/extension/api/GoAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/GoAPIGenerator.java
@@ -52,6 +52,18 @@ public class GoAPIGenerator extends AbstractAPIGenerator {
 		super(path, optional);
 	}
 
+	/**
+	 * Generates the API client files of the given API implementors.
+	 *
+	 * @param implementors the implementors
+	 * @throws IOException if an error occurred while generating the APIs.
+	 * @deprecated (TODO add version) Use {@link #generateAPIFiles(List)} instead.
+	 */
+	@Deprecated
+	public void generateGoFiles(List<ApiImplementor> implementors) throws IOException {
+		this.generateAPIFiles(implementors);
+	}
+
 	@Override
 	protected void generateAPIFiles(ApiImplementor imp) throws IOException {
 		String className = imp.getPrefix().substring(0, 1).toUpperCase() + imp.getPrefix().substring(1);

--- a/src/org/zaproxy/zap/extension/api/JavaAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/JavaAPIGenerator.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class JavaAPIGenerator extends AbstractAPIGenerator {
@@ -78,6 +79,18 @@ public class JavaAPIGenerator extends AbstractAPIGenerator {
 
     public JavaAPIGenerator(String path, boolean optional) {
     	super(path, optional);
+    }
+
+    /**
+     * Generates the API client files of the given API implementors.
+     *
+     * @param implementors the implementors
+     * @throws IOException if an error occurred while generating the APIs.
+     * @deprecated (TODO add version) Use {@link #generateAPIFiles(List)} instead.
+     */
+    @Deprecated
+    public void generateJavaFiles(List<ApiImplementor> implementors) throws IOException {
+        generateAPIFiles(implementors);
     }
 
 	private void generateJavaElement(ApiElement element, String component, 

--- a/src/org/zaproxy/zap/extension/api/NodeJSAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/NodeJSAPIGenerator.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class NodeJSAPIGenerator extends AbstractAPIGenerator {
@@ -68,6 +69,18 @@ public class NodeJSAPIGenerator extends AbstractAPIGenerator {
 
     public NodeJSAPIGenerator(String path, boolean optional) {
     	super(path, optional);
+    }
+
+    /**
+     * Generates the API client files of the given API implementors.
+     *
+     * @param implementors the implementors
+     * @throws IOException if an error occurred while generating the APIs.
+     * @deprecated (TODO add version) Use {@link #generateAPIFiles(List)} instead.
+     */
+    @Deprecated
+    public void generateNodeJSFiles(List<ApiImplementor> implementors) throws IOException {
+        this.generateAPIFiles(implementors);
     }
 
     private void generateNodeJSElement(ApiElement element, String component, 

--- a/src/org/zaproxy/zap/extension/api/PhpAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/PhpAPIGenerator.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class PhpAPIGenerator extends AbstractAPIGenerator {
@@ -70,6 +71,18 @@ public class PhpAPIGenerator extends AbstractAPIGenerator {
 
     public PhpAPIGenerator(String path, boolean optional) {
     	super(path, optional);
+    }
+
+    /**
+     * Generates the API client files of the given API implementors.
+     *
+     * @param implementors the implementors
+     * @throws IOException if an error occurred while generating the APIs.
+     * @deprecated (TODO add version) Use {@link #generateAPIFiles(List)} instead.
+     */
+    @Deprecated
+    public void generatePhpFiles(List<ApiImplementor> implementors) throws IOException {
+        this.generateAPIFiles(implementors);
     }
 
 	private void generatePhpElement(ApiElement element, String component, 

--- a/src/org/zaproxy/zap/extension/api/PythonAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/PythonAPIGenerator.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class PythonAPIGenerator extends AbstractAPIGenerator {
@@ -74,6 +75,18 @@ public class PythonAPIGenerator extends AbstractAPIGenerator {
 
     public PythonAPIGenerator(String path, boolean optional) {
     	super(path, optional);
+    }
+
+    /**
+     * Generates the API client files of the given API implementors.
+     *
+     * @param implementors the implementors
+     * @throws IOException if an error occurred while generating the APIs.
+     * @deprecated (TODO add version) Use {@link #generateAPIFiles(List)} instead.
+     */
+    @Deprecated
+    public void generatePythonFiles(List<ApiImplementor> implementors) throws IOException {
+        this.generateAPIFiles(implementors);
     }
 
 	private void generatePythonElement(ApiElement element, String component, 

--- a/src/org/zaproxy/zap/extension/api/WikiAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/WikiAPIGenerator.java
@@ -89,6 +89,21 @@ public class WikiAPIGenerator extends AbstractAPIGenerator {
 		}
 	}
 
+	/**
+	 * Generates the wiki files of the given API implementors.
+	 *
+	 * @param implementors the implementors
+	 * @throws IOException if an error occurred while generating the APIs.
+	 * @deprecated (TODO add version) Use {@link #generateAPIFiles(List)} instead.
+	 */
+	@Deprecated
+	public void generateWikiFiles(List<ApiImplementor> implementors) throws IOException {
+		generateAPIFiles(implementors);
+	}
+
+	/**
+	 * Generates the wiki files of the given API implementors.
+	 */
 	@Override
 	public void generateAPIFiles(List<ApiImplementor> implementors) throws IOException {
 		// Generate index first


### PR DESCRIPTION
Restore (and deprecate) methods of the API generators to keep binary
compatibility with current/previous version (they are in use by
zap-extensions project).