### PR TITLE
Log to file even if ZAP is run 'inline'

### DIFF
--- a/src/org/zaproxy/zap/CommandLineBootstrap.java
+++ b/src/org/zaproxy/zap/CommandLineBootstrap.java
@@ -21,9 +21,7 @@ package org.zaproxy.zap;
 
 import java.io.FileNotFoundException;
 
-import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.apache.log4j.varia.NullAppender;
 import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -49,10 +47,7 @@ public class CommandLineBootstrap extends HeadlessBootstrap {
             return rc;
         }
 
-        // Turn off log4j
-        Logger.getRootLogger().removeAllAppenders();
-        Logger.getRootLogger().addAppender(new NullAppender());
-        Logger.getRootLogger().setLevel(Level.OFF);
+        logger.info(getStartingMessage());
 
         try {
             initModel();


### PR DESCRIPTION
Change CommandLineBootstrap to not disable the logging (to log to file
by default), also, log when ZAP is started. It's useful to know what ZAP
is doing or did.