### PR TITLE
Return requests' timestamp/RTT through the ZAP API

### DIFF
--- a/src/org/zaproxy/zap/extension/api/ApiResponseConversionUtils.java
+++ b/src/org/zaproxy/zap/extension/api/ApiResponseConversionUtils.java
@@ -69,6 +69,8 @@ public final class ApiResponseConversionUtils {
         Map<String, String> map = new HashMap<>();
         map.put("id", String.valueOf(historyId));
         map.put("type", String.valueOf(historyType));
+        map.put("timestamp", String.valueOf(msg.getTimeSentMillis()));
+        map.put("rtt", String.valueOf(msg.getTimeElapsedMillis()));
         map.put("cookieParams", msg.getCookieParamsAsString());
         map.put("note", msg.getNote());
         map.put("requestHeader", msg.getRequestHeader().toString());

--- a/test/org/zaproxy/zap/extension/api/ApiResponseConversionUtilsUnitTest.java
+++ b/test/org/zaproxy/zap/extension/api/ApiResponseConversionUtilsUnitTest.java
@@ -85,6 +85,8 @@ public class ApiResponseConversionUtilsUnitTest {
 		given(requestHeader.toString()).willReturn("testRequestHeader");
 		given(requestBody.toString()).willReturn("testRequestBody");
 		given(responseHeader.toString()).willReturn("testResponseHeader");
+		given(message.getTimeSentMillis()).willReturn(1010101010101L);
+		given(message.getTimeElapsedMillis()).willReturn(200);
 		
 		ApiResponseSet response = ApiResponseConversionUtils.httpMessageToSet(0, message);
 		
@@ -94,6 +96,8 @@ public class ApiResponseConversionUtilsUnitTest {
 		assertThat(response.getValues(), hasEntry("requestHeader", (Object)requestHeader.toString()));
 		assertThat(response.getValues(), hasEntry("requestBody", (Object)requestBody.toString()));
 		assertThat(response.getValues(), hasEntry("responseHeader", (Object)responseHeader.toString()));
+		assertThat(response.getValues(), hasEntry("timestamp", (Object) "1010101010101"));
+		assertThat(response.getValues(), hasEntry("rtt", (Object) "200"));
 	}
 
 	@Test


### PR DESCRIPTION
Change ApiResponseConversionUtils to also return the timestamp and RTT
of the HTTP message.
Update test to assert the returned data.