### PR TITLE
Warn about expired Root CA certificate

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1039,6 +1039,7 @@ dynssl.options.name              = Dynamic SSL Certificates
 dynssl.text.createnow            = Go to options panel and create certificate now.
 dynssl.text.notnow               = Not now, but create certificate later.
 dynssl.text.sslwontwork          = SSL won't work if you haven't created and imported an OWASP ZAP CA root certificate. You can create such a certificate any time in the options menu, so you do not have to create it right now.
+dynssl.warn.cert.expired = ZAPs Root CA certificate has expired as of {0} (now: {1}).\nYou should regenerate it and re-install it in your browsers.
 
 edit.find.button.cancel = Cancel
 edit.find.button.find   = Find


### PR DESCRIPTION
Modified ExtensionDynSSL adding methods (`getRootCaCertificate()`, `isCertExpired()`, `warnRootCaCertExpired()`) and handling leveraging those methods to check and handle the expiration status of ZAPs Root CA certificate on startup.

Fixes zaproxy/zaproxy#2411