### PR TITLE
Issue 3521 Add Filter To Options Passive Scan Rules

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -666,8 +666,6 @@ To install it either:<ul>\
 cfu.label.cfuonstart = Check for updates on start?
 cfu.label.dir.border   = Add-on Directories
 cfu.label.addons.border = Add-ons
-cfu.label.addons.filter = Filter:
-cfu.label.addons.filter.tooltip = The add-ons filtering system supports regular expressions.
 cfu.label.norecentcfu =  You have not checked for updates for over 3 months.\nZAP is updated regularly, so you are probably\n\
 running with out of date add-ons.\n\nCheck for new updates now?\n\n
 cfu.label.oldzap = This version of ZAP was created over a year ago!\nZAP is updated regularly, so you are probably\n\
@@ -1165,6 +1163,8 @@ footer.scans.label           = Current Scans
 
 form.dialog.button.cancel = Cancel
 
+generic.filter.label = Filter:
+generic.filter.tooltip = The filtering system supports regular expressions.
 generic.options.panel.security.protocols.title = Security Protocols
 generic.options.panel.security.protocols.ssl2hello.label = SSLv2Hello
 generic.options.panel.security.protocols.ssl3.label = SSL 3

--- a/src/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.autoupdate;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Desktop;
@@ -36,7 +35,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.PatternSyntaxException;
 
 import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
@@ -50,13 +48,8 @@ import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
 import javax.swing.RowSorter;
 import javax.swing.SortOrder;
-import javax.swing.UIManager;
-import javax.swing.JTextField;
 import javax.swing.KeyStroke;
-import javax.swing.RowFilter;
 import javax.swing.border.TitledBorder;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.event.TableModelEvent;
@@ -84,6 +77,7 @@ import org.zaproxy.zap.control.AddOnCollection;
 import org.zaproxy.zap.utils.DesktopUtils;
 import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.view.LayoutHelper;
+import org.zaproxy.zap.view.panels.TableFilterPanel;
 
 public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateCallback {
 
@@ -288,7 +282,7 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
 			scrollPane.setHorizontalScrollBarPolicy(javax.swing.JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
 			scrollPane.setViewportView(getInstalledAddOnsTable());
 
-			installedAddOnsFilterPanel = createFilterPanel(getInstalledAddOnsTable());
+			installedAddOnsFilterPanel = new TableFilterPanel<JXTable>(getInstalledAddOnsTable());
 
 			int row = 0;
 			installedAddOnsPanel.add(installedAddOnsFilterPanel, LayoutHelper.getGBC(0, row++, 5, 0.0D));
@@ -315,7 +309,7 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
 							FontUtils.getFont(FontUtils.Size.standard),
 							java.awt.Color.black));
 
-			uninstalledAddOnsFilterPanel = createFilterPanel(getUninstalledAddOnsTable());
+			uninstalledAddOnsFilterPanel = new TableFilterPanel<JXTable>(getUninstalledAddOnsTable());
 
 			if (latestInfo == null) {
 				// Not checked yet
@@ -337,57 +331,7 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
 
 		}
 		return uninstalledAddOnsPanel;
