### PR TITLE
Return correct error on missing auth parameters

### DIFF
--- a/src/org/zaproxy/zap/extension/authentication/AuthenticationAPI.java
+++ b/src/org/zaproxy/zap/extension/authentication/AuthenticationAPI.java
@@ -23,11 +23,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 
 import org.apache.log4j.Logger;
-import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.authentication.AuthenticationMethodType;
 import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.api.ApiAction;
@@ -199,46 +197,14 @@ public class AuthenticationAPI extends ApiImplementor {
 	}
 
 	/**
-	 * Gets the context from the parameters or throws a Missing Parameter exception, if any problems
-	 * occured.
+	 * Gets the context from the given parameters.
 	 * 
 	 * @param params the params
-	 * @return the context
-	 * @throws ApiException the api exception
+	 * @return the context, never {@code null}.
+	 * @throws ApiException if the ID of the context is not provided/valid or the context does not exist.
 	 */
 	private Context getContext(JSONObject params) throws ApiException {
-		// NOTE: Still use this method as maybe we'll switch to using context names instead of id
-		int contextId = getContextId(params);
-		Context context = Model.getSingleton().getSession().getContext(contextId);
-		if (context == null)
-			throw new ApiException(Type.CONTEXT_NOT_FOUND, PARAM_CONTEXT_ID);
-		return context;
-	}
-
-	/**
-	 * Gets the context id from the parameters or throws a Missing Parameter exception, if any
-	 * problems occured.
-	 * 
-	 * @param params the params
-	 * @return the context id
-	 * @throws ApiException the api exception
-	 */
-	private int getContextId(JSONObject params) throws ApiException {
-		try {
-			return params.getInt(PARAM_CONTEXT_ID);
-		} catch (JSONException ex) {
-			throw new ApiException(ApiException.Type.MISSING_PARAMETER, PARAM_CONTEXT_ID);
-		}
-	}
-
-	@SuppressWarnings("unused")
-	private boolean hasContextId(JSONObject params) {
-		try {
-			params.getInt(PARAM_CONTEXT_ID);
-		} catch (JSONException ex) {
-			return false;
-		}
-		return true;
+		return ApiUtils.getContextByParamId(params, PARAM_CONTEXT_ID);
 	}
 
 }

--- a/src/org/zaproxy/zap/utils/ApiUtils.java
+++ b/src/org/zaproxy/zap/utils/ApiUtils.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.utils;
 
+import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 
 import java.util.Locale;
@@ -43,13 +44,15 @@ public final class ApiUtils {
 	 * @throws ApiException the api exception
 	 */
 	public static int getIntParam(JSONObject params, String paramName) throws ApiException {
-		int value;
-		try {
-			value = params.getInt(paramName);
-		} catch (Exception ex) {
-			throw new ApiException(Type.MISSING_PARAMETER, paramName + ": " + ex.getLocalizedMessage());
+		if (!params.containsKey(paramName)) {
+			throw new ApiException(ApiException.Type.MISSING_PARAMETER, paramName);
 		}
-		return value;
+
+		try {
+			return params.getInt(paramName);
+		} catch (JSONException e) {
+			throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, paramName, e);
+		}
 	}
 
 	/**

--- a/test/org/zaproxy/zap/utils/ApiUtilsUnitTest.java
+++ b/test/org/zaproxy/zap/utils/ApiUtilsUnitTest.java
@@ -24,6 +24,9 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
+import org.zaproxy.zap.extension.api.ApiException;
+
+import net.sf.json.JSONObject;
 
 /**
  * Unit test for {@link ApiUtils}.
@@ -31,6 +34,57 @@ import org.junit.Test;
 public class ApiUtilsUnitTest {
 
     private static final String HOST = "example.com";
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowNullPointerExceptionWhenGettingIntFromNullParams() throws Exception {
+        // Given
+        JSONObject params = null;
+        // When
+        ApiUtils.getIntParam(params, "name");
+        // Then = NullPointerException
+    }
+
+    @Test
+    public void shouldThrowMissingParameterWhenGettingIntIfMissingParam() {
+        // Given
+        String name = "ParamNotInObject";
+        JSONObject params = new JSONObject();
+        try {
+            // When
+            ApiUtils.getIntParam(params, name);
+        } catch (ApiException e) {
+            // Then
+            assertThat(e.getType(), is(equalTo(ApiException.Type.MISSING_PARAMETER)));
+        }
+    }
+
+    @Test
+    public void shouldThrowIllegalParameterWhenGettingIntIfParamNotInt() {
+        // Given
+        String name = "ParamNotInt";
+        JSONObject params = new JSONObject();
+        params.put(name, "String");
+        try {
+            // When
+            ApiUtils.getIntParam(params, name);
+        } catch (ApiException e) {
+            // Then
+            assertThat(e.getType(), is(equalTo(ApiException.Type.ILLEGAL_PARAMETER)));
+        }
+    }
+
+    @Test
+    public void shouldReturnIntValueWhenGettingInt() throws Exception {
+        // Given
+        String name = "ParamInt";
+        int value = 0;
+        JSONObject params = new JSONObject();
+        params.put(name, value);
+        // When
+        int obtainedValue = ApiUtils.getIntParam(params, name);
+        // Then
+        assertThat(obtainedValue, is(equalTo(value)));
+    }
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowExceptionWhenGettingAuthorityFromNullSite() {


### PR DESCRIPTION
Change AuthenticationAPI to use the existing method from ApiUtils to
obtain the context (reduce code duplication), also remove unused method.
Change ApiUtils to throw a "missing parameter" exception if the required
parameter is not provided and just throw "illegal parameter" if provided
but not valid (used by the method that obtains the Context, using the ID
provided in the parameters).
Add tests to assert the expected behaviour.