### PR TITLE
Initial CustomPages Implementation

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -66,6 +66,7 @@
 // ZAP: 2019/10/21 Use and expose Alert builder.
 // ZAP: 2020/01/27 Extracted code from sendAndReceive method into regenerateAntiCsrfToken method in
 // ExtensionAntiCSRF.
+// ZAP: 2020/09/23 Add functionality for custom error pages handling (Issue 9).
 package org.parosproxy.paros.core.scanner;
 
 import java.io.IOException;
@@ -87,6 +88,7 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.extension.anticsrf.ExtensionAntiCSRF;
+import org.zaproxy.zap.extension.custompages.CustomPage;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 
@@ -585,6 +587,62 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
      */
     protected boolean isFileExist(HttpMessage msg) {
         return parent.getAnalyser().isFileExist(msg);
+    }
+
+    /**
+     * Tells whether or not the message matches the specific {@code CustomPageType}
+     *
+     * @param msg the message that will be checked
+     * @param cpType the custom page type to be checked
+     * @return {@code true} if the message matches, {@code false} otherwise
+     * @since TODO Add version
+     */
+    private boolean isCustomPage(HttpMessage msg, CustomPage.Type cpType) {
+        return parent.isCustomPage(msg, cpType);
+    }
+
+    /**
+     * Tells whether or not the message matches {@code CustomPageType.OK_200} definitions.
+     *
+     * @param msg the message that will be checked
+     * @return {@code true} if the message matches, {@code false} otherwise
+     * @since TODO Add version
+     */
+    protected boolean isPage200(HttpMessage msg) {
+        return isCustomPage(msg, CustomPage.Type.OK_200);
+    }
+
+    /**
+     * Tells whether or not the message matches {@code CustomPageType.ERROR_500} definitions.
+     *
+     * @param msg the message that will be checked
+     * @return {@code true} if the message matches, {@code false} otherwise
+     * @since TODO Add version
+     */
+    protected boolean isPage500(HttpMessage msg) {
+        return isCustomPage(msg, CustomPage.Type.ERROR_500);
+    }
+
+    /**
+     * Tells whether or not the message matches {@code CustomPageType.NOTFOUND_404} definitions.
+     *
+     * @param msg the message that will be checked
+     * @return {@code true} if the message matches, {@code false} otherwise
+     * @since TODO Add version
+     */
+    protected boolean isPage404(HttpMessage msg) {
+        return isCustomPage(msg, CustomPage.Type.NOTFOUND_404);
+    }
+
+    /**
+     * Tells whether or not the message matches {@code CustomPageType.OTHER} definitions.
+     *
+     * @param msg the message that will be checked
+     * @return {@code true} if the message matches, {@code false} otherwise
+     * @since TODO Add version
+     */
+    protected boolean isPageOther(HttpMessage msg) {
+        return isCustomPage(msg, CustomPage.Type.OTHER);
     }
 
     /**

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/HostProcess.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/HostProcess.java
@@ -90,7 +90,8 @@
 // ZAP: 2019/01/19 Handle counting alerts raised by scan (Issue 3929).
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
-// ZAP: 2019/11/09 Ability to filter to active scan (Issue 5278)
+// ZAP: 2019/11/09 Ability to filter to active scan (Issue 5278).
+// ZAP: 2020/09/23 Add functionality for custom error pages handling (Issue 9).
 package org.parosproxy.paros.core.scanner;
 
 import java.io.IOException;
@@ -117,8 +118,10 @@ import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.extension.ascan.ScanPolicy;
 import org.zaproxy.zap.extension.ascan.filters.FilterResult;
 import org.zaproxy.zap.extension.ascan.filters.ScanFilter;
+import org.zaproxy.zap.extension.custompages.CustomPage;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfig;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
+import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.SessionStructure;
 import org.zaproxy.zap.model.StructuralNode;
 import org.zaproxy.zap.model.TechSet;
@@ -145,6 +148,7 @@ public class HostProcess implements Runnable {
     private TechSet techSet;
     private RuleConfigParam ruleConfigParam;
     private String stopReason = null;
+    private Context context;
 
     /**
      * A {@code Map} from plugin IDs to corresponding {@link PluginStats}.
@@ -1282,6 +1286,29 @@ public class HostProcess implements Runnable {
         synchronized (mapPluginStats) {
             return mapPluginStats.get(pluginId);
         }
+    }
+
+    /**
+     * Tells whether or not the message matches the specific {@code CustomPageType}
+     *
+     * @param msg the message that will be checked
+     * @param cpType the custom page type to be checked
+     * @return {@code true} if the message matches, {@code false} otherwise
+     * @since TODO Add version
+     */
+    protected boolean isCustomPage(HttpMessage msg, CustomPage.Type cpType) {
+        if (getContext() != null) {
+            return getContext().isCustomPageWithFallback(msg, cpType);
+        }
+        return false;
+    }
+
+    public Context getContext() {
+        return context;
+    }
+
+    public void setContext(Context context) {
+        this.context = context;
     }
 
     /**

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Scanner.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Scanner.java
@@ -48,6 +48,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/11/09 Ability to filter to active scan (Issue 5278)
 // ZAP: 2020/05/19 simplifying duplicate HostProcess for readability
+// ZAP: 2020/09/23 Add functionality for custom error pages handling (Issue 9).
 package org.parosproxy.paros.core.scanner;
 
 import java.security.InvalidParameterException;
@@ -308,6 +309,7 @@ public class Scanner implements Runnable {
         hostProcess.setStartNode(node);
         hostProcess.setUser(this.user);
         hostProcess.setTechSet(this.techSet);
+        hostProcess.setContext(target.getContext());
         return hostProcess;
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/control/CoreFunctionality.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/CoreFunctionality.java
@@ -131,6 +131,7 @@ public final class CoreFunctionality {
             extensions.add(new org.zaproxy.zap.extension.stdmenus.ExtensionStdMenus());
             extensions.add(new org.zaproxy.zap.extension.uiutils.ExtensionUiUtils());
             extensions.add(new org.zaproxy.zap.extension.users.ExtensionUserManagement());
+            extensions.add(new org.zaproxy.zap.extension.custompages.ExtensionCustomPages());
             extensions.trimToSize();
 
             builtInExtensions = Collections.unmodifiableList(extensions);

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScriptsActiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScriptsActiveScanner.java
@@ -330,4 +330,24 @@ public class ScriptsActiveScanner extends AbstractAppParamPlugin {
     public int getWascId() {
         return 0;
     }
+
+    @Override
+    public boolean isPage200(HttpMessage msg) {
+        return super.isPage200(msg);
+    }
+
+    @Override
+    public boolean isPage404(HttpMessage msg) {
+        return super.isPage404(msg);
+    }
+
+    @Override
+    public boolean isPage500(HttpMessage msg) {
+        return super.isPage500(msg);
+    }
+
+    @Override
+    public boolean isPageOther(HttpMessage msg) {
+        return super.isPageOther(msg);
+    }
 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/custompages/ContextCustomPagePanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/custompages/ContextCustomPagePanel.java
@@ -1,0 +1,226 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompages;
+
+import java.awt.CardLayout;
+import java.awt.Component;
+import java.awt.GridBagLayout;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.model.Session;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.view.AbstractContextPropertiesPanel;
+import org.zaproxy.zap.view.AbstractMultipleOptionsTablePanel;
+import org.zaproxy.zap.view.LayoutHelper;
+
+class ContextCustomPagePanel extends AbstractContextPropertiesPanel {
+
+    // The i18n prefix
+    protected static final String PREFIX = "custompages";
+
+    /** The Constant serialVersionUID. */
+    private static final long serialVersionUID = -3920598166129639573L;
+
+    private static final String PANEL_NAME = Constant.messages.getString(PREFIX + ".panel.title");
+
+    private CustomPagesMultipleOptionsPanel customPagesOptionsPanel;
+    private Context context;
+    private CustomPageTableModel customPageTableModel;
+
+    public ContextCustomPagePanel(int contextId) {
+        super(contextId);
+        this.context = Model.getSingleton().getSession().getContext(contextId);
+        initialize();
+    }
+
+    public static String getPanelName(int contextId) {
+        // Panel names have to be unique, so prefix with the context id
+        return contextId + ": " + PANEL_NAME;
+    }
+
+    private void initialize() {
+        this.setLayout(new CardLayout());
+        this.setName(getPanelName(getContextId()));
+        this.setLayout(new GridBagLayout());
+
+        this.add(
+                new JLabel(Constant.messages.getString(PREFIX + ".panel.description")),
+                LayoutHelper.getGBC(0, 0, 1, 1.0d, 0.0d));
+
+        customPageTableModel = new CustomPageTableModel();
+        customPagesOptionsPanel =
+                new CustomPagesMultipleOptionsPanel(customPageTableModel, getContextId());
+        this.add(customPagesOptionsPanel, LayoutHelper.getGBC(0, 1, 1, 1.0d, 1.0d));
+    }
+
+    @Override
+    public String getHelpIndex() {
+        // TODO Add help via zap-core-help
+        return "custompages";
+    }
+
+    public static class CustomPagesMultipleOptionsPanel
+            extends AbstractMultipleOptionsTablePanel<CustomPage> {
+
+        private static final long serialVersionUID = -7216673905642941770L;
+
+        private static final String REMOVE_DIALOG_TITLE =
+                Constant.messages.getString(PREFIX + ".dialog.remove.title");
+        private static final String REMOVE_DIALOG_TEXT =
+                Constant.messages.getString(PREFIX + ".dialog.remove.text");
+
+        private static final String REMOVE_DIALOG_CONFIRM_BUTTON_LABEL =
+                Constant.messages.getString(PREFIX + ".dialog.remove.button.confirm");
+        private static final String REMOVE_DIALOG_CANCEL_BUTTON_LABEL =
+                Constant.messages.getString(PREFIX + ".dialog.remove.button.cancel");
+
+        private static final String REMOVE_DIALOG_CHECKBOX_LABEL =
+                Constant.messages.getString(PREFIX + ".dialog.remove.checkbox.label");
+
+        private DialogAddCustomPage addDialog = null;
+        private DialogModifyCustomPage modifyDialog = null;
+        private Context uiSharedContext;
+
+        public CustomPagesMultipleOptionsPanel(CustomPageTableModel model, int contextId) {
+            super(model);
+
+            Component rendererComponent;
+            if (getTable().getColumnExt(0).getHeaderRenderer() == null) { // If there isn't a header
+                // renderer then get the
+                // default renderer
+                rendererComponent =
+                        getTable()
+                                .getTableHeader()
+                                .getDefaultRenderer()
+                                .getTableCellRendererComponent(
+                                        null,
+                                        getTable().getColumnExt(0).getHeaderValue(),
+                                        false,
+                                        false,
+                                        0,
+                                        0);
+            } else { // If there is a custom renderer then get it
+                rendererComponent =
+                        getTable()
+                                .getColumnExt(0)
+                                .getHeaderRenderer()
+                                .getTableCellRendererComponent(
+                                        null,
+                                        getTable().getColumnExt(0).getHeaderValue(),
+                                        false,
+                                        false,
+                                        0,
+                                        0);
+            }
+
+            getTable().getColumnExt(0).setMaxWidth(rendererComponent.getMaximumSize().width);
+            getTable().packAll();
+        }
+
+        @Override
+        public CustomPage showAddDialogue() {
+            if (addDialog == null) {
+                addDialog = new DialogAddCustomPage(View.getSingleton().getSessionDialog());
+            }
+            addDialog.setWorkingContext(this.uiSharedContext);
+            addDialog.setVisible(true);
+
+            CustomPage customPage = addDialog.getCustomPage();
+            addDialog.clear();
+
+            return customPage;
+        }
+
+        @Override
+        public CustomPage showModifyDialogue(CustomPage customPage) {
+            if (modifyDialog == null) {
+                modifyDialog = new DialogModifyCustomPage(View.getSingleton().getSessionDialog());
+            }
+            modifyDialog.setWorkingContext(this.uiSharedContext);
+            modifyDialog.setCustomPage(customPage);
+            modifyDialog.setVisible(true);
+
+            customPage = modifyDialog.getCustomPage();
+            modifyDialog.clear();
+
+            return customPage;
+        }
+
+        @Override
+        public boolean showRemoveDialogue(CustomPage customPage) {
+            JCheckBox removeWithoutConfirmationCheckBox =
+                    new JCheckBox(REMOVE_DIALOG_CHECKBOX_LABEL);
+            Object[] messages = {REMOVE_DIALOG_TEXT, " ", removeWithoutConfirmationCheckBox};
+            int option =
+                    JOptionPane.showOptionDialog(
+                            View.getSingleton().getMainFrame(),
+                            messages,
+                            REMOVE_DIALOG_TITLE,
+                            JOptionPane.OK_CANCEL_OPTION,
+                            JOptionPane.QUESTION_MESSAGE,
+                            null,
+                            new String[] {
+                                REMOVE_DIALOG_CONFIRM_BUTTON_LABEL,
+                                REMOVE_DIALOG_CANCEL_BUTTON_LABEL
+                            },
+                            null);
+
+            if (option == JOptionPane.OK_OPTION) {
+                setRemoveWithoutConfirmation(removeWithoutConfirmationCheckBox.isSelected());
+                return true;
+            }
+
+            return false;
+        }
+
+        protected void setWorkingContext(Context context) {
+            this.uiSharedContext = context;
+        }
+    }
+
+    @Override
+    public void initContextData(Session session, Context uiCommonContext) {
+        this.customPagesOptionsPanel.setWorkingContext(uiCommonContext);
+        getCustomPagesTableModel().setCustomPages(uiCommonContext.getCustomPages());
+    }
+
+    @Override
+    public void validateContextData(Session session) throws Exception {
+        // Nothing to validate
+    }
+
+    @Override
+    public void saveContextData(Session session) throws Exception {
+        this.context.setCustomPages(customPageTableModel.getCustomPages());
+    }
+
+    @Override
+    public void saveTemporaryContextData(Context uiSharedContext) {
+        // Data is already saved in the uiSharedContext
+    }
+
+    protected CustomPageTableModel getCustomPagesTableModel() {
+        return customPageTableModel;
+    }
+}

