### PR TITLE
Move alert related functionality to alert package

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -8,6 +8,7 @@ acsrf.api.action.removeOptionToken = Removes the anti-CSRF token with the given 
 acsrf.api.other.genForm = Generate a form for testing lack of anti-CSRF tokens - typically invoked via ZAP
 acsrf.api.view.optionTokensNames = Lists the names of all anti-CSRF tokens
 
+alert.add.popup             = New Alert...
 alert.add.button.cancel     = Cancel
 alert.add.button.save       = Save
 alert.add.title             = Add Alert
@@ -1187,7 +1188,6 @@ help.menu.guide     = OWASP ZAP User Guide
 help.name = Help Extension
 
 history.addnote.title                  = Add Note
-history.alert.popup                    = New Alert...
 history.browser.popup                  = Open URL in Browser
 history.browser.warning                = Failed to display HTTP message in browser.
 history.delete.popup                   = Delete (from view)

--- a/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -74,6 +74,7 @@
 // ZAP: 2017/03/28 Issue 3253 Allow URLs to be exported per context.
 // ZAP: 2017/04/07 Added getUIName()
 // ZAP: 2017/05/01 Issue 3446 - Add ability to export a Site Map via Context Menu.
+// ZAP: 2017/05/02 Move alert related code to ExtensionAlert.
 // ZAP: 2017/05/03 Register and process events from HistoryReference.
 
 package org.parosproxy.paros.extension.history;
@@ -111,7 +112,6 @@ import org.zaproxy.zap.eventBus.EventConsumer;
 import org.zaproxy.zap.extension.alert.AlertEventPublisher;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
-import org.zaproxy.zap.extension.history.AlertAddDialog;
 import org.zaproxy.zap.extension.history.HistoryFilterPlusDialog;
 import org.zaproxy.zap.extension.history.ManageTagsDialog;
 import org.zaproxy.zap.extension.history.NotesAddDialog;
@@ -148,7 +148,6 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
     // ZAP: Added history notes
     private PopupMenuNote popupMenuNote = null;
 	private NotesAddDialog dialogNotesAdd = null;
-	private AlertAddDialog dialogAlertAdd = null;
 	private ManageTagsDialog manageTags = null;
 	
 	private boolean showJustInScope = false;
@@ -602,13 +601,17 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
 		dialogNotesAdd.dispose();
 	}
 	
+    /**
+     * @deprecated (TODO add version) Use {@link ExtensionAlert#showAlertAddDialog(HistoryReference)} instead.
+     * @param ref the {@code HistoryReference} that will have the new alert, if created.
+     */
+    @Deprecated
     public void showAlertAddDialog(HistoryReference ref) {
-		if (dialogAlertAdd == null || ! dialogAlertAdd.isVisible()) {
-			dialogAlertAdd = new AlertAddDialog(getView().getMainFrame(), false);
-	    	dialogAlertAdd.setPlugin(this);
-	    	dialogAlertAdd.setVisible(true);
-	    	dialogAlertAdd.setHistoryRef(ref);
-		}
+        ExtensionAlert extAlert = Control.getSingleton().getExtensionLoader().getExtension(ExtensionAlert.class);
+        if (extAlert == null) {
+            return;
+        }
+        extAlert.showAlertAddDialog(ref);
     }
 
     /**
@@ -623,6 +626,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
      * deleted when the session is closed.
      * </p>
      * 
+     * @deprecated (TODO add version) Use {@link ExtensionAlert#showAlertAddDialog(HttpMessage, int)} instead.
      * @param httpMessage
      *            the {@code HttpMessage} that will be used to create the
      *            {@code HistoryReference}, must not be {@code null}
@@ -634,23 +638,26 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
      * @see HistoryReference#HistoryReference(org.parosproxy.paros.model.Session,
      *      int, HttpMessage)
      */
