### PR TITLE
Do not require status/version in add-on file name

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnCollection.java
+++ b/src/org/zaproxy/zap/control/AddOnCollection.java
@@ -22,6 +22,9 @@ package org.zaproxy.zap.control;
 
 import java.io.File;
 import java.net.URL;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -163,11 +166,10 @@ public class AddOnCollection {
     	if (! dir.isDirectory()) {
     		logger.error("Not a directory: " + dir.getAbsolutePath());
     	}
-    	// Load the addons
-        File[] listFile = dir.listFiles();
 
-        if (listFile != null) {
-        	for (File addOnFile : listFile) {
+    	// Load the addons
+    	try (DirectoryStream<Path> addOnFiles = Files.newDirectoryStream(dir.toPath(), "*" + AddOn.FILE_EXTENSION)) {
+        	for (Path addOnFile : addOnFiles) {
         		if (AddOn.isAddOn(addOnFile)) {
 	            	AddOn ao = createAddOn(addOnFile);
                     if (ao == null) {
@@ -210,7 +212,7 @@ public class AddOnCollection {
         }
     }
 
-    private static AddOn createAddOn(File addOnFile) {
+    private static AddOn createAddOn(Path addOnFile) {
         try {
             return new AddOn(addOnFile);
         } catch (Exception e) {

--- a/src/org/zaproxy/zap/control/AddOnLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnLoader.java
@@ -643,7 +643,8 @@ public class AddOnLoader extends URLClassLoader {
 	/**
 	 * Returns all the {@code Extension}s of all the installed add-ons.
 	 * <p>
-	 * The discovery of {@code Extension}s is done by resorting to the {@code ZapAddOn.xml} file bundled in the add-ons.
+	 * The discovery of {@code Extension}s is done by resorting to the {@link AddOn#MANIFEST_FILE_NAME manifest file} bundled in
+	 * the add-ons.
 	 * <p>
 	 * Extensions with unfulfilled dependencies are not be returned.
 	 *
@@ -664,7 +665,8 @@ public class AddOnLoader extends URLClassLoader {
     /**
      * Returns all {@code Extension}s of the given {@code addOn}.
      * <p>
-     * The discovery of {@code Extension}s is done by resorting to {@code ZapAddOn.xml} file bundled in the add-on.
+     * The discovery of {@code Extension}s is done by resorting to {@link AddOn#MANIFEST_FILE_NAME manifest file} bundled in the
+     * add-on.
      * <p>
      * Extensions with unfulfilled dependencies are not be returned.
      * <p>
@@ -737,7 +739,8 @@ public class AddOnLoader extends URLClassLoader {
 	/**
 	 * Gets the active scan rules of all the loaded add-ons.
 	 * <p>
-	 * The discovery of active scan rules is done by resorting to {@code ZapAddOn.xml} file bundled in the add-ons.
+	 * The discovery of active scan rules is done by resorting to  {@link AddOn#MANIFEST_FILE_NAME manifest file} bundled in the
+	 * add-ons.
 	 *
 	 * @return an unmodifiable {@code List} with all the active scan rules, never {@code null}
 	 * @since 2.4.0
@@ -758,7 +761,8 @@ public class AddOnLoader extends URLClassLoader {
 	/**
 	 * Gets the passive scan rules of all the loaded add-ons.
 	 * <p>
-	 * The discovery of passive scan rules is done by resorting to {@code ZapAddOn.xml} file bundled in the add-ons.
+	 * The discovery of passive scan rules is done by resorting to {@link AddOn#MANIFEST_FILE_NAME manifest file} bundled in the
+	 * add-ons.
 	 *
 	 * @return an unmodifiable {@code List} with all the passive scan rules, never {@code null}
 	 * @since 2.4.0

--- a/src/org/zaproxy/zap/control/BaseZapAddOnXmlData.java
+++ b/src/org/zaproxy/zap/control/BaseZapAddOnXmlData.java
@@ -38,6 +38,7 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
  * Reads:
  * <ul>
  * <li>name;</li>
+ * <li>status (since TODO add version);</li>
  * <li>version;</li>
  * <li>semver;</li>
  * <li>description;</li>
@@ -91,6 +92,7 @@ public abstract class BaseZapAddOnXmlData {
     private static final Logger LOGGER = Logger.getLogger(BaseZapAddOnXmlData.class);
 
     private static final String NAME_ELEMENT = "name";
+    private static final String STATUS = "status";
     private static final String VERSION_ELEMENT = "version";
     private static final String SEM_VER_ELEMENT = "semver";
     private static final String DESCRIPTION_ELEMENT = "description";
@@ -119,6 +121,7 @@ public abstract class BaseZapAddOnXmlData {
     private static final String CLASSNAMES_RESTRICTED_ALL_ELEMENTS = "classnames/" + CLASSNAMES_RESTRICTED_ELEMENT;
 
     private String name;
+    private String status;
     private int packageVersion;
     private Version version;
     private String description;
@@ -171,6 +174,7 @@ public abstract class BaseZapAddOnXmlData {
     private void readDataImpl(HierarchicalConfiguration zapAddOnXml) {
         name = zapAddOnXml.getString(NAME_ELEMENT, "");
         packageVersion = zapAddOnXml.getInt(VERSION_ELEMENT, 0);
+        status = zapAddOnXml.getString(STATUS, "alpha");
         version = createVersion(zapAddOnXml.getString(SEM_VER_ELEMENT, ""));
         description = zapAddOnXml.getString(DESCRIPTION_ELEMENT, "");
         author = zapAddOnXml.getString(AUTHOR_ELEMENT, "");
@@ -209,6 +213,16 @@ public abstract class BaseZapAddOnXmlData {
 
     public String getName() {
         return name;
+    }
+
+    /**
+     * Returns the status of the add-on, "alpha", "beta" or "release".
+     *
+     * @return the status of the add-on
+     * @since TODO add version
+     */
+    public String getStatus() {
+        return status;
     }
 
     public String getDescription() {
@@ -364,7 +378,8 @@ public abstract class BaseZapAddOnXmlData {
     }
 
     private void malformedFile(String reason) {
-        throw new IllegalArgumentException("Add-on \"" + name + "\" contains malformed ZapAddOn.xml file, " + reason);
+        throw new IllegalArgumentException(
+                "Add-on \"" + name + "\" contains malformed " + AddOn.MANIFEST_FILE_NAME + " file, " + reason);
     }
 
     public static class Dependencies {

--- a/src/org/zaproxy/zap/control/ZapAddOnXmlFile.java
+++ b/src/org/zaproxy/zap/control/ZapAddOnXmlFile.java
@@ -26,7 +26,7 @@ import java.util.List;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 
 /**
- * Helper class that reads a {@code ZapAddOn.xml} file.
+ * Helper class that reads a {@link AddOn#MANIFEST_FILE_NAME manifest file}.
  * 
  * @since 2.4.0
  */

--- a/src/org/zaproxy/zap/control/ZapVersionsAddOnEntry.java
+++ b/src/org/zaproxy/zap/control/ZapVersionsAddOnEntry.java
@@ -26,7 +26,6 @@ import org.apache.commons.configuration.HierarchicalConfiguration;
  * <p>
  * It also reads:
  * <ul>
- * <li>status;</li>
  * <li>file;</li>
  * <li>size;</li>
  * <li>info;</li>
@@ -37,13 +36,11 @@ import org.apache.commons.configuration.HierarchicalConfiguration;
  */
 public class ZapVersionsAddOnEntry extends BaseZapAddOnXmlData {
 
-    private static final String STATUS = "status";
     private static final String FILE = "file";
     private static final String SIZE = "size";
     private static final String INFO = "info";
     private static final String HASH = "hash";
 
-    private String status;
     private String file;
     private long size;
     private String info;
@@ -55,20 +52,10 @@ public class ZapVersionsAddOnEntry extends BaseZapAddOnXmlData {
 
     @Override
     protected void readAdditionalData(HierarchicalConfiguration zapAddOnData) {
-        status = zapAddOnData.getString(STATUS);
         file = zapAddOnData.getString(FILE);
         size = zapAddOnData.getLong(SIZE);
         info = zapAddOnData.getString(INFO);
         hash = zapAddOnData.getString(HASH, null);
-    }
-
-    /**
-     * Returns the status of the add-on, ("alpha", "beta" or "release").
-     *
-     * @return the status of the add-on
-     */
-    public String getStatus() {
-        return status;
     }
 
     /**

--- a/test/org/zaproxy/zap/control/AddOnUnitTest.java
+++ b/test/org/zaproxy/zap/control/AddOnUnitTest.java
@@ -20,16 +20,24 @@
 
 package org.zaproxy.zap.control;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import org.apache.commons.configuration.tree.xpath.XPathExpressionEngine;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
@@ -40,53 +48,65 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
  */
 public class AddOnUnitTest {
 
+	@Rule
+	public TemporaryFolder tempDir = new TemporaryFolder();
+
 	private static final File ZAP_VERSIONS_XML = 
 			Paths.get("test/resources/org/zaproxy/zap/control", "ZapVersions-deps.xml").toFile();
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testIsAddon() throws Exception {
 		assertTrue(AddOn.isAddOn("test-alpha-1.zap"));
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testNotAddonNoState() throws Exception {
 		assertFalse(AddOn.isAddOn("test-1.zap"));
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testNotAddonBadExt() throws Exception {
 		assertFalse(AddOn.isAddOn("test-beta-1.zip"));
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testNotAddonBadStatus() throws Exception {
 		assertFalse(AddOn.isAddOn("test-xxx-1.zap"));
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testNotAddonBadVersion() throws Exception {
 		assertFalse(AddOn.isAddOn("test-beta-A.zap"));
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testId() throws Exception {
 		AddOn addOn = new AddOn("test-alpha-1.zap");
 		assertThat(addOn.getId(), is("test"));
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testStatus() throws Exception {
 		AddOn addOn = new AddOn("test-alpha-1.zap");
 		assertThat(addOn.getStatus().name(), is("alpha"));
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testVersion() throws Exception {
 		AddOn addOn = new AddOn("test-alpha-1.zap");
 		assertThat(addOn.getFileVersion(), is(1));
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testAlpha2UpdatesAlpha1() throws Exception {
 		AddOn addOnA1 = new AddOn("test-alpha-1.zap");
 		AddOn addOnA2 = new AddOn("test-alpha-2.zap");
@@ -94,6 +114,7 @@ public class AddOnUnitTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testAlpha1DoesNotUpdateAlpha2() throws Exception {
 		AddOn addOnA1 = new AddOn("test-alpha-1.zap");
 		AddOn addOnA2 = new AddOn("test-alpha-2.zap");
@@ -101,6 +122,7 @@ public class AddOnUnitTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testAlpha2UpdatesBeta1() throws Exception {
 		AddOn addOnB1 = new AddOn("test-beta-1.zap");
 		AddOn addOnA2 = new AddOn("test-alpha-2.zap");
@@ -108,6 +130,7 @@ public class AddOnUnitTest {
 	}
 
 	@Test(expected = IllegalArgumentException.class)
+	@SuppressWarnings("deprecation")
 	public void testAlpha2DoesNotUpdateTestyAlpha1() throws Exception {
 		// Given 
 		AddOn addOnA1 = new AddOn("test-alpha-1.zap");
@@ -118,6 +141,7 @@ public class AddOnUnitTest {
 	}
 	
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testCanLoadAddOnNotBefore() throws Exception {
 		AddOn ao = new AddOn("test-alpha-1.zap");
 		ao.setNotBeforeVersion("2.4.0");
@@ -131,6 +155,7 @@ public class AddOnUnitTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testCanLoadAddOnNotFrom() throws Exception {
 		AddOn ao = new AddOn("test-alpha-1.zap");
 		ao.setNotBeforeVersion("2.4.0");
@@ -144,6 +169,7 @@ public class AddOnUnitTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testCanLoadAddOnNotBeforeNotFrom() throws Exception {
 		AddOn ao = new AddOn("test-alpha-1.zap");
 		ao.setNotBeforeVersion("2.4.0");
@@ -157,7 +183,169 @@ public class AddOnUnitTest {
 		assertFalse(ao.canLoadInVersion("2.8.0"));
 		
 	}
+	
+	@Test
+	public void shouldNotBeAddOnFileNameIfNull() throws Exception {
+		// Given
+		String fileName = null;
+		// When
+		boolean addOnFileName = AddOn.isAddOnFileName(fileName);
+		// Then
+		assertThat(addOnFileName, is(equalTo(false)));
+	}
 
+	@Test
+	public void shouldNotBeAddOnFileNameIfNotEndsWithZapExtension() throws Exception {
+		// Given
+		String fileName = "addon.txt";
+		// When
+		boolean addOnFileName = AddOn.isAddOnFileName(fileName);
+		// Then
+		assertThat(addOnFileName, is(equalTo(false)));
+	}
+
+	@Test
+	public void shouldBeAddOnFileNameIfEndsWithZapExtension() throws Exception {
+		// Given
+		String fileName = "addon.zap";
+		// When
+		boolean addOnFileName = AddOn.isAddOnFileName(fileName);
+		// Then
+		assertThat(addOnFileName, is(equalTo(true)));
+	}
+
+	@Test
+	public void shouldBeAddOnFileNameEvenIfZapExtensionIsUpperCase() throws Exception {
+		// Given
+		String fileName = "addon.ZAP";
+		// When
+		boolean addOnFileName = AddOn.isAddOnFileName(fileName);
+		// Then
+		assertThat(addOnFileName, is(equalTo(true)));
+	}
+
+	@Test
+	public void shouldNotBeAddOnIfPathIsNull() throws Exception {
+		// Given
+		Path file = null;
+		// When
+		boolean addOnFile = AddOn.isAddOn(file);
+		// Then
+		assertThat(addOnFile, is(equalTo(false)));
+	}
+
+	@Test
+	public void shouldNotBeAddOnIfPathIsDirectory() throws Exception {
+		// Given
+		Path file = tempDir.newFolder("addon.zap").toPath();
+		// When
+		boolean addOnFile = AddOn.isAddOn(file);
+		// Then
+		assertThat(addOnFile, is(equalTo(false)));
+	}
+
+	@Test
+	public void shouldNotBeAddOnIfFileNameNotEndsWithZapExtension() throws Exception {
+		// Given
+		Path file = createAddOnFile("addon.txt", "alpha", "1");
+		// When
+		boolean addOnFile = AddOn.isAddOn(file);
+		// Then
+		assertThat(addOnFile, is(equalTo(false)));
+	}
+
+	@Test
+	public void shouldNotBeAddOnIfAddOnDoesNotHaveManifestFile() throws Exception {
+		// Given
+		Path file = createEmptyAddOnFile("addon.zap");
+		// When
+		boolean addOnFile = AddOn.isAddOn(file);
+		// Then
+		assertThat(addOnFile, is(equalTo(false)));
+	}
+
+	@Test
+	public void shouldBeAddOnIfPathEndsWithZapExtension() throws Exception {
+		// Given
+		Path file = createAddOnFile("addon.zap", "alpha", "1");
+		// When
+		boolean addOnFile = AddOn.isAddOn(file);
+		// Then
+		assertThat(addOnFile, is(equalTo(true)));
+	}
+
+	@Test
+	public void shouldBeAddOnEvenIfZapExtensionIsUpperCase() throws Exception {
+		// Given
+		Path file = createAddOnFile("addon.ZAP", "alpha", "1");
+		// When
+		boolean addOnFile = AddOn.isAddOn(file);
+		// Then
+		assertThat(addOnFile, is(equalTo(true)));
+	}
+
+	@Test(expected = IOException.class)
+	public void shouldFailToCreateAddOnFromNullFile() throws Exception {
+		// Given
+		Path file = null;
+		// When
+		new AddOn(file);
+		// Then = IOException
+	}
+
+	@Test(expected = IOException.class)
+	public void shouldFailToCreateAddOnFromFileWithInvalidFileName() throws Exception {
+		// Given
+		String invalidFileName = "addon.txt";
+		Path file = createAddOnFile(invalidFileName, "alpha", "1");
+		// When
+		new AddOn(file);
+		// Then = IOException
+	}
+
+	@Test
+	public void shouldCreateAddOnFromFileAndUseManifestData() throws Exception {
+		// Given
+		Path file = createAddOnFile("addon.zap", "beta", "1");
+		// When
+		AddOn addOn = new AddOn(file);
+		// Then
+		assertThat(addOn.getId(), is(equalTo("addon")));
+		assertThat(addOn.getStatus(), is(equalTo(AddOn.Status.beta)));
+		assertThat(addOn.getFileVersion(), is(equalTo(1)));
+	}
+
+	@Test
+	public void shouldIgnoreStatusInFileNameWhenCreatingAddOnFromFile() throws Exception {
+		// Given
+		Path file = createAddOnFile("addon-alpha.zap", "release", "1");
+		// When
+		AddOn addOn = new AddOn(file);
+		// Then
+		assertThat(addOn.getStatus(), is(equalTo(AddOn.Status.release)));
+	}
+
+	@Test
+	public void shouldIgnoreVersionInFileNameWhenCreatingAddOnFromFile() throws Exception {
+		// Given
+		Path file = createAddOnFile("addon-alpha-2.zap", "alpha", "3");
+		// When
+		AddOn addOn = new AddOn(file);
+		// Then
+		assertThat(addOn.getFileVersion(), is(equalTo(3)));
+	}
+
+	@Test
+	public void shouldReturnNormalisedFileName() throws Exception {
+		// Given
+		Path file = createAddOnFile("addon.zap", "alpha", "2");
+		AddOn addOn = new AddOn(file);
+		// When
+		String normalisedFileName = addOn.getNormalisedFileName();
+		// Then
+		assertThat(normalisedFileName, is(equalTo("addon-2.zap")));
+	}
+	
 	@Test
 	public void shouldDependOnDependency() throws Exception {
 		// Given
@@ -173,7 +361,7 @@ public class AddOnUnitTest {
 	@Test
 	public void shouldNotDependIfNoDependencies() throws Exception {
 		// Given
-		AddOn addOn = new AddOn("AddOn-release-1.zap");
+		AddOn addOn = new AddOn(createAddOnFile("AddOn-release-1.zap", "release", "1"));
 		AddOn nonDependency = createAddOn("AddOn3", createZapVersionsXml());
 		// When
 		boolean depends = addOn.dependsOn(nonDependency);
@@ -265,6 +453,37 @@ public class AddOnUnitTest {
 		return zapVersionsXml;
 	}
 
+	private Path createEmptyAddOnFile(String fileName) {
+		try {
+			File file = tempDir.newFile(fileName);
+			new ZipOutputStream(new FileOutputStream(file)).close();
+			return file.toPath();
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private Path createAddOnFile(String fileName, String status, String version) {
+		try {
+			File file = tempDir.newFile(fileName);
+			try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(file))) {
+				ZipEntry manifest = new ZipEntry(AddOn.MANIFEST_FILE_NAME);
+				zos.putNextEntry(manifest);
+				StringBuilder strBuilder = new StringBuilder(150);
+				strBuilder.append("<zapaddon>");
+				strBuilder.append("<version>").append(version).append("</version>");
+				strBuilder.append("<status>").append(status).append("</status>");
+				strBuilder.append("</zapaddon>");
+				byte[] bytes = strBuilder.toString().getBytes(StandardCharsets.UTF_8);
+				zos.write(bytes, 0, bytes.length);
+				zos.closeEntry();
+			}
+			return file.toPath();
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+	
 	protected static AddOn createAddOn(String addOnId, ZapXmlConfiguration zapVersions) throws Exception {
 		return new AddOn(addOnId, Paths.get("").toFile(), zapVersions.configurationAt("addon_" + addOnId));
 	}


### PR DESCRIPTION
Change AddOn class to not require the status and/or the version in the
file name of the add-on. The add-on file name just needs to have the ID
and have a ZAP extension. Also, deprecate old constructor/methods that
require the file name to have the status/version and introduce new
constructor/methods where applicable.
Change BaseZapAddOnXmlData to read the status from the manifest file of
the add-on (ZapAddOn.xml).
Remove hardcoded manifest file name (ZapAddOn.xml) from JavaDoc and code
(by using the constant from AddOn).
Change AddOnCollection to iterate just ZAP add-on files and use the new
AddOn constructor.
Change ExtensionAutoUpdate to use the new constructors/methods and to
copy the file from manual add-on installations using a normalised file
name.
Add some tests to assert the expected behaviour of AddOn class.

Fix #3090 - Be more lenient on add-on's file name format