### PR TITLE
Log stack trace on failed authentication message

### DIFF
--- a/src/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
@@ -230,7 +230,7 @@ public class FormBasedAuthenticationMethodType extends AuthenticationMethodType 
 			try {
 				msg = prepareRequestMessage(cred);
 			} catch (Exception e) {
-				log.error("Unable to prepare authentication message: " + e.getMessage());
+				log.error("Unable to prepare authentication message: " + e.getMessage(), e);
 				return null;
 			}
 


### PR DESCRIPTION
Change FormBasedAuthenticationMethod to log the exception stack trace
that might happen when preparing the authentication message.
The change allows to know where the issue occurred, as it's now it just
might show:
>Unable to prepare authentication message: null

which is not very informative.