### PR TITLE
Allow to select multiple parameters in Params tab

### DIFF
--- a/src/org/zaproxy/zap/extension/params/ParamsPanel.java
+++ b/src/org/zaproxy/zap/extension/params/ParamsPanel.java
@@ -238,7 +238,6 @@ public class ParamsPanel extends AbstractPanel{
 
 			paramsTable.setName(PANEL_NAME);
 			paramsTable.setDoubleBuffered(true);
-			paramsTable.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
 			paramsTable.addMouseListener(new java.awt.event.MouseAdapter() { 
 			    @Override
 			    public void mousePressed(java.awt.event.MouseEvent e) {
@@ -360,5 +359,16 @@ public class ParamsPanel extends AbstractPanel{
 			return sps.getParam(HtmlParameter.Type.valueOf(type.toLowerCase()), name);	// TODO HACK!
 		}
 		return null;
+	}
+
+	/**
+	 * Tells whether or not only one of the parameters is selected.
+	 *
+	 * @return {@code true} if only one parameter is selected, {@code false} otherwise.
+	 * @see #getSelectedParam()
+	 * @since TODO add version
+	 */
+	boolean isOnlyOneParamSelected() {
+		return getParamsTable().getSelectedRowCount() == 1;
 	}
 }

--- a/src/org/zaproxy/zap/extension/params/PopupMenuAddAntiCSRF.java
+++ b/src/org/zaproxy/zap/extension/params/PopupMenuAddAntiCSRF.java
@@ -51,6 +51,10 @@ public class PopupMenuAddAntiCSRF extends ExtensionPopupMenuItem {
     @Override
     public boolean isEnableForComponent(Component invoker) {
         if (invoker.getName() != null && invoker.getName().equals(ParamsPanel.PANEL_NAME)) {
+            if (!extension.getParamsPanel().isOnlyOneParamSelected()) {
+                this.setEnabled(false);
+                return true;
+            }
         	
         	HtmlParameterStats item = extension.getParamsPanel().getSelectedParam();
         	// Note that only form params are currently supported

--- a/src/org/zaproxy/zap/extension/params/PopupMenuAddSession.java
+++ b/src/org/zaproxy/zap/extension/params/PopupMenuAddSession.java
@@ -53,6 +53,10 @@ public class PopupMenuAddSession extends ExtensionPopupMenuItem {
     @Override
     public boolean isEnableForComponent(Component invoker) {
         if (invoker.getName() != null && invoker.getName().equals(ParamsPanel.PANEL_NAME)) {
+            if (!extension.getParamsPanel().isOnlyOneParamSelected()) {
+                this.setEnabled(false);
+                return true;
+            }
         	
         	HtmlParameterStats item = extension.getParamsPanel().getSelectedParam();
         	// Note that only cookie params are currently supported

--- a/src/org/zaproxy/zap/extension/params/PopupMenuParamSearch.java
+++ b/src/org/zaproxy/zap/extension/params/PopupMenuParamSearch.java
@@ -51,7 +51,7 @@ public class PopupMenuParamSearch extends ExtensionPopupMenuItem {
     @Override
     public boolean isEnableForComponent(Component invoker) {
         if (invoker.getName() != null && invoker.getName().equals(ParamsPanel.PANEL_NAME)) {
-            this.setEnabled(true);
+            this.setEnabled(extension.getParamsPanel().isOnlyOneParamSelected());
             return true;
         }
         return false;

--- a/src/org/zaproxy/zap/extension/params/PopupMenuRemoveAntiCSRF.java
+++ b/src/org/zaproxy/zap/extension/params/PopupMenuRemoveAntiCSRF.java
@@ -53,6 +53,9 @@ public class PopupMenuRemoveAntiCSRF extends ExtensionPopupMenuItem {
     @Override
     public boolean isEnableForComponent(Component invoker) {
         if (invoker.getName() != null && invoker.getName().equals(ParamsPanel.PANEL_NAME)) {
+            if (!extension.getParamsPanel().isOnlyOneParamSelected()) {
+                return false;
+            }
         	
         	HtmlParameterStats item = extension.getParamsPanel().getSelectedParam();
         	// Note that only form params are currently supported

--- a/src/org/zaproxy/zap/extension/params/PopupMenuRemoveSession.java
+++ b/src/org/zaproxy/zap/extension/params/PopupMenuRemoveSession.java
@@ -53,6 +53,9 @@ public class PopupMenuRemoveSession extends ExtensionPopupMenuItem {
     @Override
     public boolean isEnableForComponent(Component invoker) {
         if (invoker.getName() != null && invoker.getName().equals(ParamsPanel.PANEL_NAME)) {
+            if (!extension.getParamsPanel().isOnlyOneParamSelected()) {
+                return false;
+            }
         	
         	HtmlParameterStats item = extension.getParamsPanel().getSelectedParam();
         	if (item != null && item.getFlags().contains(HtmlParameter.Flags.session.name())) {


### PR DESCRIPTION
Change ParamsPanel to allow to select multiple parameters (rows).
Change Params tab pop up menus to be enabled only when one of the
parameters is selected (to keep the same behaviour).

Related to #3040 - Export param tab contents