### PR TITLE
Delay success message when exporting

### DIFF
--- a/src/org/zaproxy/zap/utils/TableExportButton.java
+++ b/src/org/zaproxy/zap/utils/TableExportButton.java
@@ -73,6 +73,7 @@ public class TableExportButton extends JButton {
 					if (!file.endsWith(".csv")) {
 						file += ".csv";
 					}
+					boolean success = true;
 					try (CSVPrinter pw = new CSVPrinter(
 							Files.newBufferedWriter(chooser.getSelectedFile().toPath(), StandardCharsets.UTF_8),
 							CSVFormat.DEFAULT)) {
@@ -88,13 +89,18 @@ public class TableExportButton extends JButton {
 							}
 							pw.printRecord(valueOfRow);
 						}
-						JOptionPane.showMessageDialog(View.getSingleton().getMainFrame(),
-								Constant.messages.getString("export.button.success"));
 					} catch (Exception ex) {
+						success = false;
 						JOptionPane.showMessageDialog(View.getSingleton().getMainFrame(),
 								Constant.messages.getString("export.button.error") + "\n"
 										+ ex.getMessage());
 						LOGGER.error("Export Failed: " + ex.getMessage(), ex);
+					}
+
+					// Delay the presentation of success message, to ensure all the data was already flushed.
+					if (success) {
+						JOptionPane.showMessageDialog(View.getSingleton().getMainFrame(),
+								Constant.messages.getString("export.button.success"));
 					}
 				}
 			}


### PR DESCRIPTION
Change TableExportButton to show the message after flushing/closing the
file, to ensure that all the data was already written when the message
is shown.