### PR TITLE
Set global excluded URLs to the proxy during init

### DIFF
--- a/src/org/parosproxy/paros/control/Control.java
+++ b/src/org/parosproxy/paros/control/Control.java
@@ -63,6 +63,7 @@
 // ZAP: 2016/09/06 Hook OverrideMessageProxyListener into the Proxy
 // ZAP: 2016/10/06 Issue 2855: Added method to allow for testing when a model is required
 // ZAP: 2017/03/10 Reset proxy excluded URLs on new session
+// ZAP: 2017/03/13 Set global excluded URLs to the proxy when creating a new session or initialising.
 
 package org.parosproxy.paros.control;
 
@@ -70,7 +71,6 @@ import java.awt.Desktop;
 import java.io.File;
 import java.io.IOException;
 import java.text.MessageFormat;
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.JOptionPane;
@@ -122,6 +122,7 @@ public class Control extends AbstractControl implements SessionListener {
 
 		// ZAP: Start proxy even if no view
 	    Proxy proxy = getProxy(overrides);
+	    proxy.setIgnoreList(model.getOptionsParam().getGlobalExcludeURLParam().getTokensNames());
 	    getExtensionLoader().hookProxyListener(proxy);
 	    getExtensionLoader().hookOverrideMessageProxyListener(proxy);
 	    getExtensionLoader().hookPersistentConnectionListener(proxy);
@@ -350,7 +351,7 @@ public class Control extends AbstractControl implements SessionListener {
 	 */
 	private Session createNewSession() {
 		Session session = model.newSession();
-		getProxy().setIgnoreList(new ArrayList<String>());
+		getProxy().setIgnoreList(model.getOptionsParam().getGlobalExcludeURLParam().getTokensNames());
 		return session;
 	}
     

--- a/src/org/zaproxy/zap/extension/globalexcludeurl/GlobalExcludeURLParam.java
+++ b/src/org/zaproxy/zap/extension/globalexcludeurl/GlobalExcludeURLParam.java
@@ -27,6 +27,7 @@ import org.apache.commons.configuration.ConversionException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.common.AbstractParam;
+import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.extension.api.ZapApiIgnore;
 
 public class GlobalExcludeURLParam extends AbstractParam {
@@ -215,6 +216,9 @@ public class GlobalExcludeURLParam extends AbstractParam {
         
         enabledTokens.trimToSize();
         this.enabledTokensNames = enabledTokens;
+
+        // after saving, force the proxy to refresh the URL lists.
+        Model.getSingleton().getSession().forceGlobalExcludeURLRefresh();
     }
 
     public void addToken(String regex) {

--- a/src/org/zaproxy/zap/extension/globalexcludeurl/OptionsGlobalExcludeURLPanel.java
+++ b/src/org/zaproxy/zap/extension/globalexcludeurl/OptionsGlobalExcludeURLPanel.java
@@ -20,8 +20,6 @@
  */
 package org.zaproxy.zap.extension.globalexcludeurl;
 
-import java.util.List;
-
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 
@@ -30,9 +28,7 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.SortOrder;
 
-import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.view.AbstractParamPanel;
 import org.parosproxy.paros.view.View;
@@ -83,9 +79,6 @@ public class OptionsGlobalExcludeURLPanel extends AbstractParamPanel {
     }
 
 
-    private static Logger log = Logger.getLogger(OptionsGlobalExcludeURLPanel.class);
-
-
     @Override
     public void saveParam(Object obj) throws Exception {
 
@@ -93,16 +86,6 @@ public class OptionsGlobalExcludeURLPanel extends AbstractParamPanel {
 	    GlobalExcludeURLParam globalExcludeURLParam = optionsParam.getGlobalExcludeURLParam();
 	    globalExcludeURLParam.setTokens(getGlobalExcludeURLModel().getElements());
 	    globalExcludeURLParam.setConfirmRemoveToken(!tokensOptionsPanel.isRemoveWithoutConfirmation());
-	    
-	    globalExcludeURLParam.parse();
-	    List<String> ignoredRegexs = globalExcludeURLParam.getTokensNames();
-
-	    Model.getSingleton().getSession().setGlobalExcludeURLRegexs(ignoredRegexs);
-	    // after saving, force the proxy/spider/scanner to refresh the URL lists.
-	    Model.getSingleton().getSession().forceGlobalExcludeURLRefresh();
-	    if (log.isDebugEnabled()) {
-	        log.debug("Done saving Global Exclude URL: " + ignoredRegexs.toString());
-	    }
     }
 
     /**


### PR DESCRIPTION
Change Control to set the global excluded URLs to the proxy during
initialisation and when a new session is created.
Remove global excluded URLs (and redundant statements) from Session
class and deprecate methods that changed them. Also, add JavaDoc to
clarify the usage of existing related methods.
Change GlobalExcludeURLParam to (re)set the global URLs to the proxy to
ensure that the proxy has always the URLs set/saved.
Remove code no longer needed from OptionsGlobalExcludeURLPanel.

Fix #3275 - Global Exclude URL (beta) - after close and reopen does not
pick up added regex for excluding URLs