### PR TITLE
Deprecate "level" in PassiveScanner

### DIFF
--- a/src/org/zaproxy/zap/extension/anticsrf/AntiCsrfDetectScanner.java
+++ b/src/org/zaproxy/zap/extension/anticsrf/AntiCsrfDetectScanner.java
@@ -24,7 +24,6 @@ import java.util.List;
 import net.htmlparser.jericho.Source;
 
 import org.apache.commons.httpclient.URIException;
-import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PassiveScanner;
@@ -87,17 +86,6 @@ public class AntiCsrfDetectScanner implements PassiveScanner {
 
 	@Override
 	public void setEnabled(boolean enabled) {
-		// Ignore
-	}
-
-	@Override
-	public AlertThreshold getLevel() {
-		// Always this level
-		return AlertThreshold.MEDIUM;
-	}
-
-	@Override
-	public void setLevel(AlertThreshold level) {
 		// Ignore
 	}
 

--- a/src/org/zaproxy/zap/extension/params/ParamScanner.java
+++ b/src/org/zaproxy/zap/extension/params/ParamScanner.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.extension.params;
 
 import net.htmlparser.jericho.Source;
 
-import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PassiveScanner;
@@ -63,17 +62,6 @@ public class ParamScanner implements PassiveScanner {
 	@Override
 	public void setEnabled(boolean enabled) {
 		// Ignore
-	}
-
-	@Override
-	public AlertThreshold getLevel() {
-		// Fixed
-		return AlertThreshold.MEDIUM;
-	}
-
-	@Override
-	public void setLevel(AlertThreshold level) {
-		// Always ignore
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -356,7 +356,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
     void setPluginPassiveScannerAlertThreshold(int pluginId, Plugin.AlertThreshold alertThreshold) {
         for (PluginPassiveScanner scanner : getPluginPassiveScanners()) {
             if (pluginId == scanner.getPluginId()) {
-                scanner.setLevel(alertThreshold);
+                scanner.setAlertThreshold(alertThreshold);
                 scanner.setEnabled(!Plugin.AlertThreshold.OFF.equals(alertThreshold));
                 scanner.save();
             }
@@ -369,7 +369,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
      */
     public void setAllScannerThreshold(AlertThreshold at) {
         for (PluginPassiveScanner test : getPluginPassiveScanners()) {        
-            test.setLevel(at);
+            test.setAlertThreshold(at);
             test.setEnabled(!AlertThreshold.OFF.equals(at));
             test.save();
         }
@@ -384,9 +384,9 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
         
         for (PluginPassiveScanner test : getPluginPassiveScanners()) {                
             if (at == null) {
-                at = test.getLevel();
+                at = test.getAlertThreshold();
             
-            } else if (!at.equals(test.getLevel())) {
+            } else if (!at.equals(test.getAlertThreshold())) {
                 // Not all the same
                 return null;
             }

--- a/src/org/zaproxy/zap/extension/pscan/PassiveScanAPI.java
+++ b/src/org/zaproxy/zap/extension/pscan/PassiveScanAPI.java
@@ -173,7 +173,7 @@ public class PassiveScanAPI extends ApiImplementor {
 				map.put("id", String.valueOf(scanner.getPluginId()));
 				map.put("name", scanner.getName());
 				map.put("enabled", String.valueOf(scanner.isEnabled()));
-				map.put("alertThreshold", scanner.getLevel(true).name());
+				map.put("alertThreshold", scanner.getAlertThreshold(true).name());
 				map.put("quality", scanner.getStatus().toString());
 				resultList.addItem(new ApiResponseSet<String>("scanner", map));
 			}

--- a/src/org/zaproxy/zap/extension/pscan/PassiveScanner.java
+++ b/src/org/zaproxy/zap/extension/pscan/PassiveScanner.java
@@ -38,9 +38,31 @@ public interface PassiveScanner {
 	
 	boolean isEnabled();
 	
-	AlertThreshold getLevel();
-	
-	void setLevel (AlertThreshold level);
+	/**
+	 * Gets the alert threshold of the scanner.
+	 * <p>
+	 * Default implementation returns always {@link AlertThreshold#MEDIUM}.
+	 *
+	 * @return the alert threshold of the scanner.
+	 * @deprecated (TODO add version) No longer used, the {@code AlertThreshold} is only needed for/by {@link PluginPassiveScanner}.
+	 */
+	@Deprecated
+	default AlertThreshold getLevel() {
+		return AlertThreshold.MEDIUM;
+	}
+
+	/**
+	 * Sets the alert threshold of the scanner.
+	 * <p>
+	 * Default implementation does nothing.
+	 *
+	 * @param level the new alert threshold.
+	 * @throws IllegalArgumentException if the given parameter is {@code null}.
+	 * @deprecated (TODO add version) No longer used, the {@code AlertThreshold} is only needed for/by {@link PluginPassiveScanner}.
+	 */
+	@Deprecated
+	default void setLevel(AlertThreshold level) {
+	}
 	
 	boolean appliesToHistoryType (int historyType);
 }

--- a/src/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
+++ b/src/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
@@ -53,8 +53,15 @@ public abstract class PluginPassiveScanner extends Enableable implements Passive
 
 	/**
 	 * The configuration key used to save/load the alert threshold of a passive scanner.
+	 * <p>
+	 * To be replaced by {@link #ALERT_THRESHOLD_KEY}.
 	 */
 	private static final String LEVEL_KEY = "level";
+
+	/**
+	 * The configuration key used to save/load the alert threshold of a passive scanner.
+	 */
+	private static final String ALERT_THRESHOLD_KEY = "alertthreshold";
 
 	/**
 	 * The configuration key used to save/load the enabled state of a passive scanner.
@@ -68,8 +75,8 @@ public abstract class PluginPassiveScanner extends Enableable implements Passive
 	private static final Set<Integer> DEFAULT_HISTORY_TYPES_SET = 
 			Collections.unmodifiableSet(new HashSet<Integer>(Arrays.asList(DEFAULT_HISTORY_TYPES)));
 
-	private AlertThreshold level = AlertThreshold.DEFAULT;
-	private AlertThreshold defaultLevel = AlertThreshold.MEDIUM;
+	private AlertThreshold alertThreshold = AlertThreshold.DEFAULT;
+	private AlertThreshold defaultAlertThreshold = AlertThreshold.MEDIUM;
 	private Configuration config = null;
 	private AddOn.Status status = AddOn.Status.unknown;
 
@@ -97,7 +104,12 @@ public abstract class PluginPassiveScanner extends Enableable implements Passive
 		List<HierarchicalConfiguration> fields = ((HierarchicalConfiguration) getConfig()).configurationsAt(PSCANS_KEY);
 		for (HierarchicalConfiguration sub : fields) {
 			if (isPluginConfiguration(sub)) {
-				setLevel(AlertThreshold.valueOf(sub.getString(LEVEL_KEY, AlertThreshold.DEFAULT.name())));
+				// For compatibility with older versions:
+				String alertThresholdName = sub.getString(LEVEL_KEY, null);
+				if (alertThresholdName == null) {
+					alertThresholdName = sub.getString(ALERT_THRESHOLD_KEY, AlertThreshold.DEFAULT.name());
+				}
+				setAlertThreshold(AlertThreshold.valueOf(alertThresholdName));
 				setEnabled(sub.getBoolean(ENABLED_KEY, true));
 				break;
 			}
@@ -157,8 +169,10 @@ public abstract class PluginPassiveScanner extends Enableable implements Passive
 		boolean persistId = false;
 		String entryKey = PSCANS_KEY + "(" + (removed ? fields.size() - 1 : fields.size()) + ").";
 
-		if (getLevel() != AlertThreshold.MEDIUM) {
-			conf.setProperty(entryKey + LEVEL_KEY, getLevel().name());
+		if (getAlertThreshold() != AlertThreshold.MEDIUM) {
+			conf.setProperty(entryKey + ALERT_THRESHOLD_KEY, getAlertThreshold().name());
+			// For compatibility with older versions:
+			conf.setProperty(entryKey + LEVEL_KEY, getAlertThreshold().name());
 			persistId = true;
 		}
 
@@ -172,28 +186,80 @@ public abstract class PluginPassiveScanner extends Enableable implements Passive
 		}
 	}
 
+	/**
+	 * @deprecated (TODO add version) Replaced by {@link #getAlertThreshold()}.
+	 */
 	@Override
+	@Deprecated
 	public AlertThreshold getLevel() {
-		if (AlertThreshold.DEFAULT.equals(level)) {
-			return defaultLevel;
-		}
-		return level;
+		return getAlertThreshold();
 	}
 	
+	/**
+	 * Gets the alert threshold of the scanner, possibly returning {@link AlertThreshold#DEFAULT}.
+	 * 
+	 * @param incDefault {@code true} if the value {@link AlertThreshold#DEFAULT} can be returned, {@code false} otherwise.
+	 * @return the alert threshold.
+	 * @deprecated (TODO add version) Replaced by {@link #getAlertThreshold(boolean)}.
+	 */
+	@Deprecated
 	public AlertThreshold getLevel(boolean incDefault) {
-		return level;
+		return getAlertThreshold(incDefault);
+	}
+	
+	/**
+	 * Gets the alert threshold of the scanner.
+	 * <p>
+	 * If the alert threshold was set to DEFAULT it's returned the default value set.
+	 *
+	 * @return the alert threshold of the scanner.
+	 * @since TODO add version
+	 * @see #setAlertThreshold(AlertThreshold)
+	 * @see #getAlertThreshold(boolean)
+	 */
+	public AlertThreshold getAlertThreshold() {
+		if (AlertThreshold.DEFAULT.equals(alertThreshold)) {
+			return defaultAlertThreshold;
+		}
+		return alertThreshold;
+	}
+
+	/**
+	 * Gets the alert threshold of the scanner, possibly returning {@link AlertThreshold#DEFAULT}.
+	 *
+	 * @param incDefault {@code true} if the value {@link AlertThreshold#DEFAULT} can be returned, {@code false} otherwise.
+	 * @return the alert threshold.
+	 */
+	public AlertThreshold getAlertThreshold(boolean incDefault) {
+		if (!incDefault && alertThreshold == AlertThreshold.DEFAULT) {
+			return defaultAlertThreshold;
+		}
+		return alertThreshold;
 	}
 	
 	/**
 	 * @throws IllegalArgumentException if the given parameter is {@code null}.
-	 * @see #getLevel()
+	 * @deprecated (TODO add version) Replaced by {@link #setAlertThreshold(AlertThreshold)}.
 	 */
 	@Override
+	@Deprecated
 	public void setLevel(AlertThreshold level) {
-		if (level == null) {
-			throw new IllegalArgumentException("Parameter level must not be null.");
+		setAlertThreshold(level);
+	}
+
+	/**
+	 * Sets the alert threshold of the scanner.
+	 *
+	 * @param alertThreshold the new alert threshold.
+	 * @throws IllegalArgumentException if the given parameter is {@code null}.
+	 * @since TODO add version
+	 * @see #getAlertThreshold()
+	 */
+	public void setAlertThreshold(AlertThreshold alertThreshold) {
+		if (alertThreshold == null) {
+			throw new IllegalArgumentException("Parameter alertThreshold must not be null.");
 		}
-		this.level = level;
+		this.alertThreshold = alertThreshold;
 	}
 
 	/**
@@ -202,13 +268,28 @@ public abstract class PluginPassiveScanner extends Enableable implements Passive
 	 * @param level the value of default alert threshold
 	 * @throws IllegalArgumentException if the given parameter is {@code null} or {@code AlertThreshold.DEFAULT}.
 	 * @since 2.0.0
-	 * @see #setLevel(AlertThreshold)
+	 * @deprecated (TODO add version) Replaced by {@link #setDefaultAlertThreshold(AlertThreshold)}.
+	 * @see #setAlertThreshold(AlertThreshold)
 	 */
+	@Deprecated
 	public void setDefaultLevel(AlertThreshold level) {
-		if (level == null || level == AlertThreshold.DEFAULT) {
-			throw new IllegalArgumentException("Parameter level must not be null or DEFAULT.");
+		setDefaultAlertThreshold(level);
+	}
+
+	/**
+	 * Sets the alert threshold that should be returned when set to {@link AlertThreshold#DEFAULT}.
+	 *
+	 * @param alertThreshold the value of default alert threshold.
+	 * @throws IllegalArgumentException if the given parameter is {@code null} or {@code AlertThreshold.DEFAULT}.
+	 * @since TODO add version
+	 * @see #setDefaultAlertThreshold(AlertThreshold)
+	 * @see #setAlertThreshold(AlertThreshold)
+	 */
+	public void setDefaultAlertThreshold(AlertThreshold alertThreshold) {
+		if (alertThreshold == null || alertThreshold == AlertThreshold.DEFAULT) {
+			throw new IllegalArgumentException("Parameter alertThreshold must not be null or DEFAULT.");
 		}
-		this.defaultLevel = level;
+		this.defaultAlertThreshold = alertThreshold;
 	}
 
 	/**

--- a/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanTableModel.java
+++ b/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanTableModel.java
@@ -248,11 +248,11 @@ public class PolicyPassiveScanTableModel extends DefaultTableModel {
         }
 
     	public void reset() {
-    		this.threshold = scanner.getLevel();
+    		this.threshold = scanner.getAlertThreshold();
     	}
     	
     	public void persistChanges() {
-    		this.scanner.setLevel(threshold);
+    		this.scanner.setAlertThreshold(threshold);
     		this.scanner.setEnabled(!AlertThreshold.OFF.equals(threshold));
     		this.scanner.save();
     	}

--- a/src/scripts/templates/passive/Passive default template.js
+++ b/src/scripts/templates/passive/Passive default template.js
@@ -34,9 +34,9 @@ function scan(ps, msg, src) {
 		ps.addTag('tag')			
 	}
 	
-	// Raise less reliable alert (that is, prone to false positives) when in LOW alert threshold (level)
+	// Raise less reliable alert (that is, prone to false positives) when in LOW alert threshold
 	// Expected values: "LOW", "MEDIUM", "HIGH"
-	if (ps.getLevel() == "LOW") {
+	if (ps.getAlertThreshold() == "LOW") {
 		// ...
 	}
 }

--- a/test/org/zaproxy/zap/extension/pscan/PluginPassiveScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscan/PluginPassiveScannerUnitTest.java
@@ -72,56 +72,56 @@ public class PluginPassiveScannerUnitTest {
 	}
 
 	@Test
-	public void shouldHaveMediumAsDefaultLevel() {
-		assertThat(scanner.getLevel(), is(equalTo(AlertThreshold.MEDIUM)));
+	public void shouldHaveMediumAsDefaultAlertThreshold() {
+		assertThat(scanner.getAlertThreshold(), is(equalTo(AlertThreshold.MEDIUM)));
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void shouldFailToSetNullLevel() {
+	public void shouldFailToSetNullAlertThreshold() {
 		// Given
-		AlertThreshold level = null;
+		AlertThreshold alertThreshold = null;
 		// When
-		scanner.setLevel(level);
+		scanner.setAlertThreshold(alertThreshold);
 		// Then = IllegalArgumentException.
 	}
 
 	@Test
-	public void shouldSetValidLevel() {
+	public void shouldSetValidAlertThreshold() {
 		// Given
-		AlertThreshold level = AlertThreshold.HIGH;
+		AlertThreshold alertThreshold = AlertThreshold.HIGH;
 		// When
-		scanner.setLevel(level);
+		scanner.setAlertThreshold(alertThreshold);
 		// Then
-		assertThat(scanner.getLevel(), is(equalTo(level)));
+		assertThat(scanner.getAlertThreshold(), is(equalTo(alertThreshold)));
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void shouldFailToSetNullDefaultLevel() {
+	public void shouldFailToSetNullDefaultAlertThreshold() {
 		// Given
-		AlertThreshold level = null;
+		AlertThreshold alertThreshold = null;
 		// When
-		scanner.setDefaultLevel(level);
+		scanner.setDefaultAlertThreshold(alertThreshold);
 		// Then = IllegalArgumentException.
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void shouldFailToSetDefaultToDefaultLevel() {
+	public void shouldFailToSetDefaultToDefaultAlertThreshold() {
 		// Given
-		AlertThreshold level = AlertThreshold.DEFAULT;
+		AlertThreshold alertThreshold = AlertThreshold.DEFAULT;
 		// When
-		scanner.setDefaultLevel(level);
+		scanner.setDefaultAlertThreshold(alertThreshold);
 		// Then = IllegalArgumentException.
 	}
 
 	@Test
-	public void shouldSetValidDefaultLevel() {
+	public void shouldSetValidDefaultAlertThreshold() {
 		// Given
-		scanner.setLevel(AlertThreshold.DEFAULT);
-		AlertThreshold level = AlertThreshold.HIGH;
+		scanner.setAlertThreshold(AlertThreshold.DEFAULT);
+		AlertThreshold alertThreshold = AlertThreshold.HIGH;
 		// When
-		scanner.setDefaultLevel(level);
+		scanner.setDefaultAlertThreshold(alertThreshold);
 		// Then
-		assertThat(scanner.getLevel(), is(equalTo(level)));
+		assertThat(scanner.getAlertThreshold(), is(equalTo(alertThreshold)));
 	}
 
 	@Test
@@ -139,29 +139,29 @@ public class PluginPassiveScannerUnitTest {
 	}
 
 	@Test
-	public void shouldNotChangeEnabledStateOrLevelIfConfigurationSetIsEmpty() {
+	public void shouldNotChangeEnabledStateOrAlertThresholdIfConfigurationSetIsEmpty() {
 		Configuration configuration = createEmptyConfiguration();
 		// given
 		scanner.setEnabled(false);
-		scanner.setLevel(AlertThreshold.HIGH);
+		scanner.setAlertThreshold(AlertThreshold.HIGH);
 		// when
 		scanner.setConfig(configuration);
 		// then
 		assertThat(scanner.isEnabled(), is(false));
-		assertThat(scanner.getLevel(), is(equalTo(AlertThreshold.HIGH)));
+		assertThat(scanner.getAlertThreshold(), is(equalTo(AlertThreshold.HIGH)));
 	}
 
 	@Test
-	public void shouldNotChangeEnabledStateOrLevelIfNoApplicableDataIsPresentInConfigurationSet() {
+	public void shouldNotChangeEnabledStateOrAlertThresholdIfNoApplicableDataIsPresentInConfigurationSet() {
 		Configuration configuration = createConfiguration(Integer.MIN_VALUE, Boolean.TRUE, AlertThreshold.LOW);
 		// given
 		scanner.setEnabled(false);
-		scanner.setLevel(AlertThreshold.HIGH);
+		scanner.setAlertThreshold(AlertThreshold.HIGH);
 		// when
 		scanner.setConfig(configuration);
 		// then
 		assertThat(scanner.isEnabled(), is(false));
-		assertThat(scanner.getLevel(), is(equalTo(AlertThreshold.HIGH)));
+		assertThat(scanner.getAlertThreshold(), is(equalTo(AlertThreshold.HIGH)));
 	}
 
 	@Test
@@ -187,26 +187,26 @@ public class PluginPassiveScannerUnitTest {
 	}
 
 	@Test
-	public void shouldUseDefaultLevelIfNotSpecifiedInConfigurationSet() {
+	public void shouldUseDefaultAlertThresholdIfNotSpecifiedInConfigurationSet() {
 		// given
 		Configuration configuration = createConfiguration(TestPluginPassiveScanner.PLUGIN_ID, Boolean.TRUE, null);
-		scanner.setDefaultLevel(AlertThreshold.HIGH);
-		scanner.setLevel(AlertThreshold.LOW);
+		scanner.setDefaultAlertThreshold(AlertThreshold.HIGH);
+		scanner.setAlertThreshold(AlertThreshold.LOW);
 		// when
 		scanner.setConfig(configuration);
 		// then
-		assertThat(scanner.getLevel(), is(equalTo(AlertThreshold.HIGH)));
+		assertThat(scanner.getAlertThreshold(), is(equalTo(AlertThreshold.HIGH)));
 	}
 
 	@Test
-	public void shouldUseLevelSpecifiedInConfigurationSet() {
+	public void shouldUseAlertThresholdSpecifiedInConfigurationSet() {
 		// given
 		Configuration configuration = createConfiguration(TestPluginPassiveScanner.PLUGIN_ID, null, AlertThreshold.HIGH);
-		scanner.setLevel(AlertThreshold.LOW);
+		scanner.setAlertThreshold(AlertThreshold.LOW);
 		// when
 		scanner.setConfig(configuration);
 		// then
-		assertThat(scanner.getLevel(), is(equalTo(AlertThreshold.HIGH)));
+		assertThat(scanner.getAlertThreshold(), is(equalTo(AlertThreshold.HIGH)));
 	}
 
 	@Test
@@ -217,12 +217,12 @@ public class PluginPassiveScannerUnitTest {
 				Boolean.FALSE,
 				AlertThreshold.HIGH);
 		scanner.setEnabled(true);
-		scanner.setLevel(AlertThreshold.LOW);
+		scanner.setAlertThreshold(AlertThreshold.LOW);
 		// when
 		scanner.setConfig(configuration);
 		// then
 		assertThat(scanner.isEnabled(), is(false));
-		assertThat(scanner.getLevel(), is(equalTo(AlertThreshold.HIGH)));
+		assertThat(scanner.getAlertThreshold(), is(equalTo(AlertThreshold.HIGH)));
 	}
 
 	@Test
@@ -235,12 +235,12 @@ public class PluginPassiveScannerUnitTest {
 		addConfiguration(configuration, 3, 1011, null, AlertThreshold.LOW);
 		addConfiguration(configuration, 4, "OtherTestClassName", Boolean.FALSE, AlertThreshold.OFF);
 		scanner.setEnabled(true);
-		scanner.setLevel(AlertThreshold.LOW);
+		scanner.setAlertThreshold(AlertThreshold.LOW);
 		// when
 		scanner.setConfig(configuration);
 		// then
 		assertThat(scanner.isEnabled(), is(false));
-		assertThat(scanner.getLevel(), is(equalTo(AlertThreshold.MEDIUM)));
+		assertThat(scanner.getAlertThreshold(), is(equalTo(AlertThreshold.MEDIUM)));
 	}
 
 	@Test(expected = IllegalStateException.class)
@@ -279,31 +279,31 @@ public class PluginPassiveScannerUnitTest {
 	}
 
 	@Test
-	public void shouldNotPersistLevelOnSaveIfDefaultValue() {
+	public void shouldNotPersistAlertThresholdOnSaveIfDefaultValue() {
 		// Given
 		Configuration configuration = createEmptyConfiguration();
 		scanner.setConfig(configuration);
-		scanner.setLevel(AlertThreshold.MEDIUM);
+		scanner.setAlertThreshold(AlertThreshold.MEDIUM);
 		scanner.setEnabled(true);
 		// When
 		scanner.save();
 		// Then
-		assertThat(configuration.containsKey("pscans.pscanner(0).level"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(0).alertthreshold"), is(false));
 		assertThat(configuration.containsKey("pscans.pscanner(0).id"), is(false));
 	}
 
 	@Test
-	public void shouldPersistLevelOnSaveIfNotDefaultValue() {
+	public void shouldPersistAlertThresholdOnSaveIfNotDefaultValue() {
 		// Given
 		Configuration configuration = createEmptyConfiguration();
 		scanner.setConfig(configuration);
-		scanner.setLevel(AlertThreshold.HIGH);
+		scanner.setAlertThreshold(AlertThreshold.HIGH);
 		scanner.setEnabled(true);
 		// When
 		scanner.save();
 		// Then
-		assertThat(configuration.containsKey("pscans.pscanner(0).level"), is(true));
-		assertThat(configuration.getString("pscans.pscanner(0).level"), is(equalTo(AlertThreshold.HIGH.name())));
+		assertThat(configuration.containsKey("pscans.pscanner(0).alertthreshold"), is(true));
+		assertThat(configuration.getString("pscans.pscanner(0).alertthreshold"), is(equalTo(AlertThreshold.HIGH.name())));
 		assertThat(configuration.containsKey("pscans.pscanner(0).id"), is(true));
 		assertThat(configuration.getInt("pscans.pscanner(0).id"), is(equalTo(TestPluginPassiveScanner.PLUGIN_ID)));
 	}
@@ -317,12 +317,12 @@ public class PluginPassiveScannerUnitTest {
 				AlertThreshold.HIGH);
 		scanner.setConfig(configuration);
 		scanner.setEnabled(true);
-		scanner.setLevel(AlertThreshold.MEDIUM);
+		scanner.setAlertThreshold(AlertThreshold.MEDIUM);
 		// When
 		scanner.save();
 		// Then
 		assertThat(configuration.containsKey("pscans.pscanner(0).enabled"), is(false));
-		assertThat(configuration.containsKey("pscans.pscanner(0).level"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(0).alertthreshold"), is(false));
 		assertThat(configuration.containsKey("pscans.pscanner(0).id"), is(false));
 	}
 
@@ -335,13 +335,13 @@ public class PluginPassiveScannerUnitTest {
 				AlertThreshold.HIGH);
 		scanner.setConfig(configuration);
 		scanner.setEnabled(true);
-		scanner.setLevel(AlertThreshold.MEDIUM);
+		scanner.setAlertThreshold(AlertThreshold.MEDIUM);
 		// When
 		scanner.save();
 		// Then
 		assertThat(configuration.containsKey("pscans.pscanner(0).classname"), is(false));
 		assertThat(configuration.containsKey("pscans.pscanner(0).enabled"), is(false));
-		assertThat(configuration.containsKey("pscans.pscanner(0).level"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(0).alertthreshold"), is(false));
 		assertThat(configuration.containsKey("pscans.pscanner(0).id"), is(false));
 	}
 
@@ -355,38 +355,38 @@ public class PluginPassiveScannerUnitTest {
 		addConfiguration(configuration, 3, 1011, null, AlertThreshold.LOW);
 		scanner.setConfig(configuration);
 		scanner.setEnabled(false);
-		scanner.setLevel(AlertThreshold.LOW);
+		scanner.setAlertThreshold(AlertThreshold.LOW);
 		// When
 		scanner.save();
 		// Then
 		assertThat(configuration.containsKey("pscans.pscanner(0).id"), is(true));
 		assertThat(configuration.getInt("pscans.pscanner(0).id"), is(equalTo(10)));
 		assertThat(configuration.containsKey("pscans.pscanner(0).enabled"), is(false));
-		assertThat(configuration.containsKey("pscans.pscanner(0).level"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(0).alertthreshold"), is(false));
 
 		assertThat(configuration.containsKey("pscans.pscanner(1).id"), is(false));
 		assertThat(configuration.containsKey("pscans.pscanner(1).classname"), is(true));
 		assertThat(configuration.getString("pscans.pscanner(1).classname"), is(equalTo("TestClassName")));
 		assertThat(configuration.containsKey("pscans.pscanner(1).enabled"), is(true));
 		assertThat(configuration.getBoolean("pscans.pscanner(1).enabled"), is(true));
-		assertThat(configuration.containsKey("pscans.pscanner(1).level"), is(true));
-		assertThat(configuration.getString("pscans.pscanner(1).level"), is(equalTo(AlertThreshold.HIGH.name())));
+		assertThat(configuration.containsKey("pscans.pscanner(1).alertthreshold"), is(true));
+		assertThat(configuration.getString("pscans.pscanner(1).alertthreshold"), is(equalTo(AlertThreshold.HIGH.name())));
 
 		assertThat(configuration.containsKey("pscans.pscanner(2).id"), is(true));
 		assertThat(configuration.getInt("pscans.pscanner(2).id"), is(equalTo(1011)));
 		assertThat(configuration.containsKey("pscans.pscanner(2).enabled"), is(false));
-		assertThat(configuration.containsKey("pscans.pscanner(2).level"), is(true));
-		assertThat(configuration.getString("pscans.pscanner(2).level"), is(equalTo(AlertThreshold.LOW.name())));
+		assertThat(configuration.containsKey("pscans.pscanner(2).alertthreshold"), is(true));
+		assertThat(configuration.getString("pscans.pscanner(2).alertthreshold"), is(equalTo(AlertThreshold.LOW.name())));
 
 		assertThat(configuration.containsKey("pscans.pscanner(3).id"), is(true));
 		assertThat(configuration.getInt("pscans.pscanner(3).id"), is(equalTo(TestPluginPassiveScanner.PLUGIN_ID)));
 		assertThat(configuration.containsKey("pscans.pscanner(3).enabled"), is(true));
 		assertThat(configuration.getBoolean("pscans.pscanner(3).enabled"), is(false));
-		assertThat(configuration.containsKey("pscans.pscanner(3).level"), is(true));
-		assertThat(configuration.getString("pscans.pscanner(3).level"), is(equalTo(AlertThreshold.LOW.name())));
+		assertThat(configuration.containsKey("pscans.pscanner(3).alertthreshold"), is(true));
+		assertThat(configuration.getString("pscans.pscanner(3).alertthreshold"), is(equalTo(AlertThreshold.LOW.name())));
 
 		assertThat(configuration.containsKey("pscans.pscanner(4).enabled"), is(false));
-		assertThat(configuration.containsKey("pscans.pscanner(4).level"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(4).alertthreshold"), is(false));
 		assertThat(configuration.containsKey("pscans.pscanner(5).id"), is(false));
 	}
 
@@ -400,31 +400,31 @@ public class PluginPassiveScannerUnitTest {
 		addConfiguration(configuration, 3, 1011, null, AlertThreshold.LOW);
 		scanner.setConfig(configuration);
 		scanner.setEnabled(true);
-		scanner.setLevel(AlertThreshold.MEDIUM);
+		scanner.setAlertThreshold(AlertThreshold.MEDIUM);
 		// When
 		scanner.save();
 		// Then
 		assertThat(configuration.containsKey("pscans.pscanner(0).id"), is(true));
 		assertThat(configuration.getInt("pscans.pscanner(0).id"), is(equalTo(10)));
 		assertThat(configuration.containsKey("pscans.pscanner(0).enabled"), is(false));
-		assertThat(configuration.containsKey("pscans.pscanner(0).level"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(0).alertthreshold"), is(false));
 
 		assertThat(configuration.containsKey("pscans.pscanner(1).id"), is(false));
 		assertThat(configuration.containsKey("pscans.pscanner(1).classname"), is(true));
 		assertThat(configuration.getString("pscans.pscanner(1).classname"), is(equalTo("TestClassName")));
 		assertThat(configuration.containsKey("pscans.pscanner(1).enabled"), is(true));
 		assertThat(configuration.getBoolean("pscans.pscanner(1).enabled"), is(true));
-		assertThat(configuration.containsKey("pscans.pscanner(1).level"), is(true));
-		assertThat(configuration.getString("pscans.pscanner(1).level"), is(equalTo(AlertThreshold.HIGH.name())));
+		assertThat(configuration.containsKey("pscans.pscanner(1).alertthreshold"), is(true));
+		assertThat(configuration.getString("pscans.pscanner(1).alertthreshold"), is(equalTo(AlertThreshold.HIGH.name())));
 
 		assertThat(configuration.containsKey("pscans.pscanner(2).id"), is(true));
 		assertThat(configuration.getInt("pscans.pscanner(2).id"), is(equalTo(1011)));
 		assertThat(configuration.containsKey("pscans.pscanner(2).enabled"), is(false));
-		assertThat(configuration.containsKey("pscans.pscanner(2).level"), is(true));
-		assertThat(configuration.getString("pscans.pscanner(2).level"), is(equalTo(AlertThreshold.LOW.name())));
+		assertThat(configuration.containsKey("pscans.pscanner(2).alertthreshold"), is(true));
+		assertThat(configuration.getString("pscans.pscanner(2).alertthreshold"), is(equalTo(AlertThreshold.LOW.name())));
 
 		assertThat(configuration.containsKey("pscans.pscanner(3).enabled"), is(false));
-		assertThat(configuration.containsKey("pscans.pscanner(3).level"), is(false));
+		assertThat(configuration.containsKey("pscans.pscanner(3).alertthreshold"), is(false));
 		assertThat(configuration.containsKey("pscans.pscanner(3).id"), is(false));
 	}
 
@@ -497,7 +497,7 @@ public class PluginPassiveScannerUnitTest {
 			configuration.setProperty("pscans.pscanner(" + index + ").enabled", enabled);
 		}
 		if (alertThreshold != null) {
-			configuration.setProperty("pscans.pscanner(" + index + ").level", alertThreshold.name());
+			configuration.setProperty("pscans.pscanner(" + index + ").alertthreshold", alertThreshold.name());
 		}
 	}
 }


### PR DESCRIPTION
Deprecate the methods PassiveScanner.get/setLevel and add default
implementation, extending classes should not need to implement them. The
methods get/setLevel are only used/needed by PluginPassiveScanner.
Add replacement methods, get/setAlertThreshold, to PluginPassiveScanner,
related "level" methods are also replaced with "AlertThreshold" ones.
Update codebase and example JavaScript passive script to use the new
methods.

Fix #3495 - getLevel() vs getAlertThreshold()