### PR TITLE
Add missing document modal values to form dialogue

### DIFF
--- a/src/org/zaproxy/zap/view/AbstractFormDialog.java
+++ b/src/org/zaproxy/zap/view/AbstractFormDialog.java
@@ -61,19 +61,12 @@ public abstract class AbstractFormDialog extends JDialog {
 		initialise(initView);
 	}
 
-	private void initialise(boolean initView) {
-		firstTime = true;
-		if (initView) {
-			initView();
-		}
-	}
-
 	public AbstractFormDialog(Frame owner, String title) {
 		this(owner, title, true);
 	}
 
 	public AbstractFormDialog(Frame owner, String title, boolean initView) {
-		super(owner, title, true);
+		super(owner, title, ModalityType.DOCUMENT_MODAL);
 		initialise(initView);
 	}
 
@@ -82,8 +75,15 @@ public abstract class AbstractFormDialog extends JDialog {
 	}
 
 	public AbstractFormDialog(Window owner, String title, boolean initView) {
-		super(owner, title, Dialog.DEFAULT_MODALITY_TYPE);
+		super(owner, title, ModalityType.DOCUMENT_MODAL);
 		initialise(initView);
+	}
+
+	private void initialise(boolean initView) {
+		firstTime = true;
+		if (initView) {
+			initView();
+		}
 	}
 
 	protected void initView() {


### PR DESCRIPTION
Add document modal value to other AbstractFormDialog constructors.
Move helper constructor method to after the constructors, to have all
the constructors together.

Related to #3183 - Change form dialogue to document modal