### PR TITLE
Correct Content-Length of generated anti-CSRF form

### DIFF
--- a/src/org/zaproxy/zap/extension/anticsrf/AntiCsrfAPI.java
+++ b/src/org/zaproxy/zap/extension/anticsrf/AntiCsrfAPI.java
@@ -78,8 +78,9 @@ public class AntiCsrfAPI extends ApiImplementor {
 				    charset = " charset=" + charset;
 				}
 
-	            msg.setResponseHeader(API.getDefaultResponseHeader("text/html; " + charset, response.length()));
+	            msg.setResponseHeader(API.getDefaultResponseHeader("text/html; " + charset));
 		    	msg.setResponseBody(response);
+		    	msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
 				
 			} catch (NumberFormatException e) {
 				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, OTHER_GENERATE_FORM_PARAM_HREFID);


### PR DESCRIPTION
Change AntiCsrfAPI to return the number of bytes of the response (not
the number of characters) as the value of the Content-Length response
header.