### PR TITLE
Increase CFU timeout when getting ZapVersions.xml

### DIFF
--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -1003,9 +1003,10 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
     			this.remoteCallThread.start();
     		}
     		if (callback == null) {
-    			// Synchronous, but include a 30 sec max anyway
+    			// Synchronous, but include a 60 sec max anyway, give enough(?) time for 1st request to timeout (default 20s)
+    			// and the 2nd to be fully processed (e.g. in case the connection is throttled, requires proxy authentication).
     			int i=0;
-				while (latestVersionInfo == null && this.remoteCallThread.isAlive() && i < 30) {
+				while (latestVersionInfo == null && this.remoteCallThread.isAlive() && i < 60) {
 					try {
 						Thread.sleep(1000);
 						i++;


### PR DESCRIPTION
Change ExtensionAutoUpdate to give more time (up to 60s) to obtain the
ZapVersions.xml file, the current time (30s) might not be enough if the
1st request/URL times out and the 2nd takes more time than usual (in
case it requires proxy authentication, DNS queries take longer, or the
connection is slow/throttled).
Based on ZAP logs provided in IRC and mailing list, which indicated that
the CFU failed (because of the max time) but the download of the file
ended up happening.