### PR TITLE
Issue 3043 Add helper for printing to JS templates

### DIFF
--- a/src/scripts/templates/active/Active default template.js
+++ b/src/scripts/templates/active/Active default template.js
@@ -1,6 +1,10 @@
 // Note that new active scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"  
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 /**
  * Scans a "node", i.e. an individual entry in the Sites Tree.
  * The scanNode function will typically be called once for every page. 

--- a/src/scripts/templates/authentication/Authentication default template.js
+++ b/src/scripts/templates/authentication/Authentication default template.js
@@ -1,3 +1,7 @@
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 // The authenticate function will be called for authentications made via ZAP.
 
 // The authenticate function is called whenever ZAP requires to authenticate, for a Context for which this script

--- a/src/scripts/templates/authentication/BodgeIt Store Authentication.js
+++ b/src/scripts/templates/authentication/BodgeIt Store Authentication.js
@@ -1,3 +1,7 @@
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 // The authenticate function is called whenever ZAP requires to authenticate, for a Context for which this script
 // was selected as the Authentication Method. The function should send any messages that are required to do the authentication
 // and should return a message with an authenticated response so the calling method.

--- a/src/scripts/templates/authentication/Simple Form-Based Authentication.js
+++ b/src/scripts/templates/authentication/Simple Form-Based Authentication.js
@@ -1,3 +1,7 @@
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 // This authentication script can be used to authenticate in a webapplication via forms.
 // The submit target for the form, the name of the username field, the name of the password field
 // and, optionally, any extra POST Data fields need to be specified after loading the script.

--- a/src/scripts/templates/authentication/Wordpress Authentication.js
+++ b/src/scripts/templates/authentication/Wordpress Authentication.js
@@ -4,6 +4,10 @@
 //	Path: The path, with a '/' at the end, in which the app is found. E.g.: /wp/
 // The parameters must chosen such that: "http://" + domain + path + "wp-login.php"  is the uri of the login page. In case https is used,modify the script below.
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 // The authenticate function is called whenever ZAP requires to authenticate, for a Context for which this script
 // was selected as the Authentication Method. The function should send any messages that are required to do the authentication
 // and should return a message with an authenticated response so the calling method.

--- a/src/scripts/templates/httpsender/HttpSender default template.js
+++ b/src/scripts/templates/httpsender/HttpSender default template.js
@@ -25,6 +25,10 @@
 // helper.getHttpSender().sendAndReceive(msg2, false);
 // println('msg2 response=' + msg2.getResponseHeader().getStatusCode())
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 function sendingRequest(msg, initiator, helper) {
 	// Debugging can be done using println like this
 	println('sendingRequest called for url=' + msg.getRequestHeader().getURI().toString())

--- a/src/scripts/templates/passive/Passive default template.js
+++ b/src/scripts/templates/passive/Passive default template.js
@@ -3,6 +3,10 @@
 // Note that new passive scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"  
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 /**
  * Passively scans an HTTP message. The scan function will be called for 
  * request/response made via ZAP, excluding some of the automated tools.

--- a/src/scripts/templates/proxy/Proxy default template.js
+++ b/src/scripts/templates/proxy/Proxy default template.js
@@ -6,6 +6,10 @@
 // Note that new proxy scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"  
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 /**
  * This function allows interaction with proxy requests (i.e.: outbound from the browser/client to the server).
  * 

--- a/src/scripts/templates/standalone/Loop through history table.js
+++ b/src/scripts/templates/standalone/Loop through history table.js
@@ -3,6 +3,10 @@
 // Standalone scripts have no template.
 // They are only evaluated when you run them. 
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 extHist = org.parosproxy.paros.control.Control.getSingleton().
     getExtensionLoader().getExtension(
         org.parosproxy.paros.extension.history.ExtensionHistory.NAME) 

--- a/src/scripts/templates/standalone/Standalone default template.js
+++ b/src/scripts/templates/standalone/Standalone default template.js
@@ -1,3 +1,6 @@
 // Standalone scripts have no template.
 // They are only evaluated when you run them. 
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;

--- a/src/scripts/templates/standalone/Traverse sites tree.js
+++ b/src/scripts/templates/standalone/Traverse sites tree.js
@@ -3,12 +3,14 @@
 // Standalone scripts have no template.
 // They are only evaluated when you run them. 
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 function listChildren(node, level) {
-    var i;
-    for (i=0;i<level;i++) print ("    ");
     var j;
     for (j=0;j<node.getChildCount();j++) {
-        println(node.getChildAt(j).getNodeName());
+        println(Array(level+1).join("    ") + node.getChildAt(j).getNodeName());
         listChildren(node.getChildAt(j), level+1);
     }
 }

--- a/src/scripts/templates/targeted/Find HTML comments.js
+++ b/src/scripts/templates/targeted/Find HTML comments.js
@@ -1,5 +1,9 @@
 // Targeted scripts can only be invoked by you, the user, eg via a right-click option on the Sites or History tabs
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 function invokeWith(msg) {
 	// Debugging can be done using println like this
 	println('Finding comments under ' + msg.getRequestHeader().getURI().toString()); 
@@ -18,11 +22,11 @@ function invokeWith(msg) {
 				body = hr.getHttpMessage().getResponseBody().toString()
 				// Look for html comments
 				if (body.indexOf('<!--') > 0) {
-		           	print(hr.getHttpMessage().getRequestHeader().getURI() + "\n") 
+		           	println(hr.getHttpMessage().getRequestHeader().getURI()) 
 					o = body.indexOf('<!--');
 					while (o > 0) {
 						e = body.indexOf('-->', o);
-			           	print("\t" + body.substr(o,e-o+3) + "\n") 
+			           	println("\t" + body.substr(o,e-o+3)) 
 						o = body.indexOf('<!--', e);
 					}
 				}

--- a/src/scripts/templates/targeted/Targeted default template.js
+++ b/src/scripts/templates/targeted/Targeted default template.js
@@ -1,5 +1,9 @@
 // Targeted scripts can only be invoked by you, the user, eg via a right-click option on the Sites or History tabs
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 /**
  * A function which will be invoked against a specific "targeted" message.
  *

--- a/src/scripts/templates/variant/Input Vector default template.js
+++ b/src/scripts/templates/variant/Input Vector default template.js
@@ -4,6 +4,10 @@
 // Note that new custom input vector scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"  
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 function parseParameters(helper, msg) {
     // Debugging can be done using println like this
     println('custom input vector handler called for url=' + msg.getRequestHeader().getURI().toString());

--- a/src/scripts/templates/variant/Input Vector sharp query separator.js
+++ b/src/scripts/templates/variant/Input Vector sharp query separator.js
@@ -4,6 +4,10 @@
 // Note that new custom input vector scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"  
 
+// The following handles differences in printing between Java 7's Rhino JS engine
+// and Java 8's Nashorn JS engine
+if (typeof println == 'undefined') this.println = print;
+
 function parseParameters(helper, msg) {
     // Debugging can be done using println like this
     println('Google variant called for url=' + msg.getRequestHeader().getURI().toString());


### PR DESCRIPTION
Add helper code that overcomes the lack of println when scripts are run
using Java 8's Nashorn JS engine, by reassigning the function when
undefined.

Fixes zaproxy/zaproxy#3043