### PR TITLE
Move RedirectionValidator to a top level class

### DIFF
--- a/src/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
+++ b/src/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
@@ -50,6 +50,8 @@ import org.zaproxy.zap.extension.httppanel.HttpPanelRequest;
 import org.zaproxy.zap.extension.httppanel.HttpPanelResponse;
 import org.zaproxy.zap.extension.httppanel.Message;
 import org.zaproxy.zap.model.SessionStructure;
+import org.zaproxy.zap.network.HttpRedirectionValidator;
+import org.zaproxy.zap.network.HttpRequestConfig;
 
 /**
  * Knows how to send {@link HttpMessage} objects.
@@ -89,7 +91,9 @@ public class HttpPanelSender implements MessageSender {
         try {
             final ModeRedirectionValidator redirectionValidator = new ModeRedirectionValidator();
             if (getButtonFollowRedirects().isSelected()) {
-                getDelegate().sendAndReceive(httpMessage, redirectionValidator);
+                getDelegate().sendAndReceive(
+                        httpMessage,
+                        HttpRequestConfig.builder().setRedirectionValidator(redirectionValidator).build());
             } else {
                 getDelegate().sendAndReceive(httpMessage, false);
             }
@@ -237,11 +241,11 @@ public class HttpPanelSender implements MessageSender {
     }
 
     /**
-     * A {@code RedirectionValidator} that enforces the {@link Mode} when validating the {@code URI} of redirections.
+     * A {@link HttpRedirectionValidator} that enforces the {@link Mode} when validating the {@code URI} of redirections.
      *
      * @see #isRequestValid()
      */
