### PR TITLE
Skip process automated msgs for HTTP Sessions tab

### DIFF
--- a/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
@@ -626,6 +626,7 @@ public class ExtensionHttpSessions extends ExtensionAdaptor implements SessionCh
 	@Override
 	public void onHttpResponseReceive(HttpMessage msg, int initiator, HttpSender sender) {
 		if (initiator == HttpSender.ACTIVE_SCANNER_INITIATOR || initiator == HttpSender.SPIDER_INITIATOR
+				|| initiator == HttpSender.AJAX_SPIDER_INITIATOR || initiator == HttpSender.FORCED_BROWSE_INITIATOR
 				|| initiator == HttpSender.CHECK_FOR_UPDATES_INITIATOR || initiator == HttpSender.FUZZER_INITIATOR
 				|| initiator == HttpSender.AUTHENTICATION_INITIATOR) {
 			// Not a session we care about


### PR DESCRIPTION
Change class ExtensionHttpSessions to skip/ignore the responses of AJAX
Spider and Forced Browse, as with other automated responses they should
not be processed (would end up creating a lot of unnecessary sessions).

Related to #2674 - Automated authentication requests shown in HTTP
Sessions tab

 ---
Reported in IRC channel.