### PR TITLE
Use G1 as default garbage collector

### DIFF
--- a/src/zap.sh
+++ b/src/zap.sh
@@ -41,12 +41,17 @@ if [ "`echo ${JAVA_OUTPUT} | grep "continuing with system-provided Java"`" ] ; t
   unset JAVA_HOME
 fi
 
+DEFAULTJAVAGC="-XX:+UseG1GC"
+
 JAVA_VERSION=$(java -version 2>&1 | awk -F\" '/version/ { print $2 }')
 JAVA_MAJOR_VERSION=${JAVA_VERSION%%[.|-]*}
 JAVA_MINOR_VERSION=$(echo $JAVA_VERSION | awk -F\. '{ print $2 }')
 
 # JEP 223, newer Java versions (>= 9) no longer use 1 as major version
-if [ $JAVA_MAJOR_VERSION -ge 9 ] || ([ $JAVA_MAJOR_VERSION -ge 1 ] && [ $JAVA_MINOR_VERSION -ge 8 ]); then
+if [ $JAVA_MAJOR_VERSION -ge 9 ]; then
+  DEFAULTJAVAGC=""
+  echo "Found Java version $JAVA_VERSION"
+elif [ $JAVA_MAJOR_VERSION -ge 1 ] && [ $JAVA_MINOR_VERSION -ge 8 ]; then
   echo "Found Java version $JAVA_VERSION"
 else
   echo "Exiting: ZAP requires a minimum of Java 8 to run, found $JAVA_VERSION"
@@ -75,10 +80,13 @@ fi
 
 if [ ! -z "$JMEM" ]; then
   echo "Using jvm memory setting from $JVMPROPS"
+  JAVAGC=""
 elif [ -z "$MEM" ]; then
   echo "Failed to obtain current memory, using jvm default memory settings"
+  JAVAGC=${DEFAULTJAVAGC}
 else
   echo "Available memory: $MEM MB"
+  JAVAGC=${DEFAULTJAVAGC}
   if [ "$MEM" -gt 512 ]; then
     # Always go with 1/4 of the available memory - specific JVMs may round this up or down
     QMEM=$(($MEM/4))
@@ -106,7 +114,7 @@ fi
 # Start ZAP; it's likely that -Xdock:icon would be ignored on other platforms, but this is known to work
 if [ "$OS" = "Darwin" ]; then
   # It's likely that -Xdock:icon would be ignored on other platforms, but this is known to work
-  exec java ${JMEM} -Xdock:icon="../Resources/ZAP.icns" -jar "${BASEDIR}/zap-dev.jar" "${ARGS[@]}"
+  exec java ${JMEM} ${JAVAGC} -Xdock:icon="../Resources/ZAP.icns" -jar "${BASEDIR}/zap-dev.jar" "${ARGS[@]}"
 else
-  exec java ${JMEM} -jar "${BASEDIR}/zap-dev.jar" "${ARGS[@]}"
+  exec java ${JMEM} ${JAVAGC} -jar "${BASEDIR}/zap-dev.jar" "${ARGS[@]}"
 fi


### PR DESCRIPTION
After have some performance problems and freezes, I change the JVM Garbage Collector to CMS and it works for me.

I add this new configuration as default one, but you can still use .ZAP_JVM.properties to configure it.

Default configuration = -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalMode -XX:+PrintGCDetails -XX:+PrintGCTimeStamps
As oracle suggest for [java 8](https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/cms.html)

-----
<sub>Edit by @kingthorin:</sub>
> Add G1 GC as default garbage collector
> Per http://openjdk.java.net/jeps/248