### PR TITLE
Notify when a note is set to a message

### DIFF
--- a/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -77,6 +77,7 @@
 // ZAP: 2017/05/02 Move alert related code to ExtensionAlert.
 // ZAP: 2017/05/03 Register and process events from HistoryReference.
 // ZPA: 2017/06/05 Sync HistoryReference cache.
+// ZAP: 2017/06/13 Handle notification of notes set and deprecate/remove code no longer needed.
 
 package org.parosproxy.paros.extension.history;
 
@@ -594,15 +595,17 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
     public void showNotesAddDialog(HistoryReference ref, String note) {
     	if (dialogNotesAdd == null) {
 	    	dialogNotesAdd = new NotesAddDialog(getView().getMainFrame(), false);
-	    	dialogNotesAdd.setPlugin(this);
 	    	populateNotesAddDialogAndSetVisible(ref, note);
     	} else if (!dialogNotesAdd.isVisible()) {
     		populateNotesAddDialogAndSetVisible(ref, note);
     	}
     }
 
+	/**
+	 * @deprecated (TODO add version) No longer used/needed.
+	 */
+	@Deprecated
 	public void hideNotesAddDialog() {
-		dialogNotesAdd.dispose();
 	}
 	
     /**
@@ -859,6 +862,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
         @Override
         public void eventReceived(Event event) {
             switch (event.getEventType()) {
+            case HistoryReferenceEventPublisher.EVENT_NOTE_SET:
             case HistoryReferenceEventPublisher.EVENT_TAG_ADDED:
             case HistoryReferenceEventPublisher.EVENT_TAG_REMOVED:
             case HistoryReferenceEventPublisher.EVENT_TAGS_SET:

--- a/src/org/parosproxy/paros/model/HistoryReference.java
+++ b/src/org/parosproxy/paros/model/HistoryReference.java
@@ -51,6 +51,7 @@
 // ZAP: 2017/05/17 Allow to obtain the tags of a message.
 // ZAP: 2017/05/31 Add a multi-catch for a specific handler. 
 // ZAP: 2017/06/08 Allow to keep the HttpMessage in memory for immediate reuse.
+// ZAP: 2017/06/13 Notify when a note is set.
 
 package org.parosproxy.paros.model;
 
@@ -517,7 +518,7 @@ public class HistoryReference {
    	public void addTag(String tag) {
    		if (insertTagDb(tag)) {
    			this.tags.add(tag);
-   			notifyTagEvent(HistoryReferenceEventPublisher.EVENT_TAG_ADDED);
+   			notifyEvent(HistoryReferenceEventPublisher.EVENT_TAG_ADDED);
    		}
    	}
 
@@ -531,7 +532,7 @@ public class HistoryReference {
         return false;
     }
 
-    private void notifyTagEvent(String event) {
+    private void notifyEvent(String event) {
         Map<String, String> map = new HashMap<>();
         map.put(HistoryReferenceEventPublisher.FIELD_HISTORY_REFERENCE_ID, Integer.toString(historyId));
         ZAP.getEventBus().publishSyncEvent(
@@ -542,7 +543,7 @@ public class HistoryReference {
    	public void deleteTag(String tag) {
    		if (deleteTagDb(tag)) {
    			this.tags.remove(tag);
-   			notifyTagEvent(HistoryReferenceEventPublisher.EVENT_TAG_REMOVED);
+   			notifyEvent(HistoryReferenceEventPublisher.EVENT_TAG_REMOVED);
    		}
    	}
 
@@ -565,6 +566,7 @@ public class HistoryReference {
        try {
            staticTableHistory.updateNote(historyId, note);
            httpMessageCachedData.setNote(note != null && note.length() > 0);
+           notifyEvent(HistoryReferenceEventPublisher.EVENT_NOTE_SET);
        } catch (DatabaseException e) {
            log.error(e.getMessage(), e);
        }
@@ -743,7 +745,7 @@ public class HistoryReference {
 		}
 
 		this.tags = new ArrayList<>(tags);
-		notifyTagEvent(HistoryReferenceEventPublisher.EVENT_TAGS_SET);
+		notifyEvent(HistoryReferenceEventPublisher.EVENT_TAGS_SET);
 	}
 
 	/**

--- a/src/org/parosproxy/paros/model/HistoryReferenceEventPublisher.java
+++ b/src/org/parosproxy/paros/model/HistoryReferenceEventPublisher.java
@@ -47,6 +47,11 @@ public final class HistoryReferenceEventPublisher implements EventPublisher {
     public static final String EVENT_TAGS_SET = "href.tags.set";
 
     /**
+     * The event sent when a new note has been (re)set to a {@code HistoryReference}.
+     */
+    public static final String EVENT_NOTE_SET = "href.note.set";
+
+    /**
      * The event's field that contains the ID of the {@code HistoryReference} of the event.
      */
     public static final String FIELD_HISTORY_REFERENCE_ID = "historyReferenceId";
