### PR TITLE
Issue 2699 SSL Error Handling

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1491,6 +1491,12 @@ multiple.options.panel.ordered.move.down.button.tooltip = Moves the selected ele
 multiple.options.panel.ordered.move.bottom.button.label = Bottom
 multiple.options.panel.ordered.move.bottom.button.tooltip = Moves the selected element to bottom position.
 
+network.ssl.error.connect = An exception occurred while attempting to connect to: 
+network.ssl.error.exception = The exception was: \n
+network.ssl.error.exception.rootcause = Root cause: \n
+network.ssl.error.help = The following document may be of assistance in resolving this failure:\n{0} 
+network.ssl.error.help.url = https://github.com/zaproxy/zaproxy/wiki/FAQsslHandshake
+
 output.panel.clear.button.label = Clear
 output.panel.clear.button.toolTip = Clear Output Panel
 

--- a/src/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
+++ b/src/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and 
  * limitations under the License. 
  */
+// ZAP: 2017/02/20 Issue 2699: Make SSLException handling more user friendly
 package org.parosproxy.paros.extension.manualrequest.http.impl;
 
 import java.awt.EventQueue;
@@ -24,6 +25,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.net.ssl.SSLException;
 import javax.swing.ImageIcon;
 import javax.swing.JToggleButton;
 
@@ -130,6 +132,8 @@ public class HttpPanelSender implements MessageSender {
         } catch (final UnknownHostException uhe) {
             throw new IOException("Error forwarding to an Unknown host: " + uhe.getMessage(), uhe);
 
+        } catch (final SSLException sslEx) {
+        	throw sslEx;
         } catch (final IOException ioe) {
             throw new IOException("IO error in sending request: " + ioe.getClass() + ": " + ioe.getMessage(), ioe);
 


### PR DESCRIPTION
Make SSL exception error handling more user friendly (ProxyThread and
ManualRequestEditorDialog). The console, web response, or dialog (as
applicable) now display:
* The URL for the attempted connection. 
* The exception message.
* A link to the FAQsslHandshake which has been isolated to it's own
Messages.properties key for ease of future update.
* The stack trace (if debug is enabled).

HttpPanelSender:
* Catch and re-throw SSLException (instead of generic IOException).

Fixes zaproxy/zaproxy#2699