### PR TITLE
Use correct component when filtering Sites nodes

### DIFF
--- a/src/org/zaproxy/zap/view/SiteMapTreeCellRenderer.java
+++ b/src/org/zaproxy/zap/view/SiteMapTreeCellRenderer.java
@@ -89,10 +89,11 @@ public class SiteMapTreeCellRenderer extends DefaultTreeCellRenderer {
 	        if( node.isFiltered()) {
 	        	// Hide the node
 	            setPreferredSize( new Dimension(0, 0) );
-	        } else {
-	            setPreferredSize(null);	// clears the prefered size, making the node visible
-	            super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus);
+	            return this;
 	        }
+
+			setPreferredSize(null);	// clears the prefered size, making the node visible
+			super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus);
 
 			// folder / file icons with scope 'target' if relevant
 			if (node.isRoot()) {


### PR DESCRIPTION
Change SiteMapTreeCellRenderer to use/return the label (the one hidden)
instead of the panel, also, return immediately (no need to further
process the panel/label).

Fix #3675 - Sites tree option Show only URLs in Scope not working