### PR TITLE
Issue 3555 Session Name Window Title Consistency

### DIFF
--- a/src/org/parosproxy/paros/control/Control.java
+++ b/src/org/parosproxy/paros/control/Control.java
@@ -343,7 +343,6 @@ public class Control extends AbstractControl implements SessionListener {
 					view.getSiteTreePanel().getTreeSite().setModel(session.getSiteTree());
 
 					// refresh display
-					view.getMainFrame().setTitle(session.getSessionName());
 					view.getOutputPanel().clear();
 				}
 			});
@@ -413,7 +412,6 @@ public class Control extends AbstractControl implements SessionListener {
 			});
 			
 			// refresh display
-			view.getMainFrame().setTitle(session.getSessionName());
 			view.getOutputPanel().clear();
 		}
 		

--- a/src/org/parosproxy/paros/control/MenuFileControl.java
+++ b/src/org/parosproxy/paros/control/MenuFileControl.java
@@ -44,6 +44,7 @@
 // ZAP: 2015/12/14 Log exception and internationalise error message
 // ZAP: 2016/10/26 Issue 1952: Do not allow Contexts with same name
 // ZAP: 2017/02/25 Issue 2618: Let the user select the name for snapshots
+// ZAP: 2017/06/01 Issue 3555: setTitle() functionality moved in order to ensure consistent application
 
 package org.parosproxy.paros.control;
  