-	}
-	
-	private static JPanel createFilterPanel(final JXTable table) {
-		JPanel filterPanel = new JPanel();
-		filterPanel.setLayout(new GridBagLayout());
-
-		JLabel filterLabel = new JLabel(Constant.messages.getString("cfu.label.addons.filter"));
-		final JTextField filterTextField = new JTextField();
-
-		filterLabel.setLabelFor(filterTextField);
-		filterPanel.add(filterLabel, LayoutHelper.getGBC(0, 0, 1, 0.0D));
-		filterPanel.add(filterTextField, LayoutHelper.getGBC(1, 0, 1, 1.0D));
-
-		String tooltipText = Constant.messages.getString("cfu.label.addons.filter.tooltip");
-		filterLabel.setToolTipText(tooltipText);
-		filterTextField.setToolTipText(tooltipText);
-
-		// Set filter listener
-		filterTextField.getDocument().addDocumentListener(new DocumentListener() {
-			@Override
-			public void insertUpdate(DocumentEvent e) {
-				updateFilter();
-			}
-
-			@Override
-			public void removeUpdate(DocumentEvent e) {
-				updateFilter();
-			}
-
-			@Override
-			public void changedUpdate(DocumentEvent e) {
-				updateFilter();
-			}
-
-			public void updateFilter() {
-				String filterText = filterTextField.getText();
-				if (filterText.isEmpty()) {
-					table.setRowFilter(null);
-					filterTextField.setForeground(UIManager.getColor("TextField.foreground"));
-				} else {
-					try {
-						table.setRowFilter(RowFilter.regexFilter("(?i)" + filterText));
-						filterTextField.setForeground(UIManager.getColor("TextField.foreground"));
-					} catch (PatternSyntaxException e) {
-						filterTextField.setForeground(Color.RED);
-					}
-				}
-			}
-		});
-		return filterPanel;
-	}
+	}	
 
 	private JScrollPane getMarketPlaceScrollPane () {
 		if (marketPlaceScrollPane == null) {

--- a/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanPanel.java
+++ b/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanPanel.java
@@ -33,11 +33,11 @@ import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
-import javax.swing.JTable;
 import javax.swing.RowSorter;
 import javax.swing.SortOrder;
 import javax.swing.table.TableColumn;
 
+import org.jdesktop.swingx.JXTable;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.model.Model;
@@ -46,11 +46,12 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.LayoutHelper;
+import org.zaproxy.zap.view.panels.TableFilterPanel;
 
 public class PolicyPassiveScanPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;
-    private JTable tableTest = null;
+    private JXTable tableTest = null;
     private JScrollPane jScrollPane = null;
     private PolicyPassiveScanTableModel passiveScanTableModel = null;
     private JComboBox<String> applyToThreshold = null;
@@ -70,6 +71,7 @@ public class PolicyPassiveScanPanel extends AbstractParamPanel {
             this.setSize(375, 204);
         }
         this.setName(Constant.messages.getString("pscan.options.policy.title"));
+    	JPanel passiveScannersFilterPanel = new TableFilterPanel<JXTable>(getTableTest());
         
         // 'Apply to' controls
         JPanel applyToPanel = new JPanel();
@@ -97,9 +99,11 @@ public class PolicyPassiveScanPanel extends AbstractParamPanel {
         this.add(applyToPanel,
                 LayoutHelper.getGBC(0, 0, 3, 0.0D, 0.0D, GridBagConstraints.BOTH, new Insets(0, 0, 0, 0)));
 
-        
+        this.add(passiveScannersFilterPanel,LayoutHelper.getGBC(0, 1, 1, 1.0D, 0.0D,
+                        GridBagConstraints.BOTH, GridBagConstraints.NORTHWEST, new Insets(0, 0, 0, 0)));
+
         this.add(getJScrollPane(), 
-        		LayoutHelper.getGBC(0, 1, 1, 1.0, 1.0,
+        		LayoutHelper.getGBC(0, 2, 1, 1.0, 1.0,
         				GridBagConstraints.BOTH, GridBagConstraints.NORTHWEST, new Insets(0, 0, 0, 0)));
     }
 
@@ -151,14 +155,9 @@ public class PolicyPassiveScanPanel extends AbstractParamPanel {
 
     private static final int[] width = {300, 60, 100};
 
-    /**
-     * This method initializes tableTest
-     *
-     * @return javax.swing.JTable
-     */
-    private JTable getTableTest() {
+    private JXTable getTableTest() {
         if (tableTest == null) {
-            tableTest = new JTable();
+            tableTest = new JXTable();
             tableTest.setModel(getPassiveScanTableModel());
             tableTest.setRowHeight(DisplayUtils.getScaledSize(18));
             tableTest.setIntercellSpacing(new java.awt.Dimension(1, 1));

--- a/src/org/zaproxy/zap/view/panels/TableFilterPanel.java
+++ b/src/org/zaproxy/zap/view/panels/TableFilterPanel.java
@@ -1,0 +1,96 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.view.panels;
+
+import java.awt.Color;
+import java.awt.GridBagLayout;
+import java.util.regex.PatternSyntaxException;
+
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.RowFilter;
+import javax.swing.UIManager;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+
+import org.jdesktop.swingx.JXTable;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.view.LayoutHelper;
+
+/**
+ * A component class to facilitate filtering of JXTables.
+ * 
+ * @param <T> the type of the table.
+ * @since TODO add version
+ */
+public class TableFilterPanel<T extends JXTable> extends JPanel {
+
+	private static final long serialVersionUID = -756376186276203390L;
+
+	public TableFilterPanel(T table) {
+		this.setLayout(new GridBagLayout());
+
+		JLabel filterLabel = new JLabel(Constant.messages.getString("generic.filter.label"));
+		final JTextField filterTextField = new JTextField();
+
+		filterLabel.setLabelFor(filterTextField);
+		this.add(filterLabel, LayoutHelper.getGBC(0, 0, 1, 0.0D));
+		this.add(filterTextField, LayoutHelper.getGBC(1, 0, 1, 1.0D));
+
+		String tooltipText = Constant.messages.getString("generic.filter.tooltip");
+		filterLabel.setToolTipText(tooltipText);
+		filterTextField.setToolTipText(tooltipText);
+
+		// Set filter listener
+		filterTextField.getDocument().addDocumentListener(new DocumentListener() {
+			@Override
+			public void insertUpdate(DocumentEvent e) {
+				updateFilter();
+			}
+
+			@Override
+			public void removeUpdate(DocumentEvent e) {
+				updateFilter();
+			}
+
+			@Override
+			public void changedUpdate(DocumentEvent e) {
+				updateFilter();
+			}
+
+			public void updateFilter() {
+				String filterText = filterTextField.getText();
+				if (filterText.isEmpty()) {
+					table.setRowFilter(null);
+					filterTextField.setForeground(UIManager.getColor("TextField.foreground"));
+				} else {
+					try {
+						table.setRowFilter(RowFilter.regexFilter("(?i)" + filterText));
+						filterTextField.setForeground(UIManager.getColor("TextField.foreground"));
+					} catch (PatternSyntaxException e) {
+						filterTextField.setForeground(Color.RED);
+					}
+				}
+			}
+		});
+	}
+
+}


### PR DESCRIPTION
- Add generic TableFilterPanel component which accepts a JXTable supported by additions to Messages.properties.
- Added filter components and functionality to PolicyPassiveScanPanel, changed the passive scan rules table to a JXTable (from JTable).
- Updated ManageAddOnsDialog to leverage the new generic component.
- Removed now unused cfu keys from Messages.properties

(Based on https://github.com/zaproxy/zaproxy/pull/2341)

Fixes zaproxy/zaproxy#3521