### PR TITLE
Use column highlighter in the HTTP Sessions table

### DIFF
--- a/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsPanel.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsPanel.java
@@ -30,6 +30,7 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.KeyEvent;
 
+import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -40,6 +41,10 @@ import javax.swing.JToolBar;
 import javax.swing.KeyStroke;
 
 import org.jdesktop.swingx.JXTable;
+import org.jdesktop.swingx.renderer.DefaultTableRenderer;
+import org.jdesktop.swingx.renderer.IconValues;
+import org.jdesktop.swingx.renderer.MappedValue;
+import org.jdesktop.swingx.renderer.StringValues;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.AbstractPanel;
@@ -49,6 +54,7 @@ import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.SortedComboBoxModel;
 import org.zaproxy.zap.utils.TableExportButton;
 import org.zaproxy.zap.view.ScanPanel;
+import org.zaproxy.zap.view.table.decorator.AbstractTableCellItemIconHighlighter;
 
 /**
  * The HttpSessionsPanel used as a display panel for the {@link ExtensionHttpSessions}, allowing the
@@ -312,6 +318,11 @@ public class HttpSessionsPanel extends AbstractPanel {
 			sessionsTable.setRowSelectionAllowed(true);
 			sessionsTable.setAutoCreateRowSorter(true);
 			sessionsTable.setColumnControlVisible(true);
+			sessionsTable.setAutoCreateColumnsFromModel(false);
+
+			sessionsTable.getColumnExt(0).setCellRenderer(
+					new DefaultTableRenderer(new MappedValue(StringValues.EMPTY, IconValues.NONE), JLabel.CENTER));
+			sessionsTable.getColumnExt(0).setHighlighters(new ActiveSessionIconHighlighter(0));
 
 			this.setSessionsTableColumnSizes();
 
@@ -494,5 +505,32 @@ public class HttpSessionsPanel extends AbstractPanel {
 		}
 		final int rowIndex = sessionsTable.convertRowIndexToModel(selectedRow);
 		return this.sessionsModel.getHttpSessionAt(rowIndex);
+	}
+
+	/**
+	 * A {@link org.jdesktop.swingx.decorator.Highlighter Highlighter} for a column that indicates, using an icon, whether or
+	 * not a session is active.
+	 * <p>
+	 * The expected type/class of the cell value is {@code Boolean}.
+	 */
+	private static class ActiveSessionIconHighlighter extends AbstractTableCellItemIconHighlighter {
+
+		/** The icon that indicates that a session is active. */
+		private static final ImageIcon ACTIVE_ICON = new ImageIcon(
+				HttpSessionsPanel.class.getResource("/resource/icon/16/102.png"));
+
+		public ActiveSessionIconHighlighter(int columnIndex) {
+			super(columnIndex);
+		}
+
+		@Override
+		protected Icon getIcon(final Object cellItem) {
+			return ACTIVE_ICON;
+		}
+
+		@Override
+		protected boolean isHighlighted(final Object cellItem) {
+			return ((Boolean) cellItem).booleanValue();
+		}
 	}
 }

--- a/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsTableModel.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsTableModel.java
@@ -20,7 +20,6 @@ package org.zaproxy.zap.extension.httpsessions;
 import java.awt.EventQueue;
 import java.util.ArrayList;
 
-import javax.swing.ImageIcon;
 import javax.swing.table.AbstractTableModel;
 
 import org.parosproxy.paros.Constant;
@@ -47,12 +46,6 @@ public class HttpSessionsTableModel extends AbstractTableModel {
 
 	/** The site. */
 	private HttpSessionsSite site;
-
-	/** The Constant activeIcon defining the image used for marking the active session. */
-	private static final ImageIcon activeIcon;
-	static {
-		activeIcon = new ImageIcon(HttpSessionsTableModel.class.getResource("/resource/icon/16/102.png"));
-	}
 
 	/**
 	 * Instantiates a new http sessions table model.
@@ -90,10 +83,7 @@ public class HttpSessionsTableModel extends AbstractTableModel {
 		HttpSession session = sessions.get(row);
 		switch (col) {
 		case 0:
-			if (session.isActive())
-				return activeIcon;
-			else
-				return null;
+			return session.isActive();
 		case 1:
 			return session.getName();
 		case 2:
@@ -184,7 +174,7 @@ public class HttpSessionsTableModel extends AbstractTableModel {
 	public Class<?> getColumnClass(int columnIndex) {
 		switch (columnIndex) {
 		case 0:
-			return ImageIcon.class;
+			return Boolean.class;
 		case 1:
 			return String.class;
 		case 2:


### PR DESCRIPTION
Change HttpSessionsPanel to use a Highlighter for the Active column, to
prevent copying the path of the image/icon that indicates that the
session is active (instead copy true/false).
Change HttpSessionsTableModel to not return an icon for the Active
column but the actual boolean value.