### PR TITLE
Correct state of adv option in Spider dialogue

### DIFF
--- a/src/org/zaproxy/zap/extension/spider/SpiderDialog.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderDialog.java
@@ -117,7 +117,7 @@ public class SpiderDialog extends StandardFieldsDialog {
         this.addCheckBoxField(0, FIELD_RECURSE, true);
         this.addCheckBoxField(0, FIELD_SUBTREE_ONLY, subtreeOnlyPreviousCheckedState);
         // This option is always read from the 'global' options
-        this.addCheckBoxField(0, FIELD_ADVANCED, getSpiderParam().isShowAdvancedDialog());
+        this.addCheckBoxField(0, FIELD_ADVANCED, extension.getSpiderParam().isShowAdvancedDialog());
         this.addPadding(0);
 
         // Advanced options


### PR DESCRIPTION
Change SpiderDialog to set the correct state to the option Show Advanced
Options, to always show it checked when the Advanced tab is shown.