--- a/zap/src/main/java/org/zaproxy/zap/extension/custompages/CustomPage.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/custompages/CustomPage.java
@@ -1,0 +1,199 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompages;
+
+import org.apache.commons.lang.Validate;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.utils.EnableableInterface;
+
+public interface CustomPage extends EnableableInterface {
+
+    /**
+     * Returns the context ID for a Custom Page.
+     *
+     * @return the context ID {@code int}
+     */
+    int getContextId();
+
+    /**
+     * Sets the context ID for a Custom Page.
+     *
+     * @param contextId the ID of the context
+     */
+    void setContextId(int contextId);
+
+    /**
+     * Returns the page matcher for a Custom Page.
+     *
+     * @return the page matcher {@code String}
+     */
+    String getPageMatcher();
+
+    /**
+     * Sets the page matcher for a Custom Page.
+     *
+     * @param pageMatcher the page matcher being set
+     */
+    void setPageMatcher(String pageMatcher);
+
+    /**
+     * Returns the {@link CustomPageMatcherLocation} {@code enum} literal for a Custom Page.
+     *
+     * @return the custom page matcher location {@code CustomPageMatcherLocation}
+     */
+    CustomPageMatcherLocation getPageMatcherLocation();
+
+    /**
+     * Sets the {@link CustomPageMatcherLocation} {@code enum} literal for a Custom Page.
+     *
+     * @param cppmt the {@code CustomPageMatcherLocation} being set
+     */
+    void setPageMatcherLocation(CustomPageMatcherLocation cppmt);
+
+    /**
+     * Returns {@code true} if the page matcher of a Custom Page is a Regex pattern, otherwise
+     * {@code false}.
+     *
+     * @return a boolean representing whether or not the page matcher is a Regex pattern
+     */
+    boolean isRegex();
+
+    /**
+     * Sets a boolean designating whether or not the page matcher of a Custom Page is a Regex
+     * pattern.
+     *
+     * @param regex the state being set
+     */
+    void setRegex(boolean regex);
+
+    /**
+     * Returns the {@code enum} literal {@link CustomPage.Type} of a Custom Page.
+     *
+     * @return the custom page type
+     */
+    Type getType();
+
+    /**
+     * Sets the {@link CustomPage.Type} {@code enum} literal for a Custom Page.
+     *
+     * @param cpt the custom page type to be set
+     */
+    void setType(Type cpt);
+
+    /**
+     * Determines if a {@code HttpMessage} is a Custom Page of a particular {@code CustomPage.Type}.
+     *
+     * @param msg the HTTP message to be evaluated
+     * @param cpt the CustomPageType of the Custom Pages against which the HTTP message should be
+     *     evaluated
+     * @return {@code true} if the HTTP message is a Custom Page of the type in question, {@code
+     *     false} otherwise
+     */
+    boolean isCustomPage(HttpMessage msg, Type cpt);
+
+    /** Defines the types supported by the Custom Page package. */
+    enum Type {
+        ERROR_500(1, Constant.messages.getString("custompages.type.error")),
+        NOTFOUND_404(2, Constant.messages.getString("custompages.type.notfound")),
+        OK_200(3, Constant.messages.getString("custompages.type.ok")),
+        /**
+         * OTHER is intended to provide an option for scan rule scripts for usages that may not yet
+         * have been planned.
+         */
+        OTHER(4, Constant.messages.getString("custompages.type.other"));
+
+        private final int id;
+        private final String name;
+
+        Type(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        /**
+         * Gets the ID of this custom page type.
+         *
+         * <p>The ID can be used for persistence and later creation, using the method {@code
+         * getCustomPageTypeWithId(int)}.
+         *
+         * @return the ID of the custom page type
+         */
+        public int getId() {
+            return id;
+        }
+
+        /**
+         * Gets the name of this custom page type.
+         *
+         * @return the name of the custom page type
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * Gets the custom page type that has the given {@code id}.
+         *
+         * <p>Default return is {@code getDefaultType()}.
+         *
+         * @param id the ID of the custom page type
+         * @return the custom page type that matches the given {@code id}.
+         * @throws IllegalArgumentException if the given {@code id} is {@code null}.
+         * @see #getId()
+         * @see #getDefaultType()
+         */
+        public static Type getCustomPageTypeWithId(int id) {
+            Validate.notNull(id, "Parameter id must not be null.");
+
+            for (Type customPageType : values()) {
+                if (customPageType.id == id) {
+                    return customPageType;
+                }
+            }
+            return getDefaultType();
+        }
+
+        /**
+         * Gets the default custom page type (ERROR).
+         *
+         * @return the default {@code CustomPage.Type}.
+         */
+        private static Type getDefaultType() {
+            return ERROR_500;
+        }
+
+        public static String describeCustomPageTypes() {
+            StringBuilder descCustomPageTypes = new StringBuilder();
+            descCustomPageTypes.append("Available Custom Page Types (ID : Name): \n");
+            for (Type cpt : Type.values()) {
+                descCustomPageTypes.append(cpt.getId()).append(" : ").append(cpt.getName());
+                descCustomPageTypes.append("\n");
+            }
+
+            return descCustomPageTypes.toString();
+        }
+
+        @Override
+        public String toString() {
+            return getName();
+        }
+    }
+}

--- a/zap/src/main/java/org/zaproxy/zap/extension/custompages/CustomPageMatcherLocation.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/custompages/CustomPageMatcherLocation.java
@@ -1,0 +1,111 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompages;
+
+import org.apache.commons.lang.Validate;
+import org.parosproxy.paros.Constant;
+
+/** Defines the page matcher locations supported by the Custom Page package. */
+public enum CustomPageMatcherLocation {
+    RESPONSE_CONTENT(1, Constant.messages.getString("custompages.content.location.response")),
+    URL(2, Constant.messages.getString("custompages.content.location.url"));
+
+    private final int id;
+    private final String name;
+
+    private CustomPageMatcherLocation(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    /**
+     * Gets the ID of this custom page page matcher location.
+     *
+     * <p>The ID can be used for persistence and later creation, using the method {@code
+     * getCustomPagePageMatcherLocationWithId(int)}.
+     *
+     * @return the ID of the custom page page matcher location
+     */
+    public int getId() {
+        return id;
+    }
+
+    /**
+     * Gets the name of this custom page page matcher location.
+     *
+     * <p>
+     *
+     * @return the name of the custom page page matcher location
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Gets the custom page page matcher location that has the given {@code id}.
+     *
+     * <p>Default return is {@code getDefaultLocation()}.
+     *
+     * @param id the ID of the custom page page matcher location
+     * @return the custom page page matcher location that matches the given {@code id}.
+     * @throws IllegalArgumentException if the given {@code id} is {@code null}.
+     * @see #getId()
+     * @see #getDefaultLocation()
+     */
+    public static CustomPageMatcherLocation getCustomPagePageMatcherLocationWithId(int id) {
+        Validate.notNull(id, "Parameter id must not be null or empty.");
+
+        for (CustomPageMatcherLocation cpct : values()) {
+            if (cpct.getId() == id) {
+                return cpct;
+            }
+        }
+        return getDefaultLocation();
+    }
+
+    /**
+     * Gets the default custom page page matcher location (RESPONSE_CONTENT).
+     *
+     * @return the default {@code CustomPageMatcherLocation}.
+     */
+    public static CustomPageMatcherLocation getDefaultLocation() {
+        return RESPONSE_CONTENT;
+    }
+
+    public static String describeCustomPagePageMatcherLocationss() {
+        StringBuilder descCustomPagePageMatcherLocations = new StringBuilder();
+        descCustomPagePageMatcherLocations.append(
+                "Available Custom Page Page Matcher Locations (ID : Name): \n");
+        for (CustomPageMatcherLocation cpct : CustomPageMatcherLocation.values()) {
+            descCustomPagePageMatcherLocations
+                    .append(cpct.getId())
+                    .append(" : ")
+                    .append(cpct.getName());
+            descCustomPagePageMatcherLocations.append("\n");
+        }
+
+        return descCustomPagePageMatcherLocations.toString();
+    }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
+}

--- a/zap/src/main/java/org/zaproxy/zap/extension/custompages/CustomPageTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/custompages/CustomPageTableModel.java
@@ -1,0 +1,182 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompages;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
+
+/** A table model for holding a set of DefaultCustomPage, for a {@link Context}. */
+class CustomPageTableModel extends AbstractMultipleOptionsTableModel<CustomPage> {
+
+    /** The Constant serialVersionUID. */
+    private static final long serialVersionUID = 4463944219657112162L;
+
+    /** The Constant defining the table column names. */
+    private static final String[] COLUMN_NAMES = {
+        Constant.messages.getString("custompages.table.header.enabled"),
+        Constant.messages.getString("custompages.table.header.content"),
+        Constant.messages.getString("custompages.table.header.contentlocation"),
+        Constant.messages.getString("custompages.table.header.isregex"),
+        Constant.messages.getString("custompages.table.header.type")
+    };
+
+    private List<CustomPage> customPages = new ArrayList<>();
+
+    /**
+     * Instantiates a new custom pages table model. An internal copy of the provided list is stored.
+     *
+     * @param customPages the list of custom pages
+     */
+    public CustomPageTableModel(List<CustomPage> customPages) {
+        this.customPages = new ArrayList<>(customPages);
+    }
+
+    /** Instantiates a new user table model. */
+    public CustomPageTableModel() {
+        this.customPages = new ArrayList<>();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return COLUMN_NAMES.length;
+    }
+
+    @Override
+    public int getRowCount() {
+        return customPages.size();
+    }
+
+    @Override
+    public Object getValueAt(int rowIndex, int columnIndex) {
+        CustomPage cp = customPages.get(rowIndex);
+
+        if (cp == null) {
+            return null;
+        }
+        switch (columnIndex) {
+            case 0:
+                return cp.isEnabled();
+            case 1:
+                return cp.getPageMatcher();
+            case 2:
+                return cp.getPageMatcherLocation().getName();
+            case 3:
+                return cp.isRegex();
+            case 4:
+                return cp.getType().getName();
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public List<CustomPage> getElements() {
+        return getCustomPages();
+    }
+
+    /**
+     * Gets the internal list of defaultCustomPages managed by this model.
+     *
+     * @return the defaultCustomPages
+     */
+    public List<CustomPage> getCustomPages() {
+        return customPages;
+    }
+
+    @Override
+    public boolean isCellEditable(int rowIndex, int columnIndex) {
+        switch (columnIndex) {
+            case 0: // Enabled Column
+            case 3: // IsRegex Column
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Sets a new list of defaultCustomPages for this model. An internal copy of the provided list
+     * is stored.
+     *
+     * @param list the list of custom pages (expects non-null list)
+     */
+    public void setCustomPages(List<CustomPage> list) {
+        this.customPages = new ArrayList<>(list);
+        this.fireTableDataChanged();
+    }
+
+    /** Removes all the defaultCustomPages for this model. */
+    public void removeAllCustomPages() {
+        this.customPages = new ArrayList<>();
+        this.fireTableDataChanged();
+    }
+
+    /**
+     * Adds a new custom page to this model
+     *
+     * @param cp the custom page to be added
+     */
+    public void addCustomPage(CustomPage cp) {
+        this.customPages.add(cp);
+        this.fireTableRowsInserted(this.customPages.size() - 1, this.customPages.size() - 1);
+    }
+
+    @Override
+    public Class<?> getColumnClass(int columnIndex) {
+        switch (columnIndex) {
+            case 0:
+                return Boolean.class;
+            case 1:
+                return String.class;
+            case 2:
+                return String.class;
+            case 3:
+                return Boolean.class;
+            case 4:
+                return String.class;
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public String getColumnName(int column) {
+        return COLUMN_NAMES[column];
+    }
+
+    @Override
+    public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
+        if (columnIndex == 0) {
+            if (aValue instanceof Boolean) {
+                customPages.get(rowIndex).setEnabled(((Boolean) aValue).booleanValue());
+                fireTableCellUpdated(rowIndex, columnIndex);
+            }
+        }
+        if (columnIndex == 3) {
+            if (aValue instanceof Boolean) {
+                customPages.get(rowIndex).setRegex(((Boolean) aValue).booleanValue());
+                fireTableCellUpdated(rowIndex, columnIndex);
+            }
+        }
+    }
+}

--- a/zap/src/main/java/org/zaproxy/zap/extension/custompages/DefaultCustomPage.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/custompages/DefaultCustomPage.java
@@ -1,0 +1,276 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompages;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.regex.Pattern;
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.utils.Enableable;
+
+public class DefaultCustomPage extends Enableable implements CustomPage {
+
+    /**
+     * The Constant FIELD_SEPARATOR used for separating DefaultCustomPage's fields during
+     * encode/decode operations.
+     */
+    private static final String FIELD_SEPARATOR = ";";
+
+    private static final Logger LOGGER = Logger.getLogger(DefaultCustomPage.class);
+
+    private int contextId;
+    private String pageMatcher;
+    private CustomPageMatcherLocation pageMatcherLocation;
+    private boolean regex;
+    private Type type;
+    private Pattern pattern;
+
+    /**
+     * Constructs a {@code DefaultCustomPage} with the given details.
+     *
+     * @param contextId the context ID for which the {@code DefaultCustomPage} is being created
+     * @param pageMatcher the page matcher of the {@code DefaultCustomPage}
+     * @param pageMatcherLocation the {@link CustomPageMatcherLocation} of the {@code
+     *     DefaultCustomPage}
+     * @param regex a boolean specifying whether or not the {@code DefaultCustomPage} page matcher
+     *     is represented by a Regex pattern
+     * @param type the {@link CustomPage.Type} of the {@code DefaultCustomPage}
+     * @param enabled a boolean specifying whether or not the {@code DefaultCustomPage} is enabled
+     *     or not
+     */
+    public DefaultCustomPage(
+            int contextId,
+            String pageMatcher,
+            CustomPageMatcherLocation pageMatcherLocation,
+            boolean regex,
+            Type type,
+            boolean enabled) {
+        super();
+        this.contextId = contextId;
+        this.pageMatcher = pageMatcher;
+        this.pageMatcherLocation = pageMatcherLocation;
+        this.regex = regex;
+        this.type = type;
+        this.setEnabled(enabled);
+    }
+
+    /**
+     * Constructs a {@code DefaultCustomPage} with the given details. {@link CustomPage.Type} and
+     * {@link CustomPageMatcherLocation} are specified by {@code int} ID instead of {@code enum}
+     * literal.
+     *
+     * @param contextId the context ID for which the {@code DefaultCustomPage} is being created
+     * @param pageMatcher the page matcher of the {@code DefaultCustomPage}
+     * @param pageMatcherLocationID the ID of the {@link CustomPageMatcherLocation} of the {@code
+     *     DefaultCustomPage}
+     * @param regex a boolean specifying whether or not the {@code DefaultCustomPage} page matcher
+     *     is represented by a Regex pattern
+     * @param type the {@code CustomPage.Type} of the {@code DefaultCustomPage}
+     * @param enabled a boolean specifying whether or not the {@code DefaultCustomPage} is enabled
+     *     or not
+     */
+    public DefaultCustomPage(
+            int contextId,
+            String pageMatcher,
+            int pageMatcherLocationID,
+            boolean regex,
+            Type type,
+            boolean enabled) {
+        super();
+        this.contextId = contextId;
+        this.pageMatcher = pageMatcher;
+        this.pageMatcherLocation =
+                CustomPageMatcherLocation.getCustomPagePageMatcherLocationWithId(
+                        pageMatcherLocationID);
+        this.regex = regex;
+        this.type = type;
+        this.setEnabled(enabled);
+    }
+
+    @Override
+    public int getContextId() {
+        return contextId;
+    }
+
+    @Override
+    public void setContextId(int contextId) {
+        this.contextId = contextId;
+    }
+
+    @Override
+    public String getPageMatcher() {
+        return pageMatcher;
+    }
+
+    @Override
+    public void setPageMatcher(String pageMatcher) {
+        this.pageMatcher = pageMatcher;
+    }
+
+    @Override
+    public CustomPageMatcherLocation getPageMatcherLocation() {
+        return pageMatcherLocation;
+    }
+
+    @Override
+    public void setPageMatcherLocation(CustomPageMatcherLocation cppmt) {
+        this.pageMatcherLocation = cppmt;
+    }
+
+    @Override
+    public boolean isRegex() {
+        return regex;
+    }
+
+    @Override
+    public void setRegex(boolean regex) {
+        this.regex = regex;
+    }
+
+    @Override
+    public Type getType() {
+        return type;
+    }
+
+    @Override
+    public void setType(Type cpt) {
+        this.type = cpt;
+    }
+
+    /**
+     * Determines if a {@code HttpMessage} is a Custom Page of a particular {@code CustomPage.Type}.
+     *
+     * @param msg the HTTP message to be evaluated
+     * @param cpt the CustomPage.Type of the Custom Pages against which the HTTP message should be
+     *     evaluated
+     * @return {@code true} if the HTTP message is a Custom Page of the type in question, {@code
+     *     false} otherwise
+     */
+    public boolean isCustomPage(HttpMessage msg, Type cpt) {
+        if (isEnabled() && getType() == cpt) {
+            String value = getPageMatcherByType(msg);
+            return matchByLocation(value);
+        }
+        return false; // Default
+    }
+
+    private String getPageMatcherByType(HttpMessage msg) {
+        if (CustomPageMatcherLocation.URL.equals(getPageMatcherLocation())) {
+            return msg.getRequestHeader().getURI().toString();
+        } else if (CustomPageMatcherLocation.RESPONSE_CONTENT.equals(getPageMatcherLocation())) {
+            return getHttpMessageAsString(msg);
+        }
+        LOGGER.error(
+                "Could not get page matcher for the given message, with: "
+                        + getPageMatcherLocation());
+        return "";
+    }
+
+    private boolean matchByLocation(String value) {
+        if (isRegex()) {
+            return isRegexMatch(pageMatcher, value);
+        }
+        return CustomPageMatcherLocation.URL.equals(getPageMatcherLocation())
+                ? value.equals(getPageMatcher())
+                : value.contains(getPageMatcher());
+    }
+
+    private static String getHttpMessageAsString(HttpMessage msg) {
+        return msg.getResponseHeader().toString() + msg.getResponseBody().toString();
+    }
+
+    private boolean isRegexMatch(String pageMatcher, String toMatch) {
+        if (pattern == null) {
+            pattern = Pattern.compile(pageMatcher);
+        }
+
+        return pattern.matcher(toMatch).find();
+    }
+
+    public String toString() {
+        StringBuilder cp = new StringBuilder();
+        cp.append("ContextId: ").append(this.getContextId());
+        cp.append(", Content: ").append(this.getPageMatcher()).append(".");
+        cp.append(", Content Type: ").append(this.getPageMatcherLocation().getName());
+        cp.append(", Is RegEx: ").append(this.isRegex());
+        cp.append(", Type: ").append(this.getType().getName());
+        cp.append(", IsEnabled: ").append(this.isEnabled());
+        return cp.toString();
+    }
+
+    /**
+     * Encodes the DefaultCustomPage in a String. Fields that contain strings are Base64 encoded.
+     *
+     * @param cp the custom page to be encoded
+     * @return the encoded string
+     */
+    public static String encode(CustomPage cp) {
+        StringBuilder encodedCP = new StringBuilder();
+        String matcherComponent = cp.getPageMatcher() != null ? cp.getPageMatcher() : "";
+
+        encodedCP
+                .append(
+                        new String(
+                                Base64.getEncoder()
+                                        .encode(matcherComponent.getBytes(StandardCharsets.UTF_8)),
+                                StandardCharsets.US_ASCII))
+                .append(FIELD_SEPARATOR);
+        encodedCP.append(cp.getPageMatcherLocation().getId()).append(FIELD_SEPARATOR);
+        encodedCP.append(cp.isRegex()).append(FIELD_SEPARATOR);
+        encodedCP.append(cp.getType().getId()).append(FIELD_SEPARATOR);
+        encodedCP.append(cp.isEnabled()).append(FIELD_SEPARATOR);
+
+        return encodedCP.toString();
+    }
+
+    /**
+     * Decodes a DefaultCustomPage from an encoded string. The string provided as input should have
+     * been obtained through calls to {@link #encode(CustomPage)}.
+     *
+     * @param contextId the ID of the context for which the encoded ({@code DefaultCustomPage})
+     *     string is being decoded
+     * @param encodedString the encoded string
+     * @return the DefaultCustomPage
+     */
+    protected static DefaultCustomPage decode(int contextId, String encodedString) {
+        String[] pieces = encodedString.split(FIELD_SEPARATOR, -1);
+        DefaultCustomPage defaultCustomPage = null;
+        try {
+            defaultCustomPage =
+                    new DefaultCustomPage(
+                            contextId, // ContextID
+                            new String(
+                                    Base64.getDecoder().decode(pieces[0]),
+                                    StandardCharsets.UTF_8), // Content
+                            CustomPageMatcherLocation.getCustomPagePageMatcherLocationWithId(
+                                    Integer.parseInt(pieces[1])), // Content
+                            // Type
+                            Boolean.parseBoolean(pieces[2]), // IsRegex
+                            Type.getCustomPageTypeWithId(Integer.parseInt(pieces[3])), // Type
+                            Boolean.parseBoolean(pieces[4])); // Enabled
+        } catch (Exception ex) {
+            LOGGER.error(
+                    "An error occured while decoding DefaultCustomPage from: " + encodedString, ex);
+            return null;
+        }
+        return defaultCustomPage;
+    }
+}

--- a/zap/src/main/java/org/zaproxy/zap/extension/custompages/DialogAddCustomPage.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/custompages/DialogAddCustomPage.java
@@ -1,0 +1,279 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompages;
+
+import java.awt.Dialog;
+import java.awt.Dimension;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import javax.swing.AbstractAction;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.KeyStroke;
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.utils.ZapTextField;
+import org.zaproxy.zap.view.AbstractFormDialog;
+import org.zaproxy.zap.view.LayoutHelper;
+
+/** The Dialog for adding and configuring a new {@link DefaultCustomPage}. */
+class DialogAddCustomPage extends AbstractFormDialog {
+
+    /** The Constant serialVersionUID. */
+    private static final long serialVersionUID = -7210879426146833234L;
+
+    /** The Constant logger. */
+    protected static final Logger LOGGER = Logger.getLogger(DialogAddCustomPage.class);
+
+    private static final String DIALOG_TITLE =
+            Constant.messages.getString("custompages.dialog.add.title");
+    private static final String CONFIRM_BUTTON_LABEL =
+            Constant.messages.getString("custompages.dialog.add.button.confirm");
+
+    private JPanel fieldsPanel;
+    private JCheckBox enabledCheckBox;
+    private JComboBox<CustomPage.Type> customPageTypesCombo;
+    private JCheckBox regexCheckBox;
+    private ZapTextField pageMatcherTextField;
+    private JComboBox<CustomPageMatcherLocation> customPagePageMatcherLocationsCombo;
+    protected Context workingContext;
+    protected CustomPage customPage;
+
+    public DialogAddCustomPage() {
+        super(View.getSingleton().getSessionDialog(), DIALOG_TITLE);
+    }
+
+    /**
+     * Instantiates a new dialog to add a Custom Page. The title is set based on the constant {@link
+     * #DIALOG_TITLE}.
+     *
+     * @param owner the parent (@code Dialog}
+     */
+    public DialogAddCustomPage(Window owner) {
+        super(owner, DIALOG_TITLE);
+    }
+
+    /**
+     * Instantiates a new dialog to add a Custom Page.
+     *
+     * @param owner the parent (@code Dialog}
+     * @param title the title for the dialog
+     */
+    protected DialogAddCustomPage(Dialog owner, String title) {
+        super(owner, title);
+    }
+
+    /**
+     * Sets the context on which the Dialog is working.
+     *
+     * @param context the new working context
+     */
+    public void setWorkingContext(Context context) {
+        this.workingContext = context;
+    }
+
+    @Override
+    protected void init() {
+        if (this.workingContext == null) {
+            throw new IllegalStateException(
+                    "A working Context should be set before setting the 'Add Dialog' visible.");
+        }
+
+        // Handle escape key to close the dialog
+        KeyStroke escape = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0, false);
+        AbstractAction escapeAction =
+                new AbstractAction() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        DialogAddCustomPage.this.setVisible(false);
+                        DialogAddCustomPage.this.dispose();
+                    }
+                };
+        getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(escape, "ESCAPE");
+        getRootPane().getActionMap().put("ESCAPE", escapeAction);
+
+        this.setConfirmButtonEnabled(true);
+        this.pack();
+    }
+
+    public void clear() {
+        this.customPage = null;
+        this.workingContext = null;
+    }
+
+    @Override
+    protected boolean validateFields() {
+        String contentMatchString = this.getPageMatcherTextField().getText();
+        if (StringUtils.isBlank(contentMatchString)
+                || (contentMatchString.trim().equals(".*") && getRegexCheckBox().isSelected())) {
+            View.getSingleton()
+                    .showWarningDialog(
+                            Constant.messages.getString(
+                                    "custompages.dialog.add.field.content.empty.warn"));
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    protected void performAction() {
+        this.customPage =
+                new DefaultCustomPage(
+                        workingContext.getId(),
+                        getPageMatcherTextField().getText(),
+                        (CustomPageMatcherLocation)
+                                getCustomPagePageMatcherLocationsCombo().getSelectedItem(),
+                        getRegexCheckBox().isSelected(),
+                        (CustomPage.Type) getCustomPageTypesCombo().getSelectedItem(),
+                        this.getEnabledCheckBox().isSelected());
+    }
+
+    @Override
+    protected void clearFields() {
+        this.pageMatcherTextField.setText("");
+        this.pageMatcherTextField.discardAllEdits();
+        this.customPagePageMatcherLocationsCombo.setSelectedIndex(0);
+        this.enabledCheckBox.setSelected(true);
+        this.regexCheckBox.setSelected(false);
+        this.customPageTypesCombo.setSelectedIndex(0);
+        this.setConfirmButtonEnabled(true);
+    }
+
+    /**
+     * Gets the custom page defined in the dialog, if any.
+     *
+     * @return the custom page, if correctly built or null, otherwise
+     */
+    public CustomPage getCustomPage() {
+        return customPage;
+    }
+
+    @Override
+    protected JPanel getFieldsPanel() {
+        if (fieldsPanel == null) {
+            fieldsPanel = new JPanel();
+
+            fieldsPanel.setLayout(new GridBagLayout());
+            fieldsPanel.setName("DialogAddCustomPage");
+            Insets insets = new Insets(4, 8, 2, 4);
+
+            JLabel paramLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "custompages.dialog.add.field.label.content"));
+            paramLabel.setLabelFor(getPageMatcherTextField());
+            fieldsPanel.add(paramLabel, LayoutHelper.getGBC(0, 1, 1, 0.5D, insets));
+            fieldsPanel.add(getPageMatcherTextField(), LayoutHelper.getGBC(1, 1, 1, 0.5D, insets));
+
+            JLabel customPagePageMatcherLocationLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "custompages.dialog.add.field.label.contentlocation"));
+            customPagePageMatcherLocationLabel.setLabelFor(
+                    getCustomPagePageMatcherLocationsCombo());
+            fieldsPanel.add(
+                    customPagePageMatcherLocationLabel, LayoutHelper.getGBC(0, 2, 1, 0.5D, insets));
+            fieldsPanel.add(
+                    getCustomPagePageMatcherLocationsCombo(),
+                    LayoutHelper.getGBC(1, 2, 1, 0.5D, insets));
+
+            JLabel regexLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "custompages.dialog.add.field.label.regex"));
+            regexLabel.setLabelFor(getRegexCheckBox());
+            fieldsPanel.add(regexLabel, LayoutHelper.getGBC(0, 3, 1, 0.5D, insets));
+            fieldsPanel.add(getRegexCheckBox(), LayoutHelper.getGBC(1, 3, 1, 0.5D, insets));
+
+            JLabel enabledLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "custompages.dialog.add.field.label.enabled"));
+            enabledLabel.setLabelFor(getEnabledCheckBox());
+            fieldsPanel.add(enabledLabel, LayoutHelper.getGBC(0, 4, 1, 0.5D, insets));
+            fieldsPanel.add(getEnabledCheckBox(), LayoutHelper.getGBC(1, 4, 1, 0.5D, insets));
+
+            JLabel customPageTypeLabel =
+                    new JLabel(
+                            Constant.messages.getString("custompages.dialog.add.field.label.type"));
+            customPageTypeLabel.setLabelFor(getCustomPageTypesCombo());
+            fieldsPanel.add(customPageTypeLabel, LayoutHelper.getGBC(0, 5, 1, 0.5D, insets));
+            fieldsPanel.add(getCustomPageTypesCombo(), LayoutHelper.getGBC(1, 5, 1, 0.5D, insets));
+
+            fieldsPanel.add(new JLabel(), LayoutHelper.getGBC(0, 10, 2, 1.0D)); // Spacer
+        }
+        return fieldsPanel;
+    }
+
+    protected JCheckBox getEnabledCheckBox() {
+        if (enabledCheckBox == null) {
+            enabledCheckBox = new JCheckBox();
+            enabledCheckBox.setSelected(true);
+        }
+
+        return enabledCheckBox;
+    }
+
+    protected JCheckBox getRegexCheckBox() {
+        if (regexCheckBox == null) {
+            regexCheckBox = new JCheckBox();
+        }
+        return regexCheckBox;
+    }
+
+    protected ZapTextField getPageMatcherTextField() {
+        if (pageMatcherTextField == null) {
+            pageMatcherTextField = new ZapTextField();
+        }
+        pageMatcherTextField.setPreferredSize(new Dimension(280, 30));
+        return pageMatcherTextField;
+    }
+
+    protected JComboBox<CustomPage.Type> getCustomPageTypesCombo() {
+        if (customPageTypesCombo == null) {
+            customPageTypesCombo = new JComboBox<CustomPage.Type>(CustomPage.Type.values());
+        }
+        return customPageTypesCombo;
+    }
+
+    protected JComboBox<CustomPageMatcherLocation> getCustomPagePageMatcherLocationsCombo() {
+        if (customPagePageMatcherLocationsCombo == null) {
+            customPagePageMatcherLocationsCombo =
+                    new JComboBox<CustomPageMatcherLocation>(CustomPageMatcherLocation.values());
+        }
+        return customPagePageMatcherLocationsCombo;
+    }
+
+    @Override
+    protected String getConfirmButtonLabel() {
+        return CONFIRM_BUTTON_LABEL;
+    }
+}

