### PR TITLE
Include the input in Version's exceptions

### DIFF
--- a/src/org/zaproxy/zap/Version.java
+++ b/src/org/zaproxy/zap/Version.java
@@ -47,7 +47,7 @@ public final class Version implements Comparable<Version> {
         try {
             impl = new com.github.zafarkhaja.semver.Version.Builder(version).build();
         } catch (com.github.zafarkhaja.semver.ParseException e) {
-            throw new IllegalArgumentException("Parameter version is not valid.");
+            throw new IllegalArgumentException("Parameter version [" + version + "] is not valid: " + e.getMessage());
         }
     }
 
@@ -79,10 +79,10 @@ public final class Version implements Comparable<Version> {
     }
 
     /**
-     * Tells whether or not the give version range matches this version.
+     * Tells whether or not the given version range matches this version.
      *
      * @param versionRange the range version
-     * @return {@code true} if this version matches the give version range, {@code false} otherwise
+     * @return {@code true} if this version matches the given version range, {@code false} otherwise
      * @throws IllegalArgumentException if {@code versionRange} is null or empty, or not valid range version
      */
     public boolean matches(String versionRange) throws IllegalArgumentException {
@@ -91,7 +91,7 @@ public final class Version implements Comparable<Version> {
         try {
             return impl.satisfies(versionRange);
         } catch (com.github.zafarkhaja.semver.ParseException e) {
-            throw new IllegalArgumentException("Parameter versionRange is not valid.");
+            throw new IllegalArgumentException("Parameter versionRange [" + versionRange + "] is not valid: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
Change Version class to include the (malformed) input and the message of
the cause in the exceptions thrown. Also, fix typos in JavaDoc.