### PR TITLE
Remove disabled extensions

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnInstaller.java
+++ b/src/org/zaproxy/zap/control/AddOnInstaller.java
@@ -250,6 +250,8 @@ public final class AddOnInstaller {
                 uninstalledWithoutErrors = false;
             }
             callback.extensionRemoved(extUiName);
+        } else {
+            ExtensionFactory.removeAddOnExtension(extension);
         }
         addOn.removeLoadedExtension(extension);
 

--- a/src/org/zaproxy/zap/control/ExtensionFactory.java
+++ b/src/org/zaproxy/zap/control/ExtensionFactory.java
@@ -352,10 +352,9 @@ public class ExtensionFactory {
         return test;
     }
 
-    public static void unloadAddOnExtension(Extension extension) {
+    static void removeAddOnExtension(Extension extension) {
         synchronized (mapAllExtension) {
             unloadMessages(extension);
-            unloadHelpSet(extension);
 
             mapAllExtension.remove(extension.getName());
             listAllExtension.remove(extension);
@@ -370,6 +369,13 @@ public class ExtensionFactory {
             if (isUnordered) {
                 unorderedExtensions.remove(extension);
             }
+        }
+    }
+
+    public static void unloadAddOnExtension(Extension extension) {
+        synchronized (mapAllExtension) {
+            removeAddOnExtension(extension);
+            unloadHelpSet(extension);
         }
     }
 


### PR DESCRIPTION
Change AddOnInstaller to remove the disabled extensions, otherwise they
would leak when the corresponding add-on is uninstalled.
Change ExtensionFactory to allow to remove an extension.