--- a/zap/src/main/java/org/zaproxy/zap/extension/custompages/DialogModifyCustomPage.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/custompages/DialogModifyCustomPage.java
@@ -1,0 +1,84 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompages;
+
+import java.awt.Dialog;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import javax.swing.AbstractAction;
+import javax.swing.JComponent;
+import javax.swing.KeyStroke;
+import org.parosproxy.paros.Constant;
+
+class DialogModifyCustomPage extends DialogAddCustomPage {
+
+    private static final long serialVersionUID = 7828871270310672334L;
+    private static final String DIALOG_TITLE =
+            Constant.messages.getString("custompages.dialog.modify.title");
+
+    public DialogModifyCustomPage(Dialog owner) {
+        super(owner, DIALOG_TITLE);
+    }
+
+    public void setCustomPage(CustomPage customPage) {
+        this.customPage = customPage;
+    }
+
+    @Override
+    protected String getConfirmButtonLabel() {
+        return Constant.messages.getString("custompages.dialog.modify.button.confirm");
+    }
+
+    @Override
+    protected void init() {
+        if (this.workingContext == null) {
+            throw new IllegalStateException(
+                    "A working Context should be set before setting the 'Add Dialog' visible.");
+        }
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Initializing modify Custom Page dialog for: " + customPage);
+        }
+
+        // Handle escape key to close the dialog
+        KeyStroke escape = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0, false);
+        AbstractAction escapeAction =
+                new AbstractAction() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        DialogModifyCustomPage.this.setVisible(false);
+                        DialogModifyCustomPage.this.dispose();
+                    }
+                };
+        getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(escape, "ESCAPE");
+        getRootPane().getActionMap().put("ESCAPE", escapeAction);
+
+        getEnabledCheckBox().setSelected(customPage.isEnabled());
+        getPageMatcherTextField().setText(customPage.getPageMatcher());
+        getCustomPagePageMatcherLocationsCombo()
+                .setSelectedItem(customPage.getPageMatcherLocation());
+        getRegexCheckBox().setSelected(customPage.isRegex());
+        getCustomPageTypesCombo().setSelectedItem(customPage.getType());
+
+        this.setConfirmButtonEnabled(true);
+        this.pack();
+    }
+}

