### PR TITLE
Create a new 'live' ZAP docker image based on the latest code in the repos

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -232,6 +232,7 @@
 		<replace file="${dist}/zap.bat" token="zap-dev.jar" value="${zap.jar}"/>
 		<replace file="${dist}/zap.sh" token="zap-dev.jar" value="${zap.jar}"/>
 
+		<chmod perm="755" file="${dist}/zap.sh" />
 	</target>
 
 	<target name="dist-with-source" description="Builds ZAP jar with source to be used in zap-extensions">

--- a/build/docker/Dockerfile-live
+++ b/build/docker/Dockerfile-live
@@ -1,0 +1,97 @@
+# This dockerfile builds a 'live' zap docker image using the latest files in the repos
+FROM ubuntu:16.04
+MAINTAINER Simon Bennetts "psiinon@gmail.com"
+
+RUN apt-get update && apt-get install -q -y --fix-missing \
+	make \
+	ant \
+	automake \
+	autoconf \
+	gcc g++ \
+	openjdk-8-jdk \
+	ruby \
+	wget \
+	curl \
+	xmlstarlet \
+	unzip \
+	git \
+	x11vnc \
+	xvfb \
+	openbox \
+	xterm \
+	net-tools \
+	ruby-dev \
+	python-pip \
+	firefox \
+	vim \
+	xvfb \
+	x11vnc && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*  && \
+	
+	pip install --upgrade pip && \
+	gem install zapr && \
+	pip install zapcli && \
+	# Install latest dev version of the python API
+	pip install https://github.com/zaproxy/zap-api-python/releases/download/0.0.9.dev1/python-owasp-zap-v2.4-0.0.9.dev1.tar.gz && \
+	useradd -d /home/zap -m -s /bin/bash zap && \ 
+	echo zap:zap | chpasswd && \
+	mkdir /zap  && \
+	chown zap /zap && \
+	chgrp zap /zap && \
+	mkdir /zap-src  && \
+	chown zap /zap-src && \
+	chgrp zap /zap-src
+
+WORKDIR /zap-src
+
+#Change to the zap user so things get done as the right person (apart from copy)
+USER zap
+
+RUN mkdir /home/zap/.vnc
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
+ENV PATH $JAVA_HOME/bin:/zap/:$PATH
+
+# Pull the ZAP repos
+RUN git clone https://github.com/zaproxy/zaproxy.git && \
+	git clone https://github.com/zaproxy/zap-extensions.git && \
+	git clone --branch beta https://github.com/zaproxy/zap-extensions.git zap-extensions_beta && \
+	git clone --branch alpha https://github.com/zaproxy/zap-extensions.git zap-extensions_alpha && \
+	git clone https://github.com/zaproxy/zap-core-help.git && \
+	# Download the webdrivers
+	cd zap-extensions_alpha && \
+	ant -f build/build.xml download-webdrivers && \
+	# Build ZAP
+	cd ../zaproxy && \
+	ant -f build/build.xml deploy-weekly-addons && \
+	ant -f build/build.xml day-stamped-release && \
+	cp -R /zap-src/zaproxy/build/zap/* /zap/ && \
+	rm -rf /zap-src/*
+	
+ENV ZAP_PATH /zap/zap.sh
+# Default port for use with zapcli
+ENV ZAP_PORT 8080
+ENV HOME /home/zap/
+
+COPY zap-x.sh zap-baseline.py zap-webswing.sh /zap/ 
+COPY webswing.config /zap/webswing-2.3/ 
+COPY policies /home/zap/.ZAP_D/policies/
+COPY .xinitrc /home/zap/
+
+#Copy doesn't respect USER directives so we need to chown and to do that we need to be root
+USER root
+
+RUN chown zap:zap /zap/zap-x.sh && \
+	chown zap:zap /zap/zap-baseline.py && \
+	chown zap:zap /zap/zap-webswing.sh && \
+	chown zap:zap /zap/webswing-2.3/webswing.config && \
+	chown zap:zap -R /home/zap/.ZAP_D/ && \
+	chown zap:zap /home/zap/.xinitrc && \
+	chmod a+x /home/zap/.xinitrc && \
+	chmod +x /zap/zap.sh && \
+	rm -rf /zap-src
+	
+WORKDIR /zap
+	
+USER zap


### PR DESCRIPTION
Will upload a version of this image to https://hub.docker.com/r/psiinon/ for people to try out once its finished building (and will link from this issue).
The plan is to auto generate this image whenever the zaproxy repo is changed as per https://docs.docker.com/docker-hub/builds/
I'm also hoping we can use it to auto generate daily builds using https://wiki.mozilla.org/TaskCluster