### PR TITLE
Tweak ZAP API client generated JavaDoc

### DIFF
--- a/src/org/zaproxy/zap/extension/api/JavaAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/JavaAPIGenerator.java
@@ -108,6 +108,7 @@ public class JavaAPIGenerator extends AbstractAPIGenerator {
 			out.write("\t/**\n");
 			out.write("\t * " + desc + "\n");
 			if (isOptional()) {
+				out.write("\t * <p>\n");
 				out.write("\t * " + OPTIONAL_MESSAGE + "\n");
 			}
 


### PR DESCRIPTION
Change JavaAPIGenerator to add a paragraph before the optional API
message, so that the description of the API endpoint is not shown in the
same line.