### PR TITLE
Fix NPE on Check for Updates during start up

### DIFF
--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -983,7 +983,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 						}
 						if (latestVersionInfo != null) {
 							for (AddOn addOn : latestVersionInfo.getAddOns()) {
-								AddOn localAddOn = localVersionInfo.getAddOn(addOn.getId());
+								AddOn localAddOn = getLocalVersionInfo().getAddOn(addOn.getId());
 								if (localAddOn != null && !addOn.isUpdateTo(localAddOn)) {
 									addOn.setInstallationStatus(localAddOn.getInstallationStatus());
 								}


### PR DESCRIPTION
Change ExtensionAutoUpdate to ensure the local add-on info is non-null
when setting the installation status to marketplace add-ons.

Caused by #3590 - Set installation status to marketplace add-ons