### PR TITLE
Add new Default CSRF Token for OWASP CSRF Guard

### DIFF
--- a/src/org/zaproxy/zap/extension/anticsrf/AntiCsrfParam.java
+++ b/src/org/zaproxy/zap/extension/anticsrf/AntiCsrfParam.java
@@ -43,7 +43,7 @@ public class AntiCsrfParam extends AbstractParam {
     private static final String CONFIRM_REMOVE_TOKEN_KEY = ANTI_CSRF_BASE_KEY + ".confirmRemoveToken";
     
     private static final String[] DEFAULT_TOKENS_NAMES = { "anticsrf",
-            "CSRFToken", "__RequestVerificationToken", "csrfmiddlewaretoken", "authenticity_token" };
+            "CSRFToken", "__RequestVerificationToken", "csrfmiddlewaretoken", "authenticity_token", "OWASP_CSRFTOKEN" };
 
     private List<AntiCsrfParamToken> tokens = null;
     private List<String> enabledTokensNames = null;


### PR DESCRIPTION
Added "OWASP_CSRFTOKEN" which is covered in a bunch of CSRFGuard
documentation, and all over the place online (use in wild, write-ups on
blogs, code examples, etc).