### PR TITLE
Return request's type through the ZAP API

### DIFF
--- a/src/org/zaproxy/zap/extension/api/ApiResponseConversionUtils.java
+++ b/src/org/zaproxy/zap/extension/api/ApiResponseConversionUtils.java
@@ -31,16 +31,44 @@ import org.apache.log4j.Logger;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class ApiResponseConversionUtils {
+/**
+ * A class with utility methods to convert common (ZAP) objects into {@link ApiResponse} objects.
+ * 
+ * @since 2.3.0
+ */
+public final class ApiResponseConversionUtils {
 
-    private static Logger logger = Logger.getLogger(ApiResponseConversionUtils.class);
+    private static final Logger LOGGER = Logger.getLogger(ApiResponseConversionUtils.class);
 
     private ApiResponseConversionUtils() {
     }
 
+    /**
+     * Converts the given HTTP message, of unknown type, into an {@code ApiResponseSet}.
+     * <p>
+     * Prefer the use of {@link #httpMessageToSet(int, int, HttpMessage)}, which allows to provide the type of the message.
+     * 
+     * @param historyId the ID of the message
+     * @param msg the HTTP message to be converted
+     * @return the {@code ApiResponseSet} with the ID, type and the HTTP message
+     */
     public static ApiResponseSet httpMessageToSet(int historyId, HttpMessage msg) {
+        return httpMessageToSet(historyId, -1, msg);
+    }
+
+    /**
+     * Converts the given HTTP message into an {@code ApiResponseSet}.
+     *
+     * @param historyId the ID of the message
+     * @param historyType the type of the message
+     * @param msg the HTTP message to be converted
+     * @return the {@code ApiResponseSet} with the ID, type and the HTTP message
+     * @since TODO add version
+     */
+    public static ApiResponseSet httpMessageToSet(int historyId, int historyType, HttpMessage msg) {
         Map<String, String> map = new HashMap<>();
         map.put("id", String.valueOf(historyId));
+        map.put("type", String.valueOf(historyType));
         map.put("cookieParams", msg.getCookieParamsAsString());
         map.put("note", msg.getNote());
         map.put("requestHeader", msg.getRequestHeader().toString());
@@ -60,7 +88,7 @@ public class ApiResponseConversionUtils {
                 }
                 map.put("responseBody", sb.toString());
             } catch (IOException e) {
-                logger.error("Unable to uncompress gzip content: " + e.getMessage(), e);
+                LOGGER.error("Unable to uncompress gzip content: " + e.getMessage(), e);
                 map.put("responseBody", msg.getResponseBody().toString());
             }
         } else {

--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -546,8 +546,14 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 
 				@Override
 				public void process(HttpMessage msg) {
-					int id = msg.getHistoryRef() != null ? msg.getHistoryRef().getHistoryId() : -1;
-					resultList.addItem(ApiResponseConversionUtils.httpMessageToSet(id, msg));
+					int id = -1;
+					int type = -1;
+					HistoryReference hRef = msg.getHistoryRef();
+					if (hRef != null) {
+						id = hRef.getHistoryId();
+						type = hRef.getHistoryType();
+					}
+					resultList.addItem(ApiResponseConversionUtils.httpMessageToSet(id, type, msg));
 				}
 			});
 
@@ -724,7 +730,8 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 			if (recordHistory == null || recordHistory.getHistoryType() == HistoryReference.TYPE_TEMPORARY) {
 				throw new ApiException(ApiException.Type.DOES_NOT_EXIST);
 			}
-			result = new ApiResponseElement(ApiResponseConversionUtils.httpMessageToSet(recordHistory.getHistoryId(), recordHistory.getHttpMessage()));
+			result = new ApiResponseElement(ApiResponseConversionUtils.httpMessageToSet(recordHistory.getHistoryId(),
+					recordHistory.getHistoryType(), recordHistory.getHttpMessage()));
 		} else if (VIEW_MESSAGES.equals(name)) {
 			final ApiResponseList resultList = new ApiResponseList(name);
 			processHttpMessages(
@@ -737,6 +744,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 						public void process(RecordHistory recordHistory) {
 							resultList.addItem(ApiResponseConversionUtils.httpMessageToSet(
 									recordHistory.getHistoryId(),
+									recordHistory.getHistoryType(),
 									recordHistory.getHttpMessage()));
 						}
 					});

--- a/src/org/zaproxy/zap/extension/search/SearchAPI.java
+++ b/src/org/zaproxy/zap/extension/search/SearchAPI.java
@@ -165,6 +165,7 @@ public class SearchAPI extends ApiImplementor {
 					public void processRecordHistory(RecordHistory recordHistory) {
 						result.addItem(ApiResponseConversionUtils.httpMessageToSet(
 								recordHistory.getHistoryId(),
+								recordHistory.getHistoryType(),
 								recordHistory.getHttpMessage()));
 					}
 				};

--- a/test/org/zaproxy/zap/extension/api/ApiResponseConversionUtilsUnitTest.java
+++ b/test/org/zaproxy/zap/extension/api/ApiResponseConversionUtilsUnitTest.java
@@ -61,6 +61,24 @@ public class ApiResponseConversionUtilsUnitTest {
 	}
 
 	@Test
+	public void shouldHaveUndefinedHistoryTypeByDefault() {
+		// Given / When
+		ApiResponseSet response = ApiResponseConversionUtils.httpMessageToSet(0, message);
+		// Then
+		assertThat(response.getValues(), hasEntry("type", (Object) "-1"));
+	}
+
+	@Test
+	public void shouldIncludeHistoryTypeInApiResponse() {
+		// Given
+		int historyType = 2;
+		// When
+		ApiResponseSet response = ApiResponseConversionUtils.httpMessageToSet(0, historyType, message);
+		// Then
+		assertThat(response.getValues(), hasEntry("type", (Object) "2"));
+	}
+
+	@Test
 	public void propertiesFromGivenHttpMessageShouldReflectInApiResponse() {
 		given(message.getCookieParamsAsString()).willReturn("testCookieParams");
 		given(message.getNote()).willReturn("testNote");


### PR DESCRIPTION
Change ZAP API actions/views to include the type ID of the request (e.g.
proxy, manual, spider, active) when returning the data of the HTTP
message(s).
Add JavaDoc to ApiResponseConversionUtils and made other minor changes
(change logger variable to a constant and made class final).
Update tests to check that the type is being set/used.

 ---
Mentioned in IRC channel.