### PR TITLE
Correct API's mode validation on redirections

### DIFF
--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -1601,6 +1601,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 
 		public ModeRedirectionValidator(Processor<HttpMessage> processor) {
 			this.processor = processor;
+			this.isRequestValid = true;
 		}
 
 		@Override


### PR DESCRIPTION
Change CoreAPI to assume that the redirections are valid, otherwise if
none is followed it would return as invalid, always.

Fix #3673 - API: sendHarRequest results in error if redirects are true