### PR TITLE
Remove unused imports

### DIFF
--- a/src/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
@@ -59,7 +59,6 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.view.AbstractParamPanel;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.ZapTextField;
 
 import ch.csnc.extension.httpclient.PKCS11Configuration;

--- a/src/org/zaproxy/zap/extension/history/PopupMenuExportContextURLs.java
+++ b/src/org/zaproxy/zap/extension/history/PopupMenuExportContextURLs.java
@@ -27,7 +27,6 @@ import java.util.TreeSet;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.HistoryReference;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.SiteMapPanel;
 import org.parosproxy.paros.view.View;


### PR DESCRIPTION
Remove unused imports in OptionsCertificatePanel and
PopupMenuExportContextURLs.