### PR TITLE
Log init errors of add-on classes with error level

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnLoaderUtils.java
+++ b/src/org/zaproxy/zap/control/AddOnLoaderUtils.java
@@ -112,7 +112,7 @@ final class AddOnLoaderUtils {
             T instance = c.newInstance();
             return instance;
         } catch (Exception e) {
-            LOGGER.debug(e.getMessage(), e);
+            LOGGER.error("Failed to initialise: " + classname, e);
         }
         return null;
     }


### PR DESCRIPTION
Change AddOnLoaderUtils to log add-ons' class initialisation errors with
error level, it provides more information by default.

Fix #649 - Log initialisation errors of add-on classes as error