### PR TITLE
Exit on fatal init errors when running with GUI

### DIFF
--- a/src/org/zaproxy/zap/GuiBootstrap.java
+++ b/src/org/zaproxy/zap/GuiBootstrap.java
@@ -212,7 +212,9 @@ public class GuiBootstrap extends ZapBootstrap {
                     View.getSingleton().hideSplashScreen();
 
                     logger.fatal("Failed to initialise GUI: ", e);
-                    return;
+
+                    // We must exit otherwise EDT would keep ZAP running.
+                    System.exit(1);
                 }
 
                 warnAddOnsAndExtensionsNoLongerRunnable();


### PR DESCRIPTION
Change GuiBootstrap to exit when a fatal error occurs during the
initialisation, otherwise the EDT would keep ZAP running (with no
windows shown).