### PR TITLE
Show plugin as OFF, in policy panels, if disabled

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/AllCategoryTableModel.java
+++ b/src/org/zaproxy/zap/extension/ascan/AllCategoryTableModel.java
@@ -24,6 +24,7 @@
 // ZAP: 2013/11/28 Issue 923: Allow individual rule thresholds and strengths to be set via GUI
 // ZAP: 2014/05/20 Issue 377: Unfulfilled dependencies hang the active scan
 // ZAP: 2016/07/25 Change constructor's parameter to PluginFactory
+// ZAP: 2017/06/05 Take into account the enabled state of the plugin when showing the AlertThreshold of the category.
 package org.zaproxy.zap.extension.ascan;
 
 import java.util.HashMap;
@@ -174,9 +175,9 @@ public class AllCategoryTableModel extends DefaultTableModel {
             }
             
             if (at == null) {
-                at = plugin.getAlertThreshold(true);
+                at = getAlertThreshold(plugin);
                 
-            } else if (!at.equals(plugin.getAlertThreshold(true))) {
+            } else if (!at.equals(getAlertThreshold(plugin))) {
                 // Not all the same
                 return "";
             }
@@ -187,6 +188,21 @@ public class AllCategoryTableModel extends DefaultTableModel {
         }
         
         return strToI18n(at.name());
+    }
+
+    /**
+     * Gets the appropriate {@code AlertThreshold} for the state of the given plugin.
+     * <p>
+     * If the plugin is disabled it returns {@link AlertThreshold#OFF}, otherwise it returns its {@code AlertThreshold}.
+     *
+     * @param plugin the plugin for which a {@code AlertThreshold} will be returned.
+     * @return the appropriate {@code AlertThreshold} for the plugin's state.
+     */
+    private static AlertThreshold getAlertThreshold(Plugin plugin) {
+        if (!plugin.isEnabled()) {
+            return AlertThreshold.OFF;
+        }
+        return plugin.getAlertThreshold(true);
     }
 
     private String getPluginCategoryStrength(int category) {

--- a/src/org/zaproxy/zap/extension/ascan/CategoryTableModel.java
+++ b/src/org/zaproxy/zap/extension/ascan/CategoryTableModel.java
@@ -26,6 +26,7 @@
 // ZAP: 2014/05/20 Issue 377: Unfulfilled dependencies hang the active scan
 // ZAP: 2014/11/19 Issue 1412: Manage scan policies
 // ZAP: 2016/04/04 Use StatusUI in scanners' dialogues
+// ZAP: 2017/06/05 Return AlertThreshold.OFF if the plugin is disabled.
 
 package org.zaproxy.zap.extension.ascan;
 
@@ -227,6 +228,9 @@ public class CategoryTableModel extends DefaultTableModel {
         	case 0:
         		return wrapper.getPlugin().getName();
         	case 1:
+        		if (!wrapper.getPlugin().isEnabled()) {
+        			return AlertThreshold.OFF;
+        		}
         		return strToI18n(wrapper.getPlugin().getAlertThreshold(true).name());
         	case 2:
         		return strToI18n(wrapper.getPlugin().getAttackStrength(true).name());


### PR DESCRIPTION
Change CategoryTableModel to return OFF alert threshold is the plugin is
disabled, that represents better the state of the plugin (the enabled
state is not directly shown in the table).
Change AllCategoryTableModel to take into account the enabled state of
the plugins (assume OFF if disabled) when showing the alert threshold of
each category.