### PR TITLE
Add Export URLs menus to Sites context menu

### DIFF
--- a/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -73,6 +73,7 @@
 // ZAP: 2017/03/02 Issue 1634 Improve URL export.
 // ZAP: 2017/03/28 Issue 3253 Allow URLs to be exported per context.
 // ZAP: 2017/04/07 Added getUIName()
+// ZAP: 2017/05/01 Issue 3446 - Add ability to export a Site Map via Context Menu.
 
 package org.parosproxy.paros.extension.history;
 
@@ -243,6 +244,9 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
             extensionHook.getHookMenu().addReportMenuItem(getPopupMenuExportSelectedURLs());
             extensionHook.getHookMenu().addReportMenuItem(getPopupMenuExportContextURLs());
             extensionHook.getHookMenu().addReportMenuItem(extensionHook.getHookMenu().getMenuSeparator());
+
+            extensionHook.getHookMenu().addPopupMenuItem(createPopupMenuExportURLs());
+            extensionHook.getHookMenu().addPopupMenuItem(createPopupMenuExportSelectedURLs());
 
             ExtensionHelp.enableHelpKey(this.getLogPanel(), "ui.tabs.history");
 	    }
@@ -672,25 +676,30 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
 	
 	private PopupMenuExportURLs getPopupMenuExportURLs() {
 		if (popupMenuExportURLs == null) {
-			popupMenuExportURLs = new PopupMenuExportURLs(Constant.messages.getString("exportUrls.popup"));
-			popupMenuExportURLs.setExtension(this);
+			popupMenuExportURLs = createPopupMenuExportURLs();
 		}
 		return popupMenuExportURLs;
 	}
 
+	private PopupMenuExportURLs createPopupMenuExportURLs() {
+		return new PopupMenuExportURLs(Constant.messages.getString("exportUrls.popup"), this);
+	}
+
 	private PopupMenuExportSelectedURLs getPopupMenuExportSelectedURLs() {
 		if (popupMenuExportSelectedURLs == null) {
-			popupMenuExportSelectedURLs = new PopupMenuExportSelectedURLs(Constant.messages.getString("exportUrls.popup.selected"));
-			popupMenuExportSelectedURLs.setExtension(this);
+			popupMenuExportSelectedURLs = createPopupMenuExportSelectedURLs();
 		}
 		return popupMenuExportSelectedURLs;
+	}
+
+	private PopupMenuExportSelectedURLs createPopupMenuExportSelectedURLs() {
+		return new PopupMenuExportSelectedURLs(Constant.messages.getString("exportUrls.popup.selected"), this);
 	}
 	
 	private PopupMenuExportContextURLs getPopupMenuExportContextURLs() {
 		if (popupMenuExportContextURLs == null) {
 			popupMenuExportContextURLs = new PopupMenuExportContextURLs(
-					Constant.messages.getString("context.export.urls.menu"));
-			popupMenuExportContextURLs.setExtension(this);
+					Constant.messages.getString("context.export.urls.menu"), this);
 		}
 		return popupMenuExportContextURLs;
 	}

--- a/src/org/zaproxy/zap/extension/history/PopupMenuExportContextURLs.java
+++ b/src/org/zaproxy/zap/extension/history/PopupMenuExportContextURLs.java
@@ -26,6 +26,7 @@ import java.util.TreeSet;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.SiteMapPanel;
@@ -38,8 +39,8 @@ public class PopupMenuExportContextURLs extends PopupMenuExportURLs {
 	
 	private static Logger LOG = Logger.getLogger(PopupMenuExportURLs.class);
 
-	public PopupMenuExportContextURLs(String menuItem) {
-		super(menuItem);
+	public PopupMenuExportContextURLs(String menuItem, Extension extension) {
+		super(menuItem, extension);
 	}
 	
 	@Override

--- a/src/org/zaproxy/zap/extension/history/PopupMenuExportSelectedURLs.java
+++ b/src/org/zaproxy/zap/extension/history/PopupMenuExportSelectedURLs.java
@@ -31,6 +31,7 @@ import javax.swing.tree.TreePath;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.log4j.Logger;
+import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.SiteNode;
 
@@ -40,8 +41,8 @@ public class PopupMenuExportSelectedURLs extends PopupMenuExportURLs {
 
 	private static Logger LOG = Logger.getLogger(PopupMenuExportSelectedURLs.class);
 
-	public PopupMenuExportSelectedURLs(String menuItem) {
-		super(menuItem);
+	public PopupMenuExportSelectedURLs(String menuItem, Extension extension) {
+		super(menuItem, extension);
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
@@ -138,9 +138,7 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
 			extensionHook.getHookMenu().addPopupMenuItem(getPopupContextTreeMenuOutScope());
 			extensionHook.getHookMenu().addPopupMenuItem(getPopupContextTreeMenuDelete());
 			extensionHook.getHookMenu().addPopupMenuItem(getPopupContextTreeMenuExport());
-			if (isExtensionHistoryEnabled) {
-				extensionHook.getHookMenu().addPopupMenuItem(getPopupContextTreeMenuExportUrls());
-			}
+			extensionHook.getHookMenu().addPopupMenuItem(getPopupContextTreeMenuExportUrls());
 		}
 	}
 	
@@ -193,9 +191,7 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
 	private PopupMenuExportContextURLs getPopupContextTreeMenuExportUrls() {
 		if (popupContextTreeMenuExportUrls == null) {
 			popupContextTreeMenuExportUrls = new PopupMenuExportContextURLs(
-					Constant.messages.getString("context.export.urls.menu"));
-			popupContextTreeMenuExportUrls.setExtension(
-					Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class));
+					Constant.messages.getString("context.export.urls.menu"), this);
 		}
 		return popupContextTreeMenuExportUrls;
 	}


### PR DESCRIPTION
Add menu items "Export All URLs to File..." and "Export Selected URLs to
File..." to the context menu of Sites tree.
Refactor the Export URLs menus to require an Extension, it's a
dependency (failing to set it would lead to exceptions).

Fix #3446 - Add ability to export a Site Map via Context Menu