### PR TITLE
Correct notification of row updates

### DIFF
--- a/src/org/zaproxy/zap/extension/ext/OptionsExtensionPanel.java
+++ b/src/org/zaproxy/zap/extension/ext/OptionsExtensionPanel.java
@@ -120,7 +120,7 @@ public class OptionsExtensionPanel extends AbstractParamPanel {
 		for (Extension ext : exts) {
 			ext.setEnabled(extParam.isExtensionEnabled(ext.getName()));
 		}
-    	extensionModel.fireTableRowsUpdated(0, extensionModel.getRowCount());
+    	extensionModel.fireTableRowsUpdated(0, extensionModel.getRowCount() - 1);
     }
 
 

--- a/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanTableModel.java
+++ b/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanTableModel.java
@@ -76,19 +76,27 @@ public class PolicyPassiveScanTableModel extends DefaultTableModel {
     }
     
     public void applyThreshold(AlertThreshold threshold, String quality) {
+        if (listScanners.isEmpty()) {
+            return;
+        }
+
     	for (ScannerWrapper ss : this.listScanners) {
     		if (quality.equals(ss.getQuality().toString())) {
     			ss.setThreshold(threshold);
     		}
     	}
-    	this.fireTableRowsUpdated(0, getRowCount());
+    	this.fireTableRowsUpdated(0, getRowCount() - 1);
     }
 
     public void applyThresholdToAll(AlertThreshold threshold) {
+        if (listScanners.isEmpty()) {
+            return;
+        }
+
     	for (ScannerWrapper ss : this.listScanners) {
    			ss.setThreshold(threshold);
     	}
-    	this.fireTableRowsUpdated(0, getRowCount());
+    	this.fireTableRowsUpdated(0, getRowCount() - 1);
     }
 
     /**


### PR DESCRIPTION
Change OptionsExtensionPanel and PolicyPassiveScanTableModel to use the
proper (last) row index when notifying of row changes. For the latter
class fixing an exception (IndexOutOfBoundsException: Invalid range),
throw when changing the alert threshold of the passive scanners and
resetting the options.