### PR TITLE
Allow esc to close AbstractFormDialog

### DIFF
--- a/src/org/zaproxy/zap/view/AbstractFormDialog.java
+++ b/src/org/zaproxy/zap/view/AbstractFormDialog.java
@@ -27,13 +27,17 @@ import java.awt.Rectangle;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
 
+import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
+import javax.swing.KeyStroke;
 
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
@@ -84,6 +88,20 @@ public abstract class AbstractFormDialog extends JDialog {
 		if (initView) {
 			initView();
 		}
+		
+		// Handle escape key to close the dialog
+		KeyStroke escape = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0, false);
+		AbstractAction escapeAction = new AbstractAction() {
+
+			private static final long serialVersionUID = -8088438488574461587L;
+			
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				clearAndHide();
+			}
+		};
+		getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(escape, "ESCAPE");
+		getRootPane().getActionMap().put("ESCAPE", escapeAction);
 	}
 
 	protected void initView() {


### PR DESCRIPTION
Add handling to AbstractFormDialog so that they can be closed with the escape key.

(For example when adding Global Exclude URLs)