### PR TITLE
Use home drive environment variable in zap.bat

### DIFF
--- a/src/zap.bat
+++ b/src/zap.bat
@@ -1,5 +1,5 @@
-if exist "%HOMEPATH%\OWASP ZAP\.ZAP_JVM.properties" (
-	set /p jvmopts=< "%HOMEPATH%\OWASP ZAP\.ZAP_JVM.properties"
+if exist "%HOMEDRIVE%%HOMEPATH%\OWASP ZAP\.ZAP_JVM.properties" (
+	set /p jvmopts=< "%HOMEDRIVE%%HOMEPATH%\OWASP ZAP\.ZAP_JVM.properties"
 ) else (
 	set jvmopts=-Xmx512m
 )


### PR DESCRIPTION
Change zap.bat file to use the environment variable %HOMEDRIVE%, to
ensure it's used the expected drive/path when checking if the JVM
properties file exists.

Fix #3211 - Can't find .ZAP_JVM.properties with %HOMEPATH% when using
zap.bat in windows