### PR TITLE
docker: handle non-user generated IOErrors in zap-baseline

### DIFF
--- a/build/docker/zap-baseline.py
+++ b/build/docker/zap-baseline.py
@@ -577,9 +577,14 @@ def main(argv):
     # Stop ZAP
     zap.core.shutdown()
 
-  except IOError as (errno, strerror):
-    print("ERROR " + str(strerror))
-    logging.warning ('I/O error(' + str(errno) + '): ' + str(strerror))
+  except IOError as e:
+    if hasattr(e, 'args') and len(e.args) > 1:
+      errno, strerror = e
+      print("ERROR " + str(strerror))
+      logging.warning ('I/O error(' + str(errno) + '): ' + str(strerror))
+    else:
+      print("ERROR %s" % e)
+      logging.warning ('I/O error: ' + str(e))
     dump_log_file(cid)
 
   except:


### PR DESCRIPTION
refs: https://github.com/zaproxy/zaproxy/issues/3462 similar to: https://github.com/zaproxy/zaproxy/pull/3347

This won't fix the root cause of #3462 but it should let us surface the underlying error.