### PR TITLE
Fix Issue 3261

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1585,6 +1585,7 @@ options.cert.error.accesskeystore     = Error accessing key store:
 options.cert.error.crypto             = Crypto API is not working yet - Sorry
 options.cert.error.fingerprint        = Error calculating key fingerprint: 
 options.cert.error.password           = Maybe your password or driver is wrong.
+options.cert.error.password.blank 	  = You've left the PIN field blank.
 options.cert.error.pkcs11			  = Try to add the PKCS#11 driver again...
 options.cert.error.pkcs11notavailable = <html><body><p>The required Sun/IBM PKCS#11 provider is not available.</p><p>For more information visit the pages:</p></body></html>
 options.cert.error.pkcs11notavailable.sun.hyperlink = http://docs.oracle.com/javase/7/docs/technotes/guides/security/p11guide.html#Requirements

--- a/src/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
@@ -59,6 +59,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.view.AbstractParamPanel;
+import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.ZapTextField;
 
 import ch.csnc.extension.httpclient.PKCS11Configuration;
@@ -632,8 +633,7 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 					//   - Missing library.
 					//   - Malformed configuration.
 					//   - ...
-					showGenericErrorMessagePkcs11CouldNotBeAdded();
-					logger.warn("Couldn't add key from "+name, e.getCause());
+					logAndShowGenericErrorMessagePkcs11CouldNotBeAdded(false, name, e);
 				} else if ("Initialization failed".equals(e.getCause().getMessage())) {
 					// The initialisation may fail because of:
 					//   - no smart card reader or smart card detected.
@@ -656,12 +656,10 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 						logger.warn("Couldn't add key from "+name, e);
 					}
 				} else {
-					showGenericErrorMessagePkcs11CouldNotBeAdded();
-					logger.warn("Couldn't add key from "+name, e);
+					logAndShowGenericErrorMessagePkcs11CouldNotBeAdded(false, name, e);
 				}
 			} else {
-				showGenericErrorMessagePkcs11CouldNotBeAdded();
-				logger.error("Couldn't add key from "+name, e);
+				logAndShowGenericErrorMessagePkcs11CouldNotBeAdded(false, name, e);
 			}
 		} catch (java.io.IOException e) {
 			if (e.getMessage().equals("load failed") && e.getCause().getClass().getName().equals("javax.security.auth.login.FailedLoginException")) {
@@ -684,15 +682,12 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 					logger.warn("PKCS#11: Incorrect PIN or password"+attempts+": "+name);
 				}
 			}else{
-				showGenericErrorMessagePkcs11CouldNotBeAdded();
-				logger.warn("Couldn't add key from "+name, e);
+				logAndShowGenericErrorMessagePkcs11CouldNotBeAdded(false, name, e);
 			}
 		} catch (KeyStoreException e) {
-			showGenericErrorMessagePkcs11CouldNotBeAdded();
-			logger.warn("Couldn't add key from "+name, e);
+			logAndShowGenericErrorMessagePkcs11CouldNotBeAdded(false, name, e);
 		} catch (Exception e) {
-			showGenericErrorMessagePkcs11CouldNotBeAdded();
-			logger.error("Couldn't add key from "+name, e);
+			logAndShowGenericErrorMessagePkcs11CouldNotBeAdded(true, name, e);
 		}
 
 
@@ -735,11 +730,23 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 				Constant.messages.getString("options.cert.label.client.cert"), JOptionPane.ERROR_MESSAGE);
 	}
 
-	private void showGenericErrorMessagePkcs11CouldNotBeAdded() {
-		JOptionPane.showMessageDialog(null, new String[] {
-				Constant.messages.getString("options.cert.error"),
-				Constant.messages.getString("options.cert.error.password")}, 
-				Constant.messages.getString("options.cert.label.client.cert"), JOptionPane.ERROR_MESSAGE);
+	private void logAndShowGenericErrorMessagePkcs11CouldNotBeAdded(boolean isErrorLevel, String name, Exception e) {
+		if(pkcs11PasswordField.getPassword().length == 0) {
+			JOptionPane.showMessageDialog(null, new String[] {
+					Constant.messages.getString("options.cert.error"),
+					Constant.messages.getString("options.cert.error.password.blank")}, 
+					Constant.messages.getString("options.cert.label.client.cert"), JOptionPane.ERROR_MESSAGE);
+		} else {
+			JOptionPane.showMessageDialog(null, new String[] {
+					Constant.messages.getString("options.cert.error"),
+					Constant.messages.getString("options.cert.error.password")}, 
+					Constant.messages.getString("options.cert.label.client.cert"), JOptionPane.ERROR_MESSAGE);
+			if (isErrorLevel) {
+				logger.error("Couldn't add key from "+name, e);
+			} else {
+				logger.warn("Couldn't add key from "+name, e);
+			}
+		}
 	}
 	
 	private void driverButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_driverButtonActionPerformed


### PR DESCRIPTION
Refactor OptionsCertificatePanel slightly to display an error (but not
log an exception) if the PKSCS#11 PIN field is blank when the user
clicks "Add to Keystore". If a PIN is present then the existing behavior
is still observed (display error message and log exception).

Fixes zaproxy/zaproxy#3261