### PR TITLE
Issue 3481 Export Tables via GUI

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1093,6 +1093,11 @@ exportUrls.popup = Export All URLs to File...
 exportUrls.popup.selected = Export Selected URLs to File...
 exportUrls.popup.context.error = Please select a Context.
 
+export.button.name = Export
+export.button.success = Export successful!
+export.button.error = Error while exporting:
+export.button.default.filename = Untitled.csv
+
 ext.desc = Allows you to configure which extensions are loaded when ZAP starts
 ext.name = Extension Configuration Extension
 
@@ -1745,10 +1750,6 @@ params.table.header.used    = Used
 params.table.header.values  = Values
 params.toolbar.site.label   = Site:
 params.toolbar.site.select  = --Select Site--
-params.toolbar.button.export = Export
-params.button.export.success = Export successful!
-params.button.export.error = Error while exporting:
-params.button.export.default.name = Untitled.csv
 params.type.cookie			= Cookie
 params.type.form			= FORM
 params.type.url				= URL

--- a/src/org/zaproxy/zap/extension/ascan/ActiveScanPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScanPanel.java
@@ -45,6 +45,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.model.ScanController;
 import org.zaproxy.zap.model.ScanListenner2;
 import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.utils.TableExportButton;
 import org.zaproxy.zap.view.ScanPanel2;
 import org.zaproxy.zap.view.table.HistoryReferencesTable;
 
@@ -80,6 +81,7 @@ public class ActiveScanPanel extends ScanPanel2<ActiveScan, ScanController<Activ
 	private JButton scanButton = null;
 	private JButton progressButton;
 	private JLabel numRequests;
