### PR TITLE
Mention Replacer add-on in Filters warning

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1095,7 +1095,7 @@ filter.setcookie.name          = Detect and alert 'Set-cookie' attempt in HTTP r
 filter.table.enabled           = Enabled
 filter.table.name              = Filter Name
 filter.title.filters           = Filters
-filter.warning				   = <html><b>WARNING - Filters have in effect been replaced by scripts which are more powerful and flexible.<br>Filters will be removed in a future version of ZAP</b></html>
+filter.warning				   = <html><b>WARNING - Filters have in effect been replaced by the Replacer add-on and scripts which are more powerful and flexible.<br>Filters will be removed in a future version of ZAP</b></html>
 
 flag.site.popup = Flag as
 


### PR DESCRIPTION
Change Filters warning to mention that the Replacer add-on is, along
with scripts, the replacement for filters.