--- a/zap/src/main/java/org/zaproxy/zap/extension/custompages/ExtensionCustomPages.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/custompages/ExtensionCustomPages.java
@@ -1,0 +1,280 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompages;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.configuration.Configuration;
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control.Mode;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
+import org.parosproxy.paros.extension.SessionChangedListener;
+import org.parosproxy.paros.model.Session;
+import org.parosproxy.paros.model.SiteNode;
+import org.zaproxy.zap.extension.stdmenus.PopupContextMenuItemFactory;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.model.ContextDataFactory;
+import org.zaproxy.zap.view.AbstractContextPropertiesPanel;
+import org.zaproxy.zap.view.ContextPanelFactory;
+import org.zaproxy.zap.view.popup.PopupMenuItemContext;
+import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContextMenuFactory;
+
+/**
+ * A ZAP extension which implements Custom Pages, which allows you to define custom pages which may
+ * be used in various ZAP components.
+ */
+public class ExtensionCustomPages extends ExtensionAdaptor {
+
+    // The name is public so that other extensions can access it
+    public static final String NAME = "ExtensionCustomPages";
+
+    public static final String CONTEXT_CONFIG_CUSTOM_PAGES =
+            Context.CONTEXT_CONFIG + ".custompages";
+    public static final String CONTEXT_CONFIG_CUSTOM_PAGE = CONTEXT_CONFIG_CUSTOM_PAGES + ".page";
+
+    private static final int TYPE_CUSTOM_PAGE = 600;
+    private static final Logger LOGGER = Logger.getLogger(ExtensionCustomPages.class);
+
+    // The i18n prefix
+    protected static final String PREFIX = "custompages";
+
+    private CustomPagesUtility customPagesUtility;
+
+    /** The Custom Page panels, mapped to each context. */
+    private Map<Integer, ContextCustomPagePanel> customPagePanelsMap;
+
+    private PopupContextMenuItemFactory popupFlagCustomPageIndicatorMenuFactory;
+    private PopupMenuItemSiteNodeContextMenuFactory popupFlagCustomPageUrlMenuFactory;
+
+    public ExtensionCustomPages() {
+        super();
+        this.setName(NAME);
+    }
+
+    @Override
+    public void init() {
+        super.init();
+        customPagesUtility = new CustomPagesUtility();
+        customPagePanelsMap = new HashMap<>();
+    }
+
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString("custompages.name");
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        super.hook(extensionHook);
+
+        extensionHook.addSessionListener(customPagesUtility);
+
+        // Register this as a context data factory
+        getModel().addContextDataFactory(customPagesUtility);
+
+        if (getView() != null) {
+            // Factory for generating Session Context custompage panels
+            getView().addContextPanelFactory(customPagesUtility);
+            extensionHook.getHookMenu().addPopupMenuItem(getPopupFlagCustomPageIndicatorMenu());
+            extensionHook.getHookMenu().addPopupMenuItem(getPopupFlagCustomPageUrlMenu());
+        }
+    }
+
+    @Override
+    public String getAuthor() {
+        return Constant.ZAP_TEAM;
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString(PREFIX + ".desc");
+    }
+
+    /**
+     * Gets the popup menu for flagging {@code CustomPage} patterns.
+     *
+     * @return the popup menu
+     */
+    private PopupContextMenuItemFactory getPopupFlagCustomPageIndicatorMenu() {
+        if (this.popupFlagCustomPageIndicatorMenuFactory == null) {
+            popupFlagCustomPageIndicatorMenuFactory =
+                    new PopupContextMenuItemFactory(
+                            "dd - " + Constant.messages.getString("context.flag.popup")) {
+
+                        private static final long serialVersionUID = 2453839120088204123L;
+
+                        @Override
+                        public ExtensionPopupMenuItem getContextMenu(
+                                Context context, String parentMenu) {
+                            return new PopupFlagCustomPageIndicatorMenu(context);
+                        }
+                    };
+        }
+        return this.popupFlagCustomPageIndicatorMenuFactory;
+    }
+
+    /**
+     * Gets the popup menu factory for flagging {@code CustomPage} URLs.
+     *
+     * @return the popup flag custom page URLs menu factory
+     */
+    private PopupMenuItemSiteNodeContextMenuFactory getPopupFlagCustomPageUrlMenu() {
+        if (popupFlagCustomPageUrlMenuFactory == null) {
+            popupFlagCustomPageUrlMenuFactory =
+                    new PopupMenuItemSiteNodeContextMenuFactory(
+                            Constant.messages.getString("context.flag.popup")) {
+                        private static final long serialVersionUID = 8927418764L;
+
+                        @Override
+                        public PopupMenuItemContext getContextMenu(
+                                Context context, String parentMenu) {
+                            return new PopupMenuItemContext(
+                                    context,
+                                    parentMenu,
+                                    Constant.messages.getString(
+                                            "custompages.popup.url", context.getName())) {
+
+                                private static final long serialVersionUID = 1967885623005183801L;
+
+                                @Override
+                                public void performAction(SiteNode sn) {
+                                    DialogAddCustomPage dialogAddCustomPage =
+                                            getDialogAddCustomPage(
+                                                    context,
+                                                    sn.getHistoryReference().getURI().toString());
+                                    dialogAddCustomPage.setVisible(true);
+                                    context.addCustomPage(dialogAddCustomPage.getCustomPage());
+                                }
+
+                                private DialogAddCustomPage getDialogAddCustomPage(
+                                        Context currentContext, String url) {
+                                    DialogAddCustomPage dialogAddCustomPage =
+                                            new DialogAddCustomPage(getView().getMainFrame());
+                                    dialogAddCustomPage.setWorkingContext(currentContext);
+                                    dialogAddCustomPage
+                                            .getCustomPagePageMatcherLocationsCombo()
+                                            .setSelectedItem(
+                                                    CustomPageMatcherLocation.URL.getName());
+                                    dialogAddCustomPage.getPageMatcherTextField().setText(url);
+                                    return dialogAddCustomPage;
+                                }
+                            };
+                        }
+                    };
+        }
+        return popupFlagCustomPageUrlMenuFactory;
+    }
+
+    private class CustomPagesUtility
+            implements ContextPanelFactory, ContextDataFactory, SessionChangedListener {
+
+        @Override
+        public void loadContextData(Session session, Context context) {
+            try {
+                List<String> encodedCustomPages =
+                        session.getContextDataStrings(context.getId(), TYPE_CUSTOM_PAGE);
+                for (String e : encodedCustomPages) {
+                    DefaultCustomPage cp = DefaultCustomPage.decode(context.getId(), e);
+                    context.addCustomPage(cp);
+                }
+            } catch (Exception ex) {
+                LOGGER.error("Unable to load CustomPages.", ex);
+            }
+        }
+
+        @Override
+        public void persistContextData(Session session, Context context) {
+            try {
+                List<String> encodedCustomPages = new ArrayList<>();
+                if (context != null) {
+                    for (CustomPage cp : context.getCustomPages()) {
+                        encodedCustomPages.add(DefaultCustomPage.encode(cp));
+                    }
+                    session.setContextData(context.getId(), TYPE_CUSTOM_PAGE, encodedCustomPages);
+                }
+            } catch (Exception ex) {
+                LOGGER.error("Unable to persist CustomPages", ex);
+            }
+        }
+
+        @Override
+        public void exportContextData(Context ctx, Configuration config) {
+            if (ctx != null) {
+                for (CustomPage cp : ctx.getCustomPages()) {
+                    config.addProperty(CONTEXT_CONFIG_CUSTOM_PAGE, DefaultCustomPage.encode(cp));
+                }
+            }
+        }
+
+        @Override
+        public void importContextData(Context ctx, Configuration config) {
+            List<Object> list = config.getList(CONTEXT_CONFIG_CUSTOM_PAGE);
+            for (Object o : list) {
+                CustomPage cp = DefaultCustomPage.decode(ctx.getId(), o.toString());
+                ctx.addCustomPage(cp);
+            }
+        }
+
+        @Override
+        public AbstractContextPropertiesPanel getContextPanel(Context ctx) {
+            ContextCustomPagePanel panel = customPagePanelsMap.get(ctx.getId());
+            if (panel == null) {
+                panel = new ContextCustomPagePanel(ctx.getId());
+                customPagePanelsMap.put(ctx.getId(), panel);
+            }
+            return panel;
+        }
+
+        @Override
+        public void discardContexts() {
+            customPagePanelsMap.clear();
+        }
+
+        @Override
+        public void discardContext(Context ctx) {
+            customPagePanelsMap.remove(ctx.getId());
+        }
+
+        @Override
+        public void sessionChanged(Session session) {
+            // Ignore
+        }
+
+        @Override
+        public void sessionAboutToChange(Session session) {
+            // Ignore
+        }
+
+        @Override
+        public void sessionScopeChanged(Session session) {
+            // Ignore
+        }
+
+        @Override
+        public void sessionModeChanged(Mode mode) {
+            // Ignore
+        }
+    }
+}

