### PR TITLE
Clear reference from HttpMessage in SpiderTask

### DIFF
--- a/src/org/zaproxy/zap/spider/SpiderTask.java
+++ b/src/org/zaproxy/zap/spider/SpiderTask.java
@@ -275,6 +275,8 @@ public class SpiderTask implements Runnable {
 		HttpMessage msg;
 		try {
 			msg = reference.getHttpMessage();
+			// HistoryReference is about to be deleted, so no point keeping referencing it.
+			msg.setHistoryRef(null);
 		} finally {
 			deleteHistoryReference();
 		}


### PR DESCRIPTION
Change SpiderTask to clear the HistoryReference from the HttpMessage as
the HistoryReference is going to be deleted, thus avoiding potential
consumers of the HttpMessage from using it (which could lead to
unexpected behaviour).