### PR TITLE
Do not close session when changing its properties

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1967,6 +1967,7 @@ session.ascan.label.ignore         = URLs which will be ignored by the active sc
 session.desc                       = Manage session tokens
 session.dialog.title               = Session
 session.general                    = General
+session.general.error.persist.session.props = Failed to persist the session properties (e.g. name, description).
 session.generate.popup             = Analyse Session Tokens...
 session.label.desc                 = Description
 session.label.loc				   = Location

--- a/src/org/parosproxy/paros/control/Control.java
+++ b/src/org/parosproxy/paros/control/Control.java
@@ -65,6 +65,7 @@
 // ZAP: 2017/03/10 Reset proxy excluded URLs on new session
 // ZAP: 2017/03/13 Set global excluded URLs to the proxy when creating a new session or initialising.
 // ZAP: 2017/03/16 Allow to initialise Control without starting the Local Proxy.
+// ZAP: 2017/06/07 Allow to persist the session properties (e.g. name, description).
 
 package org.parosproxy.paros.control;
 
@@ -461,6 +462,19 @@ public class Control extends AbstractControl implements SessionListener {
 		lastCallback = callback;
 		model.saveSession(fileName, this);
 		// The session is saved in a thread, so notify the listeners via the callback
+    }
+
+    /**
+     * Persists the properties (e.g. name, description) of the current session.
+     * <p>
+     * Should be called only by "core" classes.
+     *
+     * @throws Exception if an error occurred while persisting the properties.
+     * @since TODO add version
+     */
+    public void persistSessionProperties() throws Exception {
+        model.persistSessionProperties();
+        getExtensionLoader().sessionPropertiesChangedAllPlugin(model.getSession());
     }
 
     public void snapshotSession(final String fileName, final SessionListener callback) {

--- a/src/org/parosproxy/paros/extension/ExtensionLoader.java
+++ b/src/org/parosproxy/paros/extension/ExtensionLoader.java
@@ -67,6 +67,7 @@
 // ZAP: 2016/08/18 Hook ApiImplementor
 // ZAP: 2016/11/23 Call postInit() when starting an extension, startLifeCycle(Extension).
 // ZAP: 2017/02/19 Hook/remove extensions' components to/from the main tool bar.
+// ZAP: 2017/06/07 Allow to notify of changes in the session's properties (e.g. name, description).
 
 package org.parosproxy.paros.extension;
 
@@ -505,6 +506,30 @@ public class ExtensionLoader {
                         listener.sessionModeChanged(mode);
                     }
                     
+                } catch (Exception e) {
+                    logger.error(e.getMessage(), e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Notifies that the properties (e.g. name, description) of the current session were changed.
+     * <p>
+     * Should be called only by "core" classes.
+     * 
+     * @param session the session changed.
+     * @since TODO add version
+     */
+    public void sessionPropertiesChangedAllPlugin(Session session) {
+        logger.debug("sessionPropertiesChangedAllPlugin");
+        for (ExtensionHook hook : extensionHooks.values()) {
+            for (SessionChangedListener listener : hook.getSessionListenerList()) {
+                try {
+                    if (listener != null) {
+                        listener.sessionPropertiesChanged(session);
+                    }
+
                 } catch (Exception e) {
                     logger.error(e.getMessage(), e);
                 }

--- a/src/org/parosproxy/paros/extension/SessionChangedListener.java
+++ b/src/org/parosproxy/paros/extension/SessionChangedListener.java
@@ -23,6 +23,7 @@
 // ZAP: 2012/08/01 Issue 332: added support for Modes
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
 // ZAP: 2016/09/22 JavaDoc tweaks
+// ZAP: 2017/06/07 Allow to notify of changes in the session's properties (e.g. name, description).
 
 package org.parosproxy.paros.extension;
 
@@ -63,4 +64,14 @@ public interface SessionChangedListener {
      */
     void sessionModeChanged(Mode mode);
     
+    /**
+     * Called when the session properties (e.g. name, description) have been changed.
+     * <p>
+     * This method may be called by other threads than {@link java.awt.EventQueue EventQueue}.
+     * 
+     * @param session the session changed.
+     * @since TODO add version
+     */
+    default void sessionPropertiesChanged(Session session) {
+    }
 }

--- a/src/org/parosproxy/paros/model/Model.java
+++ b/src/org/parosproxy/paros/model/Model.java
@@ -40,6 +40,7 @@
 // ZAP: 2016/03/23 Issue 2331: Custom Context Panels not show in existing contexts after installation of add-on
 // ZAP: 2016/06/10 Do not clean up the database if the current session does not require it
 // ZAP: 2016/07/05 Issue 2218: Persisted Sessions don't save unconfigured Default Context
+// ZAP: 2017/06/07 Allow to persist the session properties (e.g. name, description).
 
 package org.parosproxy.paros.model;
 
@@ -161,6 +162,18 @@ public class Model {
 	 */
 	public void saveSession(String fileName) throws Exception {
 		getSession().save(fileName);
+	}
+
+	/**
+	 * Persists the properties (e.g. name, description) of the current session.
+	 * <p>
+	 * Should be called only by "core" classes.
+	 *
+	 * @throws Exception if an error occurred while persisting the properties.
+	 * @since TODO add version
+	 */
+	public void persistSessionProperties() throws Exception {
+		getSession().persistProperties();
 	}
 
 	/**

--- a/src/org/parosproxy/paros/model/Session.java
+++ b/src/org/parosproxy/paros/model/Session.java
@@ -69,6 +69,7 @@
 // ZAP: 2017/01/04 Remove dependency on ExtensionSpider
 // ZAP: 2017/01/26 Remove dependency on ExtensionActiveScan
 // ZAP: 2017/03/13 Remove global excluded URLs from Session's state.
+// ZAP: 2017/06/07 Allow to persist the session properties (e.g. name, description).
 
 package org.parosproxy.paros.model;
 
@@ -560,6 +561,25 @@ public class Session {
 			}
     	}
 		
+		model.getDb().getTableSession().update(getSessionId(), getSessionName());
+	}
+
+	/**
+	 * Persists the properties (e.g. name, description) of the session.
+	 * <p>
+	 * Should be called only by "core" classes.
+	 *
+	 * @throws Exception if an error occurred while persisting the properties.
+	 * @since TODO add version
+	 * @see #setSessionName(String)
+	 * @see #setSessionDesc(String)
+	 */
+	protected void persistProperties() throws Exception {
+		if (isNewState()) {
+			return;
+		}
+
+		configuration.save(new File(fileName));
 		model.getDb().getTableSession().update(getSessionId(), getSessionName());
 	}
 	

--- a/src/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
+++ b/src/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
@@ -101,6 +101,16 @@ public class ExtensionUiUtils extends ExtensionAdaptor implements SessionChanged
 	}
 
 	@Override
+	public void sessionPropertiesChanged(Session session) {
+		if (EventQueue.isDispatchThread()) {
+			View.getSingleton().getMainFrame().setTitle(session);
+			return;
+		}
+
+		EventQueue.invokeLater(() -> sessionPropertiesChanged(session));
+	}
+
+	@Override
 	public boolean isCore() {
 		return true;
 	}


### PR DESCRIPTION
Change how the changes to the session's properties (e.g. name,
description) are persisted/notified to other classes, now it just
persist those properties and notifies accordingly instead of saving
(closing and re-opening) the session, which stopped all the active
actions (e.g. scans) without warning.