### PR TITLE
Remove re-declaration of methods in AbstractPlugin

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/src/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -53,6 +53,7 @@
 // ZAP: 2016/06/10 Honour scan's scope when following redirections
 // ZAP: 2016/07/12 Do not allow techSet to be null
 // ZAP: 2017/03/27 Use HttpRequestConfig.
+// ZAP: 2017/05/31 Remove re-declaration of methods.
 
 package org.parosproxy.paros.core.scanner;
 
@@ -130,12 +131,6 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
     }
 
     @Override
-    public abstract int getId();
-
-    @Override
-    public abstract String getName();
-
-    @Override
     public String getCodeName() {
         String result = getClass().getName();
         int pos = getClass().getName().lastIndexOf(".");
@@ -155,18 +150,6 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
     public String[] getDependency() {
         return NO_DEPENDENCIES;
     }
-
-    @Override
-    public abstract String getDescription();
-
-    @Override
-    public abstract int getCategory();
-
-    @Override
-    public abstract String getSolution();
-
-    @Override
-    public abstract String getReference();
 
     @Override
     public void init(HttpMessage msg, HostProcess parent) {
@@ -402,12 +385,6 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
         notifyPluginCompleted(getParent());
         this.finished = new Date();
     }
-
-    /**
-     * The core scan method to be implemented by subclass.
-     */
-    @Override
-    public abstract void scan();
 
     /**
      * Generate an alert when a security issue (risk/info) is found. Default
@@ -803,9 +780,6 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
     public HostProcess getParent() {
         return parent;
     }
-
-    @Override
-    public abstract void notifyPluginCompleted(HostProcess parent);
 
     /**
      * Replace body by stripping of pattern string. The URLencoded and


### PR DESCRIPTION
Change AbstractPlugin to remove the methods already specified/declared
by the interface Plugin.