### PR TITLE
Include Webswing in live Docker image

### DIFF
--- a/build/docker/Dockerfile-live
+++ b/build/docker/Dockerfile-live
@@ -67,7 +67,11 @@ RUN git clone --depth 1 https://github.com/zaproxy/zaproxy.git && \
 	ant -f build/build.xml day-stamped-release && \
 	cp -R /zap-src/zaproxy/build/zap/* /zap/ && \
 	rm -rf /zap-src/* && \
-	touch /zap/AcceptedLicense
+	cd /zap/ && \
+	curl -s -L https://bitbucket.org/meszarv/webswing/downloads/webswing-2.3-distribution.zip > webswing.zip && \
+	unzip webswing.zip && \
+	rm webswing.zip && \
+	touch AcceptedLicense
 	
 ENV ZAP_PATH /zap/zap.sh
 # Default port for use with zapcli


### PR DESCRIPTION
Change Dockerfile-live to also include Webswing (same as other Docker
images, stable and weekly).

Related to #3550 - missing webswing executable in weekly docker