+	private TableExportButton exportButton = null;
 
     /**
      * Constructs an {@code ActiveScanPanel} with the given extension.
@@ -108,6 +110,7 @@ public class ActiveScanPanel extends ScanPanel2<ActiveScan, ScanController<Activ
 			panelToolbar.add(new JToolBar.Separator(), getGBC(x++, 0));
 			panelToolbar.add(new JLabel(Constant.messages.getString("ascan.toolbar.requests.label")), getGBC(x++,0));
 			panelToolbar.add(getNumRequests(), getGBC(x++,0));
+			panelToolbar.add(getExportButton(), getGBC(x++,0));
 		}
 		return x;
 	}
@@ -173,6 +176,13 @@ public class ActiveScanPanel extends ScanPanel2<ActiveScan, ScanController<Activ
 			spp.setActiveScan(scan);
 			spp.setVisible(true);
 		}
+	}
+	
+	private TableExportButton getExportButton() {
+		if (exportButton == null) {
+			exportButton = new TableExportButton(getMessagesTable());
+		}
+		return exportButton;
 	}
 	
 	@Override

--- a/src/org/zaproxy/zap/extension/params/ParamsPanel.java
+++ b/src/org/zaproxy/zap/extension/params/ParamsPanel.java
@@ -24,21 +24,10 @@ import java.awt.Component;
 import java.awt.Event;
 import java.awt.GridBagConstraints;
 import java.awt.Toolkit;
-import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
-import java.io.File;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.swing.AbstractAction;
-import javax.swing.Box;
 import javax.swing.ImageIcon;
-import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
-import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JToolBar;
@@ -47,9 +36,6 @@ import javax.swing.table.DefaultTableColumnModel;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
-import org.apache.log4j.Logger;
 import org.jdesktop.swingx.JXTable;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
@@ -57,15 +43,14 @@ import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.SortedComboBoxModel;
+import org.zaproxy.zap.utils.TableExportButton;
 import org.zaproxy.zap.view.ScanPanel;
-import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
 public class ParamsPanel extends AbstractPanel{
 	
 	private static final long serialVersionUID = 1L;
 
 	public static final String PANEL_NAME = "params";
-    private Logger LOGGER = Logger.getLogger(ParamsPanel.class);
 	
 	private ExtensionParams extension = null;
 	private JPanel panelCommand = null;
@@ -79,6 +64,7 @@ public class ParamsPanel extends AbstractPanel{
 
 	private JXTable paramsTable = null;
 	private ParamsTableModel paramsModel = new ParamsTableModel();
+	private TableExportButton exportButton = null;
 	
     //private static Log log = LogFactory.getLog(ParamsPanel.class);
     
@@ -154,6 +140,7 @@ public class ParamsPanel extends AbstractPanel{
 			GridBagConstraints gridBagConstraints0 = new GridBagConstraints();
 			GridBagConstraints gridBagConstraints1 = new GridBagConstraints();
 			GridBagConstraints gridBagConstraints2 = new GridBagConstraints();
+			GridBagConstraints gridBagConstraints3 = new GridBagConstraints();
 			GridBagConstraints gridBagConstraintsx = new GridBagConstraints();
 
 			gridBagConstraints0.gridx = 0;
@@ -170,8 +157,13 @@ public class ParamsPanel extends AbstractPanel{
 			gridBagConstraints2.gridy = 0;
 			gridBagConstraints2.insets = new java.awt.Insets(0,0,0,0);
 			gridBagConstraints2.anchor = java.awt.GridBagConstraints.WEST;
+			
+			gridBagConstraints3.gridx = 3;
+			gridBagConstraints3.gridy = 0;
+			gridBagConstraints3.insets = new java.awt.Insets(0,0,0,0);
+			gridBagConstraints3.anchor = java.awt.GridBagConstraints.WEST;
 
-			gridBagConstraintsx.gridx = 3;
+			gridBagConstraintsx.gridx = 4;
 			gridBagConstraintsx.gridy = 0;
 			gridBagConstraintsx.weightx = 1.0;
 			gridBagConstraintsx.weighty = 1.0;
@@ -185,56 +177,18 @@ public class ParamsPanel extends AbstractPanel{
 
 			panelToolbar.add(new JLabel(Constant.messages.getString("params.toolbar.site.label")), gridBagConstraints1);
 			panelToolbar.add(getSiteSelect(), gridBagConstraints2);
-			
+			panelToolbar.add(getExportButton(), gridBagConstraints3);
+
 			panelToolbar.add(t1, gridBagConstraintsx);
-			
-			panelToolbar.add(Box.createHorizontalGlue());
-			panelToolbar.add(getExportButton());
 		}
 		return panelToolbar;
 	}
 	
-	private JButton getExportButton() {
-		JButton csvExportButton = new JButton(Constant.messages.getString("params.toolbar.button.export"));
-		csvExportButton.setIcon(new ImageIcon(ParamsPanel.class.getResource("/resource/icon/16/115.png")));
-		csvExportButton.addActionListener((new AbstractAction() {
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				WritableFileChooser chooser = new WritableFileChooser();
-				chooser.setSelectedFile(new File(Constant.messages.getString("params.button.export.default.name")));
-				if (chooser
-						.showSaveDialog(View.getSingleton().getMainFrame()) == WritableFileChooser.APPROVE_OPTION) {
-					String file = chooser.getSelectedFile().toString();
-					if (!file.endsWith(".csv")) {
-						file += ".csv";
-					}
-					try (CSVPrinter pw = new CSVPrinter(
-							Files.newBufferedWriter(chooser.getSelectedFile().toPath(), StandardCharsets.UTF_8),
-							CSVFormat.DEFAULT)) {
-						pw.printRecord(((ParamsTableModel) paramsTable.getModel()).getColumnNames());
-						int rowCount = paramsTable.getRowCount();
-						int colCount = paramsTable.getColumnCount();
-						for (int row = 0; row < rowCount; row++) {
-							List<Object> valueOfRow = new ArrayList<Object>();
-							for (int col = 0; col < colCount; col++) {
-								valueOfRow.add(paramsTable.getValueAt(row, col));
-							}
-							pw.printRecord(valueOfRow);
-						}
-						JOptionPane.showMessageDialog(View.getSingleton().getMainFrame(),
-								Constant.messages.getString("params.button.export.success"));
-					} catch (Exception ex) {
-						JOptionPane.showMessageDialog(View.getSingleton().getMainFrame(),
-								Constant.messages.getString("params.button.export.error") + "\n"
-										+ ex.getLocalizedMessage());
-						LOGGER.error("Export Failed: " + ex);
-					}
-				}
-			}
-		}));
-		return csvExportButton;
+	private TableExportButton getExportButton() {
+		if (exportButton == null) {
+			exportButton = new TableExportButton(getParamsTable());
+		}
+		return exportButton;
 	}
 
 	/*

--- a/src/org/zaproxy/zap/extension/spider/SpiderPanel.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderPanel.java
@@ -42,6 +42,8 @@ import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
 import javax.swing.KeyStroke;
 import javax.swing.ListSelectionModel;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
 
 import org.apache.log4j.Logger;
 import org.jdesktop.swingx.JXTable;
@@ -55,6 +57,7 @@ import org.zaproxy.zap.model.ScanController;
 import org.zaproxy.zap.model.ScanListenner2;
 import org.zaproxy.zap.spider.SpiderParam;
 import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.utils.TableExportButton;
 import org.zaproxy.zap.view.ScanPanel2;
 import org.zaproxy.zap.view.ZapTable;
 import org.zaproxy.zap.view.table.decorator.AbstractTableCellItemIconHighlighter;
@@ -160,6 +163,8 @@ public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderSca
 	/** The found count value label. */
 	private JLabel foundCountValueLabel;
 	
