### PR TITLE
Correct HTTP header's empty check

### DIFF
--- a/src/org/parosproxy/paros/network/HttpHeader.java
+++ b/src/org/parosproxy/paros/network/HttpHeader.java
@@ -34,6 +34,7 @@
 // ZAP: 2015/03/26 Issue 1573: Add option to inject plugin ID in header for all ascan requests
 // ZAP: 2016/06/17 Be lenient when parsing charset and accept single quote chars around the value
 // ZAP: 2016/06/17 Remove redundant initialisations of instance variables
+// ZAP: 2017/02/08 Change isEmpty to check start line instead of headers (if it has the status/request line it's not empty).
 
 package org.parosproxy.paros.network;
 
@@ -549,8 +550,15 @@ public abstract class HttpHeader implements java.io.Serializable {
         return mMsgHeader;
     }
 
+    /**
+     * Tells whether or not the header is empty.
+     * <p>
+     * A header is empty if it has no content (for example, no start line nor headers).
+     *
+     * @return {@code true} if the header is empty, {@code false} otherwise.
+     */
     public boolean isEmpty() {
-        if (mMsgHeader == null || mMsgHeader.equals("")) {
+        if (mStartLine == null || mStartLine.isEmpty()) {
             return true;
         }
 

--- a/test/org/parosproxy/paros/network/HttpRequestHeaderUnitTest.java
+++ b/test/org/parosproxy/paros/network/HttpRequestHeaderUnitTest.java
@@ -1,0 +1,62 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.network;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit test for {@link HttpRequestHeader}.
+ */
+public class HttpRequestHeaderUnitTest {
+
+    @Test
+    public void shouldBeEmptyIfNoContents() {
+        // Given
+        HttpRequestHeader header = new HttpRequestHeader();
+        // When
+        boolean empty = header.isEmpty();
+        // Then
+        assertThat(empty, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldNotBeEmptyIfItHasRequestLine() throws Exception {
+        // Given
+        HttpRequestHeader header = new HttpRequestHeader("GET http://example.com/ HTTP/1.1\r\n\r\n");
+        // When
+        boolean empty = header.isEmpty();
+        // Then
+        assertThat(empty, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotBeEmptyIfItHasRequestLineAndHeaders() throws Exception {
+        // Given
+        HttpRequestHeader header = new HttpRequestHeader("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n");
+        // When
+        boolean empty = header.isEmpty();
+        // Then
+        assertThat(empty, is(equalTo(false)));
+    }
+}

--- a/test/org/parosproxy/paros/network/HttpResponseHeaderUnitTest.java
+++ b/test/org/parosproxy/paros/network/HttpResponseHeaderUnitTest.java
@@ -1,0 +1,62 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.network;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit test for {@link HttpResponseHeader}.
+ */
+public class HttpResponseHeaderUnitTest {
+
+    @Test
+    public void shouldBeEmptyIfNoContents() {
+        // Given
+        HttpResponseHeader header = new HttpResponseHeader();
+        // When
+        boolean empty = header.isEmpty();
+        // Then
+        assertThat(empty, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldNotBeEmptyIfItHasStatusLine() throws Exception {
+        // Given
+        HttpResponseHeader header = new HttpResponseHeader("HTTP/1.1 200 OK\r\n\r\n");
+        // When
+        boolean empty = header.isEmpty();
+        // Then
+        assertThat(empty, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotBeEmptyIfItHasStatusAndHeaders() throws Exception {
+        // Given
+        HttpResponseHeader header = new HttpResponseHeader("HTTP/1.1 200 OK\r\nX-Header: value\r\n\r\n");
+        // When
+        boolean empty = header.isEmpty();
+        // Then
+        assertThat(empty, is(equalTo(false)));
+    }
+}


### PR DESCRIPTION
Change HttpHeader to check if it's empty by using the start line (not
the header fields). If the request/status line is present it's not
empty, even if it has no headers.
Add tests to assert the expected behaviour (for request and response
header classes).