### PR TITLE
Fix typo in CFU start up dialogue

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -622,7 +622,7 @@ cfu.cmdline.updated			= Add-on update check complete
 
 cfu.confirm.launch     = The latest ZAP release: {0} has been downloaded to\n{1}\nLaunch this file and close ZAP?
 cfu.confirm.error      = Error saving configuration
-cfu.confirm.startCheck = Always check for updates on start?\nThis option can changed via Tools/Options
+cfu.confirm.startCheck = Always check for updates on start?\nThis option can be changed via Tools/Options
 cfu.confirmation.dialogue.message.addOnNewerJavaVersion=An add-on requires a newer Java version.
 cfu.confirmation.dialogue.message.addOnsNewerJavaVersion=The selected add-ons require a newer Java version:
 cfu.confirmation.dialogue.message.someAddOnsNewerJavaVersion=Some of the add-ons require a newer Java version.


### PR DESCRIPTION
Fix a typo in the main text shown in the "Check For Updates" start up
dialogue.