### PR TITLE
Add more constructors to custom pop up menus

### DIFF
--- a/src/org/parosproxy/paros/extension/ExtensionPopupMenuItem.java
+++ b/src/org/parosproxy/paros/extension/ExtensionPopupMenuItem.java
@@ -30,11 +30,14 @@
 // ZAP: 2014/03/23 Changed to implement the new method from ExtensionPopupMenuComponent
 // ZAP: 2014/03/23 Issue 1095: Replace main pop up sub menus with ExtensionPopupMenu when appropriate
 // ZAP: 2014/08/14 Issue 1302: Context menu item action might not get executed
+// ZAP: 2017/06/01 Add more constructors.
 
 package org.parosproxy.paros.extension;
 
 import java.awt.Component;
 
+import javax.swing.Action;
+import javax.swing.Icon;
 import javax.swing.JMenuItem;
 
 import org.zaproxy.zap.view.popup.ExtensionPopupMenuComponent;
@@ -54,12 +57,43 @@ public class ExtensionPopupMenuItem extends JMenuItem implements ExtensionPopupM
 	private boolean precedeWithSeparator = false;
 	private boolean succeedWithSeparator = false;
 
+    /**
+     * Constructs an {@code ExtensionPopupMenuItem} with no text nor icon.
+     */
 	public ExtensionPopupMenuItem() {
         super();
     }
     
-    public ExtensionPopupMenuItem(String label) {
-        super(label);
+    /**
+     * Constructs an {@code ExtensionPopupMenuItem} with the given text and no icon.
+     *
+     * @param text the text of the menu item.
+     */
+    public ExtensionPopupMenuItem(String text) {
+        super(text);
+    }
+
+    /**
+     * Constructs an {@code ExtensionPopupMenuItem} with the given text and icon.
+     *
+     * @param text the text of the menu item.
+     * @param icon the icon of the menu item.
+     * @since TODO add version
+     */
+    public ExtensionPopupMenuItem(String text, Icon icon) {
+        super(text, icon);
+    }
+
+    /**
+     * Constructs an {@code ExtensionPopupMenuItem} with the given action.
+     * <p>
+     * The text and icon (if any) are obtained from the given action.
+     *
+     * @param action the action of the menu item.
+     * @since TODO add version
+     */
+    public ExtensionPopupMenuItem(Action action) {
+        super(action);
     }
     
     /**

--- a/src/org/zaproxy/zap/extension/ExtensionPopupMenu.java
+++ b/src/org/zaproxy/zap/extension/ExtensionPopupMenu.java
@@ -43,12 +43,20 @@ public class ExtensionPopupMenu extends JMenu implements ExtensionPopupMenuCompo
 	 */
 	private boolean orderChildren;
 
+	/**
+	 * Constructs an {@code ExtensionPopupMenu} with no text.
+	 */
 	public ExtensionPopupMenu() {
 		super();
 	}
 
-	public ExtensionPopupMenu(String label) {
-		super(label);
+	/**
+	 * Constructs an {@code ExtensionPopupMenu} with the given text.
+	 *
+	 * @param text the text of the menu item.
+	 */
+	public ExtensionPopupMenu(String text) {
+		super(text);
 	}
 
 	/**

--- a/src/org/zaproxy/zap/view/popup/ExtensionPopupMenuItemMessageContainer.java
+++ b/src/org/zaproxy/zap/view/popup/ExtensionPopupMenuItemMessageContainer.java
@@ -21,6 +21,9 @@ package org.zaproxy.zap.view.popup;
 
 import java.awt.Component;
 
+import javax.swing.Action;
+import javax.swing.Icon;
+
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.view.messagecontainer.MessageContainer;
 
@@ -34,12 +37,43 @@ public class ExtensionPopupMenuItemMessageContainer extends ExtensionPopupMenuIt
 
     private static final long serialVersionUID = 5123729066062943072L;
 
+    /**
+     * Constructs an {@code ExtensionPopupMenuItemMessageContainer} with no text nor icon.
+     */
     public ExtensionPopupMenuItemMessageContainer() {
         super();
     }
 
+    /**
+     * Constructs an {@code ExtensionPopupMenuItemMessageContainer} with the given text and no icon.
+     *
+     * @param text the text of the menu item.
+     */
     public ExtensionPopupMenuItemMessageContainer(String text) {
         super(text);
+    }
+
+    /**
+     * Constructs an {@code ExtensionPopupMenuItemMessageContainer} with the given text and icon.
+     *
+     * @param text the text of the menu item.
+     * @param icon the icon of the menu item.
+     * @since TODO add version
+     */
+    public ExtensionPopupMenuItemMessageContainer(String text, Icon icon) {
+        super(text, icon);
+    }
+
+    /**
+     * Constructs an {@code ExtensionPopupMenuItemMessageContainer} with the given action.
+     * <p>
+     * The text and icon (if any) are obtained from the given action.
+     *
+     * @param action the action of the menu item.
+     * @since TODO add version
+     */
+    public ExtensionPopupMenuItemMessageContainer(Action action) {
+        super(action);
     }
 
     /**


### PR DESCRIPTION
Change ExtensionPopupMenuItem and ExtensionPopupMenuItemMessageContainer
to expose more constructors (e.g. easier to customise the pop up menus
when used from scripts).