### PR TITLE
Correct event sent by Extensions table model

### DIFF
--- a/src/org/zaproxy/zap/extension/ext/OptionsExtensionTableModel.java
+++ b/src/org/zaproxy/zap/extension/ext/OptionsExtensionTableModel.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.swing.event.TableModelEvent;
 import javax.swing.table.AbstractTableModel;
 
 import org.apache.log4j.Logger;
@@ -164,7 +163,7 @@ public class OptionsExtensionTableModel extends AbstractTableModel {
 
 	void setExtensionsState(Map<String, Boolean> extensionsState) {
 		this.extensionsState = extensionsState;
-		fireTableChanged(new TableModelEvent(this, 0, getRowCount() - 1, 0, TableModelEvent.UPDATE));
+		fireTableDataChanged();
 	}
 
 	Map<String, Boolean> getExtensionsState() {


### PR DESCRIPTION
Change OptionsExtensionTableModel to send the event that indicates that
the whole data might have changed, instead of just the state column, as
the extensions in the model might no longer be the same (i.e. an add-on
was installed or uninstalled).

Related to #3573 - Allow to sort in Extensions panel