### PR TITLE
Allow to show more request data in History tab

### DIFF
--- a/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -69,6 +69,7 @@
 // ZAP: 2016/05/30 Issue 2494: ZAP Proxy is not showing the HTTP CONNECT Request in history tab
 // ZAP: 2016/06/20 Removed unnecessary/unused constructor
 // ZAP: 2016/06/21 Prevent deadlock between EDT and threads adding messages to the History tab
+// ZAP: 2017/01/30 Use HistoryTableModel.
 
 package org.parosproxy.paros.extension.history;
 
@@ -112,17 +113,16 @@ import org.zaproxy.zap.extension.history.PopupMenuExportURLs;
 import org.zaproxy.zap.extension.history.PopupMenuNote;
 import org.zaproxy.zap.extension.history.PopupMenuPurgeHistory;
 import org.zaproxy.zap.extension.history.PopupMenuTag;
-import org.zaproxy.zap.view.table.DefaultHistoryReferencesTableModel;
 
 public class ExtensionHistory extends ExtensionAdaptor implements SessionChangedListener {
 
 	public static final String NAME = "ExtensionHistory";
 
-	private static final DefaultHistoryReferencesTableModel EMPTY_MODEL = new DefaultHistoryReferencesTableModel();
+	private static final HistoryTableModel EMPTY_MODEL = new HistoryTableModel();
 
 	private LogPanel logPanel = null;  //  @jve:decl-index=0:visual-constraint="161,134"
 	private ProxyListenerLog proxyListener = null;
-	private DefaultHistoryReferencesTableModel historyTableModel;
+	private HistoryTableModel historyTableModel;
     
 	// ZAP: added filter plus dialog
 	private HistoryFilterPlusDialog filterPlusDialog = null;
@@ -178,8 +178,11 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
 		return logPanel;
 	}
 	
+    /**
+     * @deprecated (TODO add version) No longer used/needed.
+     */
+    @Deprecated
 	public void clearLogPanelDisplayQueue() {
-		this.getLogPanel().clearDisplayQueue();
 	}
 	
 	public HistoryReference getSelectedHistoryReference () {
@@ -194,7 +197,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
 	public void init() {
 		super.init();
 
-		historyTableModel = new DefaultHistoryReferencesTableModel();
+		historyTableModel = new HistoryTableModel();
 		ZAP.getEventBus().registerConsumer(new AlertEventConsumer(), AlertEventPublisher.getPublisher().getPublisherName());
 	}
 
@@ -725,9 +728,6 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
 
             // delete reference in node
             removeFromHistoryList(node.getHistoryReference());
-            if (View.isInitialised()) {
-                clearLogPanelDisplayQueue();
-            }
 
             ExtensionAlert extAlert =
                     Control.getSingleton().getExtensionLoader().getExtension(ExtensionAlert.class);
@@ -743,9 +743,6 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
                 HistoryReference ref = node.getPastHistoryReference().get(0);
                 deleteAlertsFromExtensionAlert(extAlert, ref);
                 removeFromHistoryList(ref);
-                if (View.isInitialised()) {
-                    clearLogPanelDisplayQueue();
-                }
                 delete(ref);
                 node.getPastHistoryReference().remove(0);
                 map.removeHistoryReference(ref.getHistoryId());

--- a/src/org/parosproxy/paros/extension/history/HistoryTable.java
+++ b/src/org/parosproxy/paros/extension/history/HistoryTable.java
@@ -1,0 +1,47 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2017 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.extension.history;
+
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.view.table.HistoryReferencesTable;
+
+/**
+ * A {@code HistoryReferencesTable} for History tab.
+ */
+class HistoryTable extends HistoryReferencesTable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a {@code HistoryTable}.
+     */
+    public HistoryTable() {
+        super(new HistoryTableModel());
+
+        setAutoCreateColumnsFromModel(false);
+
+        setName("History Table");
+
+        getColumnExt(Constant.messages.getString("view.href.table.header.timestamp.response")).setVisible(false);
+        getColumnExt(Constant.messages.getString("view.href.table.header.size.requestheader")).setVisible(false);
+        getColumnExt(Constant.messages.getString("view.href.table.header.size.requestbody")).setVisible(false);
+        getColumnExt(Constant.messages.getString("view.href.table.header.size.responseheader")).setVisible(false);
+    }
+}

