### PR TITLE
Reuse HttpMessage when generating anti-CSRF form

### DIFF
--- a/src/org/zaproxy/zap/extension/anticsrf/AntiCsrfAPI.java
+++ b/src/org/zaproxy/zap/extension/anticsrf/AntiCsrfAPI.java
@@ -21,8 +21,8 @@ package org.zaproxy.zap.extension.anticsrf;
 
 import net.sf.json.JSONObject;
 
-import org.parosproxy.paros.control.Control;
-import org.parosproxy.paros.extension.history.ExtensionHistory;
+import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.api.ApiException;
@@ -63,15 +63,16 @@ public class AntiCsrfAPI extends ApiImplementor {
 			int hrefId;
 			try {
 				hrefId = Integer.parseInt(hrefIdStr);
-				
-		    	String response = extension.generateForm(hrefId);
-		    	if (response == null) {
-					throw new ApiException(ApiException.Type.HREF_NOT_FOUND, hrefIdStr);
-		    	}
+			} catch (NumberFormatException e) {
+				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, OTHER_GENERATE_FORM_PARAM_HREFID, e);
+			}
+
+			try {
+				HttpMessage originalMessage = new HistoryReference(hrefId, true).getHttpMessage();
+				String response = extension.generateForm(originalMessage);
 
 				// Get the charset from the original message
-				ExtensionHistory extHist = (ExtensionHistory) Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.NAME);
-				String charset = extHist.getHistoryReference(hrefId).getHttpMessage().getResponseHeader().getCharset();
+				String charset = originalMessage.getResponseHeader().getCharset();
 				if (charset == null || charset.length() == 0) {
 				    charset = "";
 				} else {
@@ -81,12 +82,10 @@ public class AntiCsrfAPI extends ApiImplementor {
 	            msg.setResponseHeader(API.getDefaultResponseHeader("text/html; " + charset, response.length()));
 		    	msg.setResponseBody(response);
 				
-			} catch (NumberFormatException e) {
-				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, OTHER_GENERATE_FORM_PARAM_HREFID);
-			} catch (ApiException e) {
-				throw e;
+			} catch (HttpMalformedHeaderException e) {
+				throw new ApiException(ApiException.Type.HREF_NOT_FOUND, hrefIdStr, e);
 			} catch (Exception e) {
-				throw new ApiException(ApiException.Type.INTERNAL_ERROR);
+				throw new ApiException(ApiException.Type.INTERNAL_ERROR, e);
 			}
 			
 		} else {


### PR DESCRIPTION
Change AntiCsrfAPI to reuse the HttpMessage read from the database when
generating the HTML form and obtaining the character encoding from the
request (instead of reading it twice).
Add a method to ExtensionAntiCSRF to generate the HTML form from a
HttpMessage.