### PR TITLE
Edit Alert Enhancements

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -12,6 +12,7 @@ alert.add.button.cancel     = Cancel
 alert.add.button.save       = Save
 alert.add.title             = Add Alert
 alert.edit.title            = Edit Alert
+alert.edit.button.tooltip = Edit the most recently selected alert.
 alert.label.attack			= Attack: 
 alert.label.cweid			= CWE ID:
 alert.label.desc			= Description:

--- a/src/org/zaproxy/zap/extension/alert/AlertPanel.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertPanel.java
@@ -29,6 +29,8 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Point;
 import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
@@ -37,7 +39,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 import javax.swing.ImageIcon;
-import javax.swing.JLabel;
+import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
@@ -131,6 +133,8 @@ public class AlertPanel extends AbstractPanel {
      * </p>
      */
     private DeselectableButtonGroup alertsTreeFiltersButtonGroup;
+    
+    private JButton editButton = null;
 
 	private ExtensionAlert extension = null;
 	private ExtensionHistory extHist = null; 
@@ -194,16 +198,16 @@ public class AlertPanel extends AbstractPanel {
 		if (panelToolbar == null) {
 			
 			panelToolbar = new javax.swing.JToolBar();
-			panelToolbar.setLayout(new java.awt.GridBagLayout());
 			panelToolbar.setEnabled(true);
 			panelToolbar.setFloatable(false);
 			panelToolbar.setRollover(true);
 			panelToolbar.setPreferredSize(new java.awt.Dimension(800,30));
 			panelToolbar.setName("AlertToolbar");
 			
-			panelToolbar.add(getScopeButton(), LayoutHelper.getGBC(0, 0, 1, 0.0D));
-			panelToolbar.add(getLinkWithSitesTreeButton(), LayoutHelper.getGBC(1, 0, 1, 0.0D));
-			panelToolbar.add(new JLabel(), LayoutHelper.getGBC(20, 0, 1, 1.0D));	// Spacer
+			panelToolbar.add(getScopeButton());
+			panelToolbar.add(getLinkWithSitesTreeButton());
+			panelToolbar.addSeparator();
+			panelToolbar.add(getEditButton());
 		}
 		return panelToolbar;
 	}
@@ -472,20 +476,7 @@ public class AlertPanel extends AbstractPanel {
 				public void mouseClicked(java.awt.event.MouseEvent e) {
 				    if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount() > 1) {
 				    	// Its a double click - edit the alert
-					    DefaultMutableTreeNode node = (DefaultMutableTreeNode) treeAlert.getLastSelectedPathComponent();
-					    if (node != null && node.getUserObject() != null) {
-					        Object obj = node.getUserObject();
-					        if (obj instanceof Alert) {
-					            Alert alert = (Alert) obj;
-					            
-								if (extHist == null) {
-									extHist = (ExtensionHistory) Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.NAME);
-								}
-								if (extHist != null) {
-									extHist.showAlertAddDialog(alert);
-								}
-					        }
-					    }
+					    editSelectedAlert();
 				    }
 				}
 			});
@@ -509,6 +500,7 @@ public class AlertPanel extends AbstractPanel {
 				}
 			});
 			treeAlert.setCellRenderer(new AlertTreeCellRenderer());
+			treeAlert.setExpandsSelectedPaths(true);
 		}
 		return treeAlert;
 	}
@@ -627,5 +619,38 @@ public class AlertPanel extends AbstractPanel {
             recreateLinkWithSitesTreeModel((SiteNode) e.getPath().getLastPathComponent());
         }
     }
+    
+    private void editSelectedAlert() {
+    	DefaultMutableTreeNode node = (DefaultMutableTreeNode) treeAlert.getLastSelectedPathComponent();
+	    if (node != null && node.getUserObject() != null) {
+	        Object obj = node.getUserObject();
+	        if (obj instanceof Alert) {
+	            Alert alert = (Alert) obj;
+	            
+				if (extHist == null) {
+					extHist = (ExtensionHistory) Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.NAME);
+				}
+				if (extHist != null) {
+					extHist.showAlertAddDialog(alert);
+				}
+	        }
+	    }
+    }
+    
+	private JButton getEditButton() {
+		if (editButton == null) {
+			editButton = new JButton();
+			editButton.setToolTipText(Constant.messages.getString("alert.edit.button.tooltip"));
+			editButton.setIcon(new ImageIcon(AlertPanel.class.getResource("/resource/icon/16/018.png")));
+
+			editButton.addActionListener(new ActionListener() {
+				@Override
+				public void actionPerformed(ActionEvent e) {
+					editSelectedAlert();
+				}
+			});
+		}
+		return editButton;
+	}
 
 }

