### PR TITLE
Remove Session dependency on ExtensionActiveScan

### DIFF
--- a/src/org/parosproxy/paros/model/Session.java
+++ b/src/org/parosproxy/paros/model/Session.java
@@ -67,6 +67,7 @@
 // ZAP: 2016/10/26 Issue 1952: Do not allow Contexts with same name
 // ZAP: 2016/12/06 Remove contexts before refreshing the UI when discarding the contexts
 // ZAP: 2017/01/04 Remove dependency on ExtensionSpider
+// ZAP: 2017/01/26 Remove dependency on ExtensionActiveScan
 
 package org.parosproxy.paros.model;
 
@@ -99,7 +100,6 @@ import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.control.ExtensionFactory;
-import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.IllegalContextNameException;
 import org.zaproxy.zap.model.NameValuePair;
@@ -958,16 +958,6 @@ public class Session {
 		Pattern.compile(ignoredRegex, Pattern.CASE_INSENSITIVE);
 		
 		this.excludeFromScanRegexs.add(ignoredRegex);
-		ExtensionActiveScan extAscan = 
-			(ExtensionActiveScan) Control.getSingleton().getExtensionLoader().getExtension(ExtensionActiveScan.NAME);
-		if (extAscan != null) {
-			// ZAP: Added fullList & globalExcludeURLRegexs code.
-		    List<String> fullList = new ArrayList<String>();
-		    fullList.addAll(this.excludeFromScanRegexs);
-		    fullList.addAll(this.globalExcludeURLRegexs);
-
-			extAscan.setExcludeList(fullList);
-		}
 		model.getDb().getTableSessionUrl().setUrls(RecordSessionUrl.TYPE_EXCLUDE_FROM_SCAN, this.excludeFromScanRegexs);
 	}
 
@@ -978,16 +968,6 @@ public class Session {
 	    }
 
 		this.excludeFromScanRegexs = stripEmptyLines(ignoredRegexs);
-		ExtensionActiveScan extAscan = 
-			(ExtensionActiveScan) Control.getSingleton().getExtensionLoader().getExtension(ExtensionActiveScan.NAME);
-		if (extAscan != null) {
-			// ZAP: Added fullList & globalExcludeURLRegexs code.
-		    List<String> fullList = new ArrayList<String>();
-		    fullList.addAll(this.excludeFromScanRegexs);
-		    fullList.addAll(this.globalExcludeURLRegexs);
-
-			extAscan.setExcludeList(fullList);
-		}
 		model.getDb().getTableSessionUrl().setUrls(RecordSessionUrl.TYPE_EXCLUDE_FROM_SCAN, this.excludeFromScanRegexs);
 	}
 

--- a/src/org/zaproxy/zap/extension/ascan/ActiveScanController.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScanController.java
@@ -29,7 +29,6 @@ import org.apache.log4j.Logger;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.ScannerParam;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.extension.ruleconfig.ExtensionRuleConfig;
@@ -125,9 +124,12 @@ public class ActiveScanController implements ScanController<ActiveScan> {
 				}
 			};
 			
-			// Set session level configs
-			Session session = Model.getSingleton().getSession();
-			ascan.setExcludeList(session.getExcludeFromScanRegexs());
+			Session session = extension.getModel().getSession();
+			List<String> excludeList = new ArrayList<>();
+			excludeList.addAll(extension.getExcludeList());
+			excludeList.addAll(session.getExcludeFromScanRegexs());
+			excludeList.addAll(session.getGlobalExcludeURLRegexs());
+			ascan.setExcludeList(excludeList);
 			ScanPolicy policy = null;
 			
 			ascan.setId(id);

--- a/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -114,6 +114,8 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
 	private PolicyManager policyManager = null;
     private List<CustomScanPanel> customScanPanels = new ArrayList<CustomScanPanel>();
     
+    private List<String> excludeList = Collections.emptyList();
+
 	private ActiveScanAPI activeScanApi;
 
     public ExtensionActiveScan() {
@@ -460,12 +462,28 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
         return arguments;
     }
 
+	/**
+	 * Sets the exclude list.
+	 * 
+	 * @param urls the new exclude list
+	 */
 	public void setExcludeList(List<String> urls) {
-		for (ActiveScan scanner : ascanController.getActiveScans()) {
-			scanner.setExcludeList(urls);
+		if (urls == null || urls.isEmpty()) {
+			excludeList = Collections.emptyList();
+			return;
 		}
+
+		this.excludeList = urls;
 	}
 
+    /**
+     * Gets the exclude list.
+     * 
+     * @return the exclude list
+     */
+    public List<String> getExcludeList() {
+        return excludeList;
+    }
 
     public void addPolicyPanel(AbstractParamPanel panel) {
         this.policyPanels.add(panel);


### PR DESCRIPTION
Change Session to no longer call/use ExtensionActiveScan.
Change ActiveScanController to obtain the excluded URLs (session and
global) instead of having the Session to set them.
Change ExtensionActiveScan to allow to set a list of excluded URLs and
to not change running active scans, normalising the behaviour with the
normal spider.

Part of #3129 - Move Active Scanner to an add-on