### PR TITLE
Always remove/unhook the extensions

### DIFF
--- a/src/org/parosproxy/paros/extension/Extension.java
+++ b/src/org/parosproxy/paros/extension/Extension.java
@@ -32,6 +32,7 @@
 // ZAP: 2015/03/16 Issue 1525: Further database independence changes
 // ZAP: 2015/03/30 Issue 1582: Enablers for low memory option
 // ZAP: 2016/09/26 JavaDoc tweaks
+// ZAP: 2017/02/17 Expose ExtensionHook to allow core code remove/unhook the extension.
 
 package org.parosproxy.paros.extension;
 
@@ -138,6 +139,17 @@ public interface Extension {
     void initXML(Session session, OptionsParam options);
     
     void hook(ExtensionHook pluginHook);
+
+    /**
+     * Gets the {@code ExtensionHook} used to hook the components during initialisation.
+     * <p>
+     * Should be called only by core functionality (e.g. to unload the hooked components).
+     * 
+     * @return the {@code ExtensionHook} used to hook the components.
+     * @since TODO add version
+     * @see #hook(ExtensionHook)
+     */
+    ExtensionHook getExtensionHook();
     
     boolean isDepreciated ();
     
@@ -175,6 +187,14 @@ public interface Extension {
 	
 	boolean canUnload();
 	
+	/**
+	 * Unloads any component manually added to ZAP or other extensions (that is, a component that was not added through the
+	 * {@code ExtensionHook}).
+	 * <p>
+	 * Should be called only by core functionality (e.g. during uninstallation of the extension).
+	 * 
+	 * @see #hook(ExtensionHook)
+	 */
 	void unload();
 
 	/**

--- a/src/org/parosproxy/paros/extension/ExtensionAdaptor.java
+++ b/src/org/parosproxy/paros/extension/ExtensionAdaptor.java
@@ -35,6 +35,7 @@
 // ZAP: 2015/02/10 Issue 1208: Search classes/resources in add-ons declared as dependencies
 // ZAP: 2015/03/16 Issue 1525: Further database independence changes
 // ZAP: 2015/03/30 Issue 1582: Enablers for low memory option
+// ZAP: 2017/02/17 Let core code remove/unhook the extension.
 
 package org.parosproxy.paros.extension;
 
@@ -43,7 +44,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.ResourceBundle;
 
-import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.db.Database;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.db.DatabaseUnsupportedException;
@@ -190,6 +190,11 @@ public abstract class ExtensionAdaptor implements Extension {
     }
 
     @Override
+    public ExtensionHook getExtensionHook() {
+        return hook;
+    }
+
+    @Override
     public boolean isDepreciated () {
     	return false;
     }
@@ -276,15 +281,13 @@ public abstract class ExtensionAdaptor implements Extension {
     }
 	
     /**
-	 * Removes extension from ZAP. Override to undo things setup in
-	 * {@link #hook(ExtensionHook)} method.
+	 * {@inheritDoc}
+	 * <p>
+	 * Does nothing by default.
 	 */
     @Override
 	public void unload() {
-		Control control = Control.getSingleton();
-		ExtensionLoader extLoader = control.getExtensionLoader();
-
-		extLoader.removeExtension(this, hook);
+		// Nothing to do.
 	}
 
     @Override

--- a/src/org/zaproxy/zap/control/AddOnInstaller.java
+++ b/src/org/zaproxy/zap/control/AddOnInstaller.java
@@ -238,6 +238,7 @@ public final class AddOnInstaller {
                 logger.debug("Unloading ext: " + extension.getName());
                 try {
                     extension.unload();
+                    Control.getSingleton().getExtensionLoader().removeExtension(extension, extension.getExtensionHook());
                     ExtensionFactory.unloadAddOnExtension(extension);
                 } catch (Exception e) {
                     logger.error("An error occurred while uninstalling the extension \"" + extension.getName()


### PR DESCRIPTION
Change AddOnInstaller to remove/unhook the extension instead of letting
the extension remove/unhook itself. Avoids the need of the extension
to call the (base) unload method when overriding it (which if not done
would cause subtle issues, like the extension not being removed and the
components not being unhooked).