### PR TITLE
Restore session comparison

### DIFF
--- a/src/org/zaproxy/zap/extension/compare/ExtensionCompare.java
+++ b/src/org/zaproxy/zap/extension/compare/ExtensionCompare.java
@@ -38,7 +38,6 @@ import org.apache.commons.httpclient.URI;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control.Mode;
-import org.parosproxy.paros.db.Database;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.db.RecordHistory;
 import org.parosproxy.paros.db.TableHistory;
@@ -46,6 +45,7 @@ import org.parosproxy.paros.db.paros.ParosDatabase;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.SessionChangedListener;
+import org.parosproxy.paros.extension.option.DatabaseParam;
 import org.parosproxy.paros.extension.report.ReportGenerator;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
@@ -191,7 +191,8 @@ public class ExtensionCompare extends ExtensionAdaptor implements SessionChanged
 	    		cmpModel.openSession(file, this);
 
 	    		// TODO support other implementations in the future
-				Database db = new ParosDatabase();
+				ParosDatabase db = new ParosDatabase();
+				db.setDatabaseParam(new DatabaseParam());
 				db.open(file.getAbsolutePath());
 				
 				Map <String, String> curMap = new HashMap<>();


### PR DESCRIPTION
Change ExtensionCompare to set the (default) database options to the
(Paros) database, they are required when connecting/opening the
database/session.

Fix #3157 - Session Comparison Exception