### PR TITLE
Do not set the "in scope" state in Contexts panel

### DIFF
--- a/src/org/zaproxy/zap/view/ContextListPanel.java
+++ b/src/org/zaproxy/zap/view/ContextListPanel.java
@@ -170,16 +170,9 @@ public class ContextListPanel extends AbstractParamPanel {
 	
 	@Override
 	public void saveParam (Object obj) throws Exception {
-	    Session session = (Session) obj;
-		List<Object[]> values = this.model.getValues();
-		
-		for (Object[] value: values) {
-			Context ctx = session.getContext((Integer)value[0]);
-			if (ctx.isInScope() != (Boolean) value[2]) {
-				ctx.setInScope( ! ctx.isInScope());
-			}
-			
-		}
+		// Nothing to do, the table does not allow to edit its values.
+		// NOTE: If changed to be editable it should be in sync with the view state (share view models?) of
+		// ContextGeneralPanel(s), the context name and "in scope" state is also shown (and editable) there.
 	}
 
 	@Override


### PR DESCRIPTION
Change ContextListPanel to not set the "in scope" state to the contexts
as that might (depending on the internal order of the panels) override
the value set by/in ContextGeneralPanel. The ContextListPanel does not
allow to change the "in scope" state so it should not be setting it.

Fix #3100 - Context's in scope change might not be applied