### PR TITLE
Correct ZAP home dir used in stable Docker image

### DIFF
--- a/build/docker/Dockerfile-stable
+++ b/build/docker/Dockerfile-stable
@@ -69,7 +69,7 @@ COPY zap-x.sh /zap/
 COPY zap-baseline.py /zap/ 
 COPY zap-webswing.sh /zap/ 
 COPY webswing.config /zap/webswing-2.3/ 
-COPY policies /home/zap/.ZAP_D/policies/
+COPY policies /home/zap/.ZAP/policies/
 COPY .xinitrc /home/zap/
 
 
@@ -80,7 +80,7 @@ RUN chown zap:zap /zap/zap-x.sh && \
 	chown zap:zap /zap/zap-baseline.py && \
 	chown zap:zap /zap/zap-webswing.sh && \
 	chown zap:zap /zap/webswing-2.3/webswing.config && \
-	chown zap:zap -R /home/zap/.ZAP_D/ && \
+	chown zap:zap -R /home/zap/.ZAP/ && \
 	chown zap:zap /home/zap/.xinitrc && \
 	chmod a+x /home/zap/.xinitrc
 #Change back to zap at the end


### PR DESCRIPTION
Change Dockerfile-stable to use the home dir of the main ZAP versions
(.ZAP) instead of the ones used in dev/weekly versions (.ZAP_D).