### PR TITLE
Set installation status to marketplace add-ons

### DIFF
--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -985,9 +985,17 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 								logger.debug("Failed to access " + longUrl, e2);
 							}
 						}
-			    		if (callback != null && latestVersionInfo != null) {
-							logger.debug("Calling callback with  " + latestVersionInfo);
-			    			callback.gotLatestData(latestVersionInfo);
+						if (latestVersionInfo != null) {
+							for (AddOn addOn : latestVersionInfo.getAddOns()) {
+								AddOn localAddOn = localVersionInfo.getAddOn(addOn.getId());
+								if (localAddOn != null && !addOn.isUpdateTo(localAddOn)) {
+									addOn.setInstallationStatus(localAddOn.getInstallationStatus());
+								}
+							}
+							if (callback != null) {
+								logger.debug("Calling callback with  " + latestVersionInfo);
+								callback.gotLatestData(latestVersionInfo);
+							}
 			    		}
 						logger.debug("Done");
 	    			}


### PR DESCRIPTION
Change ExtensionAutoUpdate to set the installation status to add-ons of
marketplace, otherwise they might be incorrectly identified as available
to install when they are already installed (they were previously being
marked as installed only after being installed from the marketplace).