### PR TITLE
Add AcceptedLicense file to docker images

### DIFF
--- a/build/docker/Dockerfile-live
+++ b/build/docker/Dockerfile-live
@@ -66,7 +66,8 @@ RUN git clone https://github.com/zaproxy/zaproxy.git && \
 	ant -f build/build.xml deploy-weekly-addons && \
 	ant -f build/build.xml day-stamped-release && \
 	cp -R /zap-src/zaproxy/build/zap/* /zap/ && \
-	rm -rf /zap-src/*
+	rm -rf /zap-src/* && \
+	touch /zap/AcceptedLicense
 	
 ENV ZAP_PATH /zap/zap.sh
 # Default port for use with zapcli

--- a/build/docker/Dockerfile-stable
+++ b/build/docker/Dockerfile-stable
@@ -53,7 +53,8 @@ RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersio
 	rm -R ZAP* && \
 	curl -s -L https://bitbucket.org/meszarv/webswing/downloads/webswing-2.3-distribution.zip > webswing.zip && \
 	unzip *.zip && \
-	rm *.zip
+	rm *.zip && \
+	touch AcceptedLicense
 
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/

--- a/build/docker/Dockerfile-weekly
+++ b/build/docker/Dockerfile-weekly
@@ -54,7 +54,8 @@ RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersio
 	rm -R ZAP* && \
 	curl -s -L https://bitbucket.org/meszarv/webswing/downloads/webswing-2.3-distribution.zip > webswing.zip && \
 	unzip *.zip && \
-	rm *.zip
+	rm *.zip && \
+	touch AcceptedLicense
 
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/


### PR DESCRIPTION
Allows to run ZAP with GUI (e.g. WebSwing) without needing to accept the
license each time.