### PR TITLE
Fix class loading lock with scripts

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnClassLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnClassLoader.java
@@ -39,6 +39,7 @@ public class AddOnClassLoader extends URLClassLoader {
     private final List<AddOnClassLoader> childClassLoaders;
     private List<AddOnClassLoader> dependencies;
     private AddOnClassnames addOnClassnames;
+    private ClassLoadingLockProvider classLoadingLockProvider;
 
     /**
      * Constructs a new {@code AddOnClassLoader} without dependencies on other add-ons.
@@ -64,6 +65,21 @@ public class AddOnClassLoader extends URLClassLoader {
      */
     public AddOnClassLoader(URL addOnFileUrl, ClassLoader parent, AddOnClassnames addOnClassnames) {
         this(addOnFileUrl, parent, Collections.<AddOnClassLoader> emptyList(), addOnClassnames);
+    }
+
+    /**
+     * Constructs a new {@code AddOnClassLoader} without dependencies on other add-ons. Possibly restricting or allowing the
+     * loading of the given {@code addOnClassnames}, directly from this {@code AddOnClassLoader}.
+     * 
+     * @param addOnFileUrl the URL to the add-on file that will be (first) used to load classes and resources
+     * @param parent the parent class loader for delegation and sharing of class loading lock(s).
+     * @param addOnClassnames the classnames that can be loaded
+     * @throws IllegalArgumentException if the {@code addOnFileUrl} or {@code parent} is {@code null}.
+     * @since TODO add version
+     */
+    public AddOnClassLoader(URL addOnFileUrl, AddOnLoader parent, AddOnClassnames addOnClassnames) {
+        this(addOnFileUrl, (ClassLoader) parent, Collections.<AddOnClassLoader> emptyList(), addOnClassnames);
+        this.classLoadingLockProvider = parent::getClassLoadingLock;
     }
 
     /**
@@ -115,6 +131,23 @@ public class AddOnClassLoader extends URLClassLoader {
 
     /**
      * Constructs a new {@code AddOnClassLoader} with the given {@code dependencies} which are used to find classes and
+     * resources when not found in the add-on or in {@code parent} ClassLoader. Possibly restricting or allowing the loading of
+     * the given {@code addOnClassnames}, directly from this {@code AddOnClassLoader}.
+     * 
+     * @param addOnFileUrl the URL to the add-on file that will be (first) used to load classes and resources
+     * @param parent the parent class loader for delegation and sharing of class loading lock(s).
+     * @param dependencies the {@code AddOnClassLoader}s of the dependencies of the add-on
+     * @param addOnClassnames the classnames that can be loaded
+     * @throws IllegalArgumentException if the {@code addOnFileUrl}, {@code parent} or {@code dependencies} is {@code null}.
+     * @since TODO add version
+     */
+    public AddOnClassLoader(URL addOnFileUrl, AddOnLoader parent, List<AddOnClassLoader> dependencies, AddOnClassnames addOnClassnames) {
+        this(addOnFileUrl, (ClassLoader) parent, dependencies, addOnClassnames);
+        this.classLoadingLockProvider = parent::getClassLoadingLock;
+    }
+
+    /**
+     * Constructs a new {@code AddOnClassLoader} with the given {@code dependencies} which are used to find classes and
      * resources when not found in the add-on or in {@code parent} {@code AddOnClassLoader}.
      * 
      * @param parent the parent class loader for delegation
@@ -135,6 +168,7 @@ public class AddOnClassLoader extends URLClassLoader {
         this.dependencies = dependencies.isEmpty() ? Collections.<AddOnClassLoader> emptyList() : new ArrayList<>(dependencies);
         this.childClassLoaders = Collections.emptyList();
         this.addOnClassnames = AddOnClassnames.ALL_ALLOWED;
+        this.classLoadingLockProvider = parent::getClassLoadingLock;
     }
 
     /**
@@ -165,6 +199,7 @@ public class AddOnClassLoader extends URLClassLoader {
         this.dependencies = dependencies.isEmpty() ? Collections.<AddOnClassLoader> emptyList() : new ArrayList<>(dependencies);
         this.childClassLoaders = Collections.emptyList();
         this.addOnClassnames = addOnClassnames;
+        this.classLoadingLockProvider = parent::getClassLoadingLock;
     }
 
     /**
@@ -183,6 +218,14 @@ public class AddOnClassLoader extends URLClassLoader {
             childClassLoader.close();
         }
         super.close();
+    }
+
+    @Override
+    protected Object getClassLoadingLock(String className) {
+        if (classLoadingLockProvider != null) {
+            return classLoadingLockProvider.getLock(className);
+        }
+        return super.getClassLoadingLock(className);
     }
 
     /**
@@ -293,5 +336,11 @@ public class AddOnClassLoader extends URLClassLoader {
         protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
             return super.loadClass(name, resolve);
         }
+    }
+
+    @FunctionalInterface
+    private static interface ClassLoadingLockProvider {
+
+        Object getLock(String className);
     }
 }

--- a/src/org/zaproxy/zap/control/AddOnLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnLoader.java
@@ -277,19 +277,27 @@ public class AddOnLoader extends URLClassLoader {
 
     @Override
     public Class<?> loadClass(String name) throws ClassNotFoundException {
-        try {
-			return loadClass(name, false);
-		} catch (ClassNotFoundException e) {
-			// Continue for now
-		}
-        for (AddOnClassLoader loader : addOnLoaders.values()) {
+        synchronized (getClassLoadingLock(name)) {
             try {
-    			return loader.loadClass(name);
+    			return loadClass(name, false);
     		} catch (ClassNotFoundException e) {
     			// Continue for now
     		}
+            for (AddOnClassLoader loader : addOnLoaders.values()) {
+                try {
+        			return loader.loadClass(name);
+        		} catch (ClassNotFoundException e) {
+        			// Continue for now
+        		}
+            }
+            throw new ClassNotFoundException(name);
         }
-        throw new ClassNotFoundException(name);
+    }
+
+    @Override
+    protected Object getClassLoadingLock(String className) {
+        // Allow AddOnClassLoader to use the same locks.
+        return super.getClassLoadingLock(className);
     }
     
     @Override


### PR DESCRIPTION
Change AddOnLoader and AddOnClassLoader to share the same class loading
locks, as both classes end up calling each other if the class is not
found in one of the class loaders.

Fix #2756 - Class loading deadlock when loading httpsender script from
API call and spidering