### PR TITLE
fix zap-baseline.py handling 401 from target url

### DIFF
--- a/build/docker/zap-baseline.py
+++ b/build/docker/zap-baseline.py
@@ -400,7 +400,15 @@ def main(argv):
         logging.error ('Failed to load context file ' + context_file + ' : ' + res)
 
     # Access the target
-    res = zap.urlopen(target)
+    try:
+        res = zap.urlopen(target)
+    except IOError as e:
+        if hasattr(e, 'args') and len(e.args) > 1 and e.args[1] == 401:
+            logging.info('Received 401 from %s' % target)
+            res = ""  # for the ZAP Error check below
+        else:
+            raise e
+
     if res.startswith("ZAP Error"):
       # errno.EIO is 5, not sure why my atempts to import it failed;) 
       raise IOError(5, 'Failed to connect')


### PR DESCRIPTION
upstreaming a change to this private repo: https://github.com/mozilla-services/foxsec/pull/243

Running the baseline scan on a target that returns a 401 without a WWW-Authenticate header from the root page produces the error:

```
» ./zap-baseline.py -t https://tigerblood.prod.mozaws.net/ -d
2017-03-31 11:55:02,341 Using port: 45874
2017-03-31 11:55:02,342 Pulling ZAP Weekly Docker image
2017-03-31 11:55:02,931 Starting ZAP
2017-03-31 11:55:02,931 Params: ['docker', 'run', '-u', 'zap', '-p', '45874:45874', '-d', 'owasp/zap2docker-weekly', 'zap-x.sh', '-daemon', '-port', '45874', '-host', '0.0.0.0', '-config', 'api.disablekey=true', '-config', 'api.addrs.addr.name=.*', '-config', 'api.addrs.addr.regex=true', '-config', 'spider.maxDuration=1', '-addonupdate']
2017-03-31 11:55:03,719 Docker CID: 4822051f4a303e2ad75fea4d0dca9612477389ec92232a1ac8b6f328a5e8a208
2017-03-31 11:55:03,748 Docker ZAP IP Addr: localhost
2017-03-31 11:55:10,863 ZAP Version D-2017-03-21
2017-03-31 11:55:10,863 Took 7 seconds
Traceback (most recent call last):
  File "./zap-baseline.py", line 620, in <module>
    main(sys.argv[1:])
  File "./zap-baseline.py", line 583, in main
    except IOError as (errno, strerror):
ValueError: too many values to unpack
```

The baseline call to [zap.urlopen](https://github.com/zaproxy/zaproxy/blob/a36ed3f0706d8ef47d70c7c4bc7f2fbf58551185/build/docker/zap-baseline.py#L403) can cause python's stdlib `urllib.urlopen` to throw an IOError fails to unpack it since it was probably only expecting errors with two args thrown from https://github.com/zaproxy/zaproxy/blob/a36ed3f0706d8ef47d70c7c4bc7f2fbf58551185/build/docker/zap-baseline.py#L406

Functional Test:

```
» ./zap-baseline.py -t https://tigerblood.prod.mozaws.net/ -d
2017-03-31 12:03:39,600 Using port: 49042
2017-03-31 12:03:39,600 Pulling ZAP Weekly Docker image
2017-03-31 12:03:40,113 Starting ZAP
2017-03-31 12:03:40,113 Params: ['docker', 'run', '-u', 'zap', '-p', '49042:49042', '-d', 'owasp/zap2docker-weekly', 'zap-x.sh', '-dae
mon', '-port', '49042', '-host', '0.0.0.0', '-config', 'api.disablekey=true', '-config', 'api.addrs.addr.name=.*', '-config', 'api.add
rs.addr.regex=true', '-config', 'spider.maxDuration=1', '-addonupdate']
2017-03-31 12:03:40,919 Docker CID: bae13b32d3fc0f2faccf253848f1b25b4c934a3ebe11896f61f0eb466656a420
2017-03-31 12:03:40,943 Docker ZAP IP Addr: localhost
2017-03-31 12:03:48,059 ZAP Version D-2017-03-21
2017-03-31 12:03:48,059 Took 7 seconds
2017-03-31 12:03:48,685 Received 401 from https://tigerblood.prod.mozaws.net/
2017-03-31 12:03:50,687 Spider https://tigerblood.prod.mozaws.net/
2017-03-31 12:03:55,719 Spider complete
2017-03-31 12:03:55,725 Records to scan...
2017-03-31 12:03:55,731 Passive scanning complete
Total of 3 URLs
...
```

Note: that I commented out https://github.com/zaproxy/zaproxy/blob/a36ed3f0706d8ef47d70c7c4bc7f2fbf58551185/build/docker/zap-baseline.py#L379 since the baseline it failed to connect otherwise, but I'm not sure if that's an artifact of the OS/docker versions I'm using (`Darwin Kernel Version 15.6.0: Mon Jan  9 23:07:29 PST 2017; root:xnu-3248.60.11.2.1~1/RELEASE_X86_64 x86_64` /  `Docker version 17.03.0-ce, build 60ccb22`).