### PR TITLE
Use expected type for Extension's dependencies

### DIFF
--- a/src/org/parosproxy/paros/extension/Extension.java
+++ b/src/org/parosproxy/paros/extension/Extension.java
@@ -33,6 +33,7 @@
 // ZAP: 2015/03/30 Issue 1582: Enablers for low memory option
 // ZAP: 2016/09/26 JavaDoc tweaks
 // ZAP: 2017/02/17 Expose ExtensionHook to allow core code remove/unhook the extension.
+// ZAP: 2017/05/22 Use Class<? extends Extension> for dependencies of the extension.
 
 package org.parosproxy.paros.extension;
 
@@ -161,7 +162,12 @@ public interface Extension {
 	
 	void setEnabled(boolean enabled);
 	
-	List<Class<?>> getDependencies();
+	/**
+	 * Gets the list of {@code Extension}s that this extension depends on.
+	 *
+	 * @return the list of dependencies, empty (or {@code null}) if none.
+	 */
+	List<Class<? extends Extension>> getDependencies();
 	
 	boolean isCore ();
 	

--- a/src/org/parosproxy/paros/extension/ExtensionAdaptor.java
+++ b/src/org/parosproxy/paros/extension/ExtensionAdaptor.java
@@ -36,6 +36,7 @@
 // ZAP: 2015/03/16 Issue 1525: Further database independence changes
 // ZAP: 2015/03/30 Issue 1582: Enablers for low memory option
 // ZAP: 2017/02/17 Let core code remove/unhook the extension.
+// ZAP: 2017/05/22 Update for change in Extension.getDependencies().
 
 package org.parosproxy.paros.extension;
 
@@ -232,7 +233,7 @@ public abstract class ExtensionAdaptor implements Extension {
 	}
 	
 	@Override
-	public List<Class<?>> getDependencies() {
+	public List<Class<? extends Extension>> getDependencies() {
 		return Collections.emptyList();
 	}
 

--- a/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -47,6 +47,7 @@ import org.parosproxy.paros.control.Control.Mode;
 import org.parosproxy.paros.core.scanner.ScannerParam;
 import org.parosproxy.paros.extension.CommandLineArgument;
 import org.parosproxy.paros.extension.CommandLineListener;
+import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.SessionChangedListener;
@@ -87,14 +88,14 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
 
     //Could be after the last one that saves the HttpMessage, as this ProxyListener doesn't change the HttpMessage.
     public static final int PROXY_LISTENER_ORDER = ProxyListenerLog.PROXY_LISTENER_ORDER + 1;
-    private static final List<Class<?>> DEPENDENCIES;
+    private static final List<Class<? extends Extension>> DEPENDENCIES;
     
     private AttackModeScanner attackModeScanner;
     
     private ActiveScanController ascanController = null;
 
     static {
-        List<Class<?>> dep = new ArrayList<>(1);
+        List<Class<? extends Extension>> dep = new ArrayList<>(1);
         dep.add(ExtensionAlert.class);
 
         DEPENDENCIES = Collections.unmodifiableList(dep);
@@ -495,7 +496,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
     }
 
     @Override
-    public List<Class<?>> getDependencies() {
+    public List<Class<? extends Extension>> getDependencies() {
         return DEPENDENCIES;
     }
 

--- a/src/org/zaproxy/zap/extension/ext/OptionsExtensionTableModel.java
+++ b/src/org/zaproxy/zap/extension/ext/OptionsExtensionTableModel.java
@@ -99,8 +99,8 @@ public class OptionsExtensionTableModel extends AbstractTableModel {
     			return false;
     		}
     		// Check dependencies
-    		List<Class<?>> deps = getExtension(rowIndex).getDependencies();
-    		for (Class<?>dep : deps) {
+    		List<Class<? extends Extension>> deps = getExtension(rowIndex).getDependencies();
+    		for (Class<? extends Extension> dep : deps) {
     			Extension ext = getExtension(dep);
     			if (ext == null || ! ext.isEnabled()) {
     				return false;
@@ -111,7 +111,7 @@ public class OptionsExtensionTableModel extends AbstractTableModel {
         return false;
     }
     
-    private Extension getExtension(Class<?> c) {
+    private Extension getExtension(Class<? extends Extension> c) {
 		for (Extension ext: extensions) {
 			if (ext.getClass().equals(c)) {
 				return ext;

--- a/src/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
+++ b/src/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
@@ -36,6 +36,7 @@ import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.db.RecordContext;
+import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.model.Model;
@@ -60,10 +61,10 @@ public class ExtensionForcedUser extends ExtensionAdaptor implements ContextPane
 		ContextDataFactory {
 
 	/** The Constant EXTENSION DEPENDENCIES. */
-	private static final List<Class<?>> EXTENSION_DEPENDENCIES;
+	private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES;
 	static {
 		// Prepare a list of Extensions on which this extension depends
-		List<Class<?>> dependencies = new ArrayList<>(1);
+		List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
 		dependencies.add(ExtensionUserManagement.class);
 		EXTENSION_DEPENDENCIES = Collections.unmodifiableList(dependencies);
 	}
@@ -243,7 +244,7 @@ public class ExtensionForcedUser extends ExtensionAdaptor implements ContextPane
 	}
 
 	@Override
-	public List<Class<?>> getDependencies() {
+	public List<Class<? extends Extension>> getDependencies() {
 		return EXTENSION_DEPENDENCIES;
 	}
 

--- a/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -35,6 +35,7 @@ import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.control.Control.Mode;
 import org.parosproxy.paros.core.scanner.Plugin;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.ExtensionLoader;
@@ -63,10 +64,10 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
     private PassiveScanThread pst = null;
     private boolean passiveScanEnabled;
     private PassiveScanParam passiveScanParam;
-    private static final List<Class<?>> DEPENDENCIES;
+    private static final List<Class<? extends Extension>> DEPENDENCIES;
 
     static {
-        List<Class<?>> dep = new ArrayList<>(1);
+        List<Class<? extends Extension>> dep = new ArrayList<>(1);
         dep.add(ExtensionAlert.class);
 
         DEPENDENCIES = Collections.unmodifiableList(dep);
@@ -474,7 +475,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
     }
 
     @Override
-    public List<Class<?>> getDependencies() {
+    public List<Class<? extends Extension>> getDependencies() {
         return DEPENDENCIES;
     }
 

--- a/src/org/zaproxy/zap/extension/users/ExtensionUserManagement.java
+++ b/src/org/zaproxy/zap/extension/users/ExtensionUserManagement.java
@@ -34,6 +34,7 @@ import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.db.RecordContext;
+import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.model.Model;
@@ -84,10 +85,10 @@ public class ExtensionUserManagement extends ExtensionAdaptor implements Context
 	private UsersAPI api;
 
 	/** The Constant EXTENSION DEPENDENCIES. */
-	private static final List<Class<?>> EXTENSION_DEPENDENCIES;
+	private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES;
 	static {
 		// Prepare a list of Extensions on which this extension depends
-		List<Class<?>> dependencies = new ArrayList<>(3);
+		List<Class<? extends Extension>> dependencies = new ArrayList<>(3);
 		dependencies.add(ExtensionHttpSessions.class);
 		dependencies.add(ExtensionAuthentication.class);
 		dependencies.add(ExtensionSessionManagement.class);
@@ -158,7 +159,7 @@ public class ExtensionUserManagement extends ExtensionAdaptor implements Context
 	}
 
 	@Override
-	public List<Class<?>> getDependencies() {
+	public List<Class<? extends Extension>> getDependencies() {
 		return EXTENSION_DEPENDENCIES;
 	}
 


### PR DESCRIPTION
Change method Extension.getDependencies() to return a list of Extension
classes (instead of any type), as that's the only expected type for
dependencies of an extension.
Update usage/overrides to use the new method signature.