### PR TITLE
Determine charset only for text responses

### DIFF
--- a/src/org/parosproxy/paros/network/HttpBody.java
+++ b/src/org/parosproxy/paros/network/HttpBody.java
@@ -23,6 +23,7 @@
 // ZAP: 2014/11/26 Issue: 1415 Fixed file uploads > 128k
 // ZAP: 2016/05/18 Always use charset set when changing the HTTP body
 // ZAP: 2016/10/18 Attempt to determine the charset when setting a String with unknown charset
+// ZAP: 2017/02/01 Allow to set whether or not the charset should be determined.
 
 package org.parosproxy.paros.network;
 
@@ -61,6 +62,7 @@ public abstract class HttpBody {
 	private int pos;
     private String cachedString;
 	private Charset charset;
+	private boolean determineCharset = true;
 
 	/**
 	 * Constructs a {@code HttpBody} with no contents (that is, zero length).
@@ -151,7 +153,7 @@ public abstract class HttpBody {
 		}
 		
 		cachedString = null;
-		if (charset == null) {
+		if (charset == null && isDetermineCharset()) {
 			// Attempt to determine the charset to avoid data loss.
 			charset = determineCharset(contents);
 		}
@@ -174,6 +176,36 @@ public abstract class HttpBody {
 	 */
 	protected Charset determineCharset(String contents) {
 		return null;
+	}
+	
+	/**
+	 * Sets whether or not the {@code Charset} of the response should be determined, when no {@code Charset} is set.
+	 * <p>
+	 * An attempt to prevent data loss when {@link #setBody(String) new contents} are set without a {@code Charset}.
+	 *
+	 * @param determine {@code true} if the {@code Charset} should be determined, {@code false} otherwise.
+	 * @since TODO add version
+	 * @see #isDetermineCharset()
+	 * @see #setCharset(String)
+	 */
+	public void setDetermineCharset(boolean determine) {
+		determineCharset = determine;
+	}
+
+	/**
+	 * Tells whether or not the {@code Charset} of the response should be determined, when no {@code Charset} is set.
+	 * <p>
+	 * An attempt to prevent data loss when {@link #setBody(String) new contents} are set without a {@code Charset}.
+	 * <p>
+	 * By default returns {@code true}.
+	 *
+	 * @return {@code true} if the {@code Charset} should be determined, {@code false} otherwise.
+	 * @since TODO add version
+	 * @see #setDetermineCharset(boolean)
+	 * @see #setCharset(String)
+	 */
+	public boolean isDetermineCharset() {
+		return determineCharset;
 	}
 
 	/**

--- a/src/org/parosproxy/paros/network/HttpMessage.java
+++ b/src/org/parosproxy/paros/network/HttpMessage.java
@@ -45,6 +45,7 @@
 // ZAP: 2015/08/07 Issue 1768: Update to use a more recent default user agent
 // ZAP: 2015/08/19 Deprecate/change methods with unused parameters 
 // ZAP: 2016/05/31 Implement hashCode()
+// ZAP: 2017/02/01 Set whether or not the charset should be determined when setting a (String) response.
 
 package org.parosproxy.paros.network;
 
@@ -315,6 +316,7 @@ public class HttpMessage implements Message {
 
 	public void setResponseBody(String body) {
 	    getResponseBody().setCharset(getResponseHeader().getCharset());
+	    getResponseBody().setDetermineCharset(getResponseHeader().isText());
 		getResponseBody().setBody(body);
 
 	}

--- a/test/org/parosproxy/paros/network/HttpBodyUnitTest.java
+++ b/test/org/parosproxy/paros/network/HttpBodyUnitTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
 
+import java.nio.charset.Charset;
 import java.util.Arrays;
 
 import org.junit.Test;
@@ -150,6 +151,50 @@ public class HttpBodyUnitTest extends HttpBodyTestUtils {
         assertThat(httpBody.getBytes(), is(allZeroBytes()));
         assertThat(httpBody.getBytes().length, is(equalTo(LIMIT_INITIAL_CAPACITY)));
         assertThat(httpBody.toString(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldDetermineCharsetByDefault() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        // When
+        boolean determineCharset = httpBody.isDetermineCharset();
+        // Then
+        assertThat(determineCharset, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldSetDetermineCharset() {
+        // Given
+        HttpBody httpBody = new HttpBodyImpl();
+        // When
+        httpBody.setDetermineCharset(false);
+        // Then
+        assertThat(httpBody.isDetermineCharset(), is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldDetermineCharsetIfSetAndHasNoCharset() {
+        // Given
+        HttpBodyImpl httpBody = new HttpBodyImpl();
+        httpBody.setDetermineCharset(true);
+        httpBody.setCharset(null);
+        // When
+        httpBody.setBody("X Y Z");
+        // Then
+        assertThat(httpBody.isDetermineCharsetCalled(), is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldNotDetermineCharsetIfNotSet() {
+        // Given
+        HttpBodyImpl httpBody = new HttpBodyImpl();
+        httpBody.setDetermineCharset(false);
+        httpBody.setCharset(null);
+        // When
+        httpBody.setBody("X Y Z");
+        // Then
+        assertThat(httpBody.isDetermineCharsetCalled(), is(equalTo(false)));
     }
 
     @Test
@@ -674,6 +719,8 @@ public class HttpBodyUnitTest extends HttpBodyTestUtils {
 
     private static class HttpBodyImpl extends HttpBody {
 
+        private boolean determineCharsetCalled;
+
         public HttpBodyImpl() {
         }
 
@@ -687,6 +734,16 @@ public class HttpBodyUnitTest extends HttpBodyTestUtils {
 
         public HttpBodyImpl(byte[] data) {
             super(data);
+        }
+
+        @Override
+        protected Charset determineCharset(String contents) {
+            determineCharsetCalled = true;
+            return super.determineCharset(contents);
+        }
+
+        public boolean isDetermineCharsetCalled() {
+            return determineCharsetCalled;
         }
     }
 

--- a/test/org/zaproxy/zap/network/HttpBodyTestUtils.java
+++ b/test/org/zaproxy/zap/network/HttpBodyTestUtils.java
@@ -28,12 +28,11 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.junit.BeforeClass;
-import org.parosproxy.paros.core.scanner.Plugin;
 
 /**
  * Class with helper/utility methods to help testing classes involving {@code HttpBody} class and its implementations.
  *
- * @see Plugin
+ * @see org.parosproxy.paros.network.HttpBody HttpBody
  */
 public class HttpBodyTestUtils {
 


### PR DESCRIPTION
Change HttpBody to allow to set whether or not the charset should be
determined.
Change HttpMessage to set to determine the charset of the (String)
response only if it's a text response.
Update tests to reflect the change in the behaviour (and fix JavaDoc
of related class).

The change prevents the incorrect body length calculation for non-text
responses (e.g. image).