### PR TITLE
Cancel form/standard dialogues on window closing

### DIFF
--- a/src/org/zaproxy/zap/view/AbstractFormDialog.java
+++ b/src/org/zaproxy/zap/view/AbstractFormDialog.java
@@ -28,6 +28,8 @@ import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 
 import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
@@ -84,6 +86,15 @@ public abstract class AbstractFormDialog extends JDialog {
 	}
 
 	private void initialise(boolean initView) {
+		setDefaultCloseOperation(javax.swing.WindowConstants.DO_NOTHING_ON_CLOSE);
+		addWindowListener(new WindowAdapter() {
+
+			@Override
+			public void windowClosing(WindowEvent e) {
+				clearAndHide();
+			}
+		});
+
 		firstTime = true;
 		if (initView) {
 			initView();

--- a/src/org/zaproxy/zap/view/StandardFieldsDialog.java
+++ b/src/org/zaproxy/zap/view/StandardFieldsDialog.java
@@ -30,6 +30,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -174,6 +176,7 @@ public abstract class StandardFieldsDialog extends AbstractDialog {
 	 */
 	public StandardFieldsDialog(Window owner, String titleLabel, Dimension dim, String[] tabLabels, boolean modal) {
 		super(owner, modal);
+		this.setDefaultCloseOperation(javax.swing.WindowConstants.DO_NOTHING_ON_CLOSE);
 		this.setTitle(Constant.messages.getString(titleLabel));
 		this.setXWeights(0.4D, 0.6D);	// Looks a bit better..
 		this.initialize(dim, tabLabels);
@@ -217,6 +220,14 @@ public abstract class StandardFieldsDialog extends AbstractDialog {
 		} else {
 			this.initializeTabbed(dim, tabLabels);
 		}
+
+		addWindowListener(new WindowAdapter() {
+
+			@Override
+			public void windowClosing(WindowEvent e) {
+				handleCloseAction();
+			}
+		});
 		
         //  Handle escape key to close the dialog    
         KeyStroke escape = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0, false);
@@ -225,16 +236,20 @@ public abstract class StandardFieldsDialog extends AbstractDialog {
 
 			@Override
             public void actionPerformed(ActionEvent e) {
-				if (hasCancelSaveButtons()) {
-					cancelPressed();
-					return;
-				}
-
-				savePressed();
+				handleCloseAction();
             }
         };
         getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(escape, "ESCAPE");
         getRootPane().getActionMap().put("ESCAPE",escapeAction);
+	}
+
+	private void handleCloseAction() {
+		if (hasCancelSaveButtons()) {
+			cancelPressed();
+			return;
+		}
+
+		savePressed();
 	}
 
 	public void setXWeights(double labelWeight, double fieldWeight) {
@@ -392,7 +407,10 @@ public abstract class StandardFieldsDialog extends AbstractDialog {
 	}
 	
 	/**
-	 * Gets called when the cancel button is pressed - override to do anything other than just close the window
+	 * Called when the dialogue is cancelled (if it {@link #hasCancelSaveButtons() has a cancel/save button}), for example,
+	 * Cancel button is pressed or the dialogue is closed through the window decorations.
+	 * <p>
+	 * Hides the dialogue by default.
 	 */
 	public void cancelPressed() {
 		setVisible(false);


### PR DESCRIPTION
Change AbstractFormDialog and StandardFieldsDialog to "cancel" the
dialogues when closed through the window decorations, instead of just
hiding/disposing the window. The concrete classes might do additional
clean up when closed (they already do when cancelled with the cancel
buttons).