### PR TITLE
Do not allow to choose just SSLv2Hello

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1156,6 +1156,7 @@ generic.options.panel.security.protocols.tlsv1.1.label = TLS 1.1
 generic.options.panel.security.protocols.tlsv1.2.label = TLS 1.2
 generic.options.panel.security.protocols.protocol.not.supported.tooltip = Protocol not supported by JRE
 generic.options.panel.security.protocols.error.no.protocols.selected = You must select at least one security protocol.
+generic.options.panel.security.protocols.error.just.sslv2hello.selected = SSLv2Hello must be selected in conjunction with other security protocols.
 generic.value.disabled	= Disabled
 generic.value.text.separator.comma = {0}, {1}
 generic.value.time.duration.value.unit = {0} {1}

--- a/src/org/parosproxy/paros/extension/option/SecurityProtocolsPanel.java
+++ b/src/org/parosproxy/paros/extension/option/SecurityProtocolsPanel.java
@@ -122,8 +122,8 @@ public class SecurityProtocolsPanel extends JPanel {
         }
     }
 
-    public void validateSecurityProtocols() throws Exception {
-        boolean protocolsSelected = false;
+    public void validateSecurityProtocols() {
+        int protocolsSelected = 0;
         JCheckBox checkBoxEnabledProtocol = null;
         for (Entry<String, JCheckBox> entry : checkBoxesSslTlsProtocols.entrySet()) {
             JCheckBox checkBox = entry.getValue();
@@ -132,16 +132,27 @@ public class SecurityProtocolsPanel extends JPanel {
                     checkBoxEnabledProtocol = checkBox;
                 }
                 if (checkBox.isSelected()) {
-                    protocolsSelected = true;
-                    break;
+                    protocolsSelected++;
+                    if (protocolsSelected > 1) {
+                        break;
+                    }
                 }
             }
         }
 
-        if (checkBoxEnabledProtocol != null && !protocolsSelected) {
-            checkBoxEnabledProtocol.requestFocusInWindow();
-            throw new Exception(
-                    Constant.messages.getString("generic.options.panel.security.protocols.error.no.protocols.selected"));
+        if (checkBoxEnabledProtocol != null) {
+            if (protocolsSelected == 0) {
+                checkBoxEnabledProtocol.requestFocusInWindow();
+                throw new IllegalArgumentException(
+                        Constant.messages.getString("generic.options.panel.security.protocols.error.no.protocols.selected"));
+            }
+
+            if (protocolsSelected == 1
+                    && checkBoxesSslTlsProtocols.get(SSLConnector.SECURITY_PROTOCOL_SSL_V2_HELLO).isSelected()) {
+                checkBoxEnabledProtocol.requestFocusInWindow();
+                throw new IllegalArgumentException(
+                        Constant.messages.getString("generic.options.panel.security.protocols.error.just.sslv2hello.selected"));
+            }
         }
     }
 

--- a/src/org/parosproxy/paros/network/SSLConnector.java
+++ b/src/org/parosproxy/paros/network/SSLConnector.java
@@ -30,6 +30,7 @@
 // ZAP: 2014/08/14 Issue 1274: ZAP Error [javax.net.ssl.SSLException]: Unsupported record version SSLv2Hello
 // ZAP: 2014/10/28 Issue 1390: Force https on cfu call
 // ZAP: 2015/10/13 Issue 1975: Allow use of default disabled cipher suites (such as RC4-SHA)
+// ZAP: 2017/04/14 Validate that SSLv2Hello is set in conjunction with at least one SSL/TLS version.
 
 package org.parosproxy.paros.network;
 
@@ -252,6 +253,16 @@ public class SSLConnector implements SecureProtocolSocketFactory {
 				"Method no longer supported since it's no longer required/called by Commons HttpClient library (version >= 3.0).");
 	}
 
+	/**
+	 * Gets the SSL/TLS versions that can be safely used (known to be supported by the JRE).
+	 *
+	 * @return the SSL/TLS versions that can be safely used.
+	 * @since TODO add version
+	 */
+	public static String[] getFailSafeProtocols() {
+		return Arrays.copyOf(FAIL_SAFE_DEFAULT_ENABLED_PROTOCOLS, FAIL_SAFE_DEFAULT_ENABLED_PROTOCOLS.length);
+	}
+
 	public static String[] getSupportedProtocols() {
 		if (supportedProtocols == null) {
 			readSupportedProtocols(null);
@@ -328,6 +339,10 @@ public class SSLConnector implements SecureProtocolSocketFactory {
 
 		if (enabledSupportedProtocols.isEmpty()) {
 			throw new IllegalArgumentException("No supported protocol(s) set.");
+		}
+
+		if (enabledSupportedProtocols.size() == 1 && enabledSupportedProtocols.contains(SECURITY_PROTOCOL_SSL_V2_HELLO)) {
+			throw new IllegalArgumentException("Only SSLv2Hello set, must have at least one SSL/TLS version enabled.");
 		}
 
 		String[] extractedSupportedProtocols = new String[enabledSupportedProtocols.size()];


### PR DESCRIPTION
Change SecurityProtocolsPanel and SSLConnector to validate that
SSLv2Hello is set in conjunction with at least one SSL/TLS version.
Otherwise it would lead to an exception when receiving/starting the
connections.
Change ConnectionParam and ProxyParam to validate that the SSL/TLS
versions persisted can be set/used, falling back to default versions if
not.