### PR TITLE
Do not try to authenticate without credentials

### DIFF
--- a/src/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
@@ -225,6 +225,11 @@ public class FormBasedAuthenticationMethodType extends AuthenticationMethodType 
 			}
 			UsernamePasswordAuthenticationCredentials cred = (UsernamePasswordAuthenticationCredentials) credentials;
 
+			if (!cred.isConfigured()) {
+				log.warn("No credentials to authenticate user: " + user.getName());
+				return null;
+			}
+			
 			// Prepare login message
 			HttpMessage msg;
 			try {


### PR DESCRIPTION
Change FormBasedAuthenticationMethod to not try to authenticate if the
user has no credentials (username/password), preventing an exception.
Also, log (with WARN level) that the user has no credentials.