### PR TITLE
Delay start of Local Proxy when in daemon mode

### DIFF
--- a/src/org/parosproxy/paros/control/Control.java
+++ b/src/org/parosproxy/paros/control/Control.java
@@ -64,6 +64,7 @@
 // ZAP: 2016/10/06 Issue 2855: Added method to allow for testing when a model is required
 // ZAP: 2017/03/10 Reset proxy excluded URLs on new session
 // ZAP: 2017/03/13 Set global excluded URLs to the proxy when creating a new session or initialising.
+// ZAP: 2017/03/16 Allow to initialise Control without starting the Local Proxy.
 
 package org.parosproxy.paros.control;
 
@@ -115,7 +116,7 @@ public class Control extends AbstractControl implements SessionListener {
 		super(null, null);
 	}
 
-	private boolean init(ControlOverrides overrides) {
+	private boolean init(ControlOverrides overrides, boolean startProxy) {
 
 		// Load extensions first as message bundles are loaded as a side effect
 		loadExtension();
@@ -134,7 +135,11 @@ public class Control extends AbstractControl implements SessionListener {
 		}
 		
 		model.postInit();
-		return proxy.startServer();
+		
+		if (startProxy) {
+			return proxy.startServer();
+		}
+		return false;
     }
 
     public Proxy getProxy() {
@@ -294,12 +299,17 @@ public class Control extends AbstractControl implements SessionListener {
 
     public static boolean initSingletonWithView(ControlOverrides overrides) {
         control = new Control(Model.getSingleton(), View.getSingleton());
-        return control.init(overrides);
+        return control.init(overrides, true);
     }
     
     public static boolean initSingletonWithoutView(ControlOverrides overrides) {
         control = new Control(Model.getSingleton(), null);
-        return control.init(overrides);
+        return control.init(overrides, true);
+    }
+
+    public static void initSingletonWithoutViewAndProxy(ControlOverrides overrides) {
+        control = new Control(Model.getSingleton(), null);
+        control.init(overrides, false);
     }
 
     // ZAP: Added method to allow for testing

--- a/src/org/zaproxy/zap/CommandLineBootstrap.java
+++ b/src/org/zaproxy/zap/CommandLineBootstrap.java
@@ -60,7 +60,7 @@ public class CommandLineBootstrap extends HeadlessBootstrap {
             throw new RuntimeException(e);
         }
 
-        Control control = initControl(true);
+        Control control = initControl();
 
         warnAddOnsAndExtensionsNoLongerRunnable();
 

--- a/src/org/zaproxy/zap/DaemonBootstrap.java
+++ b/src/org/zaproxy/zap/DaemonBootstrap.java
@@ -74,11 +74,7 @@ class DaemonBootstrap extends HeadlessBootstrap {
 
             @Override
             public void run() {
-                Control control = initControl(false);
-                if (control == null) {
-                	// Failed to listen on the specified proxy, no point in continuing (an error will already have been shown)
-                	return;
-                }
+                Control control = initControl();
 
                 warnAddOnsAndExtensionsNoLongerRunnable();
 
@@ -94,6 +90,11 @@ class DaemonBootstrap extends HeadlessBootstrap {
                     logger.error(e.getMessage(), e);
                 }
                 
+                if (!control.getProxy().startServer()) {
+                    // Failed to listen on the specified proxy, no point in continuing (an error will already have been shown)
+                    return;
+                }
+
                 ProxyParam proxyParams = Model.getSingleton().getOptionsParam().getProxyParam();
                 String message = "ZAP is now listening on " + proxyParams.getRawProxyIP() + ":" + proxyParams.getProxyPort();
                 logger.info(message);

--- a/src/org/zaproxy/zap/HeadlessBootstrap.java
+++ b/src/org/zaproxy/zap/HeadlessBootstrap.java
@@ -49,17 +49,13 @@ abstract class HeadlessBootstrap extends ZapBootstrap {
     }
 
     /**
-     * Initialises the {@code Control} singleton without view.
+     * Initialises the {@code Control} singleton without view and proxy.
      *
-     * @param ignoreProxyError Return the {@code Control} even if there is a problem setting up the proxy
-     * @return the initialised {@code Control} singleton, unless theres a problem setting up the proxy 
-     * and ignoreProxyError is false
-     * @see Control#initSingletonWithoutView(org.zaproxy.zap.control.ControlOverrides)
+     * @return the initialised {@code Control} singleton.
+     * @see Control#initSingletonWithoutViewAndProxy(org.zaproxy.zap.control.ControlOverrides)
      */
-    protected Control initControl(boolean ignoreProxyError) {
-    	if (!Control.initSingletonWithoutView(getControlOverrides()) && ! ignoreProxyError) {
-    		return null;
-    	}
+    protected Control initControl() {
+        Control.initSingletonWithoutViewAndProxy(getControlOverrides());
         return Control.getSingleton();
     }
 


### PR DESCRIPTION
Change HeadlessBootstrap to not automatically start the Local Proxy when
the Control is initialised.
Change DaemonBootstrap to start the Local Proxy only after all command
line arguments have been processed.
CommandLineBootstrap no longer starts the Local Proxy, not needed ZAP is
terminated immediately after all command line arguments have been
processed.

Fix #3297 - Start local proxy after processing command line arguments
when in daemon mode