### PR TITLE
Do not uninstall a file if it no longer exists

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnInstaller.java
+++ b/src/org/zaproxy/zap/control/AddOnInstaller.java
@@ -415,7 +415,7 @@ public final class AddOnInstaller {
             File file = new File(Constant.getZapHome(), name);
             try {
                 File parent = file.getParentFile();
-                if (!file.delete()) {
+                if (file.exists() && !file.delete()) {
                     logger.error("Failed to delete: " + file.getAbsolutePath());
                     uninstalledWithoutErrors = false;
                 }


### PR DESCRIPTION
Change AddOnInstaller to check if the files declared by the add-on exist
before attempting to uninstall/delete them. Prevents errors like:
 Failed to dynamically uninstall add-on Zest version 23
 Failed to delete: ZAP/jbrofuzz/fuzzers.jbrf

which can happen when two add-ons declare/use the same file and both of
them are uninstalled (the first uninstallation successfully deletes the
file, the following one fails, since the file no longer exists).