### PR TITLE
Correct API's hostname check

### DIFF
--- a/src/org/zaproxy/zap/extension/api/API.java
+++ b/src/org/zaproxy/zap/extension/api/API.java
@@ -82,6 +82,12 @@ public class API {
 	
 	private Map<String, Nonce> nonces = new HashMap<String, Nonce>();
 	
+	/**
+	 * The options for the API.
+	 * 
+	 * @see #getOptionsParamApi()
+	 */
+	private OptionsParamApi optionsParamApi;
 
 	private Random random = new SecureRandom();
     private static final Logger logger = Logger.getLogger(API.class);
@@ -159,8 +165,15 @@ public class API {
 		return true;
 	}
 	
-	private static OptionsParamApi getOptionsParamApi() {
-		return Model.getSingleton().getOptionsParam().getApiParam();
+	private OptionsParamApi getOptionsParamApi() {
+		if (optionsParamApi == null) {
+			optionsParamApi = Model.getSingleton().getOptionsParam().getApiParam();
+		}
+		return optionsParamApi;
+	}
+
+	void setOptionsParamApi(OptionsParamApi optionsParamApi) {
+		this.optionsParamApi = optionsParamApi;
 	}
 	
 	public boolean handleApiRequest (HttpRequestHeader requestHeader, HttpInputStream httpIn, 
@@ -168,14 +181,14 @@ public class API {
 		return this.handleApiRequest(requestHeader, httpIn, httpOut, false);
 	}
 
-	private boolean isPermittedIpAddr(HttpRequestHeader requestHeader) {
+	private boolean isPermittedAddr(HttpRequestHeader requestHeader) {
 		if (getOptionsParamApi().isPermittedAddress(requestHeader.getSenderAddress().getHostAddress())) {
 			if (getOptionsParamApi().isPermittedAddress(requestHeader.getHostName())) {
-				logger.warn("Request to API URL " + requestHeader.getURI().toString() + " with host header " +
-						requestHeader.getHostName() + " not permitted");
-				return false;
+				return true;
 			}
-			return true;
+			logger.warn("Request to API URL " + requestHeader.getURI().toString() + " with host header " +
+					requestHeader.getHostName() + " not permitted");
+			return false;
 		}
 		logger.warn("Request to API URL " + requestHeader.getURI().toString() + " from " +
 				requestHeader.getSenderAddress().getHostAddress() + " not permitted");
@@ -192,7 +205,7 @@ public class API {
 		
 		// Check for callbacks
 		if (url.contains(CALL_BACK_URL)) {
-			if (! isPermittedIpAddr(requestHeader)) {
+			if (! isPermittedAddr(requestHeader)) {
 				return true;
 			}
 			logger.debug("handleApiRequest Callback: " + url);
@@ -216,7 +229,7 @@ public class API {
 		if (shortcutImpl == null && callbackImpl == null && ! url.startsWith(API_URL) && ! url.startsWith(API_URL_S) && ! force) {
 			return false;
 		}
-		if (! isPermittedIpAddr(requestHeader)) {
+		if (! isPermittedAddr(requestHeader)) {
 			return true;
 		}
 		if (getOptionsParamApi().isSecureOnly() && ! requestHeader.isSecure()) {
@@ -753,7 +766,7 @@ public class API {
         return sb.toString();
     }
 
-    private static void handleException(HttpMessage msg, Format format, String contentType, Exception cause) {
+    private void handleException(HttpMessage msg, Format format, String contentType, Exception cause) {
         String responseStatus = STATUS_INTERNAL_SERVER_ERROR;
         if (format == Format.OTHER) {
             boolean logError = true;
@@ -815,7 +828,7 @@ public class API {
         return contentType.substring(idx + 8);
     }
     
-    private static class Nonce {
+    private class Nonce {
         private final String nonceKey;
         private final String apiPath;
         private final boolean oneTime;

--- a/test/org/zaproxy/zap/extension/api/APIUnitTest.java
+++ b/test/org/zaproxy/zap/extension/api/APIUnitTest.java
@@ -1,0 +1,230 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2017 The ZAP development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.api;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.net.Inet4Address;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.apache.log4j.varia.NullAppender;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.parosproxy.paros.network.HttpInputStream;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpOutputStream;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.network.DomainMatcher;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+import net.sf.json.JSONObject;
+
+/**
+ * Unit test for {@link API}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class APIUnitTest {
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        Logger.getRootLogger().addAppender(new NullAppender());
+    }
+
+    @Test
+    public void shouldBeEnabledWhenInDaemonMode() {
+        // Given
+        API api = new API();
+        // When
+        View.setDaemon(true);
+        // Then
+        assertThat(api.isEnabled(), is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldDenyAllAddressesIfNoneSet() throws Exception {
+        // Given
+        API api = new API();
+        api.setOptionsParamApi(new OptionsParamApi());
+        TestApiImplementor apiImplementor = new TestApiImplementor();
+        String requestUri = api.getCallBackUrl(apiImplementor, "http://example.com");
+        // When
+        boolean requestHandled = api.handleApiRequest(
+                createApiRequest(new byte[] { 127, 0, 0, 1 }, "example.com", requestUri),
+                createMockedHttpInputStream(),
+                createMockedHttpOutputStream());
+        // Then
+        assertThat(requestHandled, is(equalTo(true)));
+        assertThat(apiImplementor.wasUsed(), is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldDenyAddressNotSet() throws Exception {
+        // Given
+        API api = new API();
+        OptionsParamApi apiOptions = new OptionsParamApi();
+        apiOptions.load(new ZapXmlConfiguration());
+        apiOptions.setPermittedAddresses(createPermittedAddresses("127.0.0.1"));
+        api.setOptionsParamApi(apiOptions);
+        TestApiImplementor apiImplementor = new TestApiImplementor();
+        String requestUri = api.getCallBackUrl(apiImplementor, "http://example.com");
+        // When
+        boolean requestHandled = api.handleApiRequest(
+                createApiRequest(new byte[] { 10, 0, 0, 2 }, "example.com", requestUri),
+                createMockedHttpInputStream(),
+                createMockedHttpOutputStream());
+        // Then
+        assertThat(requestHandled, is(equalTo(true)));
+        assertThat(apiImplementor.wasUsed(), is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldDenyHostnameNotSet() throws Exception {
+        // Given
+        API api = new API();
+        OptionsParamApi apiOptions = new OptionsParamApi();
+        apiOptions.load(new ZapXmlConfiguration());
+        apiOptions.setPermittedAddresses(createPermittedAddresses("127.0.0.1", "localhost"));
+        api.setOptionsParamApi(apiOptions);
+        TestApiImplementor apiImplementor = new TestApiImplementor();
+        String requestUri = api.getCallBackUrl(apiImplementor, "http://example.com");
+        // When
+        boolean requestHandled = api.handleApiRequest(
+                createApiRequest(new byte[] { 127, 0, 0, 1 }, "example.com", requestUri),
+                createMockedHttpInputStream(),
+                createMockedHttpOutputStream());
+        // Then
+        assertThat(requestHandled, is(equalTo(true)));
+        assertThat(apiImplementor.wasUsed(), is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldAcceptAddressAndHostnameSet() throws Exception {
+        // Given
+        API api = new API();
+        OptionsParamApi apiOptions = new OptionsParamApi();
+        apiOptions.load(new ZapXmlConfiguration());
+        apiOptions.setPermittedAddresses(createPermittedAddresses("10.0.0.8", "example.com"));
+        api.setOptionsParamApi(apiOptions);
+        TestApiImplementor apiImplementor = new TestApiImplementor();
+        String requestUri = api.getCallBackUrl(apiImplementor, "http://example.com");
+        // When
+        boolean requestHandled = api.handleApiRequest(
+                createApiRequest(new byte[] { 10, 0, 0, 8 }, "example.com", requestUri),
+                createMockedHttpInputStream(),
+                createMockedHttpOutputStream());
+        // Then
+        assertThat(requestHandled, is(equalTo(true)));
+        assertThat(apiImplementor.wasUsed(), is(equalTo(true)));
+    }
+
+    private List<DomainMatcher> createPermittedAddresses(String... addresses) {
+        if (addresses == null || addresses.length == 0) {
+            return new ArrayList<>();
+        }
+
+        List<DomainMatcher> permittedAddresses = new ArrayList<>();
+        for (String address : addresses) {
+            permittedAddresses.add(new DomainMatcher(address));
+        }
+        return permittedAddresses;
+    }
+
+    private HttpRequestHeader createApiRequest(byte[] remoteAddress, String hostname, String requestUri) throws Exception {
+        HttpRequestHeader httpRequestHeader = new HttpRequestHeader(
+                "GET " + requestUri + " HTTP/1.1\r\n" + "Host: " + hostname + "\r\n");
+        httpRequestHeader.setSenderAddress(Inet4Address.getByAddress(remoteAddress));
+        return httpRequestHeader;
+    }
+
+    private HttpInputStream createMockedHttpInputStream() {
+        return Mockito.mock(HttpInputStream.class);
+    }
+
+    private HttpOutputStream createMockedHttpOutputStream() {
+        return Mockito.mock(HttpOutputStream.class);
+    }
+
+    private static class TestApiImplementor extends ApiImplementor {
+
+        public static final String PREFIX = "test";
+
+        private boolean used;
+
+        @Override
+        public String getPrefix() {
+            return PREFIX;
+        }
+
+        @Override
+        public ApiResponse handleApiView(String name, JSONObject params) throws ApiException {
+            used = true;
+            return new ApiResponseElement(name);
+        }
+
+        @Override
+        public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
+            used = true;
+            return new ApiResponseElement(name);
+        }
+
+        @Override
+        public HttpMessage handleApiOther(HttpMessage msg, String name, JSONObject params) throws ApiException {
+            used = true;
+            return new HttpMessage();
+        }
+
+        @Override
+        public String handleCallBack(HttpMessage msg) throws ApiException {
+            used = true;
+            return "response";
+        }
+
+        @Override
+        public ApiResponse handleApiOptionView(String name, JSONObject params) throws ApiException {
+            used = true;
+            return new ApiResponseElement(name);
+        }
+
+        @Override
+        public ApiResponse handleApiOptionAction(String name, JSONObject params) throws ApiException {
+            used = true;
+            return new ApiResponseElement(name);
+        }
+
+        @Override
+        public HttpMessage handleShortcut(HttpMessage msg) throws ApiException {
+            used = true;
+            return new HttpMessage();
+        }
+
+        public boolean wasUsed() {
+            return used;
+        }
+    }
+
+}


### PR DESCRIPTION
Correct API's hostname check, by swapping its statements, return true if
matched otherwise log and return false. Also, rename the method that
does the check to not have IP in the name and allow to set the API
options to ease the tests.
Add tests to assert the expected behaviour of address checks.