### PR TITLE
Ignore missing temp records when passive scanning

### DIFF
--- a/src/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
+++ b/src/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
@@ -158,7 +158,13 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
 							}
 						}
 					} catch (Exception e) {
-						logger.error("Parser failed on record " + currentId + " from History table", e);
+						if (HistoryReference.getTemporaryTypes().contains(href.getHistoryType())) {
+							if (logger.isDebugEnabled()) {
+								logger.debug("Temporary record " + currentId + " no longer available:", e);
+							}
+						} else {
+							logger.error("Parser failed on record " + currentId + " from History table", e);
+						}
 					}
 					
 				}


### PR DESCRIPTION
Change PassiveScanThread to not log an error when the temporary history
record being scanned no longer exists, temporary records are deleted
when no longer needed. Instead of an error it's logged a message, with
debug level, indicating that case.