### PR TITLE
Add description to some Spider API endpoints

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1876,12 +1876,16 @@ sites.spider.popup         = Spider...
 sites.showinsites.popup    = Show in Sites Tab
 
 spider.activeActionPrefix = Spidering: {0}
+spider.api.action.clearExcludedFromScan = Clears the regexes of URLs excluded from the spider scans.
+spider.api.action.excludeFromScan = Adds a regex of URLs that should be excluded from the spider scans.
+spider.api.action.setOptionSendRefererHeader = Sets whether or not the 'Referer' header should be sent while spidering.
 spider.api.action.setOptionMaxChildren = Sets the maximum number of child nodes (per node) that can be crawled, 0 means no limit.
 spider.api.action.scan = Runs the spider against the given URL (or context). Optionally, the 'maxChildren' parameter can be set to limit the number of children scanned, the 'recurse' parameter can be used to prevent the spider from seeding recursively, the parameter 'contextName' can be used to constrain the scan to a Context and the parameter 'subtreeOnly' allows to restrict the spider under a site's subtree (using the specified 'url').
 spider.api.action.scanAsUser = Runs the spider from the perspective of a User, obtained using the given Context ID and User ID. See 'scan' action for more details.
 spider.api.view.allUrls = Returns a list of unique URLs from the history table based on HTTP messages added by the Spider.
 spider.api.view.optionMaxChildren = Gets the maximum number of child nodes (per node) that can be crawled, 0 means no limit.
-spider.api.view.optionSendRefererHeader = Sets whether or not the 'Referer' header should be sent while spidering
+spider.api.view.optionSendRefererHeader = Gets whether or not the 'Referer' header should be sent while spidering.
+spider.api.view.excludedFromScan = Gets the regexes of URLs excluded from the spider scans.
 spider.custom.button.reset	= Reset
 spider.custom.button.scan	= Start Scan
 spider.custom.label.adv		= Show Advanced options


### PR DESCRIPTION
Add descriptions to some of the Spider API endpoints and correct one
that was wrong (it was for the action not view).