### PR TITLE
Fix Issue 3460 Add Help Menu Item

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1489,6 +1489,7 @@ menu.file.snapshotSession.mnemonic = s
 menu.help                     = Help
 menu.help.mnemonic            = h
 menu.help.about               = About OWASP ZAP
+menu.help.zap.support = Support Info...
 menu.help.about.mnemonic      = a
 menu.online                   = Online
 menu.online.mnemonic          = o
@@ -2194,6 +2195,14 @@ std.menu.ext.name = Standard Menus Extension
 
 stdexts.copyurls.popup = Copy URLs to Clipboard
 stdexts.desc = A set of common popup menus for miscellaneous tasks
+
+support.home.directory.label = ZAP Home Directory:
+support.installed.addons.label = Installed Add-ons:
+support.java.version.label = Java Version:
+support.operating.system.label = Operating System:
+support.open.button = Open
+support.open.button.tooltip = Open ZAP's Home Directory
+support.version.label = Version:
 
 tab.break               = Break
 tab.doubleClick.warning = You have double-clicked on a tab.\nThe tab window will now be maximised -\nyou can return the tab window to its previous\nsize by double clicking on the tab again.\nSelect Cancel to keep the tab window as it is. 

--- a/src/org/parosproxy/paros/CommandLine.java
+++ b/src/org/parosproxy/paros/CommandLine.java
@@ -35,6 +35,7 @@
 // ZAP: 2016/09/22 JavaDoc tweaks
 // ZAP: 2016/11/07 Allow to disable default standard output logging
 // ZAP: 2017/03/26 Allow to obtain configs in the order specified
+// ZAP: 2017/05/12 Issue 3460: Support -suppinfo 
 
 package org.parosproxy.paros;
 