--- a/zap/src/main/java/org/zaproxy/zap/extension/custompages/PopupFlagCustomPageIndicatorMenu.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/custompages/PopupFlagCustomPageIndicatorMenu.java
@@ -1,0 +1,113 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompages;
+
+import java.awt.Component;
+import java.util.regex.Pattern;
+import javax.swing.SwingUtilities;
+import javax.swing.text.JTextComponent;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.extension.httppanel.HttpPanelResponse;
+import org.zaproxy.zap.model.Context;
+
+/** The Popup Menu item used for marking a text in the response panel as a {@code CustomPage}. */
+public class PopupFlagCustomPageIndicatorMenu extends ExtensionPopupMenuItem {
+
+    private static final long serialVersionUID = 6071498013529265858L;
+    private String selectedText = null;
+    private int contextId;
+
+    public PopupFlagCustomPageIndicatorMenu(Context ctx) {
+        this.contextId = ctx.getId();
+
+        this.setText(Constant.messages.getString("custompages.popup.indicator", ctx.getName()));
+        this.addActionListener(event -> performAction());
+    }
+
+    private void performAction() {
+        Context currentContext = Model.getSingleton().getSession().getContext(this.contextId);
+
+        DialogAddCustomPage dialogAddCustomPage =
+                getDialogAddCustomPage(currentContext, getSelectedText());
+        dialogAddCustomPage.setVisible(true);
+        currentContext.addCustomPage(dialogAddCustomPage.getCustomPage());
+    }
+
+    private DialogAddCustomPage getDialogAddCustomPage(
+            Context currentContext, String selectedText) {
+        DialogAddCustomPage dialogAddCustomPage =
+                new DialogAddCustomPage(View.getSingleton().getMainFrame());
+        dialogAddCustomPage.setWorkingContext(currentContext);
+        dialogAddCustomPage.getPageMatcherTextField().setText(Pattern.quote(selectedText));
+        dialogAddCustomPage.getRegexCheckBox().setSelected(true);
+        return dialogAddCustomPage;
+    }
+
+    @Override
+    public boolean isSubMenu() {
+        return true;
+    }
+
+    @Override
+    public String getParentMenuName() {
+        return Constant.messages.getString("context.flag.popup");
+    }
+
+    @Override
+    public int getParentMenuIndex() {
+        return CONTEXT_FLAG_MENU_INDEX;
+    }
+
+    @Override
+    public boolean isEnableForComponent(Component invoker) {
+        if (invoker instanceof JTextComponent) {
+            // Is it the HttpPanelResponse?
+            JTextComponent txtComponent = (JTextComponent) invoker;
+            boolean responsePanel =
+                    (SwingUtilities.getAncestorOfClass(HttpPanelResponse.class, txtComponent)
+                            != null);
+
+            if (!responsePanel) {
+                selectedText = null;
+                return false;
+            }
+
+            // Is anything selected?
+            selectedText = txtComponent.getSelectedText();
+            if (selectedText == null || selectedText.length() == 0) {
+                this.setEnabled(false);
+            } else {
+                this.setEnabled(true);
+            }
+
+            return true;
+        } else {
+            selectedText = null;
+            return false;
+        }
+    }
+
+    public String getSelectedText() {
+        return selectedText;
+    }
+}

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanData.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanData.java
@@ -21,11 +21,14 @@ package org.zaproxy.zap.extension.pscan;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.custompages.CustomPage;
 import org.zaproxy.zap.extension.users.ExtensionUserManagement;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.TechSet;
