### PR TITLE
Issue 3253 Add Export URLs per Context

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -874,6 +874,7 @@ context.error.name.unknown = The context name is invalid.
 context.exclude.popup              = Exclude from Context
 context.export.error			   = Failed to export Context:\n{0}
 context.export.tooltip			   = Select one Context in order to export it 
+context.export.urls.menu = Export URLs for Context
 context.flag.popup                 = Flag as Context 
 context.flag.popup.datadriven      = {0} : Data Driven Node
 context.include.popup              = Include in Context
@@ -1068,6 +1069,7 @@ enc2.tools.menu.encdec.mnemonic        = e
 
 exportUrls.popup = Export All URLs to File...
 exportUrls.popup.selected = Export Selected URLs to File...
+exportUrls.popup.context.error = Please select a Context.
 
 ext.desc = Allows you to configure which extensions are loaded when ZAP starts 
 

--- a/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -71,6 +71,7 @@
 // ZAP: 2016/06/21 Prevent deadlock between EDT and threads adding messages to the History tab
 // ZAP: 2017/01/30 Use HistoryTableModel.
 // ZAP: 2017/03/02 Issue 1634 Improve URL export.
+// ZAP: 2017/03/28 Issue 3253 Allow URLs to be exported per context.
 
 package org.parosproxy.paros.extension.history;
 
@@ -110,6 +111,7 @@ import org.zaproxy.zap.extension.history.AlertAddDialog;
 import org.zaproxy.zap.extension.history.HistoryFilterPlusDialog;
 import org.zaproxy.zap.extension.history.ManageTagsDialog;
 import org.zaproxy.zap.extension.history.NotesAddDialog;
+import org.zaproxy.zap.extension.history.PopupMenuExportContextURLs;
 import org.zaproxy.zap.extension.history.PopupMenuExportSelectedURLs;
 import org.zaproxy.zap.extension.history.PopupMenuExportURLs;
 import org.zaproxy.zap.extension.history.PopupMenuNote;
@@ -138,6 +140,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
     // ZAP: Added Export URLs
 	private PopupMenuExportURLs popupMenuExportURLs = null;
 	private PopupMenuExportSelectedURLs popupMenuExportSelectedURLs = null;
+	private PopupMenuExportContextURLs popupMenuExportContextURLs = null;
     // ZAP: Added history notes
     private PopupMenuNote popupMenuNote = null;
 	private NotesAddDialog dialogNotesAdd = null;
@@ -229,8 +232,11 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
             // ZAP: Move 'export' menu items to Report menu
 	        extensionHook.getHookMenu().addReportMenuItem(getPopupMenuExportMessage2());
             extensionHook.getHookMenu().addReportMenuItem(getPopupMenuExportResponse2());
+            extensionHook.getHookMenu().addReportMenuItem(extensionHook.getHookMenu().getMenuSeparator());
             extensionHook.getHookMenu().addReportMenuItem(getPopupMenuExportURLs());
             extensionHook.getHookMenu().addReportMenuItem(getPopupMenuExportSelectedURLs());
+            extensionHook.getHookMenu().addReportMenuItem(getPopupMenuExportContextURLs());
+            extensionHook.getHookMenu().addReportMenuItem(extensionHook.getHookMenu().getMenuSeparator());
 
             ExtensionHelp.enableHelpKey(this.getLogPanel(), "ui.tabs.history");
 	    }
@@ -672,6 +678,15 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
 			popupMenuExportSelectedURLs.setExtension(this);
 		}
 		return popupMenuExportSelectedURLs;
