### PR TITLE
Log during start up the add-ons that are installed

### DIFF
--- a/src/org/zaproxy/zap/control/ExtensionFactory.java
+++ b/src/org/zaproxy/zap/control/ExtensionFactory.java
@@ -71,6 +71,7 @@ public class ExtensionFactory {
             	dirs [2+i] = extraDirs.get(i);
         	}
             addOnLoader = new AddOnLoader(dirs);
+            log.info("Installed add-ons: " + addOnLoader.getAddOnCollection().getInstalledAddOns());
         } else {
         	log.error("AddOnLoader initialised without additional directories");
         }
@@ -83,6 +84,7 @@ public class ExtensionFactory {
             addOnLoader = new AddOnLoader(new File[]{
                 new File(Constant.getZapInstall(), Constant.FOLDER_PLUGIN),
                 new File(Constant.getZapHome(), Constant.FOLDER_PLUGIN)});
+            log.info("Installed add-ons: " + addOnLoader.getAddOnCollection().getInstalledAddOns());
         }
         return addOnLoader;
     }


### PR DESCRIPTION
Change ExtensionFactory to log (as info) the IDs and version of the
add-ons that are in installed state (all dependencies/requirements are
fulfilled).