### PR TITLE
Use MouseAdapter instead of MouseListener

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/PolicyManagerDialog.java
+++ b/src/org/zaproxy/zap/extension/ascan/PolicyManagerDialog.java
@@ -23,8 +23,8 @@ import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -276,10 +276,7 @@ public class PolicyManagerDialog extends StandardFieldsDialog {
         if (paramsTable == null) {
             paramsTable = new JTable();
             paramsTable.setModel(getParamsModel());
-            paramsTable.addMouseListener(new MouseListener() {
-                @Override
-                public void mouseClicked(MouseEvent e) {
-                }
+            paramsTable.addMouseListener(new MouseAdapter() {
 
                 @Override
                 public void mousePressed(MouseEvent e) {
@@ -296,18 +293,6 @@ public class PolicyManagerDialog extends StandardFieldsDialog {
                             }
                         }
                     }
-                }
-
-                @Override
-                public void mouseReleased(MouseEvent e) {
-                }
-
-                @Override
-                public void mouseEntered(MouseEvent e) {
-                }
-
-                @Override
-                public void mouseExited(MouseEvent e) {
                 }
             });
             paramsTable.getSelectionModel().addListSelectionListener(new ListSelectionListener() {

--- a/src/org/zaproxy/zap/view/JCheckBoxTree.java
+++ b/src/org/zaproxy/zap/view/JCheckBoxTree.java
@@ -3,8 +3,8 @@ package org.zaproxy.zap.view;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
 import java.util.EventListener;
 import java.util.EventObject;
 import java.util.HashMap;
@@ -211,7 +211,7 @@ public class JCheckBoxTree extends JTree {
             }
         };
         // Calling checking mechanism on mouse click
-        this.addMouseListener(new MouseListener() {
+        this.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent arg0) {
                 TreePath tp = JCheckBoxTree.this.getPathForLocation(arg0.getX(), arg0.getY());
@@ -228,18 +228,6 @@ public class JCheckBoxTree extends JTree {
                 fireCheckChangeEvent(new CheckChangeEvent(new Object()));
                 // Repainting tree after the data structures were updated
                 JCheckBoxTree.this.repaint();                          
-            }           
-            @Override
-            public void mouseEntered(MouseEvent arg0) {         
-            }           
-            @Override
-            public void mouseExited(MouseEvent arg0) {              
-            }
-            @Override
-            public void mousePressed(MouseEvent arg0) {             
-            }
-            @Override
-            public void mouseReleased(MouseEvent arg0) {
             }           
         });
         this.setSelectionModel(dtsm);


### PR DESCRIPTION
Change PolicyManagerDialog and JCheckBoxTree to use a MouseAdapter to
handle mouse events, which allows to override just the required methods.