### PR TITLE
Apply config arguments in the order specified

### DIFF
--- a/src/org/parosproxy/paros/CommandLine.java
+++ b/src/org/parosproxy/paros/CommandLine.java
@@ -34,6 +34,7 @@
 // ZAP: 2016/08/19 Issue 2782: Support -configfile
 // ZAP: 2016/09/22 JavaDoc tweaks
 // ZAP: 2016/11/07 Allow to disable default standard output logging
+// ZAP: 2017/03/26 Allow to obtain configs in the order specified
 
 package org.parosproxy.paros;
 
@@ -41,6 +42,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.text.MessageFormat;
 import java.util.Hashtable;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -92,7 +94,7 @@ public class CommandLine {
     private int port = -1;
     private String host = null;
     private String[] args = null;
-    private final Hashtable<String, String> configs = new Hashtable<>();
+    private final Map<String, String> configs = new LinkedHashMap<>();
     private final Hashtable<String, String> keywords = new Hashtable<>();
     private List<CommandLineArgument[]> commandList = null;
 
@@ -431,7 +433,24 @@ public class CommandLine {
         return host;
     }
 
+    /**
+     * Gets the {@code config} command line arguments, in no specific order.
+     *
+     * @return the {@code config} command line arguments.
+     * @deprecated (TODO add version) Use {@link #getOrderedConfigs()} instead, which are in the order they were specified.
+     */
+    @Deprecated
     public Hashtable<String, String> getConfigs() {
+        return new Hashtable<>(configs);
+    }
+
+    /**
+     * Gets the {@code config} command line arguments, in the order they were specified.
+     *
+     * @return the {@code config} command line arguments.
+     * @since TODO add version
+     */
+    public Map<String, String> getOrderedConfigs() {
         return configs;
     }
 

--- a/src/org/parosproxy/paros/common/AbstractParam.java
+++ b/src/org/parosproxy/paros/common/AbstractParam.java
@@ -28,6 +28,7 @@
 // ZAP: 2014/02/21 Issue 1043: Custom active scan dialog
 // ZAP: 2016/09/22 JavaDoc tweaks
 // ZAP: 2016/11/17 Issue 2701 Support Factory Reset
+// ZAP: 2017/03/26 Obtain configs in the order specified
 
 package org.parosproxy.paros.common;
 
@@ -78,7 +79,7 @@ public abstract class AbstractParam implements Cloneable {
         try {
             config = new ZapXmlConfiguration(filePath);
             if (overrides != null) {
-                for (Entry<String,String> entry : overrides.getConfigs().entrySet()) {
+                for (Entry<String,String> entry : overrides.getOrderedConfigs().entrySet()) {
                 	logger.info("Setting config " + entry.getKey() + " = " + entry.getValue() + 
                 			" was " + config.getString(entry.getKey()));
                 	config.setProperty(entry.getKey(), entry.getValue());

--- a/src/org/zaproxy/zap/ZapBootstrap.java
+++ b/src/org/zaproxy/zap/ZapBootstrap.java
@@ -55,7 +55,7 @@ abstract class ZapBootstrap {
         controlOverrides = new ControlOverrides();
         controlOverrides.setProxyPort(getArgs().getPort());
         controlOverrides.setProxyHost(getArgs().getHost());
-        controlOverrides.setConfigs(getArgs().getConfigs());
+        controlOverrides.setOrderedConfigs(getArgs().getOrderedConfigs());
         controlOverrides.setExperimentalDb(getArgs().isExperimentalDb());
     }
 

--- a/src/org/zaproxy/zap/control/ControlOverrides.java
+++ b/src/org/zaproxy/zap/control/ControlOverrides.java
@@ -21,6 +21,8 @@
 package org.zaproxy.zap.control;
 
 import java.util.Hashtable;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Used to override options in the configuration file.
@@ -30,7 +32,7 @@ import java.util.Hashtable;
 public class ControlOverrides {
 	private int proxyPort = -1;
 	private String proxyHost = null;
-	private Hashtable<String, String> configs = new Hashtable<String, String>();
+	private Map<String, String> configs = new LinkedHashMap<>();
 	private boolean experimentalDb = false;
 
 	public int getProxyPort() {
@@ -53,12 +55,46 @@ public class ControlOverrides {
 		this.proxyHost = proxyHost;
 	}
 
-	public Hashtable<String, String> getConfigs() {
+	/**
+	 * Gets the {@code config} command line arguments, in the order they were specified.
+	 *
+	 * @return the {@code config} command line arguments.
+	 * @since TODO add version
+	 */
+	public Map<String, String> getOrderedConfigs() {
 		return configs;
 	}
 
-	public void setConfigs(Hashtable<String, String> configs) {
+	/**
+	 * Sets the {@code config} command line arguments, in the order they were specified.
+	 *
+	 * @param configs the {@code config} command line arguments.
+	 * @since TODO add version
+	 */
+	public void setOrderedConfigs(Map<String, String> configs) {
 		this.configs = configs;
+	}
+
+	/**
+	 * Gets the {@code config} command line arguments, in no specific order.
+	 *
+	 * @return the {@code config} command line arguments.
+	 * @deprecated (TODO add version) Use {@link #getOrderedConfigs()} instead.
+	 */
+	@Deprecated
+	public Hashtable<String, String> getConfigs() {
+		return new Hashtable<>(configs);
+	}
+
+	/**
+	 * Sets the {@code config} command line arguments, in no specific order.
+	 *
+	 * @param configs the {@code config} command line arguments.
+	 * @deprecated (TODO add version) Use {@link #setOrderedConfigs(Map)} instead.
+	 */
+	@Deprecated
+	public void setConfigs(Hashtable<String, String> configs) {
+		this.configs = new LinkedHashMap<>(configs);
 	}
 
 	public boolean isExperimentalDb() {


### PR DESCRIPTION
Change CommandLine class to keep the config command line arguments in
the order they were specified and change other classes to use the
ordered config command line arguments (deprecating the unordered args).

This ensures that the config command line arguments are applied
consistently, in the order the user specified. For example, previously
setting:
-config api.addrs.addr(0).name=X
-config api.addrs.addr(1).name=Y
-config api.addrs.addr(2).name=Z
-config api.addrs.addr(3).name=W

would be applied as:
api.addrs.addr(3).name = W was null
api.addrs.addr(0).name = X was W
api.addrs.addr(1).name = Y was null
api.addrs.addr(2).name = Z was null

leading to loss of one of the config arguments.