-    private static class ModeRedirectionValidator implements HttpSender.RedirectionValidator {
+    private static class ModeRedirectionValidator implements HttpRedirectionValidator {
 
         private boolean isRequestValid;
         private URI invalidRedirection;
@@ -252,6 +256,7 @@ public class HttpPanelSender implements MessageSender {
 
         @Override
         public void notifyMessageReceived(HttpMessage message) {
+            // Nothing to do with the message.
         }
 
         @Override

--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -77,6 +77,8 @@ import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.extension.dynssl.ExtensionDynSSL;
 import org.zaproxy.zap.model.SessionUtils;
 import org.zaproxy.zap.network.DomainMatcher;
+import org.zaproxy.zap.network.HttpRedirectionValidator;
+import org.zaproxy.zap.network.HttpRequestConfig;
 import org.zaproxy.zap.utils.HarUtils;
 
 import edu.umass.cs.benchlab.har.HarEntries;
@@ -713,7 +715,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 
 			if (followRedirects) {
 				ModeRedirectionValidator redirector = new ModeRedirectionValidator(processor);
-				sender.sendAndReceive(request, redirector);
+				sender.sendAndReceive(request, HttpRequestConfig.builder().setRedirectionValidator(redirector).build());
 
 				if (!redirector.isRequestValid()) {
 					throw new ApiException(ApiException.Type.MODE_VIOLATION);
@@ -1459,11 +1461,11 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 	}
 
 	/**
-	 * A {@code RedirectionValidator} that enforces the {@link Mode} when validating the {@code URI} of redirections.
+	 * A {@link HttpRedirectionValidator} that enforces the {@link Mode} when validating the {@code URI} of redirections.
 	 *
 	 * @see #isRequestValid()
 	 */
-	private static class ModeRedirectionValidator implements HttpSender.RedirectionValidator {
+	private static class ModeRedirectionValidator implements HttpRedirectionValidator {
 
 		private final Processor<HttpMessage> processor;
 		private boolean isRequestValid;

--- a/src/org/zaproxy/zap/network/DefaultHttpRedirectionValidator.java
+++ b/src/org/zaproxy/zap/network/DefaultHttpRedirectionValidator.java
@@ -1,0 +1,57 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.network;
+
+import org.apache.commons.httpclient.URI;
+import org.parosproxy.paros.network.HttpMessage;
+
+/**
+ * Default implementation of {@link HttpRedirectionValidator}, all redirections are considered valid and notifications of new
+ * messages are simply ignored.
+ * 
+ * @since 2.6.0
+ * @see #INSTANCE
+ */
+public class DefaultHttpRedirectionValidator implements HttpRedirectionValidator {
+
+    /**
+     * The instance of {@code DefaultHttpRedirectionValidator}.
+     */
+    public static final DefaultHttpRedirectionValidator INSTANCE = new DefaultHttpRedirectionValidator();
+
+    private DefaultHttpRedirectionValidator() {
+    }
+
+    /**
+     * Returns {@code true}, always.
+     */
+    @Override
+    public boolean isValid(URI redirection) {
+        return true;
+    }
+
+    /**
+     * Does nothing.
+     */
+    @Override
+    public void notifyMessageReceived(HttpMessage message) {
+        // Nothing to do.
+    }
+}

--- a/src/org/zaproxy/zap/network/HttpRedirectionValidator.java
+++ b/src/org/zaproxy/zap/network/HttpRedirectionValidator.java
@@ -1,0 +1,49 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.network;
+
+import org.apache.commons.httpclient.URI;
+import org.parosproxy.paros.network.HttpMessage;
+
+/**
+ * A validator of redirections, called for each redirection of a HTTP request.
+ * <p>
+ * As convenience the validator will also be notified of the HTTP messages sent and received (first message and followed
+ * redirections, if any).
+ * 
+ * @since 2.6.0
+ */
+public interface HttpRedirectionValidator {
+
+    /**
+     * Tells whether or not the given {@code redirection} is valid, to be followed.
+     *
+     * @param redirection the redirection being checked, never {@code null}.
+     * @return {@code true} if the redirection is valid, {@code false} otherwise.
+     */
+    boolean isValid(URI redirection);
+
+    /**
+     * Notifies that a new message was sent and received (called for the first message and followed redirections, if any).
+     *
+     * @param message the HTTP message that was received, never {@code null}.
+     */
+    void notifyMessageReceived(HttpMessage message);
+}

--- a/src/org/zaproxy/zap/network/HttpRequestConfig.java
+++ b/src/org/zaproxy/zap/network/HttpRequestConfig.java
@@ -1,0 +1,140 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.network;
+
+/**
+ * A configuration of a HTTP request.
+ * <p>
+ * Allows to configure how the HTTP request is sent, for example, if and how redirects are followed.
+ * 
+ * @since 2.6.0
+ */
+public class HttpRequestConfig {
+
+    private final boolean followRedirects;
+    private final HttpRedirectionValidator redirectionValidator;
+
+    HttpRequestConfig(boolean followRedirects, HttpRedirectionValidator redirectionValidator) {
+        this.followRedirects = followRedirects;
+        this.redirectionValidator = redirectionValidator;
+    }
+
+    /**
+     * Tells whether or not the redirects should be followed.
+     *
+     * @return {@code true} if the redirects should be followed, {@code false} otherwise.
+     * @see #getRedirectionValidator()
+     */
+    public boolean isFollowRedirects() {
+        return followRedirects;
+    }
+
+    /**
+     * Gets the {@code HttpRedirectionValidator}, to validate the followed redirections.
+     *
+     * @return the validator responsible for validation of redirections, never {@code null}.
+     * @see #isFollowRedirects()
+     */
+    public HttpRedirectionValidator getRedirectionValidator() {
+        return redirectionValidator;
+    }
+
+    /**
+     * Gets a new HTTP request configuration builder.
+     *
+     * @return a new HTTP request configuration builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Gets a new HTTP request configuration builder, using the following configuration as default.
+     *
+     * @param configuration the HTTP request configuration for defaults.
+     * @return a new HTTP request configuration builder.
+     * @throws IllegalArgumentException if the given parameter is {@code null}.
+     */
+    public static Builder builder(HttpRequestConfig configuration) {
+        if (configuration == null) {
+            throw new IllegalArgumentException("Parameter configuration must not be null.");
+        }
+        return new Builder(configuration);
+    }
+
+    /**
+     * Builder of {@link HttpRequestConfig}.
+     */
+    public static class Builder {
+
+        private boolean followRedirects;
+        private HttpRedirectionValidator redirectionValidator;
+
+        private Builder() {
+            this.followRedirects = false;
+            this.redirectionValidator = DefaultHttpRedirectionValidator.INSTANCE;
+        }
+
+        private Builder(HttpRequestConfig config) {
+            this.followRedirects = config.isFollowRedirects();
+            this.redirectionValidator = config.getRedirectionValidator();
+        }
+
+        /**
+         * Sets whether or not the redirects should be followed.
+         *
+         * @param followRedirects {@code true} if the redirects should be followed, {@code false} otherwise.
+         * @return the builder.
+         * @see #setRedirectionValidator(HttpRedirectionValidator)
+         */
+        public Builder setFollowRedirects(boolean followRedirects) {
+            this.followRedirects = followRedirects;
+            return this;
+        }
+
+        /**
+         * Sets the validator of redirections.
+         * <p>
+         * Automatically sets that the redirections should be followed.
+         * 
+         * @param redirectionValidator the validator of redirections.
+         * @return the builder.
+         * @throws IllegalArgumentException if the given parameter is {@code null}.
+         * @see #setFollowRedirects(boolean)
+         */
+        public Builder setRedirectionValidator(HttpRedirectionValidator redirectionValidator) {
+            if (redirectionValidator == null) {
+                throw new IllegalArgumentException("Parameter redirectionValidator must not be null.");
+            }
+            this.redirectionValidator = redirectionValidator;
+            this.followRedirects = true;
+            return this;
+        }
+
+        /**
+         * Builds a new {@code HttpRequestConfig}, with the configurations previously set.
+         *
+         * @return a new {@code HttpRequestConfig}.
+         */
+        public HttpRequestConfig build() {
+            return new HttpRequestConfig(followRedirects, redirectionValidator);
+        }
+    }
+}


### PR DESCRIPTION
Move RedirectionValidator to a top level class (and rename it to
HttpRedirectionValidator), also introduce HttpRequestConfig, to allow
to easily configure a HTTP request.
Change HttpSender class to use HttpRequestConfig as parameter to send
the requests (instead of directly RedirectionValidator).
Update the classes that were using RedirectionValidator to use the new
classes.