### PR TITLE
Fix NPE in Export URLs for Context menu item

### DIFF
--- a/src/org/zaproxy/zap/extension/history/PopupMenuExportContextURLs.java
+++ b/src/org/zaproxy/zap/extension/history/PopupMenuExportContextURLs.java
@@ -44,7 +44,7 @@ public class PopupMenuExportContextURLs extends PopupMenuExportURLs {
 	
 	@Override
 	public boolean isEnableForComponent(Component invoker) {
-		if (invoker.getName().equals(SiteMapPanel.CONTEXT_TREE_COMPONENT_NAME)) {
+		if (SiteMapPanel.CONTEXT_TREE_COMPONENT_NAME.equals(invoker.getName())) {
 			Context ctx = View.getSingleton().getSiteTreePanel().getSelectedContext();
 			if (ctx != null) {
 				return true;


### PR DESCRIPTION
Change PopupMenuExportContextURLs to check the string equality using the
constant preventing the NullPointerException when the component being
invoked does not have a name (which happens with the Response tab text
views).