### PR TITLE
Use local proxy address for Browse API menu

### DIFF
--- a/src/org/zaproxy/zap/extension/api/ExtensionAPI.java
+++ b/src/org/zaproxy/zap/extension/api/ExtensionAPI.java
@@ -35,6 +35,11 @@ import org.zaproxy.zap.view.ZapMenuItem;
 public class ExtensionAPI extends ExtensionAdaptor {
 
 	public static final String NAME = "ExtensionAPI";
+	/**
+	 * @deprecated (TODO add version) Use {@link API#getBaseURL(boolean)} instead. This URL might not be correct in all cases,
+	 *             for example, if the API is set 'Secure' (thus needing to use HTTPS).
+	 */
+	@Deprecated
 	public static final String API_URL = "http://zap/";
 	
 	private OptionsApiPanel optionsApiPanel = null;
@@ -106,7 +111,7 @@ public class ExtensionAPI extends ExtensionAdaptor {
 						Model.getSingleton().getOptionsParam().getApiParam().setEnabled(true);
 					}
 
-					DesktopUtils.openUrlInBrowser(API_URL);
+					DesktopUtils.openUrlInBrowser(API.getInstance().getBaseURL(false));
 				}
 			});
 


### PR DESCRIPTION
Change ExtensionAPI to use the address of the local proxy for Browse API
menu, which does not require the browser to be proxying through ZAP
(previously it used always the URL "http://zap/").
Change API to expose the base URL (and change the API class variables to
be final, those do not need to be changed at runtime).

Fix #3461 - Browse API Doesn't work when browser isn't using ZAP as
proxy