### PR TITLE
Clone with minimum depth when building live image

### DIFF
--- a/build/docker/Dockerfile-live
+++ b/build/docker/Dockerfile-live
@@ -53,11 +53,11 @@ ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 ENV PATH $JAVA_HOME/bin:/zap/:$PATH
 
 # Pull the ZAP repos
-RUN git clone https://github.com/zaproxy/zaproxy.git && \
-	git clone https://github.com/zaproxy/zap-extensions.git && \
-	git clone --branch beta https://github.com/zaproxy/zap-extensions.git zap-extensions_beta && \
-	git clone --branch alpha https://github.com/zaproxy/zap-extensions.git zap-extensions_alpha && \
-	git clone https://github.com/zaproxy/zap-core-help.git && \
+RUN git clone --depth 1 https://github.com/zaproxy/zaproxy.git && \
+	git clone --depth 1 https://github.com/zaproxy/zap-extensions.git && \
+	git clone --branch beta --depth 1 https://github.com/zaproxy/zap-extensions.git zap-extensions_beta && \
+	git clone --branch alpha --depth 1 https://github.com/zaproxy/zap-extensions.git zap-extensions_alpha && \
+	git clone --depth 1 https://github.com/zaproxy/zap-core-help.git && \
 	# Download the webdrivers
 	cd zap-extensions_beta && \
 	ant -f build/build.xml download-webdrivers && \


### PR DESCRIPTION
Change Dockerfile-live to clone the zaproxy repositories with minimum
depth, to slightly reduce the time it takes to build the image.