### PR TITLE
Do not postInstall disabled extensions

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnInstaller.java
+++ b/src/org/zaproxy/zap/control/AddOnInstaller.java
@@ -89,6 +89,10 @@ public final class AddOnInstaller {
  
         // postInstall actions
         for (Extension ext : listExts) {
+            if (!ext.isEnabled()) {
+                continue;
+            }
+
             try {
                 ext.postInstall();
             } catch (Exception e) {


### PR DESCRIPTION
Change AddonInstaller to skip postInstall call on disabled extensions,
disabled extensions are not fully initialised nor hooked to ZAP (thus
not in an expected/consistent state when postInstall is called).