-    // ZAP: Added the method.
+    @Deprecated
     public void showAlertAddDialog(HttpMessage httpMessage, int historyType) {
-        if (dialogAlertAdd == null || ! dialogAlertAdd.isVisible()) {
-            dialogAlertAdd = new AlertAddDialog(getView().getMainFrame(), false);
-            dialogAlertAdd.setPlugin(this);
-            dialogAlertAdd.setHttpMessage(httpMessage, historyType);
-            dialogAlertAdd.setVisible(true);
+        ExtensionAlert extAlert = Control.getSingleton().getExtensionLoader().getExtension(ExtensionAlert.class);
+        if (extAlert == null) {
+            return;
         }
+        extAlert.showAlertAddDialog(httpMessage, historyType);
     }
 
+    /**
+     * @deprecated (TODO add version) Use {@link ExtensionAlert#showAlertEditDialog(Alert)} instead.
+     * @param alert the alert to edit
+     */
+    @Deprecated
     public void showAlertAddDialog(Alert alert) {
-		if (dialogAlertAdd == null || ! dialogAlertAdd.isVisible()) {
-			dialogAlertAdd = new AlertAddDialog(getView().getMainFrame(), false);
-	    	dialogAlertAdd.setPlugin(this);
-	    	dialogAlertAdd.setVisible(true);
-	    	dialogAlertAdd.setAlert(alert);
-		}
+        ExtensionAlert extAlert = Control.getSingleton().getExtensionLoader().getExtension(ExtensionAlert.class);
+        if (extAlert == null) {
+            return;
+        }
+        extAlert.showAlertEditDialog(alert);
     }
 
 	private void populateManageTagsDialogAndSetVisible(HistoryReference ref, List<String> tags) {

--- a/src/org/zaproxy/zap/extension/alert/AlertAddDialog.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertAddDialog.java
@@ -17,7 +17,7 @@
  * See the License for the specific language governing permissions and 
  * limitations under the License. 
  */
-package org.zaproxy.zap.extension.history;
+package org.zaproxy.zap.extension.alert;
 
 import java.awt.Frame;
 import java.awt.GridBagConstraints;
@@ -34,12 +34,9 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.extension.AbstractDialog;
-import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
-import org.zaproxy.zap.extension.alert.AlertViewPanel;
-import org.zaproxy.zap.extension.alert.ExtensionAlert;
 
 public class AlertAddDialog extends AbstractDialog {
 
@@ -51,8 +48,6 @@ public class AlertAddDialog extends AbstractDialog {
 	private JButton btnOk = null;
 	private JButton btnCancel = null;
 	
-	private ExtensionHistory extension = null;
-
 	private HistoryReference historyRef;
     
     /**
@@ -197,16 +192,10 @@ public class AlertAddDialog extends AbstractDialog {
 				public void actionPerformed(java.awt.event.ActionEvent e) {
 					Alert alert = alertViewPanel.getAlert();
 					try {
-						ExtensionAlert extAlert = (ExtensionAlert) Control.getSingleton().getExtensionLoader().getExtension(ExtensionAlert.NAME);
+						ExtensionAlert extAlert = Control.getSingleton().getExtensionLoader().getExtension(ExtensionAlert.class);
 						if (alert.getAlertId() >= 0) {
 							// Its an existing alert so save it
-							if (extAlert != null) {
-								extAlert.updateAlert(alert);
-							} else if (historyRef != null) { // Update history tree
-								historyRef.updateAlert(alert);
-			                    extension.notifyHistoryItemChanged(historyRef);
-							}
-
+							extAlert.updateAlert(alert);
 						} else {
 						    if (httpMessage != null) {
 						        historyRef = new HistoryReference(Model.getSingleton().getSession(), historyType, httpMessage);
@@ -214,12 +203,7 @@ public class AlertAddDialog extends AbstractDialog {
 						    
 						    alert.setSource(Alert.Source.MANUAL);
 						    // Raise it
-							if (extAlert != null) {
-								extAlert.alertFound(alert, historyRef);
-							} else {
-							    historyRef.addAlert(alert);
-							    extension.notifyHistoryItemChanged(historyRef);
-							}
+							extAlert.alertFound(alert, historyRef);
 						}
 					} catch (Exception ex) {
 					    logger.error(ex.getMessage(), ex);
@@ -260,10 +244,6 @@ public class AlertAddDialog extends AbstractDialog {
         httpMessage = null;
         dispose();
     }
-
-	public void setPlugin(ExtensionHistory plugin) {
-	    this.extension = plugin;
-	}
 	
 	private AlertViewPanel getAlertViewPanel () {
 		if (alertViewPanel == null) {

--- a/src/org/zaproxy/zap/extension/alert/AlertPanel.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertPanel.java
@@ -57,11 +57,9 @@ import javax.swing.tree.TreePath;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.extension.AbstractPanel;
 import org.parosproxy.paros.extension.ViewDelegate;
-import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpMessage;
@@ -137,7 +135,6 @@ public class AlertPanel extends AbstractPanel {
     private JButton editButton = null;
 
 	private ExtensionAlert extension = null;
-	private ExtensionHistory extHist = null; 
 
 	
     public AlertPanel(ExtensionAlert extension) {
@@ -627,12 +624,7 @@ public class AlertPanel extends AbstractPanel {
 	        if (obj instanceof Alert) {
 	            Alert alert = (Alert) obj;
 	            
-				if (extHist == null) {
-					extHist = (ExtensionHistory) Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.NAME);
-				}
-				if (extHist != null) {
-					extHist.showAlertAddDialog(alert);
-				}
+				extension.showAlertEditDialog(alert);
 	        }
 	    }
     }

--- a/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -80,6 +80,7 @@ public class ExtensionAlert extends ExtensionAdaptor implements
     private AlertTreeModel filteredTreeModel = null;
     private AlertPanel alertPanel = null;
     private RecordScan recordScan = null;
+    private PopupMenuAlert popupMenuAlertAdd;
     private PopupMenuAlertEdit popupMenuAlertEdit = null;
     private PopupMenuAlertDelete popupMenuAlertDelete = null;
     private PopupMenuAlertsRefresh popupMenuAlertsRefresh = null;
@@ -88,6 +89,7 @@ public class ExtensionAlert extends ExtensionAdaptor implements
 	private AlertParam alertParam = null;
 	private OptionsAlertPanel optionsPanel = null;
 	private Properties alertOverrides = new Properties();
+	private AlertAddDialog dialogAlertAdd;
 
     public ExtensionAlert() {
         super(NAME);
@@ -105,6 +107,7 @@ public class ExtensionAlert extends ExtensionAdaptor implements
 	    extensionHook.addOptionsParamSet(getAlertParam());
         if (getView() != null) {
 	        extensionHook.getHookView().addOptionPanel(getOptionsPanel());
+            extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuAlertAdd());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuAlertEdit());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuAlertDelete());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuAlertsRefresh());
@@ -517,9 +520,16 @@ public class ExtensionAlert extends ExtensionAdaptor implements
         siteTree.nodeStructureChanged((SiteNode) siteTree.getRoot());
     }
 
+    private PopupMenuAlert getPopupMenuAlertAdd() {
+        if (popupMenuAlertAdd == null) {
+            popupMenuAlertAdd = new PopupMenuAlert(Constant.messages.getString("alert.add.popup"), this);
+        }
+        return popupMenuAlertAdd;
+    }
+
     private PopupMenuAlertEdit getPopupMenuAlertEdit() {
         if (popupMenuAlertEdit == null) {
-            popupMenuAlertEdit = new PopupMenuAlertEdit();
+            popupMenuAlertEdit = new PopupMenuAlertEdit(this);
         }
         return popupMenuAlertEdit;
     }
@@ -540,7 +550,7 @@ public class ExtensionAlert extends ExtensionAdaptor implements
 
     private PopupMenuShowAlerts getPopupMenuShowAlerts() {
         if (popupMenuShowAlerts == null) {
-            popupMenuShowAlerts = new PopupMenuShowAlerts(Constant.messages.getString("alerts.view.popup"));
+            popupMenuShowAlerts = new PopupMenuShowAlerts(Constant.messages.getString("alerts.view.popup"), this);
         }
         return popupMenuShowAlerts;
     }
@@ -904,6 +914,57 @@ public class ExtensionAlert extends ExtensionAdaptor implements
      */
     public void setLinkWithSitesTreeSelection(boolean enabled) {
         getAlertPanel().setLinkWithSitesTreeSelection(enabled);
+    }
+    
+    /**
+     * Shows the Add Alert dialogue, to add a new alert for the given {@code HistoryReference}.
+     *
+     * @param ref the history reference for the alert.
+     * @since TODO add version
+     */
+    public void showAlertAddDialog(HistoryReference ref) {
+        if (dialogAlertAdd == null || !dialogAlertAdd.isVisible()) {
+            dialogAlertAdd = new AlertAddDialog(getView().getMainFrame(), false);
+            dialogAlertAdd.setVisible(true);
+            dialogAlertAdd.setHistoryRef(ref);
+        }
+    }
+
+    /**
+     * Shows the Add Alert dialogue, using the given {@code HttpMessage} and history type for the {@code HistoryReference} that
+     * will be created if the user creates the alert. The current session will be used to create the {@code HistoryReference}.
+     * The alert created will be added to the newly created {@code HistoryReference}.
+     * <p>
+     * Should be used when the alert is added to a temporary {@code HistoryReference} as the temporary {@code HistoryReference}s
+     * are deleted when the session is closed.
+     * 
+     * @param httpMessage the {@code HttpMessage} that will be used to create the {@code HistoryReference}, must not be
+     *            {@code null}.
+     * @param historyType the type of the history reference that will be used to create the {@code HistoryReference}.
+     * @since TODO add version
+     * @see Model#getSession()
+     * @see HistoryReference#HistoryReference(org.parosproxy.paros.model.Session, int, HttpMessage)
+     */
+    public void showAlertAddDialog(HttpMessage httpMessage, int historyType) {
+        if (dialogAlertAdd == null || !dialogAlertAdd.isVisible()) {
+            dialogAlertAdd = new AlertAddDialog(getView().getMainFrame(), false);
+            dialogAlertAdd.setHttpMessage(httpMessage, historyType);
+            dialogAlertAdd.setVisible(true);
+        }
+    }
+
+    /**
+     * Shows the "Edit Alert" dialogue, with the given alert.
+     *
+     * @param alert the alert to be edited.
+     * @since TODO add version
+     */
+    public void showAlertEditDialog(Alert alert) {
+        if (dialogAlertAdd == null || !dialogAlertAdd.isVisible()) {
+            dialogAlertAdd = new AlertAddDialog(getView().getMainFrame(), false);
+            dialogAlertAdd.setVisible(true);
+            dialogAlertAdd.setAlert(alert);
+        }
     }
 
     /**

--- a/src/org/zaproxy/zap/extension/alert/PopupMenuAlert.java
+++ b/src/org/zaproxy/zap/extension/alert/PopupMenuAlert.java
@@ -17,12 +17,10 @@
  * See the License for the specific language governing permissions and 
  * limitations under the License. 
  */
-package org.zaproxy.zap.extension.stdmenus;
+package org.zaproxy.zap.extension.alert;
 
 import org.apache.log4j.Logger;
-import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.db.DatabaseException;
-import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
@@ -35,13 +33,18 @@ public class PopupMenuAlert extends PopupMenuItemHistoryReferenceContainer {
 
 	private static final Logger logger = Logger.getLogger(PopupMenuAlert.class);
 
-    private ExtensionHistory extension = null;
+    private final ExtensionAlert extension;
 
     /**
-     * @param label
+     * Constructs a {@code PopupMenuAlert} with the given label and extension.
+     *
+     * @param label the label of the menu item.
+     * @param extension the {@code ExtensionAlert} to show the Add Alert dialogue.
      */
-    public PopupMenuAlert(String label) {
+    public PopupMenuAlert(String label, ExtensionAlert extension) {
         super(label);
+
+        this.extension = extension;
     }
 	
 	@Override
@@ -49,33 +52,23 @@ public class PopupMenuAlert extends PopupMenuItemHistoryReferenceContainer {
 	    Invoker invoker = getInvoker();
 	    if (invoker == Invoker.ACTIVE_SCANNER_PANEL) {
 	        try {
-	            getExtensionHistory().showAlertAddDialog(href.getHttpMessage(), HistoryReference.TYPE_SCANNER);
+	            extension.showAlertAddDialog(href.getHttpMessage(), HistoryReference.TYPE_SCANNER);
 	        } catch (HttpMalformedHeaderException | DatabaseException e) {
 	            logger.error(e.getMessage(), e);
 	        }
 	    } else if (invoker == Invoker.FUZZER_PANEL) {
 	        try {
-	            getExtensionHistory().showAlertAddDialog(href.getHttpMessage(), HistoryReference.TYPE_FUZZER);
+	            extension.showAlertAddDialog(href.getHttpMessage(), HistoryReference.TYPE_FUZZER);
     	    } catch (HttpMalformedHeaderException | DatabaseException e) {
                 logger.error(e.getMessage(), e);
             }
 	    } else {
-	        getExtensionHistory().showAlertAddDialog(href);
+	        extension.showAlertAddDialog(href);
 	    }
 	}
 
-    private ExtensionHistory getExtensionHistory() {
-    	if (extension == null) {
-    		extension = (ExtensionHistory) Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.NAME);
-    	}
-    	return extension;
-    }
-
 	@Override
 	public boolean isEnableForInvoker(Invoker invoker, HttpMessageContainer httpMessageContainer) {
-		if (getExtensionHistory() == null) {
-			return false;
-		}
 		switch (invoker) {
 		case ALERTS_PANEL:
 			return false;

--- a/src/org/zaproxy/zap/extension/alert/PopupMenuAlertEdit.java
+++ b/src/org/zaproxy/zap/extension/alert/PopupMenuAlertEdit.java
@@ -20,9 +20,7 @@
 package org.zaproxy.zap.extension.alert;
 
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
-import org.parosproxy.paros.extension.history.ExtensionHistory;
 
 
 /**
@@ -34,20 +32,17 @@ public class PopupMenuAlertEdit extends PopupMenuItemAlert {
 
 	private static final long serialVersionUID = 1L;
 
-	private ExtensionHistory extHist = null; 
+	private final ExtensionAlert extension; 
 
-    public PopupMenuAlertEdit() {
+    public PopupMenuAlertEdit(ExtensionAlert extension) {
         super(Constant.messages.getString("scanner.edit.popup"));
+
+        this.extension = extension;
 	}
 	
     @Override
     protected void performAction(Alert alert) {
-        if (extHist == null) {
-            extHist = (ExtensionHistory) Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.NAME);
-        }
-        if (extHist != null) {
-            extHist.showAlertAddDialog(alert);
-        }
+        extension.showAlertEditDialog(alert);
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/alert/PopupMenuShowAlert.java
+++ b/src/org/zaproxy/zap/extension/alert/PopupMenuShowAlert.java
@@ -3,48 +3,34 @@ package org.zaproxy.zap.extension.alert;
 import javax.swing.JMenuItem;
 
 import org.apache.log4j.Logger;
-import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
-import org.parosproxy.paros.extension.history.ExtensionHistory;
 
 public class PopupMenuShowAlert extends JMenuItem implements Comparable<PopupMenuShowAlert> {
 
 	private static final long serialVersionUID = 1L;
 
-	private ExtensionHistory extHist = null; 
-	private Alert alert = null;
+	private final ExtensionAlert extension;
+	private final Alert alert;
 
     private static final Logger log = Logger.getLogger(ExtensionPopupMenuItem.class);
 
-	public PopupMenuShowAlert (String name, Alert alert) {
+	public PopupMenuShowAlert (String name, ExtensionAlert extension, Alert alert) {
 		super(name);
 		this.alert = alert;
-		this.initialize();
-	}
-	
-	private void initialize() {
+		this.extension = extension;
 
         this.addActionListener(new java.awt.event.ActionListener() { 
 
         	@Override
         	public void actionPerformed(java.awt.event.ActionEvent e) {
         	    try {
-        			if (extHist == null) {
-        				extHist = (ExtensionHistory) Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.NAME);
-        			}
-        			if (extHist != null) {
-        				extHist.showAlertAddDialog(alert);
-        			}
+        	        PopupMenuShowAlert.this.extension.showAlertEditDialog(PopupMenuShowAlert.this.alert);
 				} catch (Exception e2) {
 					log.error(e2.getMessage(), e2);
 				}
         	}
         });
-	}
-
-	public Alert getAlert() {
-		return alert;
 	}
 
 	@Override
@@ -53,6 +39,6 @@ public class PopupMenuShowAlert extends JMenuItem implements Comparable<PopupMen
 			return -1;
 		}
 		// Negate the alert comparison so higher risks shown first
-		return - this.getAlert().compareTo(o.getAlert());
+		return - alert.compareTo(o.alert);
 	}
 }

--- a/src/org/zaproxy/zap/extension/alert/PopupMenuShowAlerts.java
+++ b/src/org/zaproxy/zap/extension/alert/PopupMenuShowAlerts.java
@@ -34,13 +34,17 @@ public class PopupMenuShowAlerts extends PopupMenuHistoryReferenceContainer {
 
 	private static final long serialVersionUID = 1L;
 
+	private final ExtensionAlert extension;
+
     /**
      * Constructs a {@code PopupMenuShowAlerts} with the given label.
      * 
      * @param label the text shown in the pop up menu
+     * @param extension the {@code ExtensionAlert} to show the Edit Alert dialogue.
      */
-    public PopupMenuShowAlerts(String label) {
+    public PopupMenuShowAlerts(String label, ExtensionAlert extension) {
         super(label);
+        this.extension = extension;
         setProcessExtensionPopupChildren(false);
     }
 
@@ -71,7 +75,7 @@ public class PopupMenuShowAlerts extends PopupMenuHistoryReferenceContainer {
 			if (hrefURI != null && ! alert.getUri().equals(hrefURI.toString())) {
 				continue;
 			}
-			final PopupMenuShowAlert menuItem = new PopupMenuShowAlert(alert.getName(), alert);
+			final PopupMenuShowAlert menuItem = new PopupMenuShowAlert(alert.getName(), extension, alert);
 			menuItem.setIcon(alert.getIcon());
 			
 			alertList.add(menuItem);

--- a/src/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
@@ -75,8 +75,6 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
 
 	// Still being developed
 	// private PopupMenuShowResponseInBrowser popupMenuShowResponseInBrowser = null;
-	private PopupMenuAlert popupMenuAlert = null;
-
     private static Logger log = Logger.getLogger(ExtensionStdMenus.class);
 
 	public ExtensionStdMenus() {
@@ -123,8 +121,6 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
 			if (isExtensionHistoryEnabled) {
 				extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuResendMessage(4));
 			}
-
-			extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuAlert(5));
 
 			if (isExtensionHistoryEnabled) {
 				extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuShowInHistory(6)); // Both are index 6
@@ -371,14 +367,6 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
 			popupMenuShowInHistory.setMenuIndex(menuIndex);
 		}
 		return popupMenuShowInHistory;
-	}
-
-	private PopupMenuAlert getPopupMenuAlert(int menuIndex) {
-		if (popupMenuAlert == null) {
-			popupMenuAlert = new PopupMenuAlert(Constant.messages.getString("history.alert.popup"));
-			popupMenuAlert.setMenuIndex(menuIndex);
-		}
-		return popupMenuAlert;
 	}
 
 	private PopupMenuItemContextInclude getPopupContextIncludeMenu(int menuIndex) {


### PR DESCRIPTION
Move AlertAddDialog and PopupMenuAlert to alert package and change
ExtensionAlert to use/add them. The ExtensionAlert is required for
adding and editing the alerts (while the dialogues would be shown if the
extension was disabled the changes done to the alerts would be lost
since they were not being persisted to the session).
Update related classes to use the new/moved methods/classes.
Rename a resource message key to be under alert keys.