### PR TITLE
Add default implementations to AbstractParamPanel

### DIFF
--- a/src/org/parosproxy/paros/extension/filter/AllFilterPanel.java
+++ b/src/org/parosproxy/paros/extension/filter/AllFilterPanel.java
@@ -26,6 +26,7 @@
 // ZAP: 2014/11/06 Added warning that filters will be removed
 // ZAP: 2015/02/16 Issue 1528: Support user defined font size
 // ZAP: 2016/04/05 Issue 2458: Fix xlint warning messages 
+// ZAP: 2017/01/09 Remove method no longer needed.
 
 package org.parosproxy.paros.extension.filter;
 
@@ -123,11 +124,6 @@ public class AllFilterPanel extends AbstractParamPanel {
 
     @Override
     public void initParam(Object obj) {
-        
-    }
-
-    @Override
-    public void validateParam(Object obj) throws Exception {
         
     }
 

--- a/src/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
@@ -26,6 +26,7 @@
 // ZAP: 2014/03/23 Issue 412: Enable unsafe SSL/TLS renegotiation option not saved
 // ZAP: 2014/08/14 Issue 1184: Improve support for IBM JDK
 // ZAP: 2016/06/28: File chooser for PKCS#12 files now also accepts .pfx files
+// ZAP: 2017/01/09 Remove method no longer needed.
 
 package org.parosproxy.paros.extension.option;
 
@@ -948,11 +949,6 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 		//getBtnLocation().setEnabled(getChkUseClientCertificate().isSelected());
 		//getTxtLocation().setText(options.getCertificateParam().getClientCertLocation());
 		enableUnsafeSSLRenegotiationCheckBox.setSelected(certParam.isAllowUnsafeSslRenegotiation());
-	}
-
-	@Override
-	public void validateParam(Object obj) {
-		// no validation needed
 	}
 
 	@Override

--- a/src/org/parosproxy/paros/extension/option/OptionsDatabasePanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsDatabasePanel.java
@@ -243,10 +243,6 @@ public class OptionsDatabasePanel extends AbstractParamPanel {
     }
 
     @Override
