### PR TITLE
Change API view "contextList" to return a list

### DIFF
--- a/src/org/zaproxy/zap/extension/api/ContextAPI.java
+++ b/src/org/zaproxy/zap/extension/api/ContextAPI.java
@@ -264,12 +264,11 @@ public class ContextAPI extends ApiImplementor {
         	result = new ApiResponseElement(name, getContext(params).getIncludeInContextRegexs().toString());
         	break;
         case VIEW_CONTEXT_LIST:
-        	List<String> contextNames = new ArrayList<>();
-            List<Context> contexts = Model.getSingleton().getSession().getContexts();
-            for (Context context : contexts){
-                contextNames.add(context.getName());
+            resultList = new ApiResponseList(name);
+            for (Context context : Model.getSingleton().getSession().getContexts()){
+                resultList.addItem(new ApiResponseElement(CONTEXT_NAME, context.getName()));
             }
-            result = new ApiResponseElement(name, contextNames.toString());
+            result = resultList;
             break;
         case VIEW_CONTEXT:
         	result = new ApiResponseElement(buildResponseFromContext(getContext(params)));


### PR DESCRIPTION
Change class ContextAPI to return the context names in a list, not all
names in a single string.

The data returned is now, for example:
```JSON
{"contextList":["Context 1","Context 2"]}
```
and:
```XML
<contextList type="list">
    <contextName>Context 1</contextName>
    <contextName>Context 2</contextName>
</contextList>
```

instead of:
```JSON
{"contextList":"[Context 1, Context 2]"}
```
and:
```XML
<contextList>[Context 1, Context 2]</contextList>
```

This change breaks existing consumers that extract the names from the
string.

Fix #3353 - ZAP API View:contextList method returns a string instead of
JSON list