### PR TITLE
Change form dialogue to document modal

### DIFF
--- a/src/org/zaproxy/zap/view/AbstractFormDialog.java
+++ b/src/org/zaproxy/zap/view/AbstractFormDialog.java
@@ -57,7 +57,7 @@ public abstract class AbstractFormDialog extends JDialog {
 	}
 
 	public AbstractFormDialog(Dialog owner, String title, boolean initView) {
-		super(owner, title, true);
+		super(owner, title, ModalityType.DOCUMENT_MODAL);
 		initialise(initView);
 	}
 


### PR DESCRIPTION
Change AbstractFormDialog to document modal so that child top-level
windows can also receive input (e.g. help window).