### PR TITLE
Add Spider URIs, to the UI, in the EDT

### DIFF
--- a/src/org/zaproxy/zap/extension/spider/SpiderPanelTableModel.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderPanelTableModel.java
@@ -91,10 +91,8 @@ public class SpiderPanelTableModel extends AbstractTableModel {
 	 * Removes all the elements. Method is synchronized internally.
 	 */
 	public void removeAllElements() {
-		synchronized (scanResults) {
-			scanResults.clear();
-			fireTableDataChanged();
-		}
+		scanResults.clear();
+		fireTableDataChanged();
 	}
 
 	/**
@@ -107,14 +105,8 @@ public class SpiderPanelTableModel extends AbstractTableModel {
 	 */
 	public void addScanResult(String uri, String method, String flags, boolean skipped) {
 		SpiderScanResult result = new SpiderScanResult(uri, method, flags, !skipped);
-		synchronized (scanResults) {
-			scanResults.add(result);
-			try {
-				fireTableRowsInserted(scanResults.size() - 1, scanResults.size() - 1);
-			} catch (IndexOutOfBoundsException e) {
-				// Happens occasionally but seems benign
-			}
-		}
+		scanResults.add(result);
+		fireTableRowsInserted(scanResults.size() - 1, scanResults.size() - 1);
 	}
 
 	/**
@@ -125,12 +117,10 @@ public class SpiderPanelTableModel extends AbstractTableModel {
 	 */
 	public void removesScanResult(String uri, String method) {
 		SpiderScanResult toRemove = new SpiderScanResult(uri, method);
-		synchronized (scanResults) {
-			int index = scanResults.indexOf(toRemove);
-			if (index >= 0) {
-				scanResults.remove(index);
-				fireTableRowsDeleted(index, index);
-			}
+		int index = scanResults.indexOf(toRemove);
+		if (index >= 0) {
+			scanResults.remove(index);
+			fireTableRowsDeleted(index, index);
 		}
 	}
 


### PR DESCRIPTION
Change the SpiderThread to add the URIs found to the UI in the EDT, to
prevent concurrency issues between other threads and the EDT, e.g.:
java.lang.NullPointerException
 at JTable.sortedTableChanged(JTable.java:4129)
 at JTable.tableChanged(JTable.java:4395)
 at JXTable.tableChanged(JXTable.java:1561)
 at AbstractTableModel.fireTableChanged(AbstractTableModel.java:296)
 at AbstractTableModel.fireTableRowsInserted(...)
 at o.z.z.extension.spider.SpiderPanelTableModel.addScanResult(...)
 at o.z.z.extension.spider.SpiderThread.foundURI(Unknown Source)
 at o.z.z.spider.Spider.notifyListenersFoundURI(Unknown Source)
 at o.z.z.spider.SpiderController.addSeed(Unknown Source)
 at o.z.z.spider.Spider.start(Unknown Source)
 at o.z.z.extension.spider.SpiderThread.startSpider(Unknown Source)
 at o.z.z.extension.spider.SpiderThread.runScan(Unknown Source)
 at o.z.z.extension.spider.SpiderThread.run(Unknown Source)
(packages reduced/omitted to keep the lines short)

Also, do not create the SpiderPanelTableModel if there's no view.
Remove the synchronisation in SpiderPanelTableModel as that's not
required, the model is accessed only through the EDT.