### PR TITLE
Improve error handling when resetting the options

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1653,8 +1653,9 @@ options.dialog.rootName = Options
 options.dialog.reset.button = Reset to Factory Defaults 
 options.dialog.reset.warn = Are you sure you want to reset all of the options?\n\
 This takes effect immediately and cannot be undone!
-options.dialog.reset.error = Failed to reset the options :\n {0}
-options.dialog.save.error = Failed to save the options :\n {0}
+options.dialog.reset.error = Failed to reset the options:\n{0}
+options.dialog.reset.error.panel = Failed to reset {0} options panel:\n{1}
+options.dialog.save.error = Failed to save the options:\n{0}
 options.name = Options Extension
 options.ext.button.openurl            = Open Homepage in Browser
 options.ext.label.author              = Author


### PR DESCRIPTION
Change OptionsDialog to catch the exceptions thrown when resetting each
panel, and inform the user in that case. Also, changed to log the
exceptions (as error), necessary to easily resolve the issue(s) that
might occur during reset.
Remove extra/unnecessary spaces from the errors messages related to
reset and validation of the options.