@@ -73,7 +78,9 @@ public final class HistoryReferenceEventPublisher implements EventPublisher {
     private static synchronized void createPublisher() {
         if (publisher == null) {
             publisher = new HistoryReferenceEventPublisher();
-            ZAP.getEventBus().registerPublisher(publisher, new String[] { EVENT_TAG_ADDED, EVENT_TAG_REMOVED, EVENT_TAGS_SET });
+            ZAP.getEventBus().registerPublisher(
+                    publisher,
+                    new String[] { EVENT_TAG_ADDED, EVENT_TAG_REMOVED, EVENT_TAGS_SET, EVENT_NOTE_SET });
         }
     }
 }

--- a/src/org/zaproxy/zap/extension/history/NotesAddDialog.java
+++ b/src/org/zaproxy/zap/extension/history/NotesAddDialog.java
@@ -44,7 +44,6 @@ public class NotesAddDialog extends AbstractDialog {
 	private JButton btnOk = null;
 	private JButton btnCancel = null;
 	
-	private ExtensionHistory extension = null;
 	private HistoryReference historyRef;
 	
 	private JScrollPane jScrollPane = null;
@@ -77,13 +76,10 @@ public class NotesAddDialog extends AbstractDialog {
         	this.setSize(407, 407);
         }
         this.addWindowListener(new java.awt.event.WindowAdapter() {   
-        	@Override
-        	public void windowOpened(java.awt.event.WindowEvent e) {    
-        	} 
 
         	@Override
         	public void windowClosing(java.awt.event.WindowEvent e) {    
-        	    btnCancel.doClick();
+        	    clearAndDispose();
         	}
         });
 
@@ -167,15 +163,20 @@ public class NotesAddDialog extends AbstractDialog {
 				@Override
 				public void actionPerformed(java.awt.event.ActionEvent e) {
                     historyRef.setNote(getTxtDisplay().getText());
-                    getTxtDisplay().discardAllEdits();
-                    extension.notifyHistoryItemChanged(historyRef);
-				    extension.hideNotesAddDialog();
+                    clearAndDispose();
 				}
 			});
 
 		}
 		return btnOk;
 	}
+
+	private void clearAndDispose() {
+		setNote("");
+		historyRef = null;
+		dispose();
+	}
+
 	/**
 	 * This method initializes btnStop	
 	 * 	
@@ -189,21 +190,17 @@ public class NotesAddDialog extends AbstractDialog {
 			btnCancel.setMinimumSize(new java.awt.Dimension(70,30));
 			btnCancel.setPreferredSize(new java.awt.Dimension(70,30));
 			btnCancel.setEnabled(true);
-			btnCancel.addActionListener(new java.awt.event.ActionListener() { 
-
-				@Override
-				public void actionPerformed(java.awt.event.ActionEvent e) {
-				    getTxtDisplay().discardAllEdits();
-				    extension.hideNotesAddDialog();
-				}
-			});
-
+			btnCancel.addActionListener(e -> clearAndDispose());
 		}
 		return btnCancel;
 	}
 	
+	/**
+	 * @param plugin unused.
+	 * @deprecated (TODO add version) No longer used/needed.
+	 */
+	@Deprecated
 	public void setPlugin(ExtensionHistory plugin) {
-	    this.extension = plugin;
 	}
 	
 	/**


### PR DESCRIPTION
Add the new event to HistoryReferenceEventPublisher.
Change HistoryReference to notify when a note is set to a message.
Change NotesAddDialog to remove the manual notification of the change,
it can now be consumed when listening for the new event, also, close
the dialogue itself (no longer requiring ExtensionHistory) and properly
clear the dialogue when disposing.
Change ExtensionHistory to handle the new event and deprecate/remove
code no longer used/needed.