### PR TITLE
Test pre-release identifier in version

### DIFF
--- a/test/org/zaproxy/zap/VersionUnitTest.java
+++ b/test/org/zaproxy/zap/VersionUnitTest.java
@@ -81,6 +81,15 @@ public class VersionUnitTest {
     }
 
     @Test
+    public void shouldAcceptVersionWithPreReleaseIdentifier() {
+        // Given
+        String versionWithPreReleaseIdentifiers = "1.2.3-SNAPSHOT";
+        // When
+        new Version(versionWithPreReleaseIdentifiers);
+        // Then = no exception
+    }
+
+    @Test
     public void shouldReturnTrueWhenEqualingToTheSameVersionNumber() {
         // Given
         Version version = new Version("1.0.0");


### PR DESCRIPTION
Add a test to assert that pre-release identifiers can be used in the
versions (core and add-ons).