@@ -49,6 +52,7 @@ public final class PassiveScanData {
     private final TechSet techSet;
 
     private List<User> userList = null;
+    private Map<CustomPage.Type, Boolean> customPageMap;
 
     PassiveScanData(HttpMessage msg) {
         this.message = msg;
@@ -135,5 +139,67 @@ public final class PassiveScanData {
      */
     public TechSet getTechSet() {
         return techSet;
+    }
+
+    /**
+     * Tells whether or not the message matches the specific {@code CustomPageType}
+     *
+     * @param msg the message that will be checked
+     * @param cpType the custom page type to be checked
+     * @return {@code true} if the message matches, {@code false} otherwise
+     */
+    private boolean isCustomPage(HttpMessage msg, CustomPage.Type cpType) {
+        if (context == null) {
+            return false;
+        }
+        if (customPageMap == null) {
+            customPageMap = new HashMap<CustomPage.Type, Boolean>();
+        }
+        return customPageMap.computeIfAbsent(
+                cpType, type -> context.isCustomPageWithFallback(msg, type));
+    }
+
+    /**
+     * Tells whether or not the message matches {@code CustomPageType.OK_200} definitions.
+     *
+     * @param msg the message that will be checked
+     * @return {@code true} if the message matches, {@code false} otherwise
+     * @since TODO Add version
+     */
+    public boolean isPage200(HttpMessage msg) {
+        return isCustomPage(msg, CustomPage.Type.OK_200);
+    }
+
+    /**
+     * Tells whether or not the message matches {@code CustomPageType.ERROR_500} definitions.
+     *
+     * @param msg the message that will be checked
+     * @return {@code true} if the message matches, {@code false} otherwise
+     * @since TODO Add version
+     */
+    public boolean isPage500(HttpMessage msg) {
+        return isCustomPage(msg, CustomPage.Type.ERROR_500);
+    }
+
+    /**
+     * Tells whether or not the message matches {@code CustomPageType.NOTFOUND_404} definitions.
+     *
+     * @param msg the message that will be checked
+     * @return {@code true} if the message matches, {@code false} otherwise
+     * @since TODO Add version
+     */
+    public boolean isPage404(HttpMessage msg) {
+        return isCustomPage(msg, CustomPage.Type.NOTFOUND_404);
+    }
+
+    /**
+     * Tells whether or not the message matches {@code CustomPageType.OTHER} definitions.
+     *
+     * @param msg the message that will be checked
+     * @return {@code true} if the message matches, {@code false} otherwise
+     * @since TODO Add version
+     */
+    public boolean isPageOther(HttpMessage msg) {
+        return isCustomPage(msg, CustomPage.Type.OTHER);
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/model/Context.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/Context.java
@@ -34,13 +34,16 @@ import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteMap;
 import org.parosproxy.paros.model.SiteNode;
+import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpStatusCode;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.authentication.AuthenticationMethod;
 import org.zaproxy.zap.authentication.ManualAuthenticationMethodType.ManualAuthenticationMethod;
 import org.zaproxy.zap.extension.authorization.AuthorizationDetectionMethod;
 import org.zaproxy.zap.extension.authorization.BasicAuthorizationDetectionMethod;
 import org.zaproxy.zap.extension.authorization.BasicAuthorizationDetectionMethod.LogicalOperator;
+import org.zaproxy.zap.extension.custompages.CustomPage;
 import org.zaproxy.zap.session.CookieBasedSessionManagementMethodType.CookieBasedSessionManagementMethod;
 import org.zaproxy.zap.session.SessionManagementMethod;
 
@@ -87,6 +90,8 @@ public class Context {
 
     /** The authorization detection method used for this context. */
     private AuthorizationDetectionMethod authorizationDetectionMethod;
+
+    private List<CustomPage> customPages = new ArrayList<>();
 
     private TechSet techSet = new TechSet(Tech.builtInTech);
     private boolean inScope = true;
@@ -734,6 +739,136 @@ public class Context {
     }
 
     /**
+     * Gets an unmodifiable view of the list of custom pages.
+     *
+     * @return a List of custom pages
+     */
+    public List<CustomPage> getCustomPages() {
+        return Collections.unmodifiableList(customPages);
+    }
+
+    /**
+     * Returns {@code true} if the {@code Context} has Custom Pages.
+     *
+     * @return {@code true} if this context has Custom Pages, {@code false} otherwise.
+     */
+    public boolean hasCustomPages() {
+        return !customPages.isEmpty();
+    }
+
+    /**
+     * Returns {@code true} if the {@code Context} has Custom Page definitions of a specific {@code
+     * CustomPageType}.
+     *
+     * @return {@code true} if this context has Custom Pages, {@code false} otherwise.
+     */
+    public boolean hasCustomPageOfType(CustomPage.Type cpType) {
+        if (!hasCustomPages()) {
+            return false;
+        }
+        for (CustomPage cp : customPages) {
+            if (cp.getType().equals(cpType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Sets a new list of custom pages for this context. An internal copy of the provided list is
+     * stored.
+     *
+     * @param customPages the list of custom pages
+     */
+    public void setCustomPages(List<CustomPage> customPages) {
+        this.customPages = new ArrayList<>(customPages);
+    }
+
+    /**
+     * Adds a custom page.
+     *
+     * @param customPage the custom page being added
+     */
+    public void addCustomPage(CustomPage customPage) {
+        if (customPage != null) {
+            this.customPages.add(customPage);
+        }
+    }
+
+    /**
+     * Removes a custom page.
+     *
+     * @param customPage the defaultCustomPage to be removed
+     */
+    public boolean removeCustomPage(CustomPage customPage) {
+        return this.customPages.remove(customPage);
+    }
+
+    /** Removes all the custom pages. */
+    public void removeAllCustomPages() {
+        this.customPages.clear();
+    }
+
+    /**
+     * Determines if a {@code HttpMessage} is a Custom Page of a particular {@code CustomPage.Type}.
+     *
+     * @param msg the HTTP message to be evaluated
+     * @param cpType the CustomPage.Type of the Custom Pages against which the HTTP message should
+     *     be evaluated
+     * @return {@code true} if the HTTP message is a Custom Page of the type in question, {@code
+     *     false} otherwise
+     * @since TODO add version
+     * @see #isCustomPageWithFallback(HttpMessage,
+     *     org.zaproxy.zap.extension.custompages.CustomPage.Type)
+     */
+    public boolean isCustomPage(HttpMessage msg, CustomPage.Type cpType) {
+        return isCustomPage(msg, cpType, false);
+    }
+
+    /**
+     * Determines if a {@code HttpMessage} is a Custom Page of a particular {@code CustomPage.Type}.
+     * Falling back to check the message's status code.
+     *
+     * @param msg the HTTP message to be evaluated
+     * @param cpType the CustomPage.Type of the Custom Pages against which the HTTP message should
+     *     be evaluated
+     * @return {@code true} if the HTTP message is a Custom Page of the type in question or the
+     *     response has a relevant status code (500, 404, etc), {@code false} otherwise
+     * @since TODO add version
+     * @see #isCustomPage(HttpMessage, org.zaproxy.zap.extension.custompages.CustomPage.Type)
+     */
+    public boolean isCustomPageWithFallback(HttpMessage msg, CustomPage.Type cpType) {
+        return isCustomPage(msg, cpType, true);
+    }
+
+    private boolean isCustomPage(HttpMessage msg, CustomPage.Type cpType, boolean fallback) {
+        for (CustomPage customPage : customPages) {
+            if (customPage.isCustomPage(msg, cpType)) {
+                return true;
+            }
+        }
+
+        if (fallback) {
+            return statusCodeFallback(msg, cpType);
+        }
+        return false;
+    }
+
+    private boolean statusCodeFallback(HttpMessage msg, CustomPage.Type cpType) {
+        switch (cpType) {
+            case ERROR_500:
+                return msg.getResponseHeader().getStatusCode()
+                        == HttpStatusCode.INTERNAL_SERVER_ERROR;
+            case NOTFOUND_404:
+                return msg.getResponseHeader().getStatusCode() == HttpStatusCode.NOT_FOUND;
+            case OK_200:
+                return msg.getResponseHeader().getStatusCode() == HttpStatusCode.OK;
+            default:
+                return false;
+        }
+    }
+
+    /**
      * Creates a copy of the Context. The copy is deep, with the exception of the TechSet.
      *
      * @return the context
@@ -754,6 +889,7 @@ public class Context {
         newContext.postParamParser = this.postParamParser.clone();
         newContext.authorizationDetectionMethod = this.authorizationDetectionMethod.clone();
         newContext.dataDrivenNodes = this.getDataDrivenNodes();
+        newContext.setCustomPages(getCustomPages());
         return newContext;
     }
 

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -1528,6 +1528,48 @@ core.api.view.zapHomePath = Gets the path to ZAP's home directory.
 
 core.api.depreciated.alert = Use the API endpoint with the same name in the 'alert' component instead.
 
+custompages.content.location.url=URL
+custompages.content.location.response=Response
+
+custompages.desc=Custom Pages Definition
+
+custompages.dialog.add.title=Add Custom Page
+custompages.dialog.add.button.confirm=Confirm
+custompages.dialog.add.field.label.type=Type:
+custompages.dialog.add.field.label.enabled=Enabled:
+custompages.dialog.add.field.label.regex=Is Regex?
+custompages.dialog.add.field.label.content=Content:
+custompages.dialog.add.field.label.contentlocation=Content Location:
+custompages.dialog.add.field.content.empty.warn=The "Content" field can't be blank or simply wildcard (.*). 
+
+custompages.dialog.modify.title=Modify Custom Page
+custompages.dialog.modify.button.confirm=Confirm
+
+custompages.dialog.remove.button.cancel=Cancel
+custompages.dialog.remove.button.confirm=Remove
+custompages.dialog.remove.checkbox.label=Do not show this message again
+custompages.dialog.remove.text=Are you sure you want to remove the selected Custom Page?
+custompages.dialog.remove.title=Remove Custom Page
+
+custompages.panel.description=Define custom pages for error conditions, etc.
+custompages.panel.title=Custom Page
+
+custompages.popup.indicator = {0} : Custom Page Indicator
+custompages.popup.url =  {0} : Custom Page URL
+
+custompages.name = Custom Pages Extension
+
+custompages.table.header.enabled=Enabled
+custompages.table.header.content=Content
+custompages.table.header.contentlocation=Content Location
+custompages.table.header.isregex=Is RegEx?
+custompages.table.header.type=Custom Page Type
+
+custompages.type.error=Error Page
+custompages.type.notfound=Not Found
+custompages.type.ok=Ok
+custompages.type.other=Other
+
 database.optionspanel.name = Database
 database.optionspanel.option.compact.label = Compact (on exit)
 database.optionspanel.option.recoveryLog.label = Recovery Log


### PR DESCRIPTION
All the "gutts" of the solution for other components to take advantage of.

Add support for custom error page definitions associated with a Context. Expose those details and functionality to Passive and Active scanners (rules). Assume that if a context with custom pages is setup the user wants those details to be leveraged. Default behavior is to check custom pages and fallback to status code checking (based on the applicable custom page definition type and related status codes).

See zaproxy/zaproxy#9