--- a/src/org/parosproxy/paros/extension/history/HistoryTableModel.java
+++ b/src/org/parosproxy/paros/extension/history/HistoryTableModel.java
@@ -1,0 +1,52 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2017 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.extension.history;
+
+import org.zaproxy.zap.view.table.DefaultHistoryReferencesTableModel;
+
+/**
+ * A {@code DefaultHistoryReferencesTableModel} for History tab.
+ */
+class HistoryTableModel extends DefaultHistoryReferencesTableModel {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a {@code HistoryTableModel}.
+     */
+    public HistoryTableModel() {
+        super(new Column[] {
+                Column.HREF_ID,
+                Column.REQUEST_TIMESTAMP,
+                Column.RESPONSE_TIMESTAMP,
+                Column.METHOD,
+                Column.URL,
+                Column.STATUS_CODE,
+                Column.STATUS_REASON,
+                Column.RTT,
+                Column.SIZE_REQUEST_HEADER,
+                Column.SIZE_REQUEST_BODY,
+                Column.SIZE_RESPONSE_HEADER,
+                Column.SIZE_RESPONSE_BODY,
+                Column.HIGHEST_ALERT,
+                Column.NOTE,
+                Column.TAGS });
+    }
+}

--- a/src/org/parosproxy/paros/extension/history/LogPanel.java
+++ b/src/org/parosproxy/paros/extension/history/LogPanel.java
@@ -39,17 +39,16 @@
 // with tables instead of lists
 // ZAP: 2015/02/10 Issue 1528: Support user defined font size
 // ZAP: 2016/04/14 Use View to display the HTTP messages
+// ZAP: 2017/01/30 Use HistoryTable.
 
 package org.parosproxy.paros.extension.history;
 
 import java.awt.BorderLayout;
 import java.awt.Event;
-import java.awt.EventQueue;
 import java.awt.GridBagConstraints;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.util.List;
-import java.util.Vector;
 
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -69,7 +68,6 @@ import org.parosproxy.paros.extension.ViewDelegate;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.SiteNode;
-import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.httppanel.HttpPanel;
 import org.zaproxy.zap.utils.DisplayUtils;
@@ -79,7 +77,7 @@ import org.zaproxy.zap.view.table.DefaultHistoryReferencesTableEntry;
 import org.zaproxy.zap.view.table.HistoryReferencesTable;
 import org.zaproxy.zap.view.table.HistoryReferencesTableModel;
 
