### PR TITLE
include subjectAlternativeName extension in generated certificates

### DIFF
--- a/src/org/parosproxy/paros/security/SslCertificateServiceImpl.java
+++ b/src/org/parosproxy/paros/security/SslCertificateServiceImpl.java
@@ -46,6 +46,8 @@ import org.bouncycastle.asn1.x500.X500NameBuilder;
 import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x509.BasicConstraints;
 import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
@@ -140,6 +142,7 @@ public final class SslCertificateServiceImpl implements SslCertificateService {
 
 		certGen.addExtension(Extension.subjectKeyIdentifier, false, new SubjectKeyIdentifier(pubKey.getEncoded()));
 		certGen.addExtension(Extension.basicConstraints, false, new BasicConstraints(false));
+		certGen.addExtension(Extension.subjectAlternativeName, false, new GeneralNames(new GeneralName(GeneralName.dNSName, hostname)));
 
 		ContentSigner sigGen;
 		try {


### PR DESCRIPTION
When generating a certificate on the fly for a domain, zaproxy doesn't include a subjectAlternativeName extension (which is mandatory for new certificates in recent versions of Firefox). This appears to do the right thing.