### PR TITLE
Move Spider functionality to Spider extension

### DIFF
--- a/src/org/parosproxy/paros/model/Session.java
+++ b/src/org/parosproxy/paros/model/Session.java
@@ -66,6 +66,7 @@
 // ZAP: 2016/10/24 Delay addition of imported context until it's known that it has no errors
 // ZAP: 2016/10/26 Issue 1952: Do not allow Contexts with same name
 // ZAP: 2016/12/06 Remove contexts before refreshing the UI when discarding the contexts
+// ZAP: 2017/01/04 Remove dependency on ExtensionSpider
 
 package org.parosproxy.paros.model;
 
@@ -99,7 +100,6 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
-import org.zaproxy.zap.extension.spider.ExtensionSpider;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.IllegalContextNameException;
 import org.zaproxy.zap.model.NameValuePair;
@@ -991,29 +991,40 @@ public class Session {
 		model.getDb().getTableSessionUrl().setUrls(RecordSessionUrl.TYPE_EXCLUDE_FROM_SCAN, this.excludeFromScanRegexs);
 	}
 
+	/**
+	 * Gets the regular expressions used to exclude URLs from the spiders (e.g. traditional, AJAX).
+	 *
+	 * @return a {@code List} containing the regular expressions, never {@code null}.
+	 */
 	public List<String> getExcludeFromSpiderRegexs() {
 		return excludeFromSpiderRegexs;
 	}
 
+	/**
+	 * Adds the given regular expression to the list of regular expressions used to exclude URLs from the spiders (e.g.
+	 * traditional, AJAX).
+	 *
+	 * @param ignoredRegex the regular expression to be added
+	 * @throws IllegalArgumentException if the regular expression is not valid.
+	 * @throws DatabaseException if an error occurred while persisting the list.
+	 */
 	public void addExcludeFromSpiderRegex(String ignoredRegex) throws DatabaseException {
 		// Validate its a valid regex first
 		Pattern.compile(ignoredRegex, Pattern.CASE_INSENSITIVE);
 
 		this.excludeFromSpiderRegexs.add(ignoredRegex);
-		ExtensionSpider extSpider = 
-			(ExtensionSpider) Control.getSingleton().getExtensionLoader().getExtension(ExtensionSpider.NAME);
-		if (extSpider != null) {
-			// ZAP: Added fullList & globalExcludeURLRegexs code.
-		    List<String> fullList = new ArrayList<String>();
-		    fullList.addAll(this.excludeFromSpiderRegexs);
-		    fullList.addAll(this.globalExcludeURLRegexs);
-
-		    extSpider.setExcludeList(fullList);
-		}
 		model.getDb().getTableSessionUrl().setUrls(RecordSessionUrl.TYPE_EXCLUDE_FROM_SPIDER, this.excludeFromSpiderRegexs);
 	}
 
 
