### PR TITLE
Remove unused resource messages

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -981,9 +981,6 @@ core.api.view.proxyChainExcludedDomains = Gets all the domains that are excluded
 core.api.view.version = Gets ZAP version
 core.api.view.excludedFromProxy = Gets the regular expressions, applied to URLs, to exclude from the Proxy
 core.api.view.sessionLocation = Gets the location of the current session file
-core.api.view.stats = Gets the global stats
-core.api.view.allSitesStats = Gets all of the site stats
-core.api.view.siteStats = Gets the stats for a specific site
 
 database.optionspanel.name = Database
 database.optionspanel.option.compact.label = Compact (on exit)


### PR DESCRIPTION
Remove unused resources messages that describe(d) CoreAPI views, the
views are now in StatsAPI (which have its own messages).