### PR TITLE
Add Spider scans to GUI in the EDT

### DIFF
--- a/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
+++ b/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
@@ -588,13 +588,27 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
 
 		int id = this.scanController.startScan(displayName, target, user, customConfigurations);
     	if (View.isInitialised()) {
-    		SpiderScan scanner = this.scanController.getScan(id);
-			this.getSpiderPanel().scannerStarted(scanner);
-    		scanner.setListener(getSpiderPanel());	// So the UI gets updated
-    		this.getSpiderPanel().switchView(scanner);
-    		this.getSpiderPanel().setTabFocus();
+    		addScanToUi(this.scanController.getScan(id));
     	}
     	return id;
+	}
+
+	private void addScanToUi(final SpiderScan scan) {
+		if (!EventQueue.isDispatchThread()) {
+			EventQueue.invokeLater(new Runnable() {
+
+				@Override
+				public void run() {
+					addScanToUi(scan);
+				}
+			});
+			return;
+		}
+
+		this.getSpiderPanel().scannerStarted(scan);
+		scan.setListener(getSpiderPanel()); // So the UI gets updated
+		this.getSpiderPanel().switchView(scan);
+		this.getSpiderPanel().setTabFocus();
 	}
 
 	/**

--- a/src/org/zaproxy/zap/extension/spider/SpiderScan.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderScan.java
@@ -97,6 +97,8 @@ public class SpiderScan implements ScanListenner, SpiderListener, GenericScanner
 	
 	private ScanListenner2 listener = null;
 
+	private volatile boolean cleared;
+
 	/**
 	 * The table model of the messages sent.
 	 * <p>
@@ -327,7 +329,11 @@ public class SpiderScan implements ScanListenner, SpiderListener, GenericScanner
 	}
 
 	private void addMessageToMessagesTableModel(final HttpMessage msg) {
-		if (EventQueue.isDispatchThread()) {
+		if (EventQueue.isDispatchThread() || cleared) {
+			if (cleared) {
+				return;
+			}
+
 			if (messagesTableModel == null) {
 				messagesTableModel = new SpiderMessagesTableModel();
 			}
@@ -474,6 +480,7 @@ public class SpiderScan implements ScanListenner, SpiderListener, GenericScanner
 	 * @see #getMessagesTableModel()
 	 */
 	void clear() {
+		cleared = true;
 		if (messagesTableModel != null) {
 			messagesTableModel.clear();
 			messagesTableModel = null;


### PR DESCRIPTION
Change ExtensionSpider to add the spider scans to the GUI in the EDT, to
prevent inconsistencies between EDT and other threads, which could lead
to exceptions (and a freeze of GUI caused by inconsistent internal state
of UI components).
Change SpiderScan to not create the model when adding messages if the
scan was already cleared, to prevent a leak of AlertEventConsumer(s).