### PR TITLE
Issue 1681 Active Scan Messages FIFO

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/ActiveScan.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScan.java
@@ -262,32 +262,35 @@ public class ActiveScan extends org.parosproxy.paros.core.scanner.Scanner implem
 		}
 		
 		this.rcTotals.incResponseCodeCount(msg.getResponseHeader().getStatusCode());
-		
-        if (hRef != null && this.rcTotals.getTotal() <= this.maxResultsToList) {
-            // Very large lists significantly impact the UI responsiveness
-            // limiting them makes large scans _much_ quicker
-        	addHistoryReference(hRef);
-    	}
+
+		if (hRef != null && View.isInitialised()) {
+			// Very large lists significantly impact the UI responsiveness
+			// limiting them makes large scans _much_ quicker
+			if (this.rcTotals.getTotal() > this.maxResultsToList) {
+				removeFirstHistoryReferenceInEdt();
+			}
+			addHistoryReferenceInEdt(hRef);
+		}
 	}
 
-    private void addHistoryReference(HistoryReference hRef) {
-        if (View.isInitialised()) {
-            addHistoryReferenceInEdt(hRef);
-        }
+	private void addHistoryReferenceInEdt(final HistoryReference hRef) {
+		EventQueue.invokeLater(new Runnable() {
+
+			@Override
+			public void run() {
+				messagesTableModel.addHistoryReference(hRef);
+			}
+		});
 	}
 
-    private void addHistoryReferenceInEdt(final HistoryReference hRef) {
-        if (EventQueue.isDispatchThread()) {
-            messagesTableModel.addHistoryReference(hRef);
-        } else {
-            EventQueue.invokeLater(new Runnable() {
+	private void removeFirstHistoryReferenceInEdt() {
+		EventQueue.invokeLater(new Runnable() {
 
-                @Override
-                public void run() {
-                    addHistoryReference(hRef);
-                }
-            });
-        }
+			@Override
+			public void run() {
+				messagesTableModel.removeHistoryReference(getMessagesTableModel().getEntry(0).getHistoryReference());
+			}
+		});
 	}
 	
 	@Override

--- a/src/org/zaproxy/zap/view/table/DefaultHistoryReferencesTableModel.java
+++ b/src/org/zaproxy/zap/view/table/DefaultHistoryReferencesTableModel.java
@@ -247,6 +247,23 @@ public class DefaultHistoryReferencesTableModel extends AbstractHistoryReference
     }
 
     /**
+     * Convenience method that removes a {@code DefaultHistoryReferencesTableEntry} with the given history reference
+     * from the model. If the provided {@code HistoryReference} is {@code null} the function will return without having 
+     * done anything.
+     * 
+     * @param historyReference the history reference that will be removed from the model
+     * @see DefaultHistoryReferencesTableEntry
+     * @see HistoryReference
+     * @since TODO Add Version
+     */
+    public void removeHistoryReference(HistoryReference historyReference) {
+        if (historyReference== null) {
+        	return;
+        }
+        removeEntry(historyReference.getHistoryId());
+    }
+    
+    /**
      * Returns the history reference with the give ID. If the history reference is not found {@code null} is returned.
      * 
      * @param historyReferenceId the ID of the history reference that will be searched


### PR DESCRIPTION
Modify ActiveScan so that if the results messages table contains the maximum results the first row is removed then a new row is added.

Add convenience method `removeHistoryReference` to `DefaultHistoryReferencesTableModel`.

Fixes zaproxy/zaproxy#1681