### PR TITLE
Correctly check for add-on updates on dep calc

### DIFF
--- a/src/org/zaproxy/zap/extension/autoupdate/AddOnDependencyChecker.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/AddOnDependencyChecker.java
@@ -129,7 +129,7 @@ class AddOnDependencyChecker {
                 if (AddOn.InstallationStatus.AVAILABLE == availableAddOns.getAddOn(dep.getId()).getInstallationStatus()) {
                     installs.add(dep);
                 }
-            } else if (!addOn.dependsOn(installed)) {
+            } else if (dep.isUpdateTo(installed)) {
                 if (AddOn.InstallationStatus.AVAILABLE == availableAddOns.getAddOn(dep.getId()).getInstallationStatus()) {
                     oldVersions.add(installed);
                     newVersions.add(dep);


### PR DESCRIPTION
Change AddOnDependencyChecker to correct the check for newer versions of
an add-on when calculating the dependencies (also, transitive) of the
add-on that's being installed or updated.