### PR TITLE
Fix #2080: Access to HTTPSessions for Site via Script

### DIFF
--- a/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
@@ -450,7 +450,7 @@ public class ExtensionHttpSessions extends ExtensionAdaptor implements SessionCh
 	 *            missing, a default protocol of 80 is used.
 	 * @return the http sessions site container
 	 */
-	protected HttpSessionsSite getHttpSessionsSite(String site) {
+	public HttpSessionsSite getHttpSessionsSite(String site) {
 		return getHttpSessionsSite(site, true);
 	}
 
@@ -467,7 +467,7 @@ public class ExtensionHttpSessions extends ExtensionAdaptor implements SessionCh
 	 *         false
 	 * 
 	 */
-	protected HttpSessionsSite getHttpSessionsSite(String site, boolean createIfNeeded) {
+	public HttpSessionsSite getHttpSessionsSite(String site, boolean createIfNeeded) {
 		// Add a default port
 		if (!site.contains(":")) {
 			site = site + (":80");

--- a/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsSite.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsSite.java
@@ -567,7 +567,7 @@ public class HttpSessionsSite {
 	 * 
 	 * @return the http sessions
 	 */
-	protected Set<HttpSession> getHttpSessions() {
+	public Set<HttpSession> getHttpSessions() {
 		synchronized (this.sessions) {
 			return Collections.unmodifiableSet(sessions);
 		}
@@ -579,7 +579,7 @@ public class HttpSessionsSite {
 	 * @param name the name
 	 * @return the http session with a given name, or null, if no such session exists
 	 */
-	protected HttpSession getHttpSession(String name) {
+	public HttpSession getHttpSession(String name) {
 		synchronized (this.sessions) {
 			for (HttpSession session : sessions) {
 				if (session.getName().equals(name)) {
@@ -625,5 +625,9 @@ public class HttpSessionsSite {
 
 	static void resetLastGeneratedSessionId() {
 		lastGeneratedSessionID = 0;
+	}
+	
+	public static int getNextSessionId() {
+		return lastGeneratedSessionID++;
 	}
 }


### PR DESCRIPTION
Follow up to PR #2083 - Fixes #2080 
the Branch was messed up so i squashed the neccessary changes into this new PR
@kingthorin 

-Set methods to public
    protected HttpSessionsSite getHttpSessionsSite(String site)
    protected HttpSessionsSite getHttpSessionsSite(String site, boolean createIfNeeded)
    protected Set<HttpSession> getHttpSessions()
    protected HttpSession getHttpSession(String name)

-Method to access the next unique Session ID

Required for script development