### PR TITLE
Fix Params Tab Load Saved Session Issue

### DIFF
--- a/src/org/zaproxy/zap/extension/params/ExtensionParams.java
+++ b/src/org/zaproxy/zap/extension/params/ExtensionParams.java
@@ -224,9 +224,6 @@ public class ExtensionParams extends ExtensionAdaptor
 		Enumeration<SiteNode> en = root.children();
 		while (en.hasMoreElements()) {
 			String site = en.nextElement().getNodeName();
-			if (site.indexOf("//") >= 0) {
-				site = site.substring(site.indexOf("//") + 2);
-			}
 			if (getView() != null) {
 				this.getParamsPanel().addSite(site);
 			}


### PR DESCRIPTION
This fixes an issue whereby upon loading a saved session the param panel
site selector dropdown menu contained only http (:80) entries which do
not necessarily align properly to the session being loaded. 

Previously the scheme was being stripped when the site tree was
enumerated, this meant that all the https entries were not properly
added to the site selector dropdown.