### PR TITLE
Fix concurrency issues when publishing ZAP events

### DIFF
--- a/src/org/zaproxy/zap/eventBus/SimpleEventBus.java
+++ b/src/org/zaproxy/zap/eventBus/SimpleEventBus.java
@@ -5,6 +5,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.log4j.Logger;
 
@@ -18,6 +21,28 @@ public class SimpleEventBus implements EventBus {
 	private Map<String, RegisteredPublisher> nameToPublisher = new HashMap<String, RegisteredPublisher>();
 	private List<RegisteredConsumer> danglingConsumers = new ArrayList<RegisteredConsumer>();
 
+	/**
+	 * The read/write {@code Lock} for registration management and publishing of events.
+	 * 
+	 * @see #regMgmtLock
+	 * @see #publishLock
+	 */
+	private final ReadWriteLock rwLock = new ReentrantReadWriteLock(true);
+
+	/**
+	 * The {@code Lock} for registration management (register and unregister) of publishers and consumers.
+	 * 
+	 * @see #publishLock
+	 */
+	private final Lock regMgmtLock = rwLock.writeLock();
+
+	/**
+	 * The {@code Lock} for publishing of events.
+	 * 
+	 * @see #regMgmtLock
+	 */
+	private final Lock publishLock = rwLock.readLock();
+
 	private static Logger log = Logger.getLogger(SimpleEventBus.class);
 
 	@Override
@@ -28,24 +53,29 @@ public class SimpleEventBus implements EventBus {
 		if (eventTypes == null || eventTypes.length == 0) {
 			throw new InvalidParameterException("At least one event type must be specified");
 		}
-		if (this.nameToPublisher.get(publisher.getPublisherName()) != null) {
-			throw new InvalidParameterException("Publisher with name " + publisher.getPublisherName() + 
-					" already registered by " + this.nameToPublisher.get(publisher.getPublisherName())
-						.getPublisher().getClass().getCanonicalName());
-		}
-		log.debug("registerPublisher " + publisher.getPublisherName());
-		
-		RegisteredPublisher regProd = new RegisteredPublisher(publisher, eventTypes);
-		
-		this.nameToPublisher.put(publisher.getPublisherName(), regProd);
-
-		// Check to see if there are any cached consumers
-		for (RegisteredConsumer regCon : this.danglingConsumers) {
-			if (regCon.getPublisherName().equals(publisher.getPublisherName())) {
-				regProd.addComsumer(regCon);
-				this.danglingConsumers.remove(regCon);
-				break;
+		regMgmtLock.lock();
+		try {
+			if (this.nameToPublisher.get(publisher.getPublisherName()) != null) {
+				throw new InvalidParameterException("Publisher with name " + publisher.getPublisherName() + 
+						" already registered by " + this.nameToPublisher.get(publisher.getPublisherName())
+							.getPublisher().getClass().getCanonicalName());
 			}
+			log.debug("registerPublisher " + publisher.getPublisherName());
+
+			RegisteredPublisher regProd = new RegisteredPublisher(publisher, eventTypes);
+
+			this.nameToPublisher.put(publisher.getPublisherName(), regProd);
+
+			// Check to see if there are any cached consumers
+			for (RegisteredConsumer regCon : this.danglingConsumers) {
+				if (regCon.getPublisherName().equals(publisher.getPublisherName())) {
+					regProd.addComsumer(regCon);
+					this.danglingConsumers.remove(regCon);
+					break;
+				}
+			}
+		} finally {
+			regMgmtLock.unlock();
 		}
 
 	}
@@ -55,11 +85,17 @@ public class SimpleEventBus implements EventBus {
 		if (publisher == null) {
 			throw new InvalidParameterException("Publisher must not be null");
 		}
-		log.debug("unregisterPublisher " + publisher.getPublisherName());
-		RegisteredPublisher regPub = nameToPublisher.remove(publisher.getPublisherName());
-		if (regPub == null) {
-			throw new InvalidParameterException("Publisher with name " + publisher.getPublisherName() + 
-					" not registered");
+
+		regMgmtLock.lock();
+		try {
+			log.debug("unregisterPublisher " + publisher.getPublisherName());
+			RegisteredPublisher regPub = nameToPublisher.remove(publisher.getPublisherName());
+			if (regPub == null) {
+				throw new InvalidParameterException("Publisher with name " + publisher.getPublisherName() + 
+						" not registered");
+			}
+		} finally {
+			regMgmtLock.unlock();
 		}
 	}
 
@@ -74,13 +110,19 @@ public class SimpleEventBus implements EventBus {
 		if (consumer == null) {
 			throw new InvalidParameterException("Consumer must not be null");
 		}
-		log.debug("registerConsumer " + consumer.getClass().getCanonicalName() + " for " + publisherName);
-		RegisteredPublisher publisher = this.nameToPublisher.get(publisherName);
-		if (publisher == null) {
-			// Cache until the publisher registers
-			this.danglingConsumers.add(new RegisteredConsumer(consumer, eventTypes, publisherName));
-		} else {
-			publisher.addComsumer(consumer, eventTypes);
+
+		regMgmtLock.lock();
+		try {
+			log.debug("registerConsumer " + consumer.getClass().getCanonicalName() + " for " + publisherName);
+			RegisteredPublisher publisher = this.nameToPublisher.get(publisherName);
+			if (publisher == null) {
+				// Cache until the publisher registers
+				this.danglingConsumers.add(new RegisteredConsumer(consumer, eventTypes, publisherName));
+			} else {
+				publisher.addComsumer(consumer, eventTypes);
+			}
+		} finally {
+			regMgmtLock.unlock();
 		}
 	}
 
@@ -89,18 +131,24 @@ public class SimpleEventBus implements EventBus {
 		if (consumer == null) {
 			throw new InvalidParameterException("Consumer must not be null");
 		}
-		log.debug("unregisterConsumer " + consumer.getClass().getCanonicalName() + " for " + publisherName);
-		RegisteredPublisher publisher = this.nameToPublisher.get(publisherName);
-		if (publisher != null) {
-			publisher.removeComsumer(consumer);
-		} else {
-			// Check to see if its cached waiting for the publisher
-			for (RegisteredConsumer regCon : this.danglingConsumers) {
-				if (regCon.getConsumer().equals(consumer)) {
-					this.danglingConsumers.remove(regCon);
-					break;
+
+		regMgmtLock.lock();
+		try {
+			log.debug("unregisterConsumer " + consumer.getClass().getCanonicalName() + " for " + publisherName);
+			RegisteredPublisher publisher = this.nameToPublisher.get(publisherName);
+			if (publisher != null) {
+				publisher.removeComsumer(consumer);
+			} else {
+				// Check to see if its cached waiting for the publisher
+				for (RegisteredConsumer regCon : this.danglingConsumers) {
+					if (regCon.getConsumer().equals(consumer)) {
+						this.danglingConsumers.remove(regCon);
+						break;
+					}
 				}
 			}
+		} finally {
+			regMgmtLock.unlock();
 		}
 	}
 
@@ -110,48 +158,54 @@ public class SimpleEventBus implements EventBus {
 		if (publisher == null) {
 			throw new InvalidParameterException("Publisher must not be null");
 		}
-		RegisteredPublisher regPublisher = this.nameToPublisher.get(publisher.getPublisherName());
-		if (regPublisher == null) {
-			throw new InvalidParameterException("Publisher not registered: " + publisher.getPublisherName());
-		}
-		log.debug("publishSyncEvent " + event.getEventType() + " from " + publisher.getPublisherName());
-		boolean foundType = false;
-		for (String type : regPublisher.getEventTypes()) {
-			if (event.getEventType().equals(type)) {
-				foundType = true;
-				break;
-			}
-		}
-		if (! foundType) {
-			throw new InvalidParameterException("Event type: " + event.getEventType() + 
-					" not registered for publisher: " + publisher.getPublisherName());
-		}
 
-		for (RegisteredConsumer regCon : regPublisher.getConsumers()) {
-			String[] eventTypes = regCon.getEventTypes();
-			boolean isListeningforEvent = false;
-			if (eventTypes == null) {
-				// They are listening for all events from this publisher
-				isListeningforEvent = true;
-			} else {
-				for (String type : eventTypes) {
-					if (event.getEventType().equals(type)) {
-						isListeningforEvent = true;
-						break;
+		publishLock.lock();
+		try {
+			RegisteredPublisher regPublisher = this.nameToPublisher.get(publisher.getPublisherName());
+			if (regPublisher == null) {
+				throw new InvalidParameterException("Publisher not registered: " + publisher.getPublisherName());
+			}
+			log.debug("publishSyncEvent " + event.getEventType() + " from " + publisher.getPublisherName());
+			boolean foundType = false;
+			for (String type : regPublisher.getEventTypes()) {
+				if (event.getEventType().equals(type)) {
+					foundType = true;
+					break;
+				}
+			}
+			if (! foundType) {
+				throw new InvalidParameterException("Event type: " + event.getEventType() + 
+						" not registered for publisher: " + publisher.getPublisherName());
+			}
+
+			for (RegisteredConsumer regCon : regPublisher.getConsumers()) {
+				String[] eventTypes = regCon.getEventTypes();
+				boolean isListeningforEvent = false;
+				if (eventTypes == null) {
+					// They are listening for all events from this publisher
+					isListeningforEvent = true;
+				} else {
+					for (String type : eventTypes) {
+						if (event.getEventType().equals(type)) {
+							isListeningforEvent = true;
+							break;
+						}
+					}
+				}
+				if (isListeningforEvent) {
+					try {
+						regCon.getConsumer().eventReceived(event);
+					} catch (Exception e) {
+						log.error(e.getMessage(), e);
 					}
 				}
 			}
-			if (isListeningforEvent) {
-				try {
-					regCon.getConsumer().eventReceived(event);
-				} catch (Exception e) {
-					log.error(e.getMessage(), e);
-				}
-			}
+		}finally {
+			publishLock.unlock();
 		}
 	}
 	
-	private class RegisteredConsumer {
+	private static class RegisteredConsumer {
 		private EventConsumer consumer;
 		private String[] eventTypes;
 		private String publisherName;
@@ -176,7 +230,7 @@ public class SimpleEventBus implements EventBus {
 		}
 	}
 
-	private class RegisteredPublisher {
+	private static class RegisteredPublisher {
 		private EventPublisher publisher;
 		private String[] eventTypes;
 		private List<RegisteredConsumer> consumers = new ArrayList<RegisteredConsumer>();


### PR DESCRIPTION
Change SimpleEventBus to control the read/write accesses to the
publishers and consumers to prevent concurrency issues. For example,
when a consumer is unregistered while publishing events, which could
lead to exceptions, e.g.:
java.util.ConcurrentModificationException
 at java.util.ArrayList$Itr.checkForComodification(...)
 at java.util.ArrayList$Itr.next(...)
 at o.z.z.eventBus.SimpleEventBus.publishSyncEvent(...)
 at o.z.z.extension.alert.ExtensionAlert.publishAlertEvent(...)
 at o.z.z.extension.alert.ExtensionAlert.alertFound(...)
 at o.z.z.extension.pscan.PassiveScanThread.raiseAlert(...)
(packages reduced/omitted to keep the lines short)

Only one thread (write access) is allowed to manage the publishers and
consumers while multiple threads can publish events (read access), as
long no thread is managing the publishers or the consumers.
Change the classes RegisteredConsumer and RegisteredPublisher to be
static as they don't need to access the state of SimpleEventBus class.