### PR TITLE
Log the home directory used by ZAP

### DIFF
--- a/src/org/zaproxy/zap/ZapBootstrap.java
+++ b/src/org/zaproxy/zap/ZapBootstrap.java
@@ -127,6 +127,7 @@ abstract class ZapBootstrap {
         strBuilder.append(Constant.PROGRAM_NAME).append(' ').append(Constant.PROGRAM_VERSION);
         strBuilder.append(" started ");
         strBuilder.append(dateFormat.format(new Date()));
+        strBuilder.append(" with home ").append(Constant.getZapHome());
         return strBuilder.toString();
     }
 }


### PR DESCRIPTION
Change ZapBootstrap to log the path to ZAP's home directory, useful to
really know which directory is being used by ZAP. When not manually
specified it uses a default path/name, which depends on the user running
ZAP and the version of ZAP (weekly vs standard releases).