@@ -189,7 +190,6 @@ public class MenuFileControl implements SessionListener {
             public void sessionSaved(final Exception e) {
                 if (EventQueue.isDispatchThread()) {
                     if (e == null) {
-                        setTitle();
                         view.getSiteTreePanel().getTreeSite().setModel(model.getSession().getSiteTree());
                     } else {
                         view.showWarningDialog(Constant.messages.getString("menu.file.newSession.error"));
@@ -246,7 +246,6 @@ public class MenuFileControl implements SessionListener {
                     }
 
                     view.getSiteTreePanel().getTreeSite().setModel(model.getSession().getSiteTree());
-                    setTitle();
 
                     if (waitMessageDialog != null) {
                         waitMessageDialog.setVisible(false);
@@ -465,22 +464,9 @@ public class MenuFileControl implements SessionListener {
 	    }
 	}
 	
-	private void setTitle() {
-		StringBuilder strBuilder = new StringBuilder(model.getSession().getSessionName());
-		if (!model.getSession().isNewState()) {
-	        File file = new File(model.getSession().getFileName());
-			strBuilder.append(" - ").append(file.getName().replaceAll(".session\\z", ""));
-		}
-		view.getMainFrame().setTitle(strBuilder.toString());
-	}
-	
 	public void properties() {
 		// ZAP: proper call of existing method
 		View.getSingleton().showSessionDialog(model.getSession(), null);
-
-	    // ZAP: Set the title consistently
-	    setTitle();
-//		view.getMainFrame().setTitle(Constant.PROGRAM_NAME + " " + Constant.PROGRAM_VERSION + " - " + model.getSession().getSessionName());
 	}
 
     @Override
@@ -489,10 +475,6 @@ public class MenuFileControl implements SessionListener {
             // ZAP: Removed the statement that called the method
             // ExtensionLoader.sessionChangedAllPlugin, now it's done in the
             // class Control.
-
-            // ZAP: Set the title consistently
-            setTitle();
-            //view.getMainFrame().setTitle(file.getName().replaceAll(".session\\z","") + " - " + Constant.PROGRAM_NAME);
         } else {
             view.showWarningDialog(Constant.messages.getString("menu.file.openSession.errorFile"));
             if (file != null) {
@@ -511,12 +493,7 @@ public class MenuFileControl implements SessionListener {
 
     @Override
     public void sessionSaved(Exception e) {
-        if (e == null) {
-            // ZAP: Set the title consistently
-            setTitle();
-            //File file = new File(model.getSession().getFileName());
-            //view.getMainFrame().setTitle(file.getName().replaceAll(".session\\z","") + " - " + Constant.PROGRAM_NAME);
-        } else {
+        if (e != null) {
 		    view.showWarningDialog(Constant.messages.getString("menu.file.savingSession.error"));	// ZAP: i18n
     	    log.error("error saving session file " + model.getSession().getFileName(), e);
             log.error(e.getMessage(), e);

--- a/src/org/parosproxy/paros/view/MainFrame.java
+++ b/src/org/parosproxy/paros/view/MainFrame.java
@@ -27,6 +27,7 @@
 // ZAP: 2015/01/29 Issue 1489: Version number in window title
 // ZAP: 2016/04/04 Do not require a restart to show/hide the tool bar
 // ZAP: 2016/04/06 Fix layouts' issues
+// ZAP: 2017/06/01 Issue 3555: setTitle() functionality moved in order to ensure consistent application
 
 package org.parosproxy.paros.view;
 
@@ -35,6 +36,7 @@ import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.io.File;
 import java.net.URL;
 
 import javax.swing.AbstractAction;
@@ -52,6 +54,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
+import org.parosproxy.paros.model.Session;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.MainToolbarPanel;
 import org.zaproxy.zap.view.ZapToggleButton;
@@ -644,12 +647,37 @@ public class MainFrame extends AbstractFrame {
 	/**
 	 * Sets the title of the main window.
 	 * <p>
+	 * The actual title set is the current session name, then the filename of the session (if persisted), 
+	 * followed by the program name and version.
+	 * 
+	 * @param session the {@code Session} from which the window title is being built
+	 * 
+	 * @see Constant#PROGRAM_NAME
+	 * @see Constant#PROGRAM_VERSION
+	 * @since TODO add version
+	 */
+	public void setTitle(Session session) {
+		StringBuilder strBuilder = new StringBuilder();
+		strBuilder.append(session.getSessionName()).append(" - ");
+		if (!session.isNewState()) {
+			File file = new File(session.getFileName());
+			strBuilder.append(file.getName().replaceAll(".session\\z", "")).append(" - ");
+		}
+		strBuilder.append(Constant.PROGRAM_NAME).append(' ').append(Constant.PROGRAM_VERSION);
+		super.setTitle(strBuilder.toString());
+	}
+	
+	/**
+	 * Sets the title of the main window.
+	 * <p>
 	 * The actual title set is the given {@code title} followed by the program name and version.
 	 * 
 	 * @see Constant#PROGRAM_NAME
 	 * @see Constant#PROGRAM_VERSION
+	 * @deprecated as of TODO add version, replaced by {@link #setTitle(Session)}
 	 */
-	@Override
+	@Override 
+	@Deprecated
 	public void setTitle(String title) {
 		StringBuilder strBuilder = new StringBuilder();
 		if (title != null && !title.isEmpty()) {

--- a/src/org/parosproxy/paros/view/SessionGeneralPanel.java
+++ b/src/org/parosproxy/paros/view/SessionGeneralPanel.java
@@ -26,6 +26,7 @@
 // ZAP: 2015/02/05 Issue 1524: New Persist Session dialog
 // ZAP: 2015/02/10 Issue 1528: Support user defined font size
 // ZAP: 2017/01/09 Remove method no longer needed.
+// ZAP: 2017/06/01 Issue 3555: setTitle() functionality moved in order to ensure consistent application
 
 package org.parosproxy.paros.view;
 
@@ -148,6 +149,7 @@ public class SessionGeneralPanel extends AbstractParamPanel {
 	    boolean changed = false;
 	    if (! getTxtSessionName().getText().equals(session.getSessionName())) {
 	    	session.setSessionName(getTxtSessionName().getText());
+	    	View.getSingleton().getMainFrame().setTitle(session);
 	    	changed = true;
 	    }
 	    if (! getTxtDescription().getText().equals(session.getSessionDesc())) {

--- a/src/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
+++ b/src/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
@@ -88,6 +88,7 @@ public class ExtensionUiUtils extends ExtensionAdaptor implements SessionChanged
 	private void sessionChangedEventHandler(Session session) {
 		View.getSingleton().getMainFrame().getMainMenuBar().sessionChanged(session);
 		View.getSingleton().getMainFrame().getMainToolbarPanel().sessionChanged(session);
+		View.getSingleton().getMainFrame().setTitle(session);
 	}
 
 


### PR DESCRIPTION
Control - Removed setTitle calls
MenuFileControl - Remove local setTitle functionality
MainFrame - Deprecate old setTitle(String). Add new setTitle(Session).
SessionGeneralPanel - saveParam now calls MainFrame's setTitle().
ExtensionUiUtils - sessionChangedEventHandler(Session) now calls MainFrame's setTitle().

Fixes zaproxy/zaproxy#3555