### PR TITLE
Use current version of API client in Docker images

### DIFF
--- a/build/docker/Dockerfile-live
+++ b/build/docker/Dockerfile-live
@@ -32,8 +32,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	pip install --upgrade pip && \
 	gem install zapr && \
 	pip install zapcli && \
-	# Install latest dev version of the python API
-	pip install https://github.com/zaproxy/zap-api-python/releases/download/0.0.9.dev1/python-owasp-zap-v2.4-0.0.9.dev1.tar.gz && \
+	pip install python-owasp-zap-v2.4 && \
 	useradd -d /home/zap -m -s /bin/bash zap && \ 
 	echo zap:zap | chpasswd && \
 	mkdir /zap  && \

--- a/build/docker/Dockerfile-weekly
+++ b/build/docker/Dockerfile-weekly
@@ -30,8 +30,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 RUN pip install --upgrade pip
 RUN gem install zapr
 RUN pip install zapcli
-# Install latest dev version of the python API
-RUN pip install https://github.com/zaproxy/zap-api-python/releases/download/0.0.9.dev1/python-owasp-zap-v2.4-0.0.9.dev1.tar.gz
+RUN pip install python-owasp-zap-v2.4
 
 RUN useradd -d /home/zap -m -s /bin/bash zap 
 RUN echo zap:zap | chpasswd


### PR DESCRIPTION
Change live and weekly Docker images to use the latest released version
of python-owasp-zap-v2.4 (no longer need to use the older dev version).