### PR TITLE
Add initiator constant for Forced Browse requests

### DIFF
--- a/src/org/parosproxy/paros/network/HttpSender.java
+++ b/src/org/parosproxy/paros/network/HttpSender.java
@@ -61,6 +61,7 @@
 // ZAP: 2016/06/10 Allow to validate the URI of the redirections before being followed
 // ZAP: 2016/08/04 Added removeListener(..)
 // ZAP: 2016/12/07 Add initiator constant for AJAX spider requests
+// ZAP: 2016/12/12 Add initiator constant for Forced Browse requests
 
 package org.parosproxy.paros.network;
 
@@ -112,6 +113,7 @@ public class HttpSender {
 	public static final int BEAN_SHELL_INITIATOR = 8;
 	public static final int ACCESS_CONTROL_SCANNER_INITIATOR = 9;
 	public static final int AJAX_SPIDER_INITIATOR = 10;
+	public static final int FORCED_BROWSE_INITIATOR = 11;
 
 	private static Logger log = Logger.getLogger(HttpSender.class);
 


### PR DESCRIPTION
Add a constant to HttpSender class for requests sent by the Forced
Browse add-on.

Related to #3060 - Send Forced Browse requests through ZAP