### PR TITLE
Improve compatibility with Python passive rules

### DIFF
--- a/src/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
+++ b/src/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
@@ -19,10 +19,12 @@
  */
 package org.zaproxy.zap.extension.pscan.scanner;
 
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.List;
 
 import net.htmlparser.jericho.Source;
 
+import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -36,6 +38,8 @@ import org.zaproxy.zap.extension.script.ScriptWrapper;
 
 public class ScriptsPassiveScanner extends PluginPassiveScanner {
 	
+	private static final Logger logger = Logger.getLogger(ScriptsPassiveScanner.class);
+
 	private ExtensionScript extension = null;
 	private PassiveScanThread parent = null;
 	
@@ -79,7 +83,7 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
 						PassiveScript s = extension.getInterface(script, PassiveScript.class);
 						
 						if (s != null) {
-							if (s.appliesToHistoryType(currentHistoryType)) {
+							if (appliesToCurrentHistoryType(script, s)) {
 								s.scan(this, msg, source);
 							}
 							
@@ -96,6 +100,24 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
 			}
 		}
 		
+	}
+
+	private boolean appliesToCurrentHistoryType(ScriptWrapper wrapper, PassiveScript ps) {
+		try {
+			return ps.appliesToHistoryType(currentHistoryType);
+		} catch (UndeclaredThrowableException e) {
+			// Python script implementation throws an exception if this optional/default method is not
+			// actually implemented by the script (other script implementations, Zest/ECMAScript, just
+			// use the default method).
+			if (e.getCause() instanceof NoSuchMethodException && "appliesToHistoryType".equals(e.getCause().getMessage())) {
+				if (logger.isDebugEnabled()) {
+					logger.debug("Script [Name=" + wrapper.getName() + ", Engine=" + wrapper.getEngineName()
+									+ "]  does not implement the optional method appliesToHistoryType: ", e);
+				}
+				return true;
+			}
+			throw e;
+		}
 	}
 	
 	public void raiseAlert(int risk, int confidence, String name, String description, String uri, 


### PR DESCRIPTION
Change ScriptsPassiveScanner to catch the exception thrown by the Python
script implementation when the optional method is not implemented by the
script, allowing to run the existing scripts without changes (the Python
script implementation does not use the default methods and the script
engine returns an implementation of the interface even if not all
methods are implemented).

Related to #3476 - Allow passive rules to choose the type of msgs