@@ -74,6 +75,7 @@ public class CommandLine {
     public static final String CONFIG_FILE = "-configfile";
     public static final String LOWMEM = "-lowmem";
     public static final String EXPERIMENTALDB = "-experimentaldb";
+    public static final String SUPPORT_INFO = "-suppinfo";
 
     /**
      * Command line option to disable the default logging through standard output.
@@ -89,6 +91,7 @@ public class CommandLine {
     private boolean GUI = true;
     private boolean daemon = false;
     private boolean reportVersion = false;
+    private boolean displaySupportInfo = false;
     private boolean lowMem = false;
     private boolean experimentalDb = false;
     private int port = -1;
@@ -316,6 +319,10 @@ public class CommandLine {
             setGUI(false);
         } else if (checkSwitch(args, NOSTDOUT, i)) {
             noStdOutLog = true;
+        } else if (checkSwitch(args, SUPPORT_INFO, i)) {
+            displaySupportInfo = true;
+            setDaemon(false);
+            setGUI(false);
         }
 
         return result;
@@ -423,6 +430,10 @@ public class CommandLine {
 
 	public boolean isReportVersion() {
         return this.reportVersion;
+    }
+
+    public boolean isDisplaySupportInfo() {
+        return this.displaySupportInfo;
     }
 
     public int getPort() {

--- a/src/org/parosproxy/paros/view/MainMenuBar.java
+++ b/src/org/parosproxy/paros/view/MainMenuBar.java
@@ -29,6 +29,7 @@
 // ZAP: 2014/11/11 Issue 1406: Move online menu items to an add-on
 // ZAP: 2014/12/22 Issue 1476: Display contexts in the Sites tree
 // ZAP: 2015/02/05 Issue 1524: New Persist Session dialog
+// ZAP: 2017/05/10 Issue 3460: Add Show Support Info help menuitem
 
 package org.parosproxy.paros.view;
 
@@ -51,6 +52,7 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.zaproxy.zap.view.AboutDialog;
 import org.zaproxy.zap.view.ZapMenuItem;
+import org.zaproxy.zap.view.ZapSupportDialog;
 
 public class MainMenuBar extends JMenuBar {
 
@@ -74,6 +76,7 @@ public class MainMenuBar extends JMenuBar {
 	private ZapMenuItem menuFileProperties = null;
 	private JMenu menuHelp = null;
 	private ZapMenuItem menuHelpAbout = null;
+	private ZapMenuItem menuHelpSupport = null;
     private JMenu menuAnalyse = null;
     // ZAP: Added standard report menu
 	private JMenu menuReport = null;
@@ -427,6 +430,7 @@ public class MainMenuBar extends JMenuBar {
 			menuHelp.setText(Constant.messages.getString("menu.help")); // ZAP: i18n
 			menuHelp.setMnemonic(Constant.messages.getChar("menu.help.mnemonic"));
 			menuHelp.add(getMenuHelpAbout());
+			menuHelp.add(getMenuHelpSupport());
 		}
 		return menuHelp;
 	}
@@ -468,6 +472,21 @@ public class MainMenuBar extends JMenuBar {
 		}
 		return menuHelpAbout;
 	}
+	
+	private ZapMenuItem getMenuHelpSupport() {
+		if (menuHelpSupport == null) {			
+			menuHelpSupport = new ZapMenuItem("menu.help.zap.support");
+			menuHelpSupport.addActionListener(new java.awt.event.ActionListener() { 
+				@Override
+				public void actionPerformed(java.awt.event.ActionEvent e) {    
+					ZapSupportDialog zsd = new ZapSupportDialog(View.getSingleton().getMainFrame(), true);
+					zsd.setVisible(true);
+				}
+			});
+		}
+		return menuHelpSupport;
+	}
+	
     /**
      * This method initializes jMenu1	
      * 	

--- a/src/org/zaproxy/zap/CommandLineBootstrap.java
+++ b/src/org/zaproxy/zap/CommandLineBootstrap.java
@@ -26,6 +26,7 @@ import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.utils.ZapSupportUtils;
 
 /**
  * The bootstrap process for command line mode.
@@ -71,6 +72,9 @@ public class CommandLineBootstrap extends HeadlessBootstrap {
 
             } else if (getArgs().isReportVersion()) {
                 System.out.println(Constant.PROGRAM_VERSION);
+
+            } else if (getArgs().isDisplaySupportInfo()) {
+            	System.out.println(ZapSupportUtils.getAll(false));
 
             } else {
                 if (handleCmdLineSessionArgsSynchronously(control)) {

--- a/src/org/zaproxy/zap/utils/ZapSupportUtils.java
+++ b/src/org/zaproxy/zap/utils/ZapSupportUtils.java
@@ -1,0 +1,105 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.utils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import org.apache.commons.lang.WordUtils;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.control.AddOn;
+import org.zaproxy.zap.control.AddOnLoader;
+import org.zaproxy.zap.control.ExtensionFactory;
+
+/**
+ * A class containing utility methods that can be used for support purposes.
+ * The functions in this class return details relevant for support and tickets
+ * prefixed with labels.
+ * 
+ * @since TODO add version
+ */
+public final class ZapSupportUtils {
+	
+	private static final String NEWLINE = System.lineSeparator();
+	
+	private ZapSupportUtils() {
+		
+	}
+
+	public static String getProductName() {
+		return Constant.PROGRAM_NAME;
+	}
+
+	public static String getVersion() {
+		return Constant.messages.getString("support.version.label") + " " + Constant.PROGRAM_VERSION;
+	}
+
+	public static String getZapHomeDirectory() {
+		return Constant.messages.getString("support.home.directory.label") + " " + Constant.getZapHome();
+	}
+
+	public static String getOperatingSystem() {
+		return Constant.messages.getString("support.operating.system.label") + " " + System.getProperty("os.name");
+	}
+
+	public static String getJavaVersionVendor() {
+		String javaVersion = System.getProperty("java.version");
+		String javaVendor = System.getProperty("java.vendor");
+		return Constant.messages.getString("support.java.version.label") + " " + javaVendor + " " + javaVersion;
+	}
+
+	public static String getInstalledAddons() {
+		AddOnLoader addOnLoader = ExtensionFactory.getAddOnLoader();
+		List<AddOn> sortedAddOns = new ArrayList<>(addOnLoader.getAddOnCollection().getInstalledAddOns());
+		Collections.sort(sortedAddOns, new Comparator<AddOn>() {
+
+			@Override
+			public int compare(AddOn addOn, AddOn otherAddOn) {
+				return addOn.getId().compareTo(otherAddOn.getId());
+			}
+		});
+		return Constant.messages.getString("support.installed.addons.label") + " " + sortedAddOns;
+	}
+	
+	public static String getAll(boolean formatted) {
+		StringBuilder installedAddons = new StringBuilder(200);
+		if (formatted) {
+			installedAddons.append("---").append(NEWLINE);
+			installedAddons.append(WordUtils.wrap(getInstalledAddons(), 60)).append(NEWLINE);
+			installedAddons.append("---").append(NEWLINE);
+		} else {
+			installedAddons.append(getInstalledAddons()).append(NEWLINE);
+		}
+		
+		StringBuilder supportDetailsBuilder = new StringBuilder(300);
+		
+		supportDetailsBuilder.append(getProductName()).append(NEWLINE);
+		supportDetailsBuilder.append(getVersion()).append(NEWLINE);
+		supportDetailsBuilder.append(installedAddons);
+		supportDetailsBuilder.append(getOperatingSystem()).append(NEWLINE);
+		supportDetailsBuilder.append(getJavaVersionVendor()).append(NEWLINE);
+		supportDetailsBuilder.append(getZapHomeDirectory()).append(NEWLINE);
+		
+		return supportDetailsBuilder.toString();
+	}
+
+}

--- a/src/org/zaproxy/zap/view/ZapSupportDialog.java
+++ b/src/org/zaproxy/zap/view/ZapSupportDialog.java
@@ -1,0 +1,164 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.view;
+
+import java.awt.Desktop;
+
+import java.awt.Frame;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.HeadlessException;
+import java.awt.Insets;
+import java.io.File;
+import java.io.IOException;
+
+import javax.swing.JButton;
+import javax.swing.JPanel;
+
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.extension.AbstractDialog;
+
+/**
+ * An {@code AbstractDialog} class which facilitates GUI display of support information.
+ * 
+ * @since TODO add version
+ */
+public class ZapSupportDialog extends AbstractDialog {
+
+	private static final long serialVersionUID = 1L;
+
+	private static final Logger LOGGER = Logger.getLogger(ZapSupportDialog.class);
+
+	private JPanel mainPanel = null;
+	private ZapSupportPanel supportPanel = null;
+	private JButton btnOK = null;
+	private JButton btnOpen = null;
+
+	/**
+	 * Constructs an {@code ZapSupportDialog} with no owner and not modal.
+	 * 
+	 * @throws HeadlessException when {@code GraphicsEnvironment.isHeadless()} returns {@code true}
+	 */
+	public ZapSupportDialog() {
+		super();
+		initialize();
+	}
+
+	/**
+	 * Constructs an {@code ZapSupportDialog} with the given owner and whether
+	 * or not it's modal.
+	 * 
+	 * @param owner the {@code Frame} from which the dialog is displayed
+	 * @param modal {@code true} if the dialogue should be modal, {@code false} otherwise
+	 * @throws HeadlessException when {@code GraphicsEnvironment.isHeadless()} returns {@code true}
+	 */
+	public ZapSupportDialog(Frame owner, boolean modal) {
+		super(owner, modal);
+		initialize();
+	}
+
+	private void initialize() {
+		this.setContentPane(getMainPanel());
+		this.pack();
+	}
+
+	private JPanel getMainPanel() {
+		if (mainPanel == null) {
+			mainPanel = new JPanel(new GridBagLayout());
+
+			GridBagConstraints gbcPanel = new GridBagConstraints();
+			GridBagConstraints gbcOpenButton = new GridBagConstraints();
+			GridBagConstraints gbcOkButton = new GridBagConstraints();
+
+			gbcPanel.gridx = 0;
+			gbcPanel.gridy = 0;
+			gbcPanel.insets = new Insets(0, 0, 0, 0);
+			gbcPanel.fill = GridBagConstraints.BOTH;
+			gbcPanel.anchor = GridBagConstraints.NORTHWEST;
+			gbcPanel.weightx = 1.0D;
+			gbcPanel.weighty = 1.0D;
+			gbcPanel.ipady = 2;
+			gbcPanel.gridwidth = 2;
+
+			gbcOpenButton.gridx = 0;
+			gbcOpenButton.gridy = 1;
+			gbcOpenButton.insets = new Insets(2, 2, 2, 2);
+			gbcOpenButton.anchor = GridBagConstraints.SOUTHEAST;
+
+			gbcOkButton.gridx = 1;
+			gbcOkButton.gridy = 1;
+			gbcOkButton.insets = new Insets(2, 2, 2, 2);
+			gbcOkButton.anchor = GridBagConstraints.SOUTHEAST;
+
+			mainPanel.add(getSupportPanel(), gbcPanel);
+			mainPanel.add(getBtnOpen(), gbcOpenButton);
+			mainPanel.add(getBtnOK(), gbcOkButton);
+		}
+		return mainPanel;
+	}
+
+	private ZapSupportPanel getSupportPanel() {
+		if (supportPanel == null) {
+			supportPanel = new ZapSupportPanel();
+		}
+		return supportPanel;
+	}
+
+	private JButton getBtnOK() {
+		if (btnOK == null) {
+			btnOK = new JButton();
+			btnOK.setText(Constant.messages.getString("all.button.ok"));
+			btnOK.addActionListener(new java.awt.event.ActionListener() {
+				@Override
+				public void actionPerformed(java.awt.event.ActionEvent e) {
+					ZapSupportDialog.this.dispose();
+				}
+			});
+		}
+		return btnOK;
+	}
+
+	private JButton getBtnOpen() {
+		if (btnOpen == null) {
+			btnOpen = new JButton();
+			if (Desktop.isDesktopSupported()) {
+				btnOpen.setEnabled(Desktop.getDesktop().isSupported(Desktop.Action.OPEN));
+			} else {
+				btnOpen.setEnabled(false);
+			}
+			btnOpen.setText(Constant.messages.getString("support.open.button"));
+			btnOpen.setToolTipText(Constant.messages.getString("support.open.button.tooltip"));
+			btnOpen.addActionListener(new java.awt.event.ActionListener() {
+				@Override
+				public void actionPerformed(java.awt.event.ActionEvent e) {
+					try {
+						Desktop.getDesktop().open(new File(Constant.getZapHome()));
+					} catch (IOException e1) {
+						LOGGER.error("An exception occurred while trying to have the OS open ZAP's Home Directory.",
+								e1);
+					}
+				}
+			});
+		}
+		return btnOpen;
+	}
+
+}

--- a/src/org/zaproxy/zap/view/ZapSupportPanel.java
+++ b/src/org/zaproxy/zap/view/ZapSupportPanel.java
@@ -1,0 +1,60 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.view;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+
+import org.zaproxy.zap.utils.ZapSupportUtils;
+
+public class ZapSupportPanel extends JPanel {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Constructs an {@code ZapSupportPanel}.
+	 */
+	public ZapSupportPanel() {
+		super(new GridBagLayout(), true);
+
+		GridBagConstraints gbcSupportDetails = new GridBagConstraints();
+		
+		JTextArea supportDetailsTextArea = new JTextArea();
+		supportDetailsTextArea.setEditable(false);
+		
+		supportDetailsTextArea.setText(ZapSupportUtils.getAll(true));
+		
+		gbcSupportDetails.gridx = 3;
+		gbcSupportDetails.gridy = 0;
+		gbcSupportDetails.ipadx = 0;
+		gbcSupportDetails.ipady = 0;
+		gbcSupportDetails.weightx = 1.0D;
+		gbcSupportDetails.weighty = 1.0D;
+		gbcSupportDetails.fill = GridBagConstraints.BOTH;
+		gbcSupportDetails.anchor = GridBagConstraints.NORTHWEST;
+		gbcSupportDetails.insets = new Insets(2, 2, 2, 2);
+		
+		this.add(supportDetailsTextArea, gbcSupportDetails);
+	}
+}


### PR DESCRIPTION
Added components which facilitate a help menu item which displays various support related details (Java info, ZAP info, addon info, etc) and a button to open ZAP's home directory (for access to logs etc.)
Also added CLI handling for `-suppinfo` option, which prints all the details to stdout (similar to the -version switch).

Addresses one part of zaproxy/zaproxy#3460