### PR TITLE
Use renderer's label in Sites tree

### DIFF
--- a/src/org/zaproxy/zap/view/SiteMapTreeCellRenderer.java
+++ b/src/org/zaproxy/zap/view/SiteMapTreeCellRenderer.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.view;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
@@ -144,7 +143,9 @@ public class SiteMapTreeCellRenderer extends DefaultTreeCellRenderer {
 				}
 				
 			}
-			component.add(wrap(node.toString(), sel ? getTextSelectionColor() : getTextNonSelectionColor()));
+			setText(node.toString());
+			setIcon(null);
+			component.add(this);
 
 	        for (SiteMapListener listener : listeners) {
 	        	listener.onReturnNodeRendererComponent(this, leaf, node);
@@ -155,19 +156,6 @@ public class SiteMapTreeCellRenderer extends DefaultTreeCellRenderer {
 		return this;
 	}
 	
-    private JLabel wrap (String str) {
-        JLabel label = new JLabel(str);
-        label.setOpaque(false);
-        label.putClientProperty("html.disable", Boolean.TRUE);
-        return label;
-    }
-	
-    private JLabel wrap (String str, Color color) {
-        JLabel label = wrap(str);
-        label.setForeground(color);
-        return label;
-    }
-    
     private JLabel wrap (ImageIcon icon) {
         JLabel label = new JLabel(icon);
         label.setOpaque(false);


### PR DESCRIPTION
Change SiteMapTreeCellRenderer to use/add the renderer's label, it
already has and paints the expected colours for fore and background.

Fix #3351 - the url disappear when i click it