### PR TITLE
Remove outdated tasks

### DIFF
--- a/src/org/parosproxy/paros/model/Session.java
+++ b/src/org/parosproxy/paros/model/Session.java
@@ -1035,7 +1035,6 @@ public class Session {
 		model.getDb().getTableSessionUrl().setUrls(RecordSessionUrl.TYPE_EXCLUDE_FROM_SPIDER, this.excludeFromSpiderRegexs);
 	}
 
-	/** TODO The GlobalExcludeURL functionality is currently alpha and subject to change.  */
 	// ZAP: Added function.
 	public void forceGlobalExcludeURLRefresh() throws DatabaseException {
 		List<String> temp;
@@ -1053,25 +1052,19 @@ public class Session {
 		setExcludeFromSpiderRegexs(temp);
 	}
 
-	/** TODO The GlobalExcludeURL functionality is currently alpha and subject to change.  */
 	// ZAP: Added function.
 	public List<String> getGlobalExcludeURLRegexs() {
 		return globalExcludeURLRegexs;
 	}
 
-	/** TODO The GlobalExcludeURL functionality is currently alpha and subject to change.  */
 	// ZAP: Added function.
 	public void addGlobalExcludeURLRegexs(String ignoredRegex) throws DatabaseException {
 		// Validate its a valid regex first
 		Pattern.compile(ignoredRegex, Pattern.CASE_INSENSITIVE);
     
 		this.globalExcludeURLRegexs.add(ignoredRegex);
-		
-		// XXX This probably isn't needed in the active session, need advice here. 
-		//model.getDb().getTableSessionUrl().setUrls(RecordSessionUrl.TYPE_GLOBAL_EXCLUDE_URL, this.globalExcludeURLRegexs);
 	}
 
-	/** TODO The GlobalExcludeURL functionality is currently alpha and subject to change.  */
 	// ZAP: Added function.
 	public void setGlobalExcludeURLRegexs(List<String> ignoredRegexs) throws DatabaseException {
 		// Validate its a valid regex first
@@ -1080,8 +1073,6 @@ public class Session {
 	    }
 		this.globalExcludeURLRegexs = stripEmptyLines(ignoredRegexs);
 
-		// XXX This probably isn't needed in the active session, need advice here. 
-		//model.getDb().getTableSessionUrl().setUrls(RecordSessionUrl.TYPE_GLOBAL_EXCLUDE_URL, this.globalExcludeURLRegexs);
 	    log.debug("setGlobalExcludeURLRegexs" );
 	}
 	

--- a/src/org/zaproxy/zap/extension/globalexcludeurl/DialogAddToken.java
+++ b/src/org/zaproxy/zap/extension/globalexcludeurl/DialogAddToken.java
@@ -35,7 +35,6 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
-/** TODO The GlobalExcludeURL functionality is currently alpha and subject to change.  */
 class DialogAddToken extends AbstractFormDialog {
 
     private static final long serialVersionUID = 4460797449668634319L;

--- a/src/org/zaproxy/zap/extension/globalexcludeurl/DialogModifyToken.java
+++ b/src/org/zaproxy/zap/extension/globalexcludeurl/DialogModifyToken.java
@@ -24,7 +24,6 @@ import java.awt.Dialog;
 
 import org.parosproxy.paros.Constant;
 
-/** TODO The GlobalExcludeURL functionality is currently alpha and subject to change.  */
 class DialogModifyToken extends DialogAddToken {
 
     private static final long serialVersionUID = 6675509994290748494L;

--- a/src/org/zaproxy/zap/extension/globalexcludeurl/ExtensionGlobalExcludeURL.java
+++ b/src/org/zaproxy/zap/extension/globalexcludeurl/ExtensionGlobalExcludeURL.java
@@ -26,7 +26,6 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.model.Model;
 
-/** TODO The GlobalExcludeURL functionality is currently alpha and subject to change.  */
 public class ExtensionGlobalExcludeURL extends ExtensionAdaptor  {
 
 	public static final String NAME = "ExtensionGlobalExcludeURL"; 

--- a/src/org/zaproxy/zap/extension/globalexcludeurl/GlobalExcludeURLParam.java
+++ b/src/org/zaproxy/zap/extension/globalexcludeurl/GlobalExcludeURLParam.java
@@ -29,7 +29,6 @@ import org.apache.log4j.Logger;
 import org.parosproxy.paros.common.AbstractParam;
 import org.zaproxy.zap.extension.api.ZapApiIgnore;
 
-/** TODO The GlobalExcludeURL functionality is currently alpha and subject to change.  */
 public class GlobalExcludeURLParam extends AbstractParam {
 
     private static final Logger logger = Logger.getLogger(GlobalExcludeURLParam.class);

--- a/src/org/zaproxy/zap/extension/globalexcludeurl/GlobalExcludeURLParamToken.java
+++ b/src/org/zaproxy/zap/extension/globalexcludeurl/GlobalExcludeURLParamToken.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.extension.globalexcludeurl;
 
 import org.zaproxy.zap.utils.Enableable;
 
-/** TODO The GlobalExcludeURL functionality is currently alpha and subject to change.  */
 class GlobalExcludeURLParamToken extends Enableable {
 
     private String regex;

--- a/src/org/zaproxy/zap/extension/globalexcludeurl/OptionsGlobalExcludeURLPanel.java
+++ b/src/org/zaproxy/zap/extension/globalexcludeurl/OptionsGlobalExcludeURLPanel.java
@@ -38,7 +38,6 @@ import org.parosproxy.paros.view.AbstractParamPanel;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTablePanel;
 
-/** TODO The GlobalExcludeURL functionality is currently alpha and subject to change.  */
 public class OptionsGlobalExcludeURLPanel extends AbstractParamPanel {
 
 	private static final long serialVersionUID = 1L;

--- a/src/org/zaproxy/zap/extension/globalexcludeurl/OptionsGlobalExcludeURLTableModel.java
+++ b/src/org/zaproxy/zap/extension/globalexcludeurl/OptionsGlobalExcludeURLTableModel.java
@@ -27,7 +27,6 @@ import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
-/** TODO The GlobalExcludeURL functionality is currently alpha and subject to change.  */
 public class OptionsGlobalExcludeURLTableModel extends AbstractMultipleOptionsTableModel<GlobalExcludeURLParamToken> {
 
 	private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Remove outdated tasks related to Global Excluded URL functionality. The
functionality is no longer in alpha state, also some of the tasks are no
longer needed (i.e. addressed, the code was not needed).