+	private TableExportButton exportButton;
+	
 	private ExtensionSpider extension = null;
 
 	/**
@@ -172,6 +177,19 @@ public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderSca
 		super("spider", new ImageIcon(SpiderPanel.class.getResource("/resource/icon/16/spider.png")), extension);
 
 		tabbedPane = new JTabbedPane();
+		tabbedPane.addChangeListener(new ChangeListener() {
+			@Override
+			public void stateChanged(ChangeEvent e) {
+				switch(tabbedPane.getSelectedIndex()) {
+				case 0:
+					getExportButton().setTable(getUrlsTable());
+					break;
+				case 1:
+					getExportButton().setTable(getMessagesTable());
+					break;
+				}
+			}
+		});
 
 		this.extension = extension;
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
@@ -300,6 +318,7 @@ public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderSca
 			toolBar.add(getFoundCountValueLabel(), getGBC(gridX++, 0));
 			toolBar.add(new JToolBar.Separator(), getGBC(gridX++, 0));
 			toolBar.add(getShowMessagesToggleButton(), getGBC(gridX++, 0));
+			toolBar.add(getExportButton(), getGBC(gridX++, 0));
 		}
 		return gridX;
 	}
@@ -325,6 +344,13 @@ public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderSca
 		return showMessageToggleButton;
 	}
 
+	private TableExportButton getExportButton() {
+		if (exportButton == null) {
+			exportButton = new TableExportButton(getUrlsTable());
+		}
+		return exportButton;
+	}
+	
 	/**
 	 * Shows both tabs, the one of the URLs found and the other of the HTTP messages sent.
 	 *
@@ -355,6 +381,7 @@ public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderSca
 
 		mainPanel.add(getUrlsTableScrollPane());
 		mainPanel.revalidate();
+		getExportButton().setTable(getUrlsTable());
 	}
 
 	/**

--- a/src/org/zaproxy/zap/utils/TableExportButton.java
+++ b/src/org/zaproxy/zap/utils/TableExportButton.java
@@ -1,0 +1,135 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.utils;
+
+import java.awt.event.ActionEvent;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.AbstractAction;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JOptionPane;
+import javax.swing.JTable;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.view.widgets.WritableFileChooser;
+/**
+ * A {@code JButton} class to facilitate exporting tables (as shown) to a file (such as CSV).
+ * Filters, sorting, column order, and column visibility may all impact the data exported.
+ * 
+ * @since TODO add version
+ */
+public class TableExportButton extends JButton {
+
+	private static final long serialVersionUID = 3437613469695367668L;
+
+	private static final Logger LOGGER = Logger.getLogger(TableExportButton.class);
+	
+	private JTable exportTable = null;
+	
+	/**
+	 * Constructs a {@code TableExportButton} for the given table.
+	 * 
+	 * @param table the Table for which the data should be exported
+	 */
+	public TableExportButton(JTable table) {
+		super(Constant.messages.getString("export.button.name"));
+		setTable(table);
+		super.setIcon(new ImageIcon(TableExportButton.class.getResource("/resource/icon/16/115.png")));
+		super.addActionListener((new AbstractAction() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				WritableFileChooser chooser = new WritableFileChooser();
+				chooser.setSelectedFile(new File(Constant.messages.getString("export.button.default.filename")));
+				if (chooser.showSaveDialog(View.getSingleton().getMainFrame()) == WritableFileChooser.APPROVE_OPTION) {
+					String file = chooser.getSelectedFile().toString();
+					if (!file.endsWith(".csv")) {
+						file += ".csv";
+					}
+					try (CSVPrinter pw = new CSVPrinter(
+							Files.newBufferedWriter(chooser.getSelectedFile().toPath(), StandardCharsets.UTF_8),
+							CSVFormat.DEFAULT)) {
+						pw.printRecord(getColumnNames());
+						int rowCount = getTable().getRowCount();
+						int colCount = getTable().getColumnCount();
+						for (int row = 0; row < rowCount; row++) {
+							List<Object> valueOfRow = new ArrayList<Object>();
+							for (int col = 0; col < colCount; col++) {
+								Object value = getTable().getValueAt(row, col);
+								value = value == null ? "" : value;
+								valueOfRow.add(value.toString());
+							}
+							pw.printRecord(valueOfRow);
+						}
+						JOptionPane.showMessageDialog(View.getSingleton().getMainFrame(),
+								Constant.messages.getString("export.button.success"));
+					} catch (Exception ex) {
+						JOptionPane.showMessageDialog(View.getSingleton().getMainFrame(),
+								Constant.messages.getString("export.button.error") + "\n"
+										+ ex.getMessage());
+						LOGGER.error("Export Failed: " + ex.getMessage(), ex);
+					}
+				}
+			}
+		}));
+	}
+
+	/**
+	 * Gets a {@code List} of (visible) column names for the given table.
+	 * 
+	 * @return the {@code List} of column names
+	 */
+	private List<String> getColumnNames() {
+		List<String> columnNamesList = new ArrayList<String>();
+		for (int col = 0; col < getTable().getColumnCount(); col++) {
+			columnNamesList.add(getTable().getColumnModel().getColumn(col).getHeaderValue().toString());
+		}
+		return columnNamesList;
+	}
+	
+	/**
+	 * Gets the Table which this button is associated with.
+	 * 
+	 * @return the Table this button is associated with
+	 */
+	private JTable getTable() {
+		return exportTable;
+	}
+	
+	/**
+	 * Sets the Table this button is for.
+	 * 
+	 * @param table the Table this button applies to
+	 */
+	public void setTable(JTable table) {
+		this.exportTable = table;
+	}
+	
+}


### PR DESCRIPTION
- org.zaproxy.zap.utils.TableExportButton > New component that extends JButton and accepts a JTable (JXTable) as a parameter.
- Messages.properties > Moved param specific export button resource keys and values to be used generically.
- ParamsPanel > Revised to use the new generic component.
- SpiderPanel > Add StateChange listener to tabbedpane, add functionality to show/enable (or hide/disable) the appropriate export button.
- ActiveScanPanel > Add export button.

Fixes zaproxy/zaproxy#3481