+	}
+	
+	private PopupMenuExportContextURLs getPopupMenuExportContextURLs() {
+		if (popupMenuExportContextURLs == null) {
+			popupMenuExportContextURLs = new PopupMenuExportContextURLs(
+					Constant.messages.getString("context.export.urls.menu"));
+			popupMenuExportContextURLs.setExtension(this);
+		}
+		return popupMenuExportContextURLs;
 	}
 
 	public void showInHistory(HistoryReference href) {

--- a/src/org/parosproxy/paros/view/SiteMapPanel.java
+++ b/src/org/parosproxy/paros/view/SiteMapPanel.java
@@ -38,6 +38,7 @@
 // ZAP: 2015/06/01 Issue 1653: Support context menu key for trees
 // ZAP: 2016/04/14 Use View to display the HTTP messages
 // ZAP: 2016/07/01 Issue 2642: Slow mouse wheel scrolling in site tree
+// ZAP: 2017/03/28 Issue 3253: Facilitate exporting URLs by context (add getSelectedContext)
 
 package org.parosproxy.paros.view;
 
@@ -390,6 +391,25 @@ public class SiteMapPanel extends AbstractPanel {
 		this.contextTree.nodeStructureChanged(root);
 	}
 
+	/**
+	 * Returns the Context which is selected in the Site Map panel of the UI
+	 * or {@code null} if nothing is selected or the selection is the root node.
+	 * 
+	 * @return Context the context which is selected in the UI
+	 * @since TODO add version
+	 */
+	public Context getSelectedContext() {
+		SiteNode node = (SiteNode) treeContext.getLastSelectedPathComponent();
+		if (node == null || node.isRoot()) {
+			return null;
+		}
+		Target target = (Target) node.getUserObject();
+		if (target != null) {
+			return target.getContext();
+		}
+		return null;
+	}
+	
 	private JTree getTreeContext() {
 		if (treeContext == null) {
 			reloadContextTree();

--- a/src/org/zaproxy/zap/extension/history/PopupMenuExportContextURLs.java
+++ b/src/org/zaproxy/zap/extension/history/PopupMenuExportContextURLs.java
@@ -1,0 +1,87 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0 
+ *   
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package org.zaproxy.zap.extension.history;
+
+import java.awt.Component;
+import java.io.File;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.model.SiteNode;
+import org.parosproxy.paros.view.SiteMapPanel;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.model.Context;
+
+public class PopupMenuExportContextURLs extends PopupMenuExportURLs {
+
+	private static final long serialVersionUID = -4426560452505908380L;
+	
+	private static Logger LOG = Logger.getLogger(PopupMenuExportURLs.class);
+
+	public PopupMenuExportContextURLs(String menuItem) {
+		super(menuItem);
+	}
+	
+	@Override
+	public boolean isEnableForComponent(Component invoker) {
+		if (invoker.getName().equals(SiteMapPanel.CONTEXT_TREE_COMPONENT_NAME)) {
+			Context ctx = View.getSingleton().getSiteTreePanel().getSelectedContext();
+			if (ctx != null) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	protected void performAction() {
+		Context ctx = extension.getView().getSiteTreePanel().getSelectedContext(); 
+		if (ctx == null) {
+			View.getSingleton().showWarningDialog(Constant.messages.getString("exportUrls.popup.context.error"));
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("No context selected, when trying to export URLs for a context.");
+			}
+			return;
+		}
+		
+		File file = super.getOutputFile();
+		if (file == null) {
+			return;
+		}
+		super.writeURLs(file, this.getOutputSet(ctx));
+	}
+
+	private SortedSet<String> getOutputSet(Context ctx) {
+		SortedSet<String> outputSet = new TreeSet<String>();
+
+		for (SiteNode node : ctx.getNodesInContextFromSiteTree()) {
+			HistoryReference nodeHR = node.getHistoryReference();
+			if (nodeHR != null && !HistoryReference.getTemporaryTypes().contains(nodeHR.getHistoryType())) {
+				outputSet.add(nodeHR.getURI().toString());
+			}
+		}
+		return outputSet;
+	}
+
+}

--- a/src/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
@@ -41,6 +41,7 @@ import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
+import org.zaproxy.zap.extension.history.PopupMenuExportContextURLs;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.ContextExportDialog;
@@ -70,6 +71,7 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
 	private PopupContextTreeMenu popupContextTreeMenuOutScope = null;
 	private PopupContextTreeMenu popupContextTreeMenuDelete = null;
 	private PopupContextTreeMenu popupContextTreeMenuExport;
+	private PopupMenuExportContextURLs popupContextTreeMenuExportUrls;
 
 	// Still being developed
 	// private PopupMenuShowResponseInBrowser popupMenuShowResponseInBrowser = null;
@@ -131,6 +133,9 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
 			extensionHook.getHookMenu().addPopupMenuItem(getPopupContextTreeMenuOutScope());
 			extensionHook.getHookMenu().addPopupMenuItem(getPopupContextTreeMenuDelete());
 			extensionHook.getHookMenu().addPopupMenuItem(getPopupContextTreeMenuExport());
+			if (isExtensionHistoryEnabled) {
+				extensionHook.getHookMenu().addPopupMenuItem(getPopupContextTreeMenuExportUrls());
+			}
 		}
 	}
 	
@@ -178,6 +183,16 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
             });
 		}
 		return popupContextTreeMenuOutScope;
+	}
+	
+	private PopupMenuExportContextURLs getPopupContextTreeMenuExportUrls() {
+		if (popupContextTreeMenuExportUrls == null) {
+			popupContextTreeMenuExportUrls = new PopupMenuExportContextURLs(
+					Constant.messages.getString("context.export.urls.menu"));
+			popupContextTreeMenuExportUrls.setExtension(
+					Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class));
+		}
+		return popupContextTreeMenuExportUrls;
 	}
 
 	private PopupContextTreeMenu getPopupContextTreeMenuDelete() {


### PR DESCRIPTION
Allow URLs to be exported based on the selected Context.

- SiteMapPanel - Add getSelectedContext() method.
- PopupMenuExportContextURLs - New class, extends PopupMenuExportURLs.
- ExtensionStdMenus - Additions to support the new Context right-click menu for export of all the URLs related to the selected Context.
- ExtensionHistory - Additions to support the new menu item for export of all the URLs related to the selected Context (if no Context is selected a warning dialog is displayed).
- Messages.properties - Added resource key for menu item text

Fixes zaproxy/zaproxy#3253