### PR TITLE
Change Sites tree renderer to use L&F colours

### DIFF
--- a/src/org/zaproxy/zap/view/SiteMapTreeCellRenderer.java
+++ b/src/org/zaproxy/zap/view/SiteMapTreeCellRenderer.java
@@ -144,11 +144,7 @@ public class SiteMapTreeCellRenderer extends DefaultTreeCellRenderer {
 				}
 				
 			}
-			if (sel) {
-				component.add(wrap(node.toString(), Color.WHITE));
-			} else {
-				component.add(wrap(node.toString()));
-			}
+			component.add(wrap(node.toString(), sel ? getTextSelectionColor() : getTextNonSelectionColor()));
 
 	        for (SiteMapListener listener : listeners) {
 	        	listener.onReturnNodeRendererComponent(this, leaf, node);


### PR DESCRIPTION
Change SiteMapTreeCellRenderer to use the colours of current L&F for
foreground colour of the text.

Fix #3351 - the url disappear when i click it