### PR TITLE
Print args and error msg when failed to parse args

### DIFF
--- a/src/org/parosproxy/paros/CommandLine.java
+++ b/src/org/parosproxy/paros/CommandLine.java
@@ -36,6 +36,7 @@
 // ZAP: 2016/11/07 Allow to disable default standard output logging
 // ZAP: 2017/03/26 Allow to obtain configs in the order specified
 // ZAP: 2017/05/12 Issue 3460: Support -suppinfo 
+// ZAP: 2017/05/31 Handle null args and include a message in all exceptions.
 
 package org.parosproxy.paros;
 
@@ -96,7 +97,7 @@ public class CommandLine {
     private boolean experimentalDb = false;
     private int port = -1;
     private String host = null;
-    private String[] args = null;
+    private String[] args;
     private final Map<String, String> configs = new LinkedHashMap<>();
     private final Hashtable<String, String> keywords = new Hashtable<>();
     private List<CommandLineArgument[]> commandList = null;
@@ -107,7 +108,7 @@ public class CommandLine {
     private boolean noStdOutLog;
 
     public CommandLine(String[] args) throws Exception {
-        this.args = args;
+        this.args = args == null ? new String[0] : args;
         parseFirst(this.args);
     }
 
@@ -121,7 +122,7 @@ public class CommandLine {
         if (key.equalsIgnoreCase(paramName)) {
             value = args[i + 1];
             if (value == null) {
-                throw new Exception();
+                throw new Exception("Missing parameter for keyword '" + paramName + "'.");
             }
             
             keywords.put(paramName, value);
@@ -364,14 +365,10 @@ public class CommandLine {
             File confFile = new File(conf);
             if (! confFile.isFile()) {
                 // We cant use i18n here as the messages wont have been loaded
-                String error = "No such file: " + confFile.getAbsolutePath();
-                System.out.println(error);
-                throw new Exception(error);
+                throw new Exception("No such file: " + confFile.getAbsolutePath());
             } else if (! confFile.canRead()) {
                 // We cant use i18n here as the messages wont have been loaded
-                String error = "File not readable: " + confFile.getAbsolutePath();
-                System.out.println(error);
-                throw new Exception(error);
+                throw new Exception("File not readable: " + confFile.getAbsolutePath());
             }
             Properties prop = new Properties();
             try (FileInputStream inStream = new FileInputStream(confFile)) {

--- a/src/org/zaproxy/zap/ZAP.java
+++ b/src/org/zaproxy/zap/ZAP.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.Locale;
 
@@ -87,7 +88,9 @@ public class ZAP {
         } catch (final Exception e) {
         	// Cant use the CommandLine help here as the 
         	// i18n messages wont have been loaded
-            System.out.println("Failed due to invalid parameters. Use '-h' for more details.");
+            System.out.println("Failed due to invalid parameters: " + Arrays.toString(args));
+            System.out.println(e.getMessage());
+            System.out.println("Use '-h' for more details.");
             System.exit(1);
         }
 

--- a/test/org/parosproxy/paros/CommandLineUnitTest.java
+++ b/test/org/parosproxy/paros/CommandLineUnitTest.java
@@ -87,6 +87,25 @@ public class CommandLineUnitTest {
     }
 
     @Test
+    public void shouldAcceptNullArguments() throws Exception {
+        // Given
+        String[] args = null;
+        // When
+        cmdLine = new CommandLine(args);
+        // Then = No Exception.
+    }
+
+    @Test
+    public void shouldParseNullArguments() throws Exception {
+        // Given
+        String[] args = { null, null };
+        cmdLine = new CommandLine(args);
+        // When
+        cmdLine.parse(NO_EXTENSIONS_CUSTOM_ARGUMENTS, NO_SUPPORTED_FILE_EXTENSIONS);
+        // Then = No Exception.
+    }
+
+    @Test
     public void emptyCommandLine() throws Exception {
         cmdLine = new CommandLine(new String[] {});
         cmdLine.parse(NO_EXTENSIONS_CUSTOM_ARGUMENTS, NO_SUPPORTED_FILE_EXTENSIONS);


### PR DESCRIPTION
Change ZAP class to print the arguments and the exception's message when
failed to parse the arguments.
Change CommandLine to accept null arguments, remove print statements
(already done by ZAP class, when printing the exception's message) and
add a message to an exception thrown.
Add tests to CommandLineUnitTest to assert expected behaviour.

Per comments in #3593.