### PR TITLE
Increase limit of global script variables' value

### DIFF
--- a/src/org/zaproxy/zap/extension/script/ScriptVars.java
+++ b/src/org/zaproxy/zap/extension/script/ScriptVars.java
@@ -28,7 +28,7 @@ import javax.script.ScriptContext;
 public class ScriptVars {
 	
 	private static int MAX_KEY_SIZE = 30;
-	private static int MAX_VALUE_SIZE = 1024;
+	private static int MAX_VALUE_SIZE = 1024*1024;
 	private static int MAX_SCRIPT_VARS = 20;
 	private static int MAX_GLOBAL_VARS = 50;
 


### PR DESCRIPTION
It is unreasonable limitation of 1K for global script variable value. Let's make it 1M