### PR TITLE
Show Analyser status in Scan Progress dialogue

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -349,6 +349,7 @@ ascan.progress.label.totals		= Totals
 ascan.progress.label.skipaction	= Skip current running active script
 ascan.progress.tab.chart		= Response Chart
 ascan.progress.tab.progress		= Progress
+ascan.progress.table.analyser = Analyser
 ascan.progress.table.name		= Plugin
 ascan.progress.table.progress	= Progress
 ascan.progress.table.time		= Elapsed

--- a/src/org/parosproxy/paros/core/scanner/HostProcess.java
+++ b/src/org/parosproxy/paros/core/scanner/HostProcess.java
@@ -69,6 +69,7 @@
 // ZAP: 2017/03/25 Ensure messages to be scanned have a response.
 // ZAP: 2017/06/07 Scan just one node with AbstractHostPlugin (they apply to the whole host not individual messages).
 // ZAP: 2017/06/08 Collect messages to be scanned.
+// ZAP: 2017/06/15 Initialise the plugin factory immediately after starting the scan.
 
 package org.parosproxy.paros.core.scanner;
 
@@ -246,6 +247,10 @@ public class HostProcess implements Runnable {
 
         try {
             hostProcessStartTime = System.currentTimeMillis();
+
+            // Initialise plugin factory to report the state of the plugins ASAP.
+            pluginFactory.existPluginToRun();
+
             for (StructuralNode startNode : startNodes) {
                 traverse(startNode, true, node -> {
                     if (canScanNode(node)) {

--- a/src/org/zaproxy/zap/extension/ascan/ScanProgressTableModel.java
+++ b/src/org/zaproxy/zap/extension/ascan/ScanProgressTableModel.java
@@ -33,7 +33,7 @@ public class ScanProgressTableModel extends AbstractTableModel {
     
     private static final long serialVersionUID = 1L;
     private static final String[] columnNames = {
-        Constant.messages.getString("ascan.progress.table.name"),
+        "",
         Constant.messages.getString("ascan.policy.table.strength"),
         Constant.messages.getString("ascan.progress.table.progress"),
         Constant.messages.getString("ascan.progress.table.time"),
@@ -41,6 +41,7 @@ public class ScanProgressTableModel extends AbstractTableModel {
         Constant.messages.getString("ascan.progress.table.status"),
     };
     
+    private HostProcess hp;
     private List<ScanProgressItem> values;
     private List<ScanProgressActionIcon> actions = new ArrayList<ScanProgressActionIcon>();
     private ScanProgressActionIcon focusedAction;
@@ -72,8 +73,8 @@ public class ScanProgressTableModel extends AbstractTableModel {
             return 0;
         }
         
-        // Add other 2 rows for the final table values...
-        return values.size() + 2;
+        // Add other 5 rows for other info shown.
+        return values.size() + 5;
     }
 
     /**
@@ -84,7 +85,27 @@ public class ScanProgressTableModel extends AbstractTableModel {
      */
     @Override
     public Object getValueAt(int row, int col) {
-        
+        // 1st row is for the Analyser, 2nd row is empty (for separation with the plugins), 3rd for Plugin label.
+        if (row == 0) {
+            switch (col) {
+            case 0:
+                return Constant.messages.getString("ascan.progress.table.analyser");
+            case 3:
+                return hp != null ? getElapsedTimeLabel(hp.getAnalyser().getRunningTime()) : "";
+            case 4:
+                return hp != null ? String.valueOf(hp.getAnalyser().getRequestCount()) : "";
+            default:
+                return null;
+            }
+        } else if (row == 1) {
+            return null;
+        } else if (row == 2) {
+            return col == 0 ? Constant.messages.getString("ascan.progress.table.name") : null;
+        }
+
+        // Adjust row for the plugin checks.
+        row -= 3;
+
         // First check if we're showing the plugin status list
         if (row < values.size()) {
             
@@ -236,6 +257,8 @@ public class ScanProgressTableModel extends AbstractTableModel {
     public void updateValues(ActiveScan scan, HostProcess hp) {
         values.clear();
         
+        this.hp = hp;
+
         // Iterate all Plugins
         for (Plugin plugin : hp.getCompleted()) {
             values.add(new ScanProgressItem(hp, plugin, ScanProgressItem.STATUS_COMPLETED));


### PR DESCRIPTION
Change Scan Progress dialogue to show the status (running time and
request count) of the analyser and show all the plugins as soon as the
scan is started.

Fix #3459 - Prescan Output is Confusing. Please Clarify.