### PR TITLE
Allow to export the Extensions table

### DIFF
--- a/src/org/zaproxy/zap/extension/ext/OptionsExtensionPanel.java
+++ b/src/org/zaproxy/zap/extension/ext/OptionsExtensionPanel.java
@@ -35,7 +35,6 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 
 import org.apache.log4j.Logger;
-import org.jdesktop.swingx.JXTable;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.model.OptionsParam;
@@ -44,11 +43,12 @@ import org.zaproxy.zap.utils.DesktopUtils;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.ZapLabel;
 import org.zaproxy.zap.view.LayoutHelper;
+import org.zaproxy.zap.view.ZapTable;
 
 public class OptionsExtensionPanel extends AbstractParamPanel {
 
 	private static final long serialVersionUID = 1L;
-	private JXTable tableExt = null;
+	private ZapTable tableExt = null;
 	private JScrollPane jScrollPane = null;
 	private JPanel detailsPane = null;
 	private ZapLabel extName = new ZapLabel();
@@ -134,9 +134,18 @@ public class OptionsExtensionPanel extends AbstractParamPanel {
 	 * 	
 	 * @return javax.swing.JTable	
 	 */    
-	private JXTable getTableExtension() {
+	private ZapTable getTableExtension() {
 		if (tableExt == null) {
-			tableExt = new JXTable();
+			tableExt = new ZapTable() {
+
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				protected AutoScrollAction createAutoScrollAction() {
+					return null;
+				}
+			};
+			tableExt.setAutoScrollOnNewValues(false);
 			tableExt.setModel(getExtensionModel());
 			tableExt.setRowHeight(DisplayUtils.getScaledSize(18));
 			tableExt.getColumnModel().getColumn(0).setPreferredWidth(DisplayUtils.getScaledSize(70));

--- a/src/org/zaproxy/zap/view/ZapTable.java
+++ b/src/org/zaproxy/zap/view/ZapTable.java
@@ -81,7 +81,10 @@ public class ZapTable extends JXTable {
         JComponent columnControl = getColumnControl();
         if (columnControl instanceof ZapColumnControlButton) {
             ZapColumnControlButton zapColumnControl = ((ZapColumnControlButton) columnControl);
-            zapColumnControl.addAction(getAutoScrollAction());
+            autoScrollAction = createAutoScrollAction();
+            if (autoScrollAction != null) {
+                zapColumnControl.addAction(autoScrollAction);
+            }
             TableExportAction<ZapTable> exportAction = createTableExportAction();
             if (exportAction != null) {
                 zapColumnControl.addAction(exportAction);
@@ -92,10 +95,25 @@ public class ZapTable extends JXTable {
         setAutoScrollOnNewValues(true);
     }
 
+    /**
+     * Creates the action to change the state of auto scroll on new values.
+     * <p>
+     * Called when customising the {@link ZapColumnControlButton}.
+     *
+     * @return the action to change the state of the auto scroll on new values, might be {@code null}.
+     * @since TODO add version
+     * @see #setAutoScrollOnNewValues(boolean)
+     */
+    protected AutoScrollAction createAutoScrollAction() {
+        return new AutoScrollAction(this);
+    }
+
+    /**
+     * Gets the action to change the state of auto scroll on new values.
+     *
+     * @return the action to change the state of the auto scroll on new values, might be {@code null}.
+     */
     protected AutoScrollAction getAutoScrollAction() {
-        if (autoScrollAction == null) {
-            autoScrollAction = new AutoScrollAction(this);
-        }
         return autoScrollAction;
     }
 


### PR DESCRIPTION
Change OptionsExtensionPanel to use a ZapTable, to allow to export the
contents shown in the table.
Change ZapTable to allow to create or not an action to auto scroll on
new values (e.g. to not show the menu item when not needed).