--- a/src/org/zaproxy/zap/extension/alert/AlertTreeModel.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertTreeModel.java
@@ -92,6 +92,28 @@ class AlertTreeModel extends DefaultTreeModel {
     	return null;
     }
     
+	public AlertNode getAlertNode(Alert alert) {
+		AlertNode parent = (AlertNode) getRoot();
+		int risk = alert.getRisk();
+		if (alert.getConfidence() == Alert.CONFIDENCE_FALSE_POSITIVE) {
+			// Special case!
+			risk = -1;
+		}
+
+		AlertNode needle = new AlertNode(risk, alert.getName());
+		needle.setUserObject(alert);
+		int idx = parent.findIndex(needle);
+		if (idx < 0) {
+			return null;
+		}
+		parent = parent.getChildAt(idx);
+		idx = parent.findIndex(needle);
+		if (idx < 0) {
+			return null;
+		}
+		return parent.getChildAt(idx);
+	}
+    
     void updatePath(final Alert originalAlert, final Alert alert) {
         if (!View.isInitialised() || EventQueue.isDispatchThread()) {
         	updatePathEventHandler(originalAlert, alert);

--- a/src/org/zaproxy/zap/extension/alert/AlertViewPanel.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertViewPanel.java
@@ -40,6 +40,8 @@ import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JSpinner;
+import javax.swing.JTextField;
 import javax.swing.border.TitledBorder;
 
 import org.apache.log4j.Logger;
@@ -62,13 +64,15 @@ public class AlertViewPanel extends AbstractPanel {
 	private static final long serialVersionUID = 1L;
 	private static final Logger logger = Logger.getLogger(AlertViewPanel.class);
 	
+	private static final Insets DEFAULT_INSETS = new Insets(1,1,1,1);
+	
 	private JScrollPane defaultPane = null;
 	private JScrollPane alertPane = null;
 	private ZapTextArea defaultOutput = null;
 	private JPanel alertDisplay = null;
 	private CardLayout cardLayout = null;
 	
-	private ZapTextField alertUrl = null;
+	private ZapLabel alertUrl = null;
 	private ZapLabel alertName = null;
 	private JLabel alertRisk = null;
 	private JLabel alertConfidence = null;
@@ -93,6 +97,16 @@ public class AlertViewPanel extends AbstractPanel {
 	private DefaultComboBoxModel<String> paramListModel = null;
 	private ZapNumberSpinner alertEditCweId = null;
 	private ZapNumberSpinner alertEditWascId = null;
+	
+	private JLabel attackLabel;
+	private JLabel cweidLabel;
+	private JLabel evidenceLabel;
+	private JLabel otherLabel;
+	private JLabel confidenceLabel;
+	private JLabel riskLabel;
+	private JLabel sourceLabel;
+	private JLabel urlLabel;
+	private JLabel wascidLabel;
 	
 	private boolean editable = false;
 	private Alert originalAlert = null;
@@ -221,7 +235,15 @@ public class AlertViewPanel extends AbstractPanel {
 			
 			alertEditEvidence = new ZapTextField();
 			alertEditCweId = new ZapNumberSpinner();
+			if (alertEditCweId.getEditor() instanceof JSpinner.DefaultEditor) {
+				((JSpinner.DefaultEditor) alertEditCweId.getEditor()).getTextField()
+						.setHorizontalAlignment(JTextField.LEFT);
+			}
 			alertEditWascId = new ZapNumberSpinner();
+			if (alertEditWascId.getEditor() instanceof JSpinner.DefaultEditor) {
+				((JSpinner.DefaultEditor) alertEditWascId.getEditor()).getTextField()
+						.setHorizontalAlignment(JTextField.LEFT);
+			}
 
 			// Read only ones
 			alertName = new ZapLabel();
@@ -236,7 +258,7 @@ public class AlertViewPanel extends AbstractPanel {
 			alertWascId = new JLabel();
 			alertSource = new JLabel();
 
-			alertUrl = new ZapTextField();
+			alertUrl = new ZapLabel();
 			
 			alertDescription = createZapTextArea();
 			JScrollPane descSp = createJScrollPane(Constant.messages.getString("alert.label.desc"));
@@ -291,134 +313,62 @@ public class AlertViewPanel extends AbstractPanel {
 			});
 
 			int gbcRow = 0;
-			if (editable) {
-				alertDisplay.add(alertEditName, 
-						LayoutHelper.getGBC(0, gbcRow, 2, 0, new Insets(1,1,1,1)));
-				gbcRow++;
 
-				alertDisplay.add(new JLabel(Constant.messages.getString("alert.label.url")), 
-						LayoutHelper.getGBC(0, gbcRow, 1, 0.25D, new Insets(1,1,1,1)));
-				alertDisplay.add(alertUrl, 
-						LayoutHelper.getGBC(1, gbcRow, 1, 0.75D, new Insets(1,1,1,1)));
-				gbcRow++;
-				
-				alertDisplay.add(new JLabel(Constant.messages.getString("alert.label.risk")),
-						LayoutHelper.getGBC(0, gbcRow, 1, 0.25D, new Insets(1,1,1,1)));
-				alertDisplay.add(alertEditRisk, 
-						LayoutHelper.getGBC(1, gbcRow, 1, 0.75D, new Insets(1,1,1,1)));
-				gbcRow++;
-
-				alertDisplay.add(new JLabel(Constant.messages.getString("alert.label.confidence")),
-						LayoutHelper.getGBC(0, gbcRow, 1, 0.25D, new Insets(1,1,1,1)));
-				alertDisplay.add(alertEditConfidence, 
-						LayoutHelper.getGBC(1, gbcRow, 1, 0.75D, new Insets(1,1,1,1)));
-				gbcRow++;
-				
-				alertDisplay.add(new JLabel(Constant.messages.getString("alert.label.parameter")),
-						LayoutHelper.getGBC(0, gbcRow, 1, 0.25D, new Insets(1,1,1,1)));
-				alertDisplay.add(alertEditParam,
-						LayoutHelper.getGBC(1, gbcRow, 1, 0.75D, new Insets(1,1,1,1)));
-				gbcRow++;
-				
-				alertDisplay.add(new JLabel(Constant.messages.getString("alert.label.attack")),
-						LayoutHelper.getGBC(0, gbcRow, 1, 0.25D, new Insets(1,1,1,1)));
-				alertDisplay.add(alertEditAttack,
-						LayoutHelper.getGBC(1, gbcRow, 1, 0.75D, new Insets(1,1,1,1)));
-				gbcRow++;
-				
-				alertDisplay.add(new JLabel(Constant.messages.getString("alert.label.evidence")),
-						LayoutHelper.getGBC(0, gbcRow, 1, 0.25D, new Insets(1,1,1,1)));
-				alertDisplay.add(alertEditEvidence,
-						LayoutHelper.getGBC(1, gbcRow, 1, 0.75D, new Insets(1,1,1,1)));
-				gbcRow++;
-				
-				alertDisplay.add(new JLabel(Constant.messages.getString("alert.label.cweid")), 
-						LayoutHelper.getGBC(0, gbcRow, 1, 0.25D, new Insets(1,1,1,1)));
-				alertDisplay.add(alertEditCweId, 
-						LayoutHelper.getGBC(1, gbcRow, 1, 0.75D, new Insets(1,1,1,1)));
-				gbcRow++;
-				
-				alertDisplay.add(new JLabel(Constant.messages.getString("alert.label.wascid")),
-						LayoutHelper.getGBC(0, gbcRow, 1, 0.25D, new Insets(1,1,1,1)));
-				alertDisplay.add(alertEditWascId, 
-						LayoutHelper.getGBC(1, gbcRow, 1, 0.75D, new Insets(1,1,1,1)));
-				gbcRow++;
-			} else {
-				alertUrl.setEditable(false);
-				
-				alertDisplay.add(alertName, 
-						LayoutHelper.getGBC(0, gbcRow, 2, 0, new Insets(1,1,1,1)));
-				gbcRow++;
-				
-				alertDisplay.add(new JLabel(Constant.messages.getString("alert.label.url")), 
-						LayoutHelper.getGBC(0, gbcRow, 1, 0.25D, new Insets(1,1,1,1)));
-				alertDisplay.add(alertUrl, 
-						LayoutHelper.getGBC(1, gbcRow, 1, 0.75D, new Insets(1,1,1,1)));
-				gbcRow++;
-				
-				alertDisplay.add(new JLabel(Constant.messages.getString("alert.label.risk")), 
-						LayoutHelper.getGBC(0, gbcRow, 1, 0.25D, new Insets(1,1,1,1)));
-				alertDisplay.add(alertRisk, 
-						LayoutHelper.getGBC(1, gbcRow, 1, 0.75D, new Insets(1,1,1,1)));
-				gbcRow++;
-
-				alertDisplay.add(new JLabel(Constant.messages.getString("alert.label.confidence")), 
-						LayoutHelper.getGBC(0, gbcRow, 1, 0.25D, new Insets(1,1,1,1)));
-				alertDisplay.add(alertConfidence,
-						LayoutHelper.getGBC(1, gbcRow, 1, 0.75D, new Insets(1,1,1,1)));
-				gbcRow++;
-				
-				alertDisplay.add(new JLabel(Constant.messages.getString("alert.label.parameter")), 
-						LayoutHelper.getGBC(0, gbcRow, 1, 0.25D, new Insets(1,1,1,1)));
-				alertDisplay.add(alertParam, 
-						LayoutHelper.getGBC(1, gbcRow, 1, 0.75D, new Insets(1,1,1,1)));
-				gbcRow++;
-
-				alertDisplay.add(new JLabel(Constant.messages.getString("alert.label.attack")),
-						LayoutHelper.getGBC(0, gbcRow, 1, 0.25D, new Insets(1,1,1,1)));
-				alertDisplay.add(alertAttack,
-						LayoutHelper.getGBC(1, gbcRow, 1, 0.75D, new Insets(1,1,1,1)));
-				gbcRow++;
-
-				alertDisplay.add(new JLabel(Constant.messages.getString("alert.label.evidence")), 
-						LayoutHelper.getGBC(0, gbcRow, 1, 0.25D, new Insets(1,1,1,1)));
-				alertDisplay.add(alertEvidence,
-						LayoutHelper.getGBC(1, gbcRow, 1, 0.75D, new Insets(1,1,1,1)));
-				gbcRow++;
-				
-				alertDisplay.add(new JLabel(Constant.messages.getString("alert.label.cweid")),
-						LayoutHelper.getGBC(0, gbcRow, 1, 0.25D, new Insets(1,1,1,1)));
-				alertDisplay.add(alertCweId, 
-						LayoutHelper.getGBC(1, gbcRow, 1, 0.75D, new Insets(1,1,1,1)));
-				gbcRow++;
-				
-				alertDisplay.add(new JLabel(Constant.messages.getString("alert.label.wascid")),
-						LayoutHelper.getGBC(0, gbcRow, 1, 0.25D, new Insets(1,1,1,1)));
-				alertDisplay.add(alertWascId, 
-						LayoutHelper.getGBC(1, gbcRow, 1, 0.75D, new Insets(1,1,1,1)));
-				gbcRow++;
-
-				alertDisplay.add(new JLabel(Constant.messages.getString("alert.label.source")),
-						LayoutHelper.getGBC(0, gbcRow, 1, 0.25D, new Insets(1,1,1,1)));
-				alertDisplay.add(alertSource, 
-						LayoutHelper.getGBC(1, gbcRow, 1, 0.75D, new Insets(1,1,1,1)));
+			alertDisplay.add(editable ? alertEditName : alertName,
+					LayoutHelper.getGBC(0, gbcRow, 2, 0, DEFAULT_INSETS));
+			// Show a blank label instead of the edit button if already editing
+			gbcRow++;
+			alertDisplay.add(getUrlLabel(), LayoutHelper.getGBC(0, gbcRow, 1, 0, DEFAULT_INSETS));
+			alertDisplay.add(alertUrl, LayoutHelper.getGBC(1, gbcRow, 1, 1, DEFAULT_INSETS));
+			gbcRow++;
+			alertDisplay.add(getRiskLabel(), LayoutHelper.getGBC(0, gbcRow, 1, 0, DEFAULT_INSETS));
+			alertDisplay.add(editable ? alertEditRisk : alertRisk,
+					LayoutHelper.getGBC(1, gbcRow, 1, 1, DEFAULT_INSETS));
+			gbcRow++;
+			alertDisplay.add(getConfidenceLabel(), LayoutHelper.getGBC(0, gbcRow, 1, 0, DEFAULT_INSETS));
+			alertDisplay.add(editable ? alertEditConfidence : alertConfidence,
+					LayoutHelper.getGBC(1, gbcRow, 1, 1, DEFAULT_INSETS));
+			gbcRow++;
+			alertDisplay.add(getParameterLabel(), LayoutHelper.getGBC(0, gbcRow, 1, 0, DEFAULT_INSETS));
+			alertDisplay.add(editable ? alertEditParam : alertParam,
+					LayoutHelper.getGBC(1, gbcRow, 1, 1, DEFAULT_INSETS));
+			gbcRow++;
+			alertDisplay.add(getAttackLabel(), LayoutHelper.getGBC(0, gbcRow, 1, 0, DEFAULT_INSETS));
+			alertDisplay.add(editable ? alertEditAttack : alertAttack,
+					LayoutHelper.getGBC(1, gbcRow, 1, 1, DEFAULT_INSETS));
+			gbcRow++;
+			alertDisplay.add(getEvidenceLabel(), LayoutHelper.getGBC(0, gbcRow, 1, 0, DEFAULT_INSETS));
+			alertDisplay.add(editable ? alertEditEvidence : alertEvidence,
+					LayoutHelper.getGBC(1, gbcRow, 1, 1, DEFAULT_INSETS));
+			gbcRow++;
+			alertDisplay.add(getCweidLabel(), LayoutHelper.getGBC(0, gbcRow, 1, 0, DEFAULT_INSETS));
+			alertDisplay.add(editable ? alertEditCweId : alertCweId,
+					LayoutHelper.getGBC(1, gbcRow, 1, 1, DEFAULT_INSETS));
+			gbcRow++;
+			alertDisplay.add(getWascidLabel(), LayoutHelper.getGBC(0, gbcRow, 1, 0, DEFAULT_INSETS));
+			alertDisplay.add(editable ? alertEditWascId : alertWascId,
+					LayoutHelper.getGBC(1, gbcRow, 1, 1, DEFAULT_INSETS));
+			gbcRow++;
+			if (!editable) {
+				alertDisplay.add(getSourceLabel(), LayoutHelper.getGBC(0, gbcRow, 1, 0, DEFAULT_INSETS));
+				alertDisplay.add(alertSource, LayoutHelper.getGBC(1, gbcRow, 1, 1, DEFAULT_INSETS));
 				gbcRow++;
 			}
 			
 			alertDisplay.add(descSp, 
-					LayoutHelper.getGBC(0, gbcRow, 2, 1.0D, 1.0D, GridBagConstraints.BOTH, new Insets(1,1,1,1)));
+					LayoutHelper.getGBC(0, gbcRow, 2, 1.0D, 1.0D, GridBagConstraints.BOTH, DEFAULT_INSETS));
 			gbcRow++;
 
 			alertDisplay.add(otherSp, 
-					LayoutHelper.getGBC(0, gbcRow, 2, 1.0D, 1.0D, GridBagConstraints.BOTH, new Insets(1,1,1,1)));
+					LayoutHelper.getGBC(0, gbcRow, 2, 1.0D, 1.0D, GridBagConstraints.BOTH, DEFAULT_INSETS));
 			gbcRow++;
 
 			alertDisplay.add(solutionSp, 
-					LayoutHelper.getGBC(0, gbcRow, 2, 1.0D, 1.0D, GridBagConstraints.BOTH, new Insets(1,1,1,1)));
+					LayoutHelper.getGBC(0, gbcRow, 2, 1.0D, 1.0D, GridBagConstraints.BOTH, DEFAULT_INSETS));
 			gbcRow++;
 
 			alertDisplay.add(referenceSp, 
-					LayoutHelper.getGBC(0, gbcRow, 2, 1.0D, 1.0D, GridBagConstraints.BOTH, new Insets(1,1,1,1)));
+					LayoutHelper.getGBC(0, gbcRow, 2, 1.0D, 1.0D, GridBagConstraints.BOTH, DEFAULT_INSETS));
 			
 		}
 		return alertDisplay;
@@ -692,5 +642,68 @@ public class AlertViewPanel extends AbstractPanel {
 		textArea.discardAllEdits();
 		textArea.setCaretPosition(0);
 	}
+	
+	private JLabel getAttackLabel() {
+		if (attackLabel == null) {
+			attackLabel = new JLabel(Constant.messages.getString("alert.label.attack"));
+		}
+		return attackLabel;
+	}
+	
+	private JLabel getCweidLabel() {
+		if (cweidLabel == null) {
+			cweidLabel = new JLabel(Constant.messages.getString("alert.label.cweid"));
+		}
+		return cweidLabel;
+	}
+	
+	private JLabel getEvidenceLabel() {
+		if (evidenceLabel == null) {
+			evidenceLabel = new JLabel(Constant.messages.getString("alert.label.evidence"));
+		}
+		return evidenceLabel;
+	}
+	
+	private JLabel getParameterLabel() {
+		if (otherLabel == null) {
+			otherLabel = new JLabel(Constant.messages.getString("alert.label.parameter"));
+		}
+		return otherLabel;
+	}
+	
+	private JLabel getConfidenceLabel() {
+		if (confidenceLabel == null) {
+			confidenceLabel = new JLabel(Constant.messages.getString("alert.label.confidence"));
+		}
+		return confidenceLabel;
+	}
+	
+	private JLabel getRiskLabel() {
+		if (riskLabel == null) {
+			riskLabel = new JLabel(Constant.messages.getString("alert.label.risk"));
+		}
+		return riskLabel;
+	}
+	
+	private JLabel getSourceLabel() {
+		if (sourceLabel == null) {
+			sourceLabel = new JLabel(Constant.messages.getString("alert.label.source"));
+		}
+		return sourceLabel;
+	}
 
+	private JLabel getUrlLabel() {
+		if (urlLabel == null) {
+			urlLabel = new JLabel(Constant.messages.getString("alert.label.url"));
+		}
+		return urlLabel;
+	}
+	
+	private JLabel getWascidLabel() {
+		if (wascidLabel == null) {
+			wascidLabel = new JLabel(Constant.messages.getString("alert.label.wascid"));
+		}
+		return wascidLabel;
+	}
+	
 }

