### PR TITLE
Expose add-on's file extension

### DIFF
--- a/src/org/zaproxy/zap/control/AddOn.java
+++ b/src/org/zaproxy/zap/control/AddOn.java
@@ -100,6 +100,13 @@ public class AddOn  {
 		SOFT_UNINSTALLATION_FAILED
 	}
 	
+	/**
+	 * The file extension of ZAP add-ons.
+	 * 
+	 * @since TODO add version
+	 */
+	public static final String FILE_EXTENSION = ".zap";
+
 	private String id;
 	private String name;
 	private String description = "";
@@ -161,7 +168,7 @@ public class AddOn  {
 	private static final Logger logger = Logger.getLogger(AddOn.class);
 	
 	public static boolean isAddOn(String fileName) {
-		if (! fileName.toLowerCase().endsWith(".zap")) {
+		if (! fileName.toLowerCase().endsWith(FILE_EXTENSION)) {
 			return false;
 		}
 		if (fileName.substring(0, fileName.indexOf(".")).split("-").length < 3) {

--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -219,7 +219,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 						       public boolean accept(File file) {
 						            if (file.isDirectory()) {
 						                return true;
-						            } else if (file.isFile() && file.getName().endsWith(".zap")) {
+						            } else if (file.isFile() && file.getName().endsWith(AddOn.FILE_EXTENSION)) {
 						                return true;
 						            }
 						            return false;


### PR DESCRIPTION
Change AddOn class to expose a constant for the file extension.
Replace the literal string, in AddOn and ExtensionAutoUpdate, with the
constant created.