### PR TITLE
Issue 1644 Add Headers To Params Tab

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1701,6 +1701,7 @@ params.toolbar.site.select  = --Select Site--
 params.type.cookie			= Cookie
 params.type.form			= FORM
 params.type.url				= URL
+params.type.header          = Header
 
 paste.desc        = Provides a right click option to paste text from the clipboard
 paste.paste.popup = Paste

--- a/src/org/parosproxy/paros/network/HtmlParameter.java
+++ b/src/org/parosproxy/paros/network/HtmlParameter.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 public class HtmlParameter implements Comparable<HtmlParameter> {
 	public enum Type {
-		cookie, form, url
+		cookie, form, url, header
 	};
 
 	public enum Flags {

--- a/src/org/zaproxy/zap/extension/params/SiteParameters.java
+++ b/src/org/zaproxy/zap/extension/params/SiteParameters.java
@@ -39,6 +39,7 @@ public class SiteParameters {
 	private Map<String, HtmlParameterStats> cookieParams = new HashMap<>();
 	private Map<String, HtmlParameterStats> urlParams = new HashMap<>();
 	private Map<String, HtmlParameterStats> formParams = new HashMap<>();
+	private Map<String, HtmlParameterStats> headerParams = new HashMap<>();
 
 	public SiteParameters(ExtensionParams extension, String site) {
 		this.extension = extension;
@@ -54,13 +55,15 @@ public class SiteParameters {
 	}
 
 	/**
-	 * Tells whether or not this site has any parameters (cookies, query or form parameters).
+	 * Tells whether or not this site has any parameters (cookies, query, form
+	 * parameters, or response header fields).
 	 *
-	 * @return {@code true} if this site has parameters, {@code false} otherwise.
+	 * @return {@code true} if this site has parameters, {@code false}
+	 *         otherwise.
 	 * @since 2.5.0
 	 */
 	public boolean hasParams() {
-		return !cookieParams.isEmpty() || !urlParams.isEmpty() || !formParams.isEmpty();
+		return !cookieParams.isEmpty() || !urlParams.isEmpty() || !formParams.isEmpty() || !headerParams.isEmpty();
 	}
 
 	public HtmlParameterStats getParam(HtmlParameter.Type type, String name) {
@@ -71,6 +74,8 @@ public class SiteParameters {
 			return urlParams.get(name);
 		case form:
 			return formParams.get(name);
+		case header:
+			return headerParams.get(name);
 		}
 		return null;
 	}
@@ -79,19 +84,16 @@ public class SiteParameters {
 		List<HtmlParameterStats> params = new ArrayList<>();
 		switch (type) {
 		case cookie:
-			for (HtmlParameterStats param : this.cookieParams.values()) {
-				params.add(param);
-			}
+			params.addAll(this.cookieParams.values());
 			break;
 		case url:
-			for (HtmlParameterStats param : this.urlParams.values()) {
-				params.add(param);
-			}
+			params.addAll(this.urlParams.values());
 			break;
 		case form:
-			for (HtmlParameterStats param : this.formParams.values()) {
-				params.add(param);
-			}
+			params.addAll(this.formParams.values());
+			break;
+		case header:
+			params.addAll(this.headerParams.values());
 			break;
 		}
 		return params;
@@ -99,15 +101,10 @@ public class SiteParameters {
 
 	public List<HtmlParameterStats> getParams() {
 		List<HtmlParameterStats> params = new ArrayList<>();
-		for (HtmlParameterStats param : this.cookieParams.values()) {
-			params.add(param);
-		}
-		for (HtmlParameterStats param : this.urlParams.values()) {
-			params.add(param);
-		}
-		for (HtmlParameterStats param : this.formParams.values()) {
-			params.add(param);
-		}
+		params.addAll(this.cookieParams.values());
+		params.addAll(this.urlParams.values());
+		params.addAll(this.formParams.values());
+		params.addAll(this.headerParams.values());
 		return params;
 	}
 
@@ -124,6 +121,9 @@ public class SiteParameters {
 			break;
 		case form:
 			params = formParams;
+			break;
+		case header:
+			params = headerParams;
 			break;
 		}
 
@@ -182,6 +182,9 @@ public class SiteParameters {
 			break;
 		case form:
 			params = formParams;
+			break;
+		case header:
+			params = headerParams;
 			break;
 		}
 		// These should all be new


### PR DESCRIPTION
Response header fields are now displayed in the Params tab.

ExtensionParams modified to handle response header "parameters".
HtmlParameter add "header" type to Type enum.
Messages.properties add params.type.header.
SiteParameters modified to handle response header "parameters".

Fixes zaproxy/zaproxy#1644