-    public void validateParam(Object obj) throws Exception {
-    }
-
-    @Override
     public void saveParam(Object obj) throws Exception {
         final OptionsParam options = (OptionsParam) obj;
         final DatabaseParam param = options.getDatabaseParam();

--- a/src/org/parosproxy/paros/extension/option/OptionsJvmPanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsJvmPanel.java
@@ -113,10 +113,6 @@ public class OptionsJvmPanel extends AbstractParamPanel {
     }
 
     @Override
-    public void validateParam(Object obj) throws Exception {
-    }
-    
-    @Override
     public void reset() {
         getJvmOptionsField().setText("");
         saveJvmFile();

--- a/src/org/parosproxy/paros/extension/option/OptionsViewPanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsViewPanel.java
@@ -27,6 +27,7 @@
 // ZAP: 2014/12/16 Issue 1466: Config option for 'large display' size
 // ZAP: 2016/04/04 Do not require a restart to show/hide the tool bar
 // ZAP: 2016/04/06 Fix layouts' issues
+// ZAP: 2017/01/09 Remove method no longer needed.
 
 package org.parosproxy.paros.extension.option;
 
@@ -579,11 +580,6 @@ public class OptionsViewPanel extends AbstractParamPanel {
 		}
 	}
 
-	@Override
-	public void validateParam(Object obj) {
-	    // no validation needed
-	}
-	
 	@Override
 	public void saveParam (Object obj) throws Exception {
 	    OptionsParam options = (OptionsParam) obj;

--- a/src/org/parosproxy/paros/view/AbstractParamPanel.java
+++ b/src/org/parosproxy/paros/view/AbstractParamPanel.java
@@ -21,6 +21,7 @@
 // ZAP: 2013/05/02 Re-arranged all modifiers into Java coding standard order
 // ZAP: 2013/08/21 Added support for detecting when AbstractParamPanels are being shown/hidden in a AbstractParamDialog
 // ZAP: 2016/11/17 Issue 2701 Support Factory Reset
+// ZAP: 2017/01/09 Add default implementations to some methods.
 
 package org.parosproxy.paros.view;
 
@@ -60,11 +61,15 @@ public abstract class AbstractParamPanel extends JPanel {
 	 * <p>
 	 * The message of the exception is expected to be internationalised (as it might be shown in GUI components, for example, an
 	 * error dialogue).
+	 * <p>
+	 * Does nothing by default.
 	 * 
 	 * @param obj the object used to initialise the panel and save the data
 	 * @throws Exception if there's any validation error.
 	 */
-	public abstract void validateParam(Object obj) throws Exception;
+	public void validateParam(Object obj) throws Exception {
+		// Nothing to validate.
+	}
 	
 	/**
 	 * Saves (the data of) the panel, throwing an exception if there's any error.
@@ -87,7 +92,9 @@ public abstract class AbstractParamPanel extends JPanel {
 	 * 
 	 * @return the help index, or {@code null} if none.
 	 */
-	public abstract String getHelpIndex();
+	public String getHelpIndex() {
+		return null;
+	}
 	
 	/**
 	 * Called when the panel is shown (becomes visible) in the containing {@link AbstractParamDialog}.

--- a/src/org/parosproxy/paros/view/SessionGeneralPanel.java
+++ b/src/org/parosproxy/paros/view/SessionGeneralPanel.java
@@ -25,6 +25,7 @@
 // ZAP: 2012/10/02 Issue 385: Added support for Contexts
 // ZAP: 2015/02/05 Issue 1524: New Persist Session dialog
 // ZAP: 2015/02/10 Issue 1528: Support user defined font size
+// ZAP: 2017/01/09 Remove method no longer needed.
 
 package org.parosproxy.paros.view;
 
@@ -139,11 +140,6 @@ public class SessionGeneralPanel extends AbstractParamPanel {
 	    	getSessionLocation().setText(session.getFileName());
 	    	getSessionLocation().setToolTipText(session.getFileName());	// In case its really long
 	    }
-	}
-	
-	@Override
-	public void validateParam(Object obj) {
-	    // no validation needed
 	}
 	
 	@Override

--- a/src/org/zaproxy/zap/extension/anticsrf/OptionsAntiCsrfPanel.java
+++ b/src/org/zaproxy/zap/extension/anticsrf/OptionsAntiCsrfPanel.java
@@ -78,10 +78,6 @@ public class OptionsAntiCsrfPanel extends AbstractParamPanel {
     }
 
 
-    @Override
-    public void validateParam(Object obj) throws Exception {
-
-    }
 
 
     @Override

--- a/src/org/zaproxy/zap/extension/ascan/OptionsScannerPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/OptionsScannerPanel.java
@@ -222,11 +222,6 @@ public class OptionsScannerPanel extends AbstractParamPanel {
     }
 
     @Override
-    public void validateParam(Object obj) {
-        // no validation needed
-    }
-
-    @Override
     public void saveParam(Object obj) throws Exception {
         OptionsParam options = (OptionsParam) obj;
         ScannerParam param = options.getParamSet(ScannerParam.class);

--- a/src/org/zaproxy/zap/extension/ascan/OptionsVariantPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/OptionsVariantPanel.java
@@ -219,11 +219,6 @@ public class OptionsVariantPanel extends AbstractParamPanel {
     }
 
     @Override
-    public void validateParam(Object obj) {
-        // no validation needed
-    }
-
-    @Override
     public void saveParam(Object obj) throws Exception {
         OptionsParam options = (OptionsParam) obj;
         ScannerParam param = options.getParamSet(ScannerParam.class);

--- a/src/org/zaproxy/zap/extension/ascan/PolicyCategoryPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/PolicyCategoryPanel.java
@@ -21,6 +21,7 @@
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
 // ZAP: 2013/11/28 Issue 923: Allow individual rule thresholds and strengths to be set via GUI
 // ZAP: 2014/11/19 Issue 1412: Manage scan policies
+// ZAP: 2017/01/09 Remove method no longer needed.
 
 package org.zaproxy.zap.extension.ascan;
 
@@ -119,11 +120,6 @@ public class PolicyCategoryPanel extends AbstractParamPanel {
 
     @Override
     public void initParam(Object obj) {
-
-    }
-
-    @Override
-    public void validateParam(Object obj) throws Exception {
 
     }
 

--- a/src/org/zaproxy/zap/extension/autoupdate/OptionsCheckForUpdatesPanel.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/OptionsCheckForUpdatesPanel.java
@@ -328,11 +328,6 @@ public class OptionsCheckForUpdatesPanel extends AbstractParamPanel {
 	}
 	
 	@Override
-	public void validateParam(Object obj) {
-	    // no validation needed
-	}
-	
-	@Override
 	public void saveParam (Object obj) throws Exception {
 	    OptionsParam options = (OptionsParam) obj;
 	    options.getCheckForUpdatesParam().setCheckOnStart(getChkCheckOnStart().isSelected());

--- a/src/org/zaproxy/zap/extension/brk/BreakpointsOptionsPanel.java
+++ b/src/org/zaproxy/zap/extension/brk/BreakpointsOptionsPanel.java
@@ -122,10 +122,6 @@ public class BreakpointsOptionsPanel extends AbstractParamPanel {
     }
 
     @Override
-    public void validateParam(Object obj) throws Exception {
-    }
-
-    @Override
     public void saveParam(Object obj) throws Exception {
         final OptionsParam options = (OptionsParam) obj;
         final BreakpointsParam param = options.getParamSet(BreakpointsParam.class);

--- a/src/org/zaproxy/zap/extension/dynssl/DynamicSSLPanel.java
+++ b/src/org/zaproxy/zap/extension/dynssl/DynamicSSLPanel.java
@@ -209,11 +209,6 @@ public class DynamicSSLPanel extends AbstractParamPanel {
 	}
 
 	@Override
-	public void validateParam(Object obj) throws Exception {
-		// nothing to do here ...
-	}
-
-	@Override
 	public void saveParam(Object obj) throws Exception {
 		final OptionsParam options = (OptionsParam) obj;
 		final DynSSLParam param = options.getParamSet(DynSSLParam.class);

--- a/src/org/zaproxy/zap/extension/encoder2/EncodeDecodeParamPanel.java
+++ b/src/org/zaproxy/zap/extension/encoder2/EncodeDecodeParamPanel.java
@@ -129,10 +129,6 @@ public class EncodeDecodeParamPanel extends AbstractParamPanel {
 	}
 
 	@Override
-	public void validateParam(Object obj) throws Exception {
-	}
-
-	@Override
 	public void saveParam(Object obj) throws Exception {
 		final OptionsParam options = (OptionsParam) obj;
 		final EncodeDecodeParam param = options.getParamSet(EncodeDecodeParam.class);

--- a/src/org/zaproxy/zap/extension/ext/OptionsExtensionPanel.java
+++ b/src/org/zaproxy/zap/extension/ext/OptionsExtensionPanel.java
@@ -124,11 +124,6 @@ public class OptionsExtensionPanel extends AbstractParamPanel {
     }
 
 
-    @Override
-    public void validateParam(Object obj) throws Exception {
-
-    }
-
 
     @Override
     public void saveParam(Object obj) throws Exception {

--- a/src/org/zaproxy/zap/extension/globalexcludeurl/OptionsGlobalExcludeURLPanel.java
+++ b/src/org/zaproxy/zap/extension/globalexcludeurl/OptionsGlobalExcludeURLPanel.java
@@ -84,11 +84,6 @@ public class OptionsGlobalExcludeURLPanel extends AbstractParamPanel {
     }
 
 
-    @Override
-    public void validateParam(Object obj) throws Exception {
-
-    }
-
     private static Logger log = Logger.getLogger(OptionsGlobalExcludeURLPanel.class);
 
 

--- a/src/org/zaproxy/zap/extension/httpsessions/OptionsHttpSessionsPanel.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/OptionsHttpSessionsPanel.java
@@ -98,10 +98,6 @@ public class OptionsHttpSessionsPanel extends AbstractParamPanel {
 	}
 
 	@Override
-	public void validateParam(Object obj) throws Exception {
-	}
-
-	@Override
 	public void saveParam(Object obj) throws Exception {
 		OptionsParam optionsParam = (OptionsParam) obj;
 		HttpSessionsParam sessionParam = optionsParam.getParamSet(HttpSessionsParam.class);

--- a/src/org/zaproxy/zap/extension/keyboard/OptionsKeyboardShortcutPanel.java
+++ b/src/org/zaproxy/zap/extension/keyboard/OptionsKeyboardShortcutPanel.java
@@ -109,11 +109,6 @@ public class OptionsKeyboardShortcutPanel extends AbstractParamPanel {
 	public void addShortcut(KeyboardShortcut shortcut) {
 		getShortcutModel().addShortcut(shortcut);
 	}
-    
-    @Override
-    public void validateParam(Object obj) throws Exception {
-    	// Nothing to do
-    }
 
 	private JButton getResetButton() {
 		if (resetButton == null) {

--- a/src/org/zaproxy/zap/extension/lang/OptionsLangPanel.java
+++ b/src/org/zaproxy/zap/extension/lang/OptionsLangPanel.java
@@ -234,11 +234,6 @@ public class OptionsLangPanel extends AbstractParamPanel {
 	}
 	
 	@Override
-	public void validateParam(Object obj) {
-	    // no validation needed
-	}
-	
-	@Override
 	public void saveParam (Object obj) throws Exception {
 	    OptionsParam options = (OptionsParam) obj;
 	    ViewLocale selectedLocale = (ViewLocale) localeSelect.getSelectedItem();

--- a/src/org/zaproxy/zap/extension/option/OptionsLocalePanel.java
+++ b/src/org/zaproxy/zap/extension/option/OptionsLocalePanel.java
@@ -162,11 +162,6 @@ public class OptionsLocalePanel extends AbstractParamPanel {
 	}
 	
 	@Override
-	public void validateParam(Object obj) {
-	    // no validation needed
-	}
-	
-	@Override
 	public void saveParam (Object obj) throws Exception {
 	    OptionsParam options = (OptionsParam) obj;
 	    ViewLocale selectedLocale = (ViewLocale) localeSelect.getSelectedItem();

--- a/src/org/zaproxy/zap/extension/pscan/OptionsPassiveScan.java
+++ b/src/org/zaproxy/zap/extension/pscan/OptionsPassiveScan.java
@@ -95,11 +95,6 @@ public class OptionsPassiveScan extends AbstractParamPanel {
     }
 
     @Override
-    public void validateParam(Object obj) throws Exception {
-
-    }
-    
-    @Override
     public void saveParam(Object obj) throws Exception {
         OptionsParam optionsParam = (OptionsParam) obj;
         PassiveScanParam passiveScanParam = optionsParam.getParamSet(PassiveScanParam.class);

--- a/src/org/zaproxy/zap/extension/pscan/PassiveScannerOptionsPanel.java
+++ b/src/org/zaproxy/zap/extension/pscan/PassiveScannerOptionsPanel.java
@@ -74,11 +74,6 @@ class PassiveScannerOptionsPanel extends AbstractParamPanel {
     }
 
     @Override
-    public void validateParam(Object obj) throws Exception {
-        // Nothing to validate.
-    }
-
-    @Override
     public void saveParam(Object obj) throws Exception {
         OptionsParam optionsParam = (OptionsParam) obj;
         PassiveScanParam pscanOptions = optionsParam.getParamSet(PassiveScanParam.class);

--- a/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanPanel.java
+++ b/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanPanel.java
@@ -191,10 +191,6 @@ public class PolicyPassiveScanPanel extends AbstractParamPanel {
     }
 
     @Override
-    public void validateParam(Object obj) throws Exception {
-    }
-
-    @Override
     public void saveParam(Object obj) throws Exception {
     	this.getPassiveScanTableModel().persistChanges();
     }

--- a/src/org/zaproxy/zap/extension/ruleconfig/OptionsRuleConfigPanel.java
+++ b/src/org/zaproxy/zap/extension/ruleconfig/OptionsRuleConfigPanel.java
@@ -82,11 +82,6 @@ public class OptionsRuleConfigPanel extends AbstractParamPanel {
         ruleConfigOptionsPanel.packAll();
     }
 
-    @Override
-    public void validateParam(Object obj) throws Exception {
-        // Nothing to do
-    }
-
     private JButton getResetButton() {
         if (resetButton == null) {
             resetButton = new JButton(Constant.messages.getString("ruleconfig.options.button.reset"));

--- a/src/org/zaproxy/zap/extension/script/OptionsScriptPanel.java
+++ b/src/org/zaproxy/zap/extension/script/OptionsScriptPanel.java
@@ -79,13 +79,6 @@ public class OptionsScriptPanel extends AbstractParamPanel {
 	    tokensOptionsPanel.setRemoveWithoutConfirmation(!param.isConfirmRemoveDir());
     }
 
-
-    @Override
-    public void validateParam(Object obj) throws Exception {
-
-    }
-
-
     @Override
     public void saveParam(Object obj) throws Exception {
 	    OptionsParam optionsParam = (OptionsParam) obj;

--- a/src/org/zaproxy/zap/extension/search/OptionsSearchPanel.java
+++ b/src/org/zaproxy/zap/extension/search/OptionsSearchPanel.java
@@ -98,10 +98,6 @@ public class OptionsSearchPanel extends AbstractParamPanel {
     }
 
     @Override
-    public void validateParam(Object obj) throws Exception {
-    }
-
-    @Override
     public void saveParam(Object obj) throws Exception {
         final OptionsParam options = (OptionsParam) obj;
         final SearchParam param = options.getParamSet(SearchParam.class);

--- a/src/org/zaproxy/zap/extension/spider/OptionsSpiderPanel.java
+++ b/src/org/zaproxy/zap/extension/spider/OptionsSpiderPanel.java
@@ -217,11 +217,6 @@ public class OptionsSpiderPanel extends AbstractParamPanel {
 	}
 
 	@Override
-	public void validateParam(Object obj) {
-		// no validation needed
-	}
-
-	@Override
 	public void saveParam(Object obj) throws Exception {
 		OptionsParam options = (OptionsParam) obj;
 		SpiderParam param = options.getParamSet(SpiderParam.class);

--- a/src/org/zaproxy/zap/view/ContextListPanel.java
+++ b/src/org/zaproxy/zap/view/ContextListPanel.java
@@ -164,11 +164,6 @@ public class ContextListPanel extends AbstractParamPanel {
 	}
 	
 	@Override
-	public void validateParam(Object obj) {
-	    // no validation needed
-	}
-	
-	@Override
 	public void saveParam (Object obj) throws Exception {
 		// Nothing to do, the table does not allow to edit its values.
 		// NOTE: If changed to be editable it should be in sync with the view state (share view models?) of

--- a/src/org/zaproxy/zap/view/OptionsConnectionPanel.java
+++ b/src/org/zaproxy/zap/view/OptionsConnectionPanel.java
@@ -300,10 +300,6 @@ public class OptionsConnectionPanel extends AbstractParamPanel {
 	}
 
 	@Override
-	public void validateParam(Object obj) throws Exception {
-	}
-
-	@Override
 	public String getHelpIndex() {
 		return "ui.dialogs.options.connection";
 	}

--- a/src/org/zaproxy/zap/view/SessionExcludeFromProxyPanel.java
+++ b/src/org/zaproxy/zap/view/SessionExcludeFromProxyPanel.java
@@ -123,10 +123,6 @@ public class SessionExcludeFromProxyPanel extends AbstractParamPanel {
 	}
 	
 	@Override
-	public void validateParam(Object obj) {
-	}
-	
-	@Override
 	public void saveParam (Object obj) throws Exception {
 	    Session session = (Session) obj;
 	    session.setExcludeFromProxyRegexs(regexesPanel.getRegexes());

--- a/src/org/zaproxy/zap/view/SessionExcludeFromScanPanel.java
+++ b/src/org/zaproxy/zap/view/SessionExcludeFromScanPanel.java
@@ -123,10 +123,6 @@ public class SessionExcludeFromScanPanel extends AbstractParamPanel {
 	}
 	
 	@Override
-	public void validateParam(Object obj) {
-	}
-	
-	@Override
 	public void saveParam (Object obj) throws Exception {
 	    Session session = (Session) obj;
 	    session.setExcludeFromScanRegexs(regexesPanel.getRegexes());

--- a/src/org/zaproxy/zap/view/SessionExcludeFromSpiderPanel.java
+++ b/src/org/zaproxy/zap/view/SessionExcludeFromSpiderPanel.java
@@ -123,10 +123,6 @@ public class SessionExcludeFromSpiderPanel extends AbstractParamPanel {
 	}
 	
 	@Override
-	public void validateParam(Object obj) {
-	}
-	
-	@Override
 	public void saveParam (Object obj) throws Exception {
 	    Session session = (Session) obj;
 	    session.setExcludeFromSpiderRegexs(regexesPanel.getRegexes());


### PR DESCRIPTION
Add default implementations to validateParam(Object) and getHelpIndex(),
both methods might not be implemented (for example, if the panel does
not need to do validations (UI components already do that) or if the
panel does not have help).
Remove methods no longer needed (per previous changes).