### PR TITLE
Do not change extensions' enabled state

### DIFF
--- a/src/org/parosproxy/paros/extension/Extension.java
+++ b/src/org/parosproxy/paros/extension/Extension.java
@@ -34,6 +34,7 @@
 // ZAP: 2016/09/26 JavaDoc tweaks
 // ZAP: 2017/02/17 Expose ExtensionHook to allow core code remove/unhook the extension.
 // ZAP: 2017/05/22 Use Class<? extends Extension> for dependencies of the extension.
+// ZAP: 2017/05/25 Add JavaDoc to isEnabled/setEnabled.
 
 package org.parosproxy.paros.extension;
 
@@ -158,8 +159,23 @@ public interface Extension {
     
     void setOrder(int order);
 
+	/**
+	 * Tells whether or not this extension is enabled.
+	 * <p>
+	 * Extensions might be disabled by the user (for example, through GUI), or, automatically during loading if all its
+	 * dependencies are not fulfilled.
+	 *
+	 * @return {@code true} if the extension is enabled, {@code false} otherwise.
+	 */
 	boolean isEnabled();
 	
+	/**
+	 * Sets whether or not this extension is enabled.
+	 * <p>
+	 * <strong>Note:</strong> This method should be called only by bootstrap classes.
+	 *
+	 * @param enabled {@code true} if the extension should be enabled, {@code false} otherwise.
+	 */
 	void setEnabled(boolean enabled);
 	
 	/**

--- a/src/org/zaproxy/zap/extension/ext/ExtensionExtension.java
+++ b/src/org/zaproxy/zap/extension/ext/ExtensionExtension.java
@@ -24,6 +24,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -32,7 +33,6 @@ import org.parosproxy.paros.extension.CommandLineArgument;
 import org.parosproxy.paros.extension.CommandLineListener;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
-import org.parosproxy.paros.model.Model;
 
 public class ExtensionExtension extends ExtensionAdaptor implements CommandLineListener {
 
@@ -75,13 +75,10 @@ public class ExtensionExtension extends ExtensionAdaptor implements CommandLineL
 	}
 	
 	public void enableExtension(String name, boolean enable) {
-		if (this.getOptionsExtensionPanel().enableExtension(name, enable)) {
-			try {
-				this.getOptionsExtensionPanel().saveParam(Model.getSingleton().getOptionsParam());
-			} catch (Exception e) {
-				logger.error(e.getMessage(), e);
-			}
-		}
+		ExtensionParam extParam = getModel().getOptionsParam().getExtensionParam();
+		Map<String, Boolean> extensionsState = extParam.getExtensionsState();
+		extensionsState.put(name, enable);
+		extParam.setExtensionsState(extensionsState);
 	}
 	
 	@Override

--- a/src/org/zaproxy/zap/extension/ext/ExtensionParam.java
+++ b/src/org/zaproxy/zap/extension/ext/ExtensionParam.java
@@ -92,6 +92,7 @@ public class ExtensionParam extends AbstractParam {
      * @param extensionName the name of the extension to check.
      * @return {@code true} if extension is enabled, {@code false} otherwise.
      * @since 2.6.0
+     * @see #getExtensionsState()
      */
     public boolean isExtensionEnabled(String extensionName) {
         Boolean state = extensionsState.get(extensionName);
@@ -99,6 +100,17 @@ public class ExtensionParam extends AbstractParam {
             return true;
         }
         return state;
+    }
+
+    /**
+     * Gets the extensions' enabled state.
+     * 
+     * @return a {@code Map} containing the name of the extensions and corresponding enabled state.
+     * @since TODO add version
+     * @see #isExtensionEnabled(String)
+     */
+    public Map<String, Boolean> getExtensionsState() {
+        return new HashMap<>(extensionsState);
     }
 
     /**

--- a/src/org/zaproxy/zap/extension/ext/OptionsExtensionPanel.java
+++ b/src/org/zaproxy/zap/extension/ext/OptionsExtensionPanel.java
@@ -24,9 +24,6 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -120,11 +117,7 @@ public class OptionsExtensionPanel extends AbstractParamPanel {
 	    OptionsParam optionsParam = (OptionsParam) obj;
 		ExtensionParam extParam = optionsParam.getExtensionParam();
 
-		List<Extension> exts = extensionModel.getExtensions();
-		for (Extension ext : exts) {
-			ext.setEnabled(extParam.isExtensionEnabled(ext.getName()));
-		}
-    	extensionModel.fireTableRowsUpdated(0, extensionModel.getRowCount() - 1);
+		extensionModel.setExtensionsState(extParam.getExtensionsState());
     }
 
 
@@ -133,12 +126,7 @@ public class OptionsExtensionPanel extends AbstractParamPanel {
     public void saveParam(Object obj) throws Exception {
 	    OptionsParam optionsParam = (OptionsParam) obj;
 
-        Map<String, Boolean> extensionsState = new HashMap<>();
-        List<Extension> exts = extensionModel.getExtensions();
-        for (Extension ext : exts) {
-            extensionsState.put(ext.getName(), ext.isEnabled());
-        }
-        optionsParam.getExtensionParam().setExtensionsState(extensionsState);
+        optionsParam.getExtensionParam().setExtensionsState(extensionModel.getExtensionsState());
     }
 
 	/**
@@ -278,16 +266,6 @@ public class OptionsExtensionPanel extends AbstractParamPanel {
 		}
 		return extensionModel;
 	}
-	
-	protected boolean enableExtension(String name, boolean enable) {
-		Extension ext = this.getExtensionModel().getExtension(name);
-		if (ext != null) {
-			ext.setEnabled(enable);
-			return true;
-		}
-		return false;
-	}
-
 
 	@Override
 	public String getHelpIndex() {

--- a/src/org/zaproxy/zap/extension/ext/OptionsExtensionTableModel.java
+++ b/src/org/zaproxy/zap/extension/ext/OptionsExtensionTableModel.java
@@ -20,8 +20,11 @@
 
 package org.zaproxy.zap.extension.ext;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import javax.swing.event.TableModelEvent;
 import javax.swing.table.AbstractTableModel;
 
 import org.apache.log4j.Logger;
@@ -43,6 +46,8 @@ public class OptionsExtensionTableModel extends AbstractTableModel {
     
     private static Logger log = Logger.getLogger(OptionsExtensionTableModel.class);
 
+    private Map<String, Boolean> extensionsState = new HashMap<>();
+
     public OptionsExtensionTableModel() {
         super();
     }
@@ -63,7 +68,7 @@ public class OptionsExtensionTableModel extends AbstractTableModel {
         if (ext != null) {
         	try {
 				switch (col) {
-				case 0:	return ext.isEnabled();
+				case 0:	return getEnabledState(ext);
 				case 1:
 					if (ext.isCore()) {
 						return Constant.messages.getString("options.ext.label.iscore");
@@ -78,19 +83,28 @@ public class OptionsExtensionTableModel extends AbstractTableModel {
         }
         return null;
     }
+
+    private boolean getEnabledState(Extension extension) {
+        Boolean enabledState = extensionsState.get(extension.getName());
+        if (enabledState == null) {
+            return true;
+        }
+        return enabledState;
+    }
     
     @Override
     public boolean isCellEditable(int rowIndex, int columnIndex) {
     	if (columnIndex == 0) {
+    	    Extension selectedExtension = getExtension(rowIndex);
     		// Dont allow enabled core extensions to be edited via the UI (can edit the config file directly;)
-    		if (getExtension(rowIndex).isCore() && getExtension(rowIndex).isEnabled()) {
+    		if (selectedExtension.isCore() && getEnabledState(selectedExtension)) {
     			return false;
     		}
     		// Check dependencies
-    		List<Class<? extends Extension>> deps = getExtension(rowIndex).getDependencies();
+    		List<Class<? extends Extension>> deps = selectedExtension.getDependencies();
     		for (Class<? extends Extension> dep : deps) {
     			Extension ext = getExtension(dep);
-    			if (ext == null || ! ext.isEnabled()) {
+    			if (ext == null || ! getEnabledState(ext)) {
     				return false;
     			}
     		}
@@ -111,7 +125,7 @@ public class OptionsExtensionTableModel extends AbstractTableModel {
     @Override
     public void setValueAt(Object value, int row, int col) {
     	if (col == 0) {
-    		getExtension(row).setEnabled((Boolean) value);
+    		extensionsState.put(getExtension(row).getName(), (Boolean) value);
             fireTableCellUpdated(row, col);
     		// En/Disable dependencies
     		enableDependants(getExtension(row), (Boolean) value);
@@ -122,7 +136,7 @@ public class OptionsExtensionTableModel extends AbstractTableModel {
     	int row = 0;
 		for (Extension ext: extensions) {
 			if (ext.getDependencies().contains(extension.getClass())) {
-				ext.setEnabled(enabled);
+				extensionsState.put(ext.getName(), enabled);
 				this.fireTableCellUpdated(row, 0);
 				enableDependants(ext, enabled); 
 			}
@@ -148,17 +162,13 @@ public class OptionsExtensionTableModel extends AbstractTableModel {
         return  extensions.get(row);
 	}
 
-	protected Extension getExtension (String name) {
-		for (Extension ext : extensions) {
-			if (ext.getName().equals(name)) {
-				return ext;
-			}
-		}
-        return  null;
+	void setExtensionsState(Map<String, Boolean> extensionsState) {
+		this.extensionsState = extensionsState;
+		fireTableChanged(new TableModelEvent(this, 0, getRowCount() - 1, 0, TableModelEvent.UPDATE));
 	}
 
-	protected List<Extension> getExtensions() {
-		return extensions;
+	Map<String, Boolean> getExtensionsState() {
+		return extensionsState;
 	}
     
 }


### PR DESCRIPTION
Change OptionsExtensionPanel and OptionsExtensionTableModel to not
change the enabled state of the loaded extensions, the extensions'
enabled state should be changed only by bootstrap classes (during ZAP
initialisation or installation of an add-on).
Change Extension to document the methods isEnabled and setEnabled.