### PR TITLE
Allow passive rules to choose the type of msgs

### DIFF
--- a/src/org/zaproxy/zap/extension/pscan/PassiveScript.java
+++ b/src/org/zaproxy/zap/extension/pscan/PassiveScript.java
@@ -32,4 +32,16 @@ public interface PassiveScript {
 	void scan(ScriptsPassiveScanner scriptsPassiveScanner,
 			HttpMessage msg, Source source) throws ScriptException;
 
+	/**
+	 * Tells whether or not the scanner applies to the given history type.
+	 * <p>
+	 * By default it scans the {@link PluginPassiveScanner#getDefaultHistoryTypes() default history types}.
+	 *
+	 * @param historyType the history type of the message to be scanned.
+	 * @return {@code true} if the scanner applies to the given history type, {@code false} otherwise.
+	 * @since TODO add version
+	 */
+	default boolean appliesToHistoryType(int historyType) {
+		return PluginPassiveScanner.getDefaultHistoryTypes().contains(historyType);
+	}
 }

--- a/src/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
+++ b/src/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
@@ -41,6 +41,7 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
 	
 
 	private int currentHRefId;
+	private int currentHistoryType;
 
 	public ScriptsPassiveScanner() {
 	}
@@ -78,7 +79,9 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
 						PassiveScript s = extension.getInterface(script, PassiveScript.class);
 						
 						if (s != null) {
-							s.scan(this, msg, source);
+							if (s.appliesToHistoryType(currentHistoryType)) {
+								s.scan(this, msg, source);
+							}
 							
 						} else {
 							extension.handleFailedScriptInterface(
@@ -112,4 +115,9 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
 		this.parent = parent;
 	}
 
+	@Override
+	public boolean appliesToHistoryType(int historyType) {
+		this.currentHistoryType = historyType;
+		return true;
+	}
 }

--- a/src/scripts/templates/passive/Passive default template.js
+++ b/src/scripts/templates/passive/Passive default template.js
@@ -9,7 +9,8 @@ if (typeof println == 'undefined') this.println = print;
 
 /**
  * Passively scans an HTTP message. The scan function will be called for 
- * request/response made via ZAP, excluding some of the automated tools.
+ * request/response made via ZAP, actual messages depend on the function
+ * "appliesToHistoryType", defined below.
  * 
  * @param ps - the PassiveScan parent object that will do all the core interface tasks 
  *     (i.e.: providing access to Threshold settings, raising alerts, etc.). 
@@ -36,4 +37,18 @@ function scan(ps, msg, src) {
 	if (ps.getLevel() == "LOW") {
 		// ...
 	}
+}
+
+/**
+ * Tells whether or not the scanner applies to the given history type.
+ *
+ * @param {Number} historyType - The ID of the history type of the message to be scanned.
+ * @return {boolean} Whether or not the message with the given type should be scanned by this scanner.
+ */
+function appliesToHistoryType(historyType) {
+	// For example, to just scan spider messages:
+	// return historyType == org.parosproxy.paros.model.HistoryReference.TYPE_SPIDER;
+
+	// Default behaviour scans default types.
+	return org.zaproxy.zap.extension.pscan.PluginPassiveScanner.getDefaultHistoryTypes().contains(historyType);
 }


### PR DESCRIPTION
Add default method to PassiveScript interface to allow scripts to choose
which types of messages are scanned (as Java passive scanners can do).
Change ScriptsPassiveScanner to use the new method of PassiveScript.
Update JavaScript template with an example implementation.