### PR TITLE
Allow to set a tab scrollable in std dialogue

### DIFF
--- a/src/org/zaproxy/zap/extension/spider/SpiderDialog.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderDialog.java
@@ -177,6 +177,8 @@ public class SpiderDialog extends StandardFieldsDialog {
         	this.setAdvancedTabs(false);
         }
         
+        setTabScrollable("spider.custom.tab.adv", true);
+
         this.pack();
     }
     

--- a/src/org/zaproxy/zap/view/StandardFieldsDialog.java
+++ b/src/org/zaproxy/zap/view/StandardFieldsDialog.java
@@ -86,7 +86,23 @@ public abstract class StandardFieldsDialog extends AbstractDialog {
 	private JPanel mainPanel = null;
 	private List<JPanel> tabPanels = null;
 	private List<Integer> tabOffsets = null;
+
+	/**
+	 * The component used when showing the panels in tabs.
+	 * 
+	 * @see #getTabComponent(JPanel)
+	 * @see #panelToScrollPaneMap
+	 */
 	private JTabbedPane tabbedPane = null;
+
+	/**
+	 * The map that contains the {@code JScrollPane}s of the tabs ({@code JPanel}s) that were
+	 * {@link #setTabScrollable(String, boolean) set as scrollable}.
+	 * 
+	 * @see #getTabComponent(JPanel)
+	 * @see #tabbedPane
+	 */
+	private Map<JPanel, JScrollPane> panelToScrollPaneMap;
 	
 	private double labelWeight = 0;
 	private double fieldWeight = 1.0D;
@@ -269,6 +285,7 @@ public abstract class StandardFieldsDialog extends AbstractDialog {
 		this.setContentPane(contentPanel);
 		
 		tabbedPane = new JTabbedPane();
+		panelToScrollPaneMap = new HashMap<>();
 
 		initContentPanel(contentPanel, tabbedPane, getExtraButtons(), getHelpIndex());
 
@@ -1642,7 +1659,25 @@ public abstract class StandardFieldsDialog extends AbstractDialog {
 		if (tabIndex < 0 || tabIndex >= this.tabPanels.size()) {
 			throw new IllegalArgumentException("Invalid tab index: " + tabIndex);
 		}
-		tabbedPane.setSelectedComponent(this.tabPanels.get(tabIndex));
+		tabbedPane.setSelectedComponent(getTabComponent(this.tabPanels.get(tabIndex)));
+	}
+
+	/**
+	 * Gets the actual component added to a tab for the given panel.
+	 * <p>
+	 * Allows to transparently handle the cases where a {@link #setTabScrollable(String, boolean) tab was set scrollable}, so
+	 * the actual component added is a {@link JScrollPane} not the panel itself. This method should be used, always, when
+	 * managing the components of the {@link #tabbedPane}.
+	 *
+	 * @param panel the panel whose actual component will be returned.
+	 * @return the actual component added to the tab.
+	 */
+	private JComponent getTabComponent(JPanel panel) {
+		JScrollPane scrollPane = panelToScrollPaneMap.get(panel);
+		if (scrollPane != null) {
+			return scrollPane;
+		}
+		return panel;
 	}
 
 	/**
@@ -1656,14 +1691,118 @@ public abstract class StandardFieldsDialog extends AbstractDialog {
 			for (String label : tabLabels) {
 				String name = Constant.messages.getString(label);
 				JPanel tabPanel = this.tabNameMap.get(label);
-				tabbedPane.addTab(name, tabPanel);
+				tabbedPane.addTab(name, getTabComponent(tabPanel));
 			}
     	} else {
 			for (String label : tabLabels) {
 				JPanel tabPanel = this.tabNameMap.get(label);
-				this.tabbedPane.remove(tabPanel);
+				this.tabbedPane.remove(getTabComponent(tabPanel));
 			}
     	}
+	}
+
+	/**
+	 * Sets whether or not the tab with given label should be scrollable (that is, added to a {@link JScrollPane}).
+	 * <p>
+	 * <strong>Note:</strong> The scrollable state of the tabs should be changed only to non-custom panels, or to custom panels,
+	 * set through {@link #setCustomTabPanel(int, JComponent)}, if they are not already scrollable (otherwise it might happen
+	 * that the contents of the panel have two scroll bars).
+	 *
+	 * @param tabLabel the label of the tab, as set during construction of the dialogue.
+	 * @param scrollable {@code true} if the tab should be scrollable, {@code false} otherwise.
+	 * @since TODO add version
+	 * @see #createTabScrollable(String, JPanel)
+	 * @see #isTabScrollable(String)
+	 */
+	protected void setTabScrollable(String tabLabel, boolean scrollable) {
+		JPanel tabPanel = this.tabNameMap.get(tabLabel);
+		if (tabPanel == null) {
+			return;
+		}
+
+		if (scrollable) {
+			if (isTabScrollable(tabPanel)) {
+				return;
+			}
+
+			String title = Constant.messages.getString(tabLabel);
+			int tabIndex = tabbedPane.indexOfTab(title);
+			boolean selected = tabbedPane.getSelectedIndex() == tabIndex;
+
+			JScrollPane scrollPane = createTabScrollable(tabLabel, tabPanel);
+			if (scrollPane == null) {
+				return;
+			}
+			panelToScrollPaneMap.put(tabPanel, scrollPane);
+
+			if (tabIndex == -1) {
+				return;
+			}
+
+			tabbedPane.insertTab(title, null, scrollPane, null, tabIndex);
+			if (selected) {
+				tabbedPane.setSelectedIndex(tabIndex);
+			}
+			return;
+		}
+
+		if (!isTabScrollable(tabPanel)) {
+			return;
+		}
+
+		String title = Constant.messages.getString(tabLabel);
+		int tabIndex = tabbedPane.indexOfTab(title);
+		tabbedPane.insertTab(title, null, tabPanel, null, tabIndex);
+		tabbedPane.removeTabAt(tabIndex + 1);
+		panelToScrollPaneMap.remove(tabPanel);
+	}
+
+	/**
+	 * Tells whether or not the given panel is scrollable.
+	 * <p>
+	 * <strong>Note:</strong> The scrollable state returned by this mehtod only applies to tabs that were set to be (or not)
+	 * scrollable through the method {@link #setTabScrollable(String, boolean)}, not to "panels" added directly to a tab with
+	 * {@link #setCustomTabPanel(int, JComponent)}.
+	 *
+	 * @param tabPanel the panel to check.
+	 * @return {@code true} if the tab is scrollable, {@code false} otherwise.
+	 */
+	private boolean isTabScrollable(JPanel tabPanel) {
+		return panelToScrollPaneMap.containsKey(tabPanel);
+	}
+
+	/**
+	 * Tells whether or not the tab with the given label is scrollable.
+	 * <p>
+	 * <strong>Note:</strong> The scrollable state returned by this mehtod only applies to tabs that were set to be (or not)
+	 * scrollable through the method {@link #setTabScrollable(String, boolean)}, not to "panels" added directly to a tab with
+	 * {@link #setCustomTabPanel(int, JComponent)}.
+	 * 
+	 * @param tabLabel the label of the tab to check.
+	 * @return {@code true} if the tab is scrollable, {@code false} otherwise.
+	 * @since TODO add version
+	 */
+	protected boolean isTabScrollable(String tabLabel) {
+		JPanel tabPanel = this.tabNameMap.get(tabLabel);
+		if (tabPanel == null) {
+			return false;
+		}
+		return isTabScrollable(tabPanel);
+	}
+
+	/**
+	 * Creates and returns a {@link JScrollPane} for the given panel. Called when a tab is
+	 * {@link #setTabScrollable(String, boolean) set to be scrollable}.
+	 * <p>
+	 * By default this method returns a {@code JScrollPane} that has the vertical and horizontal scrollbars shown as needed.
+	 *
+	 * @param tabLabel the label of the tab, as set during construction of the dialogue.
+	 * @param tabPanel the panel of the tab that should be scrollable, never {@code null}.
+	 * @return the JScrollPane
+	 * @since TODO add version
+	 */
+	protected JScrollPane createTabScrollable(String tabLabel, JPanel tabPanel) {
+		return new JScrollPane(tabPanel, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED, JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
 	}
 
 	/**


### PR DESCRIPTION
Change StandardFieldsDialog to allow to set a tab/panel scrollable, to
properly show all the fields (that is, by giving an indication with the
scrollbar that a field is hidden, partially or totally).
Change SpiderDialog to set the Advanced tab as scrollable (needed
because the tab is showing more options).

---
Related to #3197.