### PR TITLE
Allow to hook tool bar components

### DIFF
--- a/src/org/parosproxy/paros/extension/ExtensionHookView.java
+++ b/src/org/parosproxy/paros/extension/ExtensionHookView.java
@@ -21,8 +21,10 @@
  // ZAP: 2012/04/25 Changed the type of the parameter "panel" of the method
  // addSessionPanel.
 // ZAP: 2016/04/08 Allow to add ContextPanelFactory
+// ZAP: 2017/02/19 Allow to add components to the main tool bar.
 package org.parosproxy.paros.extension;
 
+import java.awt.Component;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -48,6 +50,16 @@ public class ExtensionHookView {
      * @see #getContextPanelFactories()
      */
     private List<ContextPanelFactory> contextPanelFactories;
+
+    /**
+     * The {@link Component}s added to this extension hook, to be later added to the main tool bar panel.
+     * <p>
+     * Lazily initialised.
+     * 
+     * @see #addMainToolBarComponent(Component)
+     * @see #getMainToolBarComponents()
+     */
+    private List<Component> mainToolBarComponents;
 
     public ExtensionHookView() {
     }
@@ -121,5 +133,37 @@ public class ExtensionHookView {
             return Collections.emptyList();
         }
         return Collections.unmodifiableList(contextPanelFactories);
+    }
+
+    /**
+     * Adds the given {@link Component} (usually {@link javax.swing.JButton JButton}, {@link javax.swing.JToggleButton
+     * JToggleButton}, {@link javax.swing.JToolBar.Separator JToolBar.Separator}) to the view hook, to be later added to the
+     * main tool bar panel.
+     * <p>
+     * By default, the {@code Component}s added are removed from the main tool bar panel when the extension is unloaded.
+     *
+     * @param component the {@code component} that will be added to the main tool bar panel
+     * @since TODO add version
+     * @see org.zaproxy.zap.view.MainToolbarPanel#addToolBarComponent(Component)
+     * @see org.zaproxy.zap.view.MainToolbarPanel#removeToolBarComponent(Component)
+     */
+    public void addMainToolBarComponent(Component component) {
+        if (mainToolBarComponents == null) {
+            mainToolBarComponents = new ArrayList<>();
+        }
+        mainToolBarComponents.add(component);
+    }
+
+    /**
+     * Gets the {@link Component}s added to this hook, for the main tool bar panel.
+     *
+     * @return an unmodifiable {@code List} containing the added {@code Component}s, never {@code null}.
+     * @since TODO add version
+     */
+    List<Component> getMainToolBarComponents() {
+        if (mainToolBarComponents == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableList(mainToolBarComponents);
     }
 }

--- a/src/org/parosproxy/paros/extension/ExtensionLoader.java
+++ b/src/org/parosproxy/paros/extension/ExtensionLoader.java
@@ -66,9 +66,11 @@
 // ZAP: 2016/05/30 Issue 2494: ZAP Proxy is not showing the HTTP CONNECT Request in history tab
 // ZAP: 2016/08/18 Hook ApiImplementor
 // ZAP: 2016/11/23 Call postInit() when starting an extension, startLifeCycle(Extension).
+// ZAP: 2017/02/19 Hook/remove extensions' components to/from the main tool bar.
 
 package org.parosproxy.paros.extension;
 
+import java.awt.Component;
 import java.awt.EventQueue;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -111,6 +113,7 @@ import org.zaproxy.zap.extension.api.ApiImplementor;
 import org.zaproxy.zap.extension.AddOnInstallationStatusListener;
 import org.zaproxy.zap.model.ContextDataFactory;
 import org.zaproxy.zap.view.ContextPanelFactory;
+import org.zaproxy.zap.view.MainToolbarPanel;
 import org.zaproxy.zap.view.SiteMapListener;
 
 public class ExtensionLoader {
@@ -984,6 +987,16 @@ public class ExtensionLoader {
             }
         }
 
+        MainToolbarPanel mainToolBarPanel = view.getMainFrame().getMainToolbarPanel();
+        for (Component component : pv.getMainToolBarComponents()) {
+            try {
+                mainToolBarPanel.addToolBarComponent(component);
+            } catch (Exception e) {
+                logger.error("Error while adding a component to the main tool bar panel, from " +
+                        extension.getClass().getCanonicalName(), e);
+            }
+        }
+
         view.getWorkbench().addPanels(pv.getSelectPanel(), WorkbenchPanel.PanelType.SELECT);
         view.getWorkbench().addPanels(pv.getWorkPanel(), WorkbenchPanel.PanelType.WORK);
         view.getWorkbench().addPanels(pv.getStatusPanel(), WorkbenchPanel.PanelType.STATUS);
@@ -1007,6 +1020,16 @@ public class ExtensionLoader {
                 view.removeContextPanelFactory(contextPanelFactory);
             } catch (Exception e) {
                 logger.error("Error while removing a ContextPanelFactory from " + extension.getClass().getCanonicalName(), e);
+            }
+        }
+
+        MainToolbarPanel mainToolBarPanel = view.getMainFrame().getMainToolbarPanel();
+        for (Component component : pv.getMainToolBarComponents()) {
+            try {
+                mainToolBarPanel.removeToolBarComponent(component);
+            } catch (Exception e) {
+                logger.error("Error while removing a component from the main tool bar panel, from "
+                        + extension.getClass().getCanonicalName(), e);
             }
         }
 

--- a/src/org/zaproxy/zap/view/MainToolbarPanel.java
+++ b/src/org/zaproxy/zap/view/MainToolbarPanel.java
@@ -20,6 +20,7 @@
 
 package org.zaproxy.zap.view;
 
+import java.awt.Component;
 import java.awt.GridBagConstraints;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -112,6 +113,54 @@ public class MainToolbarPanel extends JPanel {
 			toolbar.setBorder(BorderFactory.createEmptyBorder());
 		}
 		return toolbar;
+	}
+
+	/**
+	 * Adds the given component to the tool bar.
+	 * <p>
+	 * The icons of the buttons ({@code JButton} and {@code JToggleButton}) added are automatically scaled.
+	 * 
+	 * @param component the component to add.
+	 * @throws IllegalArgumentException if the component is {@code null}.
+	 * @since TODO add version
+	 * @see DisplayUtils#scaleIcon(JButton)
+	 * @see DisplayUtils#scaleIcon(JToggleButton)
+	 */
+	public void addToolBarComponent(Component component) {
+		validateComponentNonNull(component);
+
+		if (component instanceof JButton) {
+			addButton((JButton) component);
+		} else if (component instanceof JToggleButton) {
+			addButton((JToggleButton) component);
+		} else {
+			getToolbar().add(component);
+		}
+	}
+
+	/**
+	 * Validates that the given component is non-{@code null}.
+	 *
+	 * @param component the component to validate.
+	 * @throws IllegalArgumentException if the component is {@code null}.
+	 */
+	private void validateComponentNonNull(Component component) {
+		if (component == null) {
+			throw new IllegalArgumentException("The component must not be null.");
+		}
+	}
+
+	/**
+	 * Removes the given component to the tool bar.
+	 * 
+	 * @param component the component to remove.
+	 * @throws IllegalArgumentException if the component is {@code null}.
+	 * @since TODO add version
+	 */
+	public void removeToolBarComponent(Component component) {
+		validateComponentNonNull(component);
+
+		getToolbar().remove(component);
 	}
 	
 	public void addButton (JButton button) {


### PR DESCRIPTION
Change class ExtensionHookView to allow to add Components to the main
tool bar, so the components can be automatically added/removed by core
code.