### PR TITLE
Correct regexes of global excluded URLs

### DIFF
--- a/src/org/zaproxy/zap/extension/globalexcludeurl/GlobalExcludeURLParam.java
+++ b/src/org/zaproxy/zap/extension/globalexcludeurl/GlobalExcludeURLParam.java
@@ -110,7 +110,7 @@ public class GlobalExcludeURLParam extends AbstractParam {
 				"Site - Bing API queries",
 				"false"
 			}, {
-				"^https?://(safebrowsing-cache|sb-ssl|sb|safebrowsing\\.clients)\\.google\\.com",
+				"^https?://(safebrowsing-cache|sb-ssl|sb|safebrowsing\\.clients)\\.google\\.com/.*$",
 				"Site - Google malware detector updates",
 				"false"
 			}, {
@@ -118,7 +118,7 @@ public class GlobalExcludeURLParam extends AbstractParam {
 				"Site - Lastpass manager",
 				"false"
 			}, {
-				"^https?://(.*addons|au[0-9])\\.mozilla\\.(org|net|com)",
+				"^https?://(.*addons|aus[0-9])\\.mozilla\\.(org|net|com)/.*$",
 				"Site - Mozilla Firefox browser updates",
 				"false"
 			}, {


### PR DESCRIPTION
Change GlobalExcludeURLParam to correct the regular expressions for
"Google malware detector updates" and "Mozilla Firefox browser updates".
For both regular expressions include everything after the authority and
for the latter also add a missing char ("s" to be "aus" subdomain).

Fix #1157 - Global Exclude URL (Beta) built-in domain based filter rules
do not work because of regexp issue.