### PR TITLE
Clear cached certs when setting Root CA cert

### DIFF
--- a/src/org/parosproxy/paros/security/CachedSslCertifificateServiceImpl.java
+++ b/src/org/parosproxy/paros/security/CachedSslCertifificateServiceImpl.java
@@ -71,8 +71,9 @@ public final class CachedSslCertifificateServiceImpl implements SslCertificateSe
 	}
 
 	@Override
-	public void initializeRootCA(KeyStore keystore) throws KeyStoreException,
+	public synchronized void initializeRootCA(KeyStore keystore) throws KeyStoreException,
 			UnrecoverableKeyException, NoSuchAlgorithmException {
+		this.cache.clear();
 		this.delegate.initializeRootCA(keystore);
 	}
 

--- a/src/org/zaproxy/zap/extension/dynssl/ExtensionDynSSL.java
+++ b/src/org/zaproxy/zap/extension/dynssl/ExtensionDynSSL.java
@@ -33,8 +33,8 @@ import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.security.CachedSslCertifificateServiceImpl;
 import org.parosproxy.paros.security.SslCertificateService;
-import org.parosproxy.paros.security.SslCertificateServiceImpl;
 import org.parosproxy.paros.view.View;
 
 /**
@@ -135,7 +135,7 @@ public class ExtensionDynSSL extends ExtensionAdaptor {
 	}
 
 	public void setRootCa(KeyStore rootca) throws UnrecoverableKeyException, KeyStoreException, NoSuchAlgorithmException {
-		SslCertificateServiceImpl.getService().initializeRootCA(rootca);
+		CachedSslCertifificateServiceImpl.getService().initializeRootCA(rootca);
 	}
 	
 	public Certificate getRootCA() throws KeyStoreException {


### PR DESCRIPTION
Change CachedSslCertifificateServiceImpl to clear the certificates cache
when a new Root CA certificate is set, to ensure that it's used the new
Root CA cert for issuing the (new) certs. Also, sync when the Root CA
cert is set to avoid concurrency issues.
Change ExtensionDynSSL to set the cert through the previously mentioned
class, to ensure the cache is cleared.