### PR TITLE
Notify changes done to tags of HistoryReferences

### DIFF
--- a/src/org/parosproxy/paros/model/HistoryReferenceEventPublisher.java
+++ b/src/org/parosproxy/paros/model/HistoryReferenceEventPublisher.java
@@ -1,0 +1,79 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.model;
+
+import org.zaproxy.zap.ZAP;
+import org.zaproxy.zap.eventBus.EventPublisher;
+
+/**
+ * A {@link EventPublisher} of {@link HistoryReference} events.
+ * <p>
+ * Notifies of changes in the {@code HistoryReference}'s state/data.
+ * 
+ * @since TODO add version
+ */
+public final class HistoryReferenceEventPublisher implements EventPublisher {
+
+    /**
+     * The event sent when a tag is added to a {@code HistoryReference}.
+     */
+    public static final String EVENT_TAG_ADDED = "href.tag.added";
+
+    /**
+     * The event sent when a tag is removed a {@code HistoryReference}.
+     */
+    public static final String EVENT_TAG_REMOVED = "href.tag.removed";
+
+    /**
+     * The event sent when new tags are set (for example, multiple added and one removed) to a {@code HistoryReference}.
+     */
+    public static final String EVENT_TAGS_SET = "href.tags.set";
+
+    /**
+     * The event's field that contains the ID of the {@code HistoryReference} of the event.
+     */
+    public static final String FIELD_HISTORY_REFERENCE_ID = "historyReferenceId";
+
+    private static HistoryReferenceEventPublisher publisher;
+
+    @Override
+    public String getPublisherName() {
+        return HistoryReferenceEventPublisher.class.getCanonicalName();
+    }
+
+    /**
+     * Gets the event publisher.
+     *
+     * @return the event publisher, never {@code null}.
+     */
+    public static HistoryReferenceEventPublisher getPublisher() {
+        if (publisher == null) {
+            createPublisher();
+        }
+        return publisher;
+    }
+
+    private static synchronized void createPublisher() {
+        if (publisher == null) {
+            publisher = new HistoryReferenceEventPublisher();
+            ZAP.getEventBus().registerPublisher(publisher, new String[] { EVENT_TAG_ADDED, EVENT_TAG_REMOVED, EVENT_TAGS_SET });
+        }
+    }
+}

--- a/src/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
+++ b/src/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
@@ -220,12 +220,6 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
 
 	}
 
-    private void notifyHistoryItemChanged(HistoryReference historyReference) {
-        if (extHist != null) {
-            extHist.notifyHistoryItemChanged(historyReference);
-        }
-    }
-	
 	public void addTag(int id, String tag) {
 		if (shutDown) {
 			return;
@@ -234,7 +228,6 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
 		try {
 			if (! href.getTags().contains(tag)) {
 				href.addTag(tag);
-				notifyHistoryItemChanged(href);
 			}
 		} catch (Exception e) {
 			logger.error(e.getMessage(), e);

--- a/src/org/zaproxy/zap/view/table/DefaultHistoryReferencesTableModel.java
+++ b/src/org/zaproxy/zap/view/table/DefaultHistoryReferencesTableModel.java
@@ -148,13 +148,7 @@ public class DefaultHistoryReferencesTableModel extends AbstractHistoryReference
             entry.refreshCachedValues();
         }
 
-        fireTableChanged(
-                new TableModelEvent(
-                        this,
-                        0,
-                        hrefList.size() - 1,
-                        getColumnIndex(Column.HIGHEST_ALERT),
-                        TableModelEvent.UPDATE));
+        fireTableChanged(new TableModelEvent(this, 0, hrefList.size() - 1));
     }
 
     @Override


### PR DESCRIPTION
Change ExtensionHistory and SpiderMessagesTableModel to register and
process events from HistoryReferenceEventPublisher, to properly update
the tags of the entries shown in the History and Spider (Messages) tabs.
Change HistoryReference to notify of the tag changes.
Add HistoryReferenceEventPublisher for HistoryReference event
notification (currently for changes in the tags).
Change ManageTagsDialog and PassiveScanThread to not call the
ExtensionHistory, per previous changes they no longer need to tell that
the tags of a HistoryReference were changed.
Change DefaultHistoryReferencesTableModel to notify that several columns
might have changed (e.g. tags, alerts) instead of just the alerts one.

Fix #3363 - Spider Messages View Includes Underused Tags Column