### PR TITLE
Correct creation of API URLs with nonces

### DIFF
--- a/test/org/zaproxy/zap/extension/api/APIUnitTest.java
+++ b/test/org/zaproxy/zap/extension/api/APIUnitTest.java
@@ -19,11 +19,14 @@
  */
 package org.zaproxy.zap.extension.api;
 
+import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import java.net.Inet4Address;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,6 +37,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.parosproxy.paros.core.proxy.ProxyParam;
 import org.parosproxy.paros.network.HttpInputStream;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpOutputStream;
@@ -69,7 +73,7 @@ public class APIUnitTest {
     public void shouldDenyAllAddressesIfNoneSet() throws Exception {
         // Given
         API api = new API();
-        api.setOptionsParamApi(new OptionsParamApi());
+        api.setOptionsParamApi(createOptionsParamApi());
         TestApiImplementor apiImplementor = new TestApiImplementor();
         String requestUri = api.getCallBackUrl(apiImplementor, "http://example.com");
         // When
@@ -86,8 +90,7 @@ public class APIUnitTest {
     public void shouldDenyAddressNotSet() throws Exception {
         // Given
         API api = new API();
-        OptionsParamApi apiOptions = new OptionsParamApi();
-        apiOptions.load(new ZapXmlConfiguration());
+        OptionsParamApi apiOptions = createOptionsParamApi();
         apiOptions.setPermittedAddresses(createPermittedAddresses("127.0.0.1"));
         api.setOptionsParamApi(apiOptions);
         TestApiImplementor apiImplementor = new TestApiImplementor();
@@ -106,8 +109,7 @@ public class APIUnitTest {
     public void shouldDenyHostnameNotSet() throws Exception {
         // Given
         API api = new API();
-        OptionsParamApi apiOptions = new OptionsParamApi();
-        apiOptions.load(new ZapXmlConfiguration());
+        OptionsParamApi apiOptions = createOptionsParamApi();
         apiOptions.setPermittedAddresses(createPermittedAddresses("127.0.0.1", "localhost"));
         api.setOptionsParamApi(apiOptions);
         TestApiImplementor apiImplementor = new TestApiImplementor();
@@ -126,8 +128,7 @@ public class APIUnitTest {
     public void shouldAcceptAddressAndHostnameSet() throws Exception {
         // Given
         API api = new API();
-        OptionsParamApi apiOptions = new OptionsParamApi();
-        apiOptions.load(new ZapXmlConfiguration());
+        OptionsParamApi apiOptions = createOptionsParamApi();
         apiOptions.setPermittedAddresses(createPermittedAddresses("10.0.0.8", "example.com"));
         api.setOptionsParamApi(apiOptions);
         TestApiImplementor apiImplementor = new TestApiImplementor();
@@ -142,6 +143,221 @@ public class APIUnitTest {
         assertThat(apiImplementor.wasUsed(), is(equalTo(true)));
     }
 
+    @Test
+    public void shouldCreateBaseUrlWithHttpSchemeAndZapAddressIfProxyingAndNotSecure() {
+        // Given
+        boolean proxying = true;
+        boolean secure = false;
+        API api = new API();
+        OptionsParamApi apiOptions = createOptionsParamApi();
+        apiOptions.setSecureOnly(secure);
+        api.setOptionsParamApi(apiOptions);
+        // When
+        String baseUrl = api.getBaseURL(proxying);
+        // Then
+        assertThat(baseUrl, is(equalTo("http://zap/")));
+    }
+
+    @Test
+    public void shouldCreateBaseUrlWithHttpsSchemeAndZapAddressIfProxyingAndSecure() {
+        // Given
+        boolean proxying = true;
+        boolean secure = true;
+        API api = new API();
+        OptionsParamApi apiOptions = createOptionsParamApi();
+        apiOptions.setSecureOnly(secure);
+        api.setOptionsParamApi(apiOptions);
+        // When
+        String baseUrl = api.getBaseURL(proxying);
+        // Then
+        assertThat(baseUrl, is(equalTo("https://zap/")));
+    }
+
+    @Test
+    public void shouldCreateBaseUrlWithHttpsSchemeAndProxyAddressIfNotProxyingAndNotSecure() {
+        // Given
+        boolean proxying = false;
+        boolean secure = false;
+        API api = new API();
+        OptionsParamApi apiOptions = createOptionsParamApi();
+        apiOptions.setSecureOnly(secure);
+        api.setOptionsParamApi(apiOptions);
+        api.setProxyParam(createProxyParam("127.0.0.1", 8080));
+        // When
+        String baseUrl = api.getBaseURL(proxying);
+        // Then
+        assertThat(baseUrl, is(equalTo("http://127.0.0.1:8080/")));
+    }
+
+    @Test
+    public void shouldCreateBaseUrlWithHttpsSchemeAndProxyAddressIfNotProxyingAndSecure() {
+        // Given
+        boolean proxying = false;
+        boolean secure = true;
+        API api = new API();
+        OptionsParamApi apiOptions = createOptionsParamApi();
+        apiOptions.setSecureOnly(secure);
+        api.setOptionsParamApi(apiOptions);
+        api.setProxyParam(createProxyParam("127.0.0.1", 8080));
+        // When
+        String baseUrl = api.getBaseURL(proxying);
+        // Then
+        assertThat(baseUrl, is(equalTo("https://127.0.0.1:8080/")));
+    }
+
+    @Test
+    public void shouldCreateBaseUrlWithApiRequestWithHttpSchemeZapAddressAndApiNonceIfProxyingNotSecureAndNotView() {
+        // Given
+        boolean proxying = true;
+        boolean secure = false;
+        API api = new API();
+        OptionsParamApi apiOptions = createOptionsParamApi();
+        apiOptions.setSecureOnly(secure);
+        api.setOptionsParamApi(apiOptions);
+        // When
+        String baseUrl = api.getBaseURL(API.Format.JSON, "test", API.RequestType.action, "test", proxying);
+        // Then
+        assertThat(baseUrl, startsWith("http://zap/JSON/test/action/test/?apinonce="));
+        assertThat(baseUrl, endsWith("&"));
+        assertApiNonceMatch(api, baseUrl);
+    }
+
+    @Test
+    public void shouldCreateBaseUrlWithApiRequestWithHttpsSchemeZapAddressAndApiNonceIfProxyingIsSecureAndNotView() {
+        // Given
+        boolean proxying = true;
+        boolean secure = true;
+        API api = new API();
+        OptionsParamApi apiOptions = createOptionsParamApi();
+        apiOptions.setSecureOnly(secure);
+        api.setOptionsParamApi(apiOptions);
+        // When
+        String baseUrl = api.getBaseURL(API.Format.JSON, "test", API.RequestType.action, "test", proxying);
+        // Then
+        assertThat(baseUrl, startsWith("https://zap/JSON/test/action/test/?apinonce="));
+        assertThat(baseUrl, endsWith("&"));
+        assertApiNonceMatch(api, baseUrl);
+    }
+
+    @Test
+    public void shouldCreateBaseUrlWithApiRequestWithHttpSchemeProxyAddressAndApiNonceIfNotProxyingNotSecureAndNotView() {
+        // Given
+        boolean proxying = false;
+        boolean secure = false;
+        API api = new API();
+        OptionsParamApi apiOptions = createOptionsParamApi();
+        apiOptions.setSecureOnly(secure);
+        api.setOptionsParamApi(apiOptions);
+        api.setProxyParam(createProxyParam("127.0.0.1", 8080));
+        // When
+        String baseUrl = api.getBaseURL(API.Format.JSON, "test", API.RequestType.action, "test", proxying);
+        // Then
+        assertThat(baseUrl, startsWith("http://127.0.0.1:8080/JSON/test/action/test/?apinonce="));
+        assertThat(baseUrl, endsWith("&"));
+        assertApiNonceMatch(api, baseUrl);
+    }
+
+    @Test
+    public void shouldCreateBaseUrlWithApiRequestWithHttpsSchemeProxyAddressAndApiNonceIfNotProxyingIsSecureAndNotView() {
+        // Given
+        boolean proxying = false;
+        boolean secure = true;
+        API api = new API();
+        OptionsParamApi apiOptions = createOptionsParamApi();
+        apiOptions.setSecureOnly(secure);
+        api.setOptionsParamApi(apiOptions);
+        api.setProxyParam(createProxyParam("127.0.0.1", 8080));
+        // When
+        String baseUrl = api.getBaseURL(API.Format.JSON, "test", API.RequestType.action, "test", proxying);
+        // Then
+        assertThat(baseUrl, startsWith("https://127.0.0.1:8080/JSON/test/action/test/?apinonce="));
+        assertThat(baseUrl, endsWith("&"));
+        assertApiNonceMatch(api, baseUrl);
+    }
+
+    @Test
+    public void shouldCreateBaseUrlWithApiRequestWithHttpSchemeZapAddressAndNoApiNonceIfProxyingNotSecureAndView() {
+        // Given
+        boolean proxying = true;
+        boolean secure = false;
+        API api = new API();
+        OptionsParamApi apiOptions = createOptionsParamApi();
+        apiOptions.setSecureOnly(secure);
+        api.setOptionsParamApi(apiOptions);
+        // When
+        String baseUrl = api.getBaseURL(API.Format.JSON, "test", API.RequestType.view, "test", proxying);
+        // Then
+        assertThat(baseUrl, is(equalTo("http://zap/JSON/test/view/test/")));
+    }
+
+    @Test
+    public void shouldCreateBaseUrlWithApiRequestWithHttpsSchemeZapAddressAndNoApiNonceIfProxyingIsSecureAndView() {
+        // Given
+        boolean proxying = true;
+        boolean secure = true;
+        API api = new API();
+        OptionsParamApi apiOptions = createOptionsParamApi();
+        apiOptions.setSecureOnly(secure);
+        api.setOptionsParamApi(apiOptions);
+        // When
+        String baseUrl = api.getBaseURL(API.Format.JSON, "test", API.RequestType.view, "test", proxying);
+        // Then
+        assertThat(baseUrl, is(equalTo("https://zap/JSON/test/view/test/")));
+    }
+
+    @Test
+    public void shouldCreateBaseUrlWithApiRequestWithHttpSchemeProxyAddressAndNoApiNonceIfNotProxyingNotSecureAndView() {
+        // Given
+        boolean proxying = false;
+        boolean secure = false;
+        API api = new API();
+        OptionsParamApi apiOptions = createOptionsParamApi();
+        apiOptions.setSecureOnly(secure);
+        api.setOptionsParamApi(apiOptions);
+        api.setProxyParam(createProxyParam("127.0.0.1", 8080));
+        // When
+        String baseUrl = api.getBaseURL(API.Format.JSON, "test", API.RequestType.view, "test", proxying);
+        // Then
+        assertThat(baseUrl, is(equalTo("http://127.0.0.1:8080/JSON/test/view/test/")));
+    }
+
+    @Test
+    public void shouldCreateBaseUrlWithApiRequestWithHttpsSchemeProxyAddressAndNoApiNonceIfNotProxyingIsSecureAndView() {
+        // Given
+        boolean proxying = false;
+        boolean secure = true;
+        API api = new API();
+        OptionsParamApi apiOptions = createOptionsParamApi();
+        apiOptions.setSecureOnly(secure);
+        api.setOptionsParamApi(apiOptions);
+        api.setProxyParam(createProxyParam("127.0.0.1", 8080));
+        // When
+        String baseUrl = api.getBaseURL(API.Format.JSON, "test", API.RequestType.view, "test", proxying);
+        // Then
+        assertThat(baseUrl, is(equalTo("https://127.0.0.1:8080/JSON/test/view/test/")));
+    }
+
+    private static void assertApiNonceMatch(API api, String baseUrl) {
+        try {
+            // Given
+            URI uri = new URI(baseUrl);
+            String hostHeader = uri.getHost() + (uri.getPort() != -1 ? ":" + uri.getPort() : "");
+            TestApiImplementor apiImplementor = new TestApiImplementor();
+            api.registerApiImplementor(apiImplementor);
+            // When
+            boolean requestHandled = api.handleApiRequest(
+                    createApiRequest(new byte[] { 127, 0, 0, 1 }, hostHeader, baseUrl),
+                    createMockedHttpInputStream(),
+                    createMockedHttpOutputStream(),
+                    true);
+            // Then
+            assertThat(requestHandled, is(equalTo(true)));
+            assertThat(apiImplementor.wasUsed(), is(equalTo(true)));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private List<DomainMatcher> createPermittedAddresses(String... addresses) {
         if (addresses == null || addresses.length == 0) {
             return new ArrayList<>();
@@ -154,18 +370,33 @@ public class APIUnitTest {
         return permittedAddresses;
     }
 
-    private HttpRequestHeader createApiRequest(byte[] remoteAddress, String hostname, String requestUri) throws Exception {
+    private static HttpRequestHeader createApiRequest(byte[] remoteAddress, String hostname, String requestUri)
+            throws Exception {
         HttpRequestHeader httpRequestHeader = new HttpRequestHeader(
                 "GET " + requestUri + " HTTP/1.1\r\n" + "Host: " + hostname + "\r\n");
         httpRequestHeader.setSenderAddress(Inet4Address.getByAddress(remoteAddress));
         return httpRequestHeader;
     }
 
-    private HttpInputStream createMockedHttpInputStream() {
+    private static OptionsParamApi createOptionsParamApi() {
+        OptionsParamApi optionsParamApi = new OptionsParamApi();
+        optionsParamApi.load(new ZapXmlConfiguration());
+        return optionsParamApi;
+    }
+
+    private static ProxyParam createProxyParam(String proxyAddress, int proxyPort) {
+        ProxyParam proxyParam = new ProxyParam();
+        proxyParam.load(new ZapXmlConfiguration());
+        proxyParam.setProxyIp(proxyAddress);
+        proxyParam.setProxyPort(proxyPort);
+        return proxyParam;
+    }
+
+    private static HttpInputStream createMockedHttpInputStream() {
         return Mockito.mock(HttpInputStream.class);
     }
 
-    private HttpOutputStream createMockedHttpOutputStream() {
+    private static HttpOutputStream createMockedHttpOutputStream() {
         return Mockito.mock(HttpOutputStream.class);
     }
 
@@ -183,13 +414,13 @@ public class APIUnitTest {
         @Override
         public ApiResponse handleApiView(String name, JSONObject params) throws ApiException {
             used = true;
-            return new ApiResponseElement(name);
+            return new ApiResponseElement(name, "value");
         }
 
         @Override
         public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
             used = true;
-            return new ApiResponseElement(name);
+            return new ApiResponseElement(name, "value");
         }
 
         @Override
@@ -207,13 +438,13 @@ public class APIUnitTest {
         @Override
         public ApiResponse handleApiOptionView(String name, JSONObject params) throws ApiException {
             used = true;
-            return new ApiResponseElement(name);
+            return new ApiResponseElement(name, "value");
         }
 
         @Override
         public ApiResponse handleApiOptionAction(String name, JSONObject params) throws ApiException {
             used = true;
-            return new ApiResponseElement(name);
+            return new ApiResponseElement(name, "value");
         }
 
         @Override


### PR DESCRIPTION
Change API to not add an extra slash (before the query component) and to
create the nonce with the expected path (slash at the beginning).
Add tests to assert the expected behaviour.

Fix #3633 - "Generate Anti-CSRF Test Form" not working