--- a/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -36,6 +36,9 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.Vector;
 
+import javax.swing.JTree;
+import javax.swing.tree.TreePath;
+
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -375,7 +378,7 @@ public class ExtensionAlert extends ExtensionAdaptor implements
         alert.setAlertId(recordAlert.getAlertId());
 
     }
-
+    
     public void updateAlert(Alert alert) throws HttpMalformedHeaderException, DatabaseException {
         logger.debug("updateAlert " + alert.getName() + " " + alert.getUri());
         HistoryReference hRef = hrefs.get(alert.getSourceHistoryId());
@@ -410,6 +413,13 @@ public class ExtensionAlert extends ExtensionAdaptor implements
     		this.getFilteredTreeModel().updatePath(originalAlert, alert);
     	}
     	this.recalcAlerts();
+    	
+    	if (View.isInitialised()) {
+    		JTree alertTree = this.getAlertPanel().getTreeAlert();
+    		TreePath alertPath = new TreePath(getTreeModel().getAlertNode(alert).getPath());
+    		alertTree.setSelectionPath(alertPath);
+    		alertTree.scrollPathToVisible(alertPath);
+    	}
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/history/AlertAddDialog.java
+++ b/src/org/zaproxy/zap/extension/history/AlertAddDialog.java
@@ -202,12 +202,6 @@ public class AlertAddDialog extends AbstractDialog {
 							// Its an existing alert so save it
 							if (extAlert != null) {
 								extAlert.updateAlert(alert);
-
-								// Update alert display
-								extAlert.displayAlert(alert);
-								
-								// Update alert tree
-								extAlert.updateAlertInTree(alertViewPanel.getOriginalAlert(), alert);
 							} else if (historyRef != null) { // Update history tree
 								historyRef.updateAlert(alert);
 			                    extension.notifyHistoryItemChanged(historyRef);


### PR DESCRIPTION
Rework AlertViewPanel so that labels are in a fixed space, left align CWE and WASC in edit mode.
AlertPanel, implement an Edit button in the toolbar.
ExtensionAlert add code to updateAlertInTree so that the alert is re-selected after editing.
AlertAddDialog remove unnecessary call to ExtensionAlert.updateAlertInTree and ExtensionAlert.displayAlert.
Messages.properties add tooltip entry for new button.

This contributes to zaproxy/zaproxy#2595