### PR TITLE
Ensure ZAP started in Python Docker scripts

### DIFF
--- a/build/docker/zap-api-scan.py
+++ b/build/docker/zap-api-scan.py
@@ -303,15 +303,9 @@ def main(argv):
             sys.exit(3)
 
     try:
-        # Wait for ZAP to start
         zap = ZAPv2(proxies={'http': 'http://' + zap_ip + ':' + str(port), 'https': 'http://' + zap_ip + ':' + str(port)})
-        for x in range(0, timeout):
-            try:
-                logging.debug('ZAP Version ' + zap.core.version)
-                logging.debug('Took ' + str(x) + ' seconds')
-                break
-            except IOError:
-                time.sleep(1)
+
+        wait_for_zap_start(zap, timeout)
 
         if context_file:
             # handle the context file, cant use base_dir as it might not have been set up

--- a/build/docker/zap-baseline.py
+++ b/build/docker/zap-baseline.py
@@ -279,15 +279,9 @@ def main(argv):
             sys.exit(3)
 
     try:
-        # Wait for ZAP to start
         zap = ZAPv2(proxies={'http': 'http://' + zap_ip + ':' + str(port), 'https': 'http://' + zap_ip + ':' + str(port)})
-        for x in range(0, timeout):
-            try:
-                logging.debug('ZAP Version ' + zap.core.version)
-                logging.debug('Took ' + str(x) + ' seconds')
-                break
-            except IOError:
-                time.sleep(1)
+
+        wait_for_zap_start(zap, timeout)
 
         if context_file:
             # handle the context file, cant use base_dir as it might not have been set up

--- a/build/docker/zap-full-scan.py
+++ b/build/docker/zap-full-scan.py
@@ -281,15 +281,9 @@ def main(argv):
             sys.exit(3)
 
     try:
-        # Wait for ZAP to start
         zap = ZAPv2(proxies={'http': 'http://' + zap_ip + ':' + str(port), 'https': 'http://' + zap_ip + ':' + str(port)})
-        for x in range(0, timeout):
-            try:
-                logging.debug('ZAP Version ' + zap.core.version)
-                logging.debug('Took ' + str(x) + ' seconds')
-                break
-            except IOError:
-                time.sleep(1)
+
+        wait_for_zap_start(zap, timeout)
 
         if context_file:
             # handle the context file, cant use base_dir as it might not have been set up

--- a/build/docker/zap_common.py
+++ b/build/docker/zap_common.py
@@ -28,6 +28,7 @@ import subprocess
 import sys
 import time
 import traceback
+import errno
 from random import randint
 
 
@@ -161,6 +162,23 @@ def start_zap(port, extra_zap_params):
 
     with open('zap.out', "w") as outfile:
         subprocess.Popen(params + extra_zap_params, stdout=outfile)
+
+
+def wait_for_zap_start(zap, timeout):
+    version = None
+    for x in range(0, timeout):
+        try:
+            version = zap.core.version
+            logging.debug('ZAP Version ' + version)
+            logging.debug('Took ' + str(x) + ' seconds')
+            break
+        except IOError:
+            time.sleep(1)
+
+    if not version:
+        raise IOError(
+          errno.EIO,
+          'Failed to connect to ZAP after {0} seconds'.format(timeout))
 
 
 def start_docker_zap(docker_image, port, extra_zap_params, mount_dir):


### PR DESCRIPTION
Change Python Docker scripts (zap-api-scan.py, zap-baseline.py, and
zap-full-scan.py) to ensure that ZAP has really started (by checking
that a version was obtained after waiting) before continuing with the
actions, otherwise it will still attempt to connect to ZAP and fail with
a not so clear error.
Move waiting function to zap_common.py (same behaviour for all scripts).