### PR TITLE
Stop the spider scan if failed to properly start

### DIFF
--- a/src/org/zaproxy/zap/extension/spider/SpiderThread.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderThread.java
@@ -149,7 +149,12 @@ public class SpiderThread extends ScanThread implements SpiderListener {
 
 	@Override
 	public void run() {
-		runScan();
+		try {
+			runScan();
+		} catch (Exception e) {
+			log.error("An error occurred while starting the spider:", e);
+			stopScan();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Change SpiderThread to stop the spider scan on exceptions during the
starting process, to prevent the spider scan from becoming in undefined
state (that is, not fully started nor stopped).

Related to issues like #3039.