### PR TITLE
Expose ZAP's home dir path through the ZAP API

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -979,6 +979,7 @@ core.api.view.proxyChainExcludedDomains = Gets all the domains that are excluded
 core.api.view.version = Gets ZAP version
 core.api.view.excludedFromProxy = Gets the regular expressions, applied to URLs, to exclude from the Proxy
 core.api.view.sessionLocation = Gets the location of the current session file
+core.api.view.zapHomePath = Gets the path to ZAP's home directory.
 
 database.optionspanel.name = Database
 database.optionspanel.option.compact.label = Compact (on exit)

--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -135,6 +135,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 	private static final String VIEW_OPTION_PROXY_CHAIN_SKIP_NAME = "optionProxyChainSkipName";
 	private static final String VIEW_OPTION_PROXY_EXCLUDED_DOMAINS = "optionProxyExcludedDomains";
 	private static final String VIEW_OPTION_PROXY_EXCLUDED_DOMAINS_ENABLED = "optionProxyExcludedDomainsEnabled";
+	private static final String VIEW_ZAP_HOME_PATH = "zapHomePath";
 
 	private static final String OTHER_PROXY_PAC = "proxy.pac";
 	private static final String OTHER_SET_PROXY = "setproxy";
@@ -264,6 +265,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 		apiView = new ApiView(VIEW_OPTION_PROXY_EXCLUDED_DOMAINS_ENABLED);
 		apiView.setDeprecated(true);
 		this.addApiView(apiView);
+		this.addApiView(new ApiView(VIEW_ZAP_HOME_PATH));
 		
 		this.addApiOthers(new ApiOther(OTHER_PROXY_PAC, false));
 		this.addApiOthers(new ApiOther(OTHER_ROOT_CERT, false));
@@ -904,6 +906,8 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 					name,
 					Model.getSingleton().getOptionsParam().getConnectionParam().getProxyExcludedDomains(),
 					true);
+		} else if (VIEW_ZAP_HOME_PATH.equals(name)) {
+			result = new ApiResponseElement(name, Constant.getZapHome());
 		} else {
 			throw new ApiException(ApiException.Type.BAD_VIEW);
 		}


### PR DESCRIPTION
Add core view, "zapHomePath", that exposes ZAP's home dir path (it might
be useful to 3rd party applications/plug-ins for resource deployment or
management).