### PR TITLE
Parameterise TableExportButton

### DIFF
--- a/src/org/parosproxy/paros/extension/history/LogPanel.java
+++ b/src/org/parosproxy/paros/extension/history/LogPanel.java
@@ -101,7 +101,7 @@ public class LogPanel extends AbstractPanel {
 
 	private DeselectableButtonGroup historyListFiltersButtonGroup;
 
-	private TableExportButton exportButton;
+	private TableExportButton<HistoryReferencesTable> exportButton;
 
 	private final ViewDelegate view;
 	
@@ -301,9 +301,9 @@ public class LogPanel extends AbstractPanel {
 		return linkWithSitesTreeButton;
 	}
 
-	private TableExportButton getExportButton() {
+	private TableExportButton<HistoryReferencesTable> getExportButton() {
 		if (exportButton == null) {
-			exportButton = new TableExportButton(getHistoryReferenceTable());
+			exportButton = new TableExportButton<>(getHistoryReferenceTable());
 		}
 		return exportButton;
 	}

--- a/src/org/zaproxy/zap/extension/ascan/ActiveScanPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScanPanel.java
@@ -81,7 +81,7 @@ public class ActiveScanPanel extends ScanPanel2<ActiveScan, ScanController<Activ
 	private JButton scanButton = null;
 	private JButton progressButton;
 	private JLabel numRequests;
-	private TableExportButton exportButton = null;
+	private TableExportButton<HistoryReferencesTable> exportButton = null;
 
     /**
      * Constructs an {@code ActiveScanPanel} with the given extension.
@@ -178,9 +178,9 @@ public class ActiveScanPanel extends ScanPanel2<ActiveScan, ScanController<Activ
 		}
 	}
 	
-	private TableExportButton getExportButton() {
+	private TableExportButton<HistoryReferencesTable> getExportButton() {
 		if (exportButton == null) {
-			exportButton = new TableExportButton(getMessagesTable());
+			exportButton = new TableExportButton<>(getMessagesTable());
 		}
 		return exportButton;
 	}

--- a/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsPanel.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsPanel.java
@@ -77,7 +77,7 @@ public class HttpSessionsPanel extends AbstractPanel {
 	private JComboBox<String> siteSelect = null;
 	private JButton newSessionButton = null;
 	private JXTable sessionsTable = null;
-	private TableExportButton exportButton = null;
+	private TableExportButton<JXTable> exportButton = null;
 	private JButton optionsButton = null;
 
 	/** The current site. */
@@ -150,9 +150,9 @@ public class HttpSessionsPanel extends AbstractPanel {
 		return panelCommand;
 	}
 
-	private TableExportButton getExportButton() {
+	private TableExportButton<JXTable> getExportButton() {
 		if (exportButton == null) {
-			exportButton = new TableExportButton(getHttpSessionsTable());
+			exportButton = new TableExportButton<>(getHttpSessionsTable());
 		}
 		return exportButton;
 	}

--- a/src/org/zaproxy/zap/extension/params/ParamsPanel.java
+++ b/src/org/zaproxy/zap/extension/params/ParamsPanel.java
@@ -64,7 +64,7 @@ public class ParamsPanel extends AbstractPanel{
 
 	private JXTable paramsTable = null;
 	private ParamsTableModel paramsModel = new ParamsTableModel();
-	private TableExportButton exportButton = null;
+	private TableExportButton<JXTable> exportButton = null;
 	
     //private static Log log = LogFactory.getLog(ParamsPanel.class);
     
@@ -184,9 +184,9 @@ public class ParamsPanel extends AbstractPanel{
 		return panelToolbar;
 	}
 	
-	private TableExportButton getExportButton() {
+	private TableExportButton<JXTable> getExportButton() {
 		if (exportButton == null) {
-			exportButton = new TableExportButton(getParamsTable());
+			exportButton = new TableExportButton<>(getParamsTable());
 		}
 		return exportButton;
 	}

--- a/src/org/zaproxy/zap/extension/search/SearchPanel.java
+++ b/src/org/zaproxy/zap/extension/search/SearchPanel.java
@@ -85,7 +85,7 @@ public class SearchPanel extends AbstractPanel implements SearchListenner {
 	private JCheckBox chkInverse = null;
 	private JLabel numberOfMatchesLabel;
 	private JButton optionsButton;
-	private TableExportButton exportButton = null;
+	private TableExportButton<SearchResultsTable> exportButton = null;
 	
 	private MessageFormat numberOfMatchesFormat;
 
@@ -366,9 +366,9 @@ public class SearchPanel extends AbstractPanel implements SearchListenner {
 		numberOfMatchesLabel.setText(numberOfMatchesFormat.format(new Object[] { Integer.valueOf(numberOfMatches) }));
 	}
 
-	private TableExportButton getExportButton() {
+	private TableExportButton<SearchResultsTable> getExportButton() {
 		if (exportButton == null) {
-			exportButton = new TableExportButton(resultsTable);
+			exportButton = new TableExportButton<>(resultsTable);
 		}
 		return exportButton;
 	}

--- a/src/org/zaproxy/zap/extension/spider/SpiderPanel.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderPanel.java
@@ -163,7 +163,7 @@ public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderSca
 	/** The found count value label. */
 	private JLabel foundCountValueLabel;
 	
-	private TableExportButton exportButton;
+	private TableExportButton<JXTable> exportButton;
 	
 	private ExtensionSpider extension = null;
 
@@ -344,9 +344,9 @@ public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderSca
 		return showMessageToggleButton;
 	}
 
-	private TableExportButton getExportButton() {
+	private TableExportButton<JXTable> getExportButton() {
 		if (exportButton == null) {
-			exportButton = new TableExportButton(getUrlsTable());
+			exportButton = new TableExportButton<>(getUrlsTable());
 		}
 		return exportButton;
 	}

--- a/src/org/zaproxy/zap/utils/TableExportButton.java
+++ b/src/org/zaproxy/zap/utils/TableExportButton.java
@@ -43,22 +43,23 @@ import org.zaproxy.zap.view.widgets.WritableFileChooser;
  * A {@code JButton} class to facilitate exporting tables (as shown) to a file (such as CSV).
  * Filters, sorting, column order, and column visibility may all impact the data exported.
  * 
+ * @param <T> the type of the table.
  * @since TODO add version
  */
-public class TableExportButton extends JButton {
+public class TableExportButton<T extends JTable> extends JButton {
 
 	private static final long serialVersionUID = 3437613469695367668L;
 
 	private static final Logger LOGGER = Logger.getLogger(TableExportButton.class);
 	
-	private JTable exportTable = null;
+	private T exportTable = null;
 	
 	/**
 	 * Constructs a {@code TableExportButton} for the given table.
 	 * 
 	 * @param table the Table for which the data should be exported
 	 */
-	public TableExportButton(JTable table) {
+	public TableExportButton(T table) {
 		super(Constant.messages.getString("export.button.name"));
 		setTable(table);
 		super.setIcon(new ImageIcon(TableExportButton.class.getResource("/resource/icon/16/115.png")));
@@ -80,15 +81,8 @@ public class TableExportButton extends JButton {
 							CSVFormat.DEFAULT)) {
 						pw.printRecord(getColumnNames());
 						int rowCount = getTable().getRowCount();
-						int colCount = getTable().getColumnCount();
 						for (int row = 0; row < rowCount; row++) {
-							List<Object> valueOfRow = new ArrayList<Object>();
-							for (int col = 0; col < colCount; col++) {
-								Object value = getTable().getValueAt(row, col);
-								value = value == null ? "" : value;
-								valueOfRow.add(value.toString());
-							}
-							pw.printRecord(valueOfRow);
+							pw.printRecord(getRowCells(row));
 						}
 					} catch (Exception ex) {
 						success = false;
@@ -110,15 +104,34 @@ public class TableExportButton extends JButton {
 
 	/**
 	 * Gets a {@code List} of (visible) column names for the given table.
+	 * <p>
+	 * Called when exporting the column names.
 	 * 
-	 * @return the {@code List} of column names
+	 * @return the {@code List} of column names, never {@code null}.
 	 */
-	private List<String> getColumnNames() {
+	protected List<String> getColumnNames() {
 		List<String> columnNamesList = new ArrayList<String>();
 		for (int col = 0; col < getTable().getColumnCount(); col++) {
 			columnNamesList.add(getTable().getColumnModel().getColumn(col).getHeaderValue().toString());
 		}
 		return columnNamesList;
+	}
+
+	/**
+	 * Gets the cell values (in view order) for the given row.
+	 * <p>
+	 * Called for each (visible) row that's being exported.
+	 *
+	 * @param row the row, in view coordinates.
+	 * @return a {@code List} containing the values of the cells for the given row, never {@code null}.
+	 */
+	protected List<Object> getRowCells(int row) {
+		List<Object> cells = new ArrayList<>();
+		for (int col = 0; col < getTable().getColumnCount(); col++) {
+			Object value = getTable().getValueAt(row, col);
+			cells.add(value == null ? "" : value.toString());
+		}
+		return cells;
 	}
 	
 	/**
@@ -126,7 +139,7 @@ public class TableExportButton extends JButton {
 	 * 
 	 * @return the Table this button is associated with
 	 */
-	private JTable getTable() {
+	protected T getTable() {
 		return exportTable;
 	}
 	
@@ -135,7 +148,7 @@ public class TableExportButton extends JButton {
 	 * 
 	 * @param table the Table this button applies to
 	 */
-	public void setTable(JTable table) {
+	public void setTable(T table) {
 		this.exportTable = table;
 	}
 	


### PR DESCRIPTION
Parameterise TableExportButton to allow extending classes to use the
table set without casts, also, expose key methods to allow extending
classes to customise what's exported (e.g. to add/replace custom cells).