### PR TITLE
Do not re-add the panel when changing visibility

### DIFF
--- a/src/org/zaproxy/zap/view/StandardFieldsDialog.java
+++ b/src/org/zaproxy/zap/view/StandardFieldsDialog.java
@@ -1657,7 +1657,6 @@ public abstract class StandardFieldsDialog extends AbstractDialog {
 				String name = Constant.messages.getString(label);
 				JPanel tabPanel = this.tabNameMap.get(label);
 				tabbedPane.addTab(name, tabPanel);
-				this.tabPanels.add(tabPanel);
 			}
     	} else {
 			for (String label : tabLabels) {


### PR DESCRIPTION
Change StandardFieldsDialog to not re-add the panels when changing its
visibility.