-public class LogPanel extends AbstractPanel implements Runnable {
+public class LogPanel extends AbstractPanel {
 	private static final long serialVersionUID = 1L;
 	// ZAP: Added logger.
 	private static final Logger logger = Logger.getLogger(LogPanel.class);
@@ -323,9 +321,7 @@ public class LogPanel extends AbstractPanel implements Runnable {
 
 	private HistoryReferencesTable getHistoryReferenceTable() {
 		if (historyReferencesTable == null) {
-			historyReferencesTable = new HistoryReferencesTable();
-			historyReferencesTable.setSelectionMode(javax.swing.ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
-			historyReferencesTable.setName("History Table");
+			historyReferencesTable = new HistoryTable();
 			historyReferencesTable.addMouseListener(new java.awt.event.MouseAdapter() {
 
 				@Override
@@ -336,90 +332,21 @@ public class LogPanel extends AbstractPanel implements Runnable {
 				    }
 				}
 			});
-			
-			historyReferencesTable.getSelectionModel().addListSelectionListener(new javax.swing.event.ListSelectionListener() {
-
-				@Override
-				public void valueChanged(javax.swing.event.ListSelectionEvent e) {
-					// ZAP: Changed to only display the message when there are no more selection changes.
-					if (!e.getValueIsAdjusting()) {
-						HistoryReference historyRef = getHistoryReferenceTable().getSelectedHistoryReference();
-						if (historyRef == null) {
-					        return;
-					    }
-	
-	                    readAndDisplay(historyRef);
-					}
-
-				}
-
-
-			});
 
 		}
 		return historyReferencesTable;
 	}
 	
-//    private void readAndDisplay(HistoryReference historyRef) {
-//
-//        HttpMessage msg = null;
-//        try {
-//            msg = historyRef.getHttpMessage();
-//            if (msg.getRequestHeader().isEmpty()) {
-//                requestPanel.setMessage(null, true);
-//            } else {
-//                requestPanel.setMessage(msg, true);
-//            }
-//            
-//            if (msg.getResponseHeader().isEmpty()) {
-//                responsePanel.setMessage(null, false);
-//            } else {
-//                responsePanel.setMessage(msg, false);
-//            }
-//        } catch (Exception e1) {
-//            e1.printStackTrace();
-//        }
-//        
-//    }
-
-    
-
-    
-    private Vector<HistoryReference> displayQueue = new Vector<>();
-    private Thread thread = null;
-    
     protected void display(final HistoryReference historyRef) {
-    	this.readAndDisplay(historyRef);
     	getHistoryReferenceTable().selectHistoryReference(historyRef.getHistoryId());
     }
 
+    /**
+     * @deprecated (TODO add version) No longer used/needed.
+     */
+    @Deprecated
     public void clearDisplayQueue() {
-    	synchronized(displayQueue) {
-    		displayQueue.clear();
-    	}
     }
-    
-    private void readAndDisplay(final HistoryReference historyRef) {
-
-        synchronized(displayQueue) {
-            if (displayQueue.size() > 0) {
-                displayQueue.clear();
-            }
-            
-            displayQueue.add(historyRef);
-
-        }
-        
-        if (thread != null && thread.isAlive()) {
-            return;
-        }
-        
-        thread = new Thread(this);
-
-        thread.setPriority(Thread.NORM_PRIORITY);
-        thread.start();
-    }
-    
     
     /**
      * @deprecated (2.5.0) No longer used/needed.
@@ -427,47 +354,6 @@ public class LogPanel extends AbstractPanel implements Runnable {
     @Deprecated
     @SuppressWarnings("javadoc")
     public void setDisplayPanel(HttpPanel requestPanel, HttpPanel responsePanel) {
-    }
-
-    @Override
-    public void run() {
-        HistoryReference ref = null;
-        int count = 0;
-        
-        do {
-            synchronized(displayQueue) {
-                count = displayQueue.size();
-                if (count == 0) {
-                    break;
-                }
-                
-                ref = displayQueue.get(0);
-                displayQueue.remove(0);
-            }
-            
-            try {
-                final HttpMessage msg = ref.getHttpMessage();
-                EventQueue.invokeAndWait(new Runnable() {
-                    @Override
-                    public void run() {
-                        view.displayMessage(msg);
-                        getHistoryReferenceTable().requestFocus();
-
-                    }
-                });
-                
-            } catch (Exception e) {
-                // ZAP: Added logging.
-                logger.error(e.getMessage(), e);
-            }
-            
-            // wait some time to allow another selection event to be triggered
-            try {
-                Thread.sleep(200);
-            } catch (Exception e) {}
-        } while (true);
-        
-        
     }
 
     public void setFilterStatus (HistoryFilter filter) {

--- a/src/org/zaproxy/zap/extension/history/PopupMenuPurgeHistory.java
+++ b/src/org/zaproxy/zap/extension/history/PopupMenuPurgeHistory.java
@@ -76,7 +76,6 @@ public class PopupMenuPurgeHistory extends PopupMenuItemHistoryReferenceContaine
         }
 
         extension.removeFromHistoryList(ref);
-        extension.clearLogPanelDisplayQueue();
 
         ExtensionAlert extAlert = (ExtensionAlert) Control.getSingleton()
                 .getExtensionLoader()


### PR DESCRIPTION
Change History tab to allow to show the request header/body sizes,
response timestamp and response header size of the HTTP messages. Also,
remove redundant functionality, already provided by HistoryTable.