### PR TITLE
Fix Adv Spider Options Render

### DIFF
--- a/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
+++ b/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
@@ -801,7 +801,7 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
 
 	public void showSpiderDialog(SiteNode node) {
 		if (spiderDialog == null) {
-			spiderDialog = new SpiderDialog(this, View.getSingleton().getMainFrame(), new Dimension(700, 400));
+			spiderDialog = new SpiderDialog(this, View.getSingleton().getMainFrame(), new Dimension(700, 430));
 		}
 		if (spiderDialog.isVisible()) {
 			// Its behind you! Actually not needed no the window is alwaysOnTop, but keeping in case we change that ;)


### PR DESCRIPTION
A minor dimension adjustment to ensure that the Spider Advanced Options
tab isn't truncated.

I tried `pack()`ing in various places but it never seemed to impact the issue.

Before:
![spider_adv_height](https://cloud.githubusercontent.com/assets/7570458/22766755/50ddf0d8-ee45-11e6-9f03-d7dad8793287.png)

After:
![spider_adv_height2](https://cloud.githubusercontent.com/assets/7570458/22766760/5e18dd9e-ee45-11e6-8306-139b43129358.png)

