### PR TITLE
Select first certificate of newly added keystore

### DIFF
--- a/src/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
@@ -27,6 +27,7 @@
 // ZAP: 2014/08/14 Issue 1184: Improve support for IBM JDK
 // ZAP: 2016/06/28: File chooser for PKCS#12 files now also accepts .pfx files
 // ZAP: 2017/01/09 Remove method no longer needed.
+// ZAP: 2017/01/23 Select first alias of selected keystore
 
 package org.parosproxy.paros.extension.option;
 
@@ -48,6 +49,8 @@ import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPasswordField;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
 import javax.swing.filechooser.FileFilter;
 
 import org.apache.log4j.Logger;
@@ -242,10 +245,11 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 			});
 
 			keyStoreList.setModel(keyStoreListModel);
-			keyStoreList.addMouseListener(new java.awt.event.MouseAdapter() {
+			keyStoreList.addListSelectionListener(new ListSelectionListener() {
+
 				@Override
-				public void mouseClicked(java.awt.event.MouseEvent evt) {
-					keyStoreListMouseClicked(evt);
+				public void valueChanged(ListSelectionEvent evt) {
+					keyStoreListSelectionChanged();
 				}
 			});
 			keyStoreScrollPane.setViewportView(keyStoreList);
@@ -543,7 +547,7 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 	}
 
 
-	private void keyStoreListMouseClicked(java.awt.event.MouseEvent evt) {//GEN-FIRST:event_keyStoreListMouseClicked
+	private void keyStoreListSelectionChanged() {
 		int keystore = keyStoreList.getSelectedIndex();
 		try {
 			aliasTableModel.setKeystore(keystore);
@@ -553,7 +557,7 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 					Constant.messages.getString("options.cert.error.accesskeystore"), JOptionPane.ERROR_MESSAGE);
 			logger.error(e.getMessage(), e);
 		}
-	}//GEN-LAST:event_keyStoreListMouseClicked
+	}
 
 	private void showActiveCertificateButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_showActiveCertificateButtonActionPerformed
 		Certificate cert = contextManager.getDefaultCertificate();
@@ -616,6 +620,7 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 			retry = true;
 
 			certificatejTabbedPane.setSelectedIndex(0);
+			selectFirstAliasOfKeyStore(ksIndex);
 
 			driverComboBox.setSelectedIndex(-1);
 			pkcs11PasswordField.setText("");
@@ -693,6 +698,17 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 
 	}//GEN-LAST:event_addPkcs11ButtonActionPerformed
 
+	private void selectFirstAliasOfKeyStore(int ksIndex) {
+		if (ksIndex < 0 || ksIndex >= keyStoreList.getModel().getSize()) {
+			return;
+		}
+
+		keyStoreList.setSelectedIndex(ksIndex);
+		if (aliasTable.getRowCount() != 0) {
+			aliasTable.setRowSelectionInterval(0, 0);
+		}
+	}
+
 	private void showErrorMessageSunPkcs11ProviderNotAvailable() {
 		final String sunReference = Constant.messages.getString("options.cert.error.pkcs11notavailable.sun.hyperlink");
 		final String ibmReference = Constant.messages.getString("options.cert.error.pkcs11notavailable.ibm.hyperlink");
@@ -745,8 +761,9 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 			return;
 		}
 
+		int ksIndex;
 		try {
-			int ksIndex = contextManager.loadPKCS12Certificate(fileTextField.getText(), kspass);
+			ksIndex = contextManager.loadPKCS12Certificate(fileTextField.getText(), kspass);
 			keyStoreListModel.insertElementAt(contextManager.getKeyStoreDescription(ksIndex), ksIndex);
 		} catch (Exception e) {
 			JOptionPane.showMessageDialog(null, new String[] {
@@ -759,6 +776,7 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 
 
 		certificatejTabbedPane.setSelectedIndex(0);
+		selectFirstAliasOfKeyStore(ksIndex);
 
 		fileTextField.setText("");
 		pkcs12PasswordField.setText("");


### PR DESCRIPTION
Change OptionsCertificatePanel to select the first certificate available
of the newly added keystore.

Fix #3163 - Autoselect Imported Certificate