+	/**
+	 * Sets the given regular expressions as the list of regular expressions used to exclude URLs from the spiders (e.g.
+	 * traditional, AJAX).
+	 *
+	 * @param ignoredRegexs the regular expressions to be set
+	 * @throws IllegalArgumentException if any of the regular expressions is not valid.
+	 * @throws DatabaseException if an error occurred while persisting the list.
+	 */
 	public void setExcludeFromSpiderRegexs(List<String> ignoredRegexs) throws DatabaseException {
 		// Validate its a valid regex first
 	    for (String url : ignoredRegexs) {
@@ -1021,16 +1032,6 @@ public class Session {
 	    }
 
 		this.excludeFromSpiderRegexs = stripEmptyLines(ignoredRegexs);
-		ExtensionSpider extSpider = 
-			(ExtensionSpider) Control.getSingleton().getExtensionLoader().getExtension(ExtensionSpider.NAME);
-		if (extSpider != null) {
-			// ZAP: Added fullList & globalExcludeURLRegexs code.
-		    List<String> fullList = new ArrayList<String>();
-		    fullList.addAll(this.excludeFromSpiderRegexs);
-		    fullList.addAll(this.globalExcludeURLRegexs);
-
-		    extSpider.setExcludeList(fullList);
-		}
 		model.getDb().getTableSessionUrl().setUrls(RecordSessionUrl.TYPE_EXCLUDE_FROM_SPIDER, this.excludeFromSpiderRegexs);
 	}
 

--- a/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
+++ b/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
@@ -33,6 +33,8 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
 import javax.swing.KeyStroke;
 
 import org.apache.commons.httpclient.URI;
@@ -79,6 +81,8 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
 
 	SpiderDialog spiderDialog = null;
 
+	private PopupMenuItemSpiderDialog popupMenuItemSpiderDialog;
+
 	/** The options spider panel. */
 	private OptionsSpiderPanel optionsSpiderPanel = null;
 
@@ -92,6 +96,8 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
 	private SpiderAPI spiderApi;
 	
 	private SpiderScanController scanController = null;
+
+	private Icon icon;
 
 	/**
 	 * The list of excluded patterns of sites. Patterns are added here with the ExcludeFromSpider
@@ -131,6 +137,7 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
 			extensionHook.getHookMenu().addToolsMenuItem(getMenuItemCustomScan());
 			extensionHook.getHookView().addStatusPanel(getSpiderPanel());
 			extensionHook.getHookView().addOptionPanel(getOptionsSpiderPanel());
+			extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuItemSpiderDialog());
 			ExtensionHelp.enableHelpKey(getSpiderPanel(), "ui.tabs.spider");
 		}
 
@@ -141,6 +148,13 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
 		spiderApi = new SpiderAPI(this);
 		spiderApi.addApiOptions(getSpiderParam());
 		extensionHook.addApiImplementor(spiderApi);
+	}
+
+	private PopupMenuItemSpiderDialog getPopupMenuItemSpiderDialog() {
+		if (popupMenuItemSpiderDialog == null) {
+			popupMenuItemSpiderDialog = new PopupMenuItemSpiderDialog(this);
+		}
+		return popupMenuItemSpiderDialog;
 	}
 
 	@Override
@@ -808,5 +822,17 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
 	@Override
 	public boolean supportsDb(String type) {
 		return true;
+	}
+
+	/**
+	 * Gets the icon for spider related functionality.
+	 *
+	 * @return the icon
+	 */
+	public Icon getIcon() {
+		if (icon == null) {
+			icon = new ImageIcon(ExtensionSpider.class.getResource("/resource/icon/16/spider.png"));
+		}
+		return icon;
 	}
 }

--- a/src/org/zaproxy/zap/extension/spider/PopupMenuItemSpiderDialog.java
+++ b/src/org/zaproxy/zap/extension/spider/PopupMenuItemSpiderDialog.java
@@ -1,0 +1,82 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.spider;
+
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.SiteNode;
+import org.zaproxy.zap.extension.spider.ExtensionSpider;
+import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
+import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
+
+/**
+ * A {@code PopupMenuItemSiteNodeContainer} that allows to show the Spider dialogue, for a selected {@link SiteNode}.
+ * 
+ * @see ExtensionSpider#showSpiderDialog(SiteNode)
+ */
+public class PopupMenuItemSpiderDialog extends PopupMenuItemSiteNodeContainer {
+
+    private static final long serialVersionUID = 1L;
+
+    private final ExtensionSpider extension;
+
+    public PopupMenuItemSpiderDialog(ExtensionSpider extension) {
+        super(Constant.messages.getString("spider.custom.popup"));
+
+        this.setIcon(extension.getIcon());
+        this.extension = extension;
+    }
+
+    @Override
+    public boolean isSubMenu() {
+        return true;
+    }
+
+    @Override
+    public String getParentMenuName() {
+        return Constant.messages.getString("attack.site.popup");
+    }
+
+    @Override
+    public int getParentMenuIndex() {
+        return ATTACK_MENU_INDEX;
+    }
+
+    @Override
+    public void performAction(SiteNode node) {
+        extension.showSpiderDialog(node);
+    }
+
+    @Override
+    protected boolean isEnableForInvoker(Invoker invoker, HttpMessageContainer httpMessageContainer) {
+        switch (invoker) {
+        case ALERTS_PANEL:
+        case ACTIVE_SCANNER_PANEL:
+        case FORCED_BROWSE_PANEL:
+        case FUZZER_PANEL:
+            return false;
+        case HISTORY_PANEL:
+        case SITES_PANEL:
+        case SEARCH_PANEL:
+        default:
+            return true;
+        }
+    }
+
+}

--- a/src/org/zaproxy/zap/extension/spider/SpiderThread.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderThread.java
@@ -19,6 +19,7 @@
 package org.zaproxy.zap.extension.spider;
 
 import java.awt.EventQueue;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Enumeration;
@@ -238,8 +239,12 @@ public class SpiderThread extends ScanThread implements SpiderListener {
 			spider.addSpiderListener(l);
 		}
 
-		// Add the list of excluded uris (added through the Exclude from Spider Popup Menu)
-		spider.setExcludeList(extension.getExcludeList());
+		// Add the list of (regex) URIs that should be excluded
+		List<String> excludeList = new ArrayList<>();
+		excludeList.addAll(extension.getExcludeList());
+		excludeList.addAll(extension.getModel().getSession().getExcludeFromSpiderRegexs());
+		excludeList.addAll(extension.getModel().getSession().getGlobalExcludeURLRegexs());
+		spider.setExcludeList(excludeList);
 
 		// Add seeds accordingly
 		addSeeds();

--- a/src/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
@@ -41,7 +41,6 @@ import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
-import org.zaproxy.zap.extension.spider.ExtensionSpider;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.ContextExportDialog;
@@ -56,7 +55,6 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
     private PopupCopyMenu popupCopyMenu = null;
     private PopupPasteMenu popupPaste = null;
 	private PopupMenuActiveScanCustom popupMenuActiveScanCustom = null;
-	private PopupMenuSpiderDialog popupMenuSpiderDialog = null;
 	private PopupExcludeFromProxyMenu popupExcludeFromProxyMenu = null;
 	private PopupExcludeFromScanMenu popupExcludeFromScanMenu = null;
 	private PopupExcludeFromSpiderMenu popupExcludeFromSpiderMenu = null;
@@ -100,26 +98,19 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
 			final ExtensionLoader extensionLoader = Control.getSingleton().getExtensionLoader();
 			boolean isExtensionHistoryEnabled = extensionLoader.isExtensionEnabled(ExtensionHistory.NAME);
 			boolean isExtensionActiveScanEnabled = extensionLoader.isExtensionEnabled(ExtensionActiveScan.NAME);
-			boolean isExtensionSpiderEnabled = extensionLoader.isExtensionEnabled(ExtensionSpider.NAME);
 			// Be careful when changing the menu indexes (and order above) - its easy to get unexpected
 			// results!
 			extensionHook.getHookMenu().addPopupMenuItem(getPopupExcludeFromProxyMenu(0));
 			if (isExtensionActiveScanEnabled) {
 				extensionHook.getHookMenu().addPopupMenuItem(getPopupExcludeFromScanMenu(0));
 			}
-			if (isExtensionSpiderEnabled) {
-				extensionHook.getHookMenu().addPopupMenuItem(getPopupExcludeFromSpiderMenu(0));
-			}
+			extensionHook.getHookMenu().addPopupMenuItem(getPopupExcludeFromSpiderMenu(0));
 			extensionHook.getHookMenu().addPopupMenuItem(getPopupContextIncludeMenu(1));
 			extensionHook.getHookMenu().addPopupMenuItem(getPopupContextExcludeMenu(2));
 			extensionHook.getHookMenu().addPopupMenuItem(getPopupContextDataDrivenMenu(2));	// TODO ??
 
 			if (isExtensionActiveScanEnabled) {
 				extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuActiveScanCustom(3));
-			}
-
-			if (isExtensionSpiderEnabled) {
-				extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuSpiderDialog(3));
 			}
 
 			if (isExtensionHistoryEnabled) {
@@ -280,13 +271,6 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
 	@Override
 	public void lostOwnership(Clipboard arg0, Transferable arg1) {
 		// Ignore
-	}
-
-	private PopupMenuSpiderDialog getPopupMenuSpiderDialog(int menuIndex) {
-		if (popupMenuSpiderDialog == null) {
-			popupMenuSpiderDialog = new PopupMenuSpiderDialog(Constant.messages.getString("spider.custom.popup"));
-		}
-		return popupMenuSpiderDialog;
 	}
 
 	private PopupMenuActiveScanCustom getPopupMenuActiveScanCustom(int menuIndex) {

--- a/src/org/zaproxy/zap/extension/stdmenus/PopupMenuSpiderDialog.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/PopupMenuSpiderDialog.java
@@ -27,6 +27,11 @@ import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
 
 
+/**
+ * @deprecated (TODO add version) No longer in use, replaced by
+ *             {@link org.zaproxy.zap.extension.spider.PopupMenuItemSpiderDialog}.
+ */
+@Deprecated
 public class PopupMenuSpiderDialog extends PopupMenuItemSiteNodeContainer {
 
 	private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Move (that is, create new class and deprecate old one) the spider
functionality to ExtensionSpider, also, all spider related functionality
is now done through classes in the spider extension package.
The functionality "Exclude from Spider" is shared by both spiders (AJAX
and traditional) therefore it belongs to core.

Preparation for #3113 - Move Spider to an add-on