### PR TITLE
build: Use env python for docker baseline script

### DIFF
--- a/build/docker/zap-baseline.py
+++ b/build/docker/zap-baseline.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Zed Attack Proxy (ZAP) and its related class files.
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.


### PR DESCRIPTION
Use the first python in $PATH to let users pick a specific python version other than the system python when it is run directly as `./zap-baseline.py`