### PR TITLE
Fix another class loading lock with scripts

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnClassLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnClassLoader.java
@@ -326,7 +326,7 @@ public class AddOnClassLoader extends URLClassLoader {
      * @see AddOnClassLoader#findClass(String)
      * @see ClassLoader#loadClass(String, boolean)
      */
-    private static class ParentClassLoader extends ClassLoader {
+    private class ParentClassLoader extends ClassLoader {
 
         public ParentClassLoader(ClassLoader classLoader) {
             super(classLoader);
@@ -335,6 +335,14 @@ public class AddOnClassLoader extends URLClassLoader {
         @Override
         protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
             return super.loadClass(name, resolve);
+        }
+
+        @Override
+        protected Object getClassLoadingLock(String className) {
+            if (classLoadingLockProvider != null) {
+                return classLoadingLockProvider.getLock(className);
+            }
+            return super.getClassLoadingLock(className);
         }
     }
 


### PR DESCRIPTION
Change ParentClassLoader to share the same class loading locks as
AddOnClassLoader, ParentClassLoader is usually AddOnLoader which might
end up calling AddOnClassLoader.

Fix #2756 - Class loading deadlock when loading httpsender script from
API call and spidering