### PR TITLE
Correct API response for outgoing proxy changes

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -970,6 +970,7 @@ core.api.action.setOptionDefaultUserAgent = Sets the user agent that ZAP should 
 core.api.action.setOptionMaximumAlertInstances = Sets the maximum number of alert instances to include in a report. A value of zero is treated as unlimited.
 core.api.action.setOptionMergeRelatedAlerts = Sets whether or not related alerts will be merged in any reports generated.
 core.api.action.setOptionAlertOverridesFilePath = Sets (or clears, if empty) the path to the file with alert overrides.
+core.api.action.setOptionUseProxyChain = Sets whether or not the outgoing proxy should be used. The address/hostname of the outgoing proxy must be set to enable this option.
 core.api.other.messagesHar = Gets the HTTP messages sent through/by ZAP, in HAR format, optionally filtered by URL and paginated with 'start' position and 'count' of messages
 core.api.other.messagesHarById = Gets the HTTP messages with the given IDs, in HAR format.
 core.api.other.sendHarRequest = Sends the first HAR request entry, optionally following redirections. Returns, in HAR format, the request sent and response received and followed redirections, if any. The Mode is enforced when sending the request (and following redirections), custom manual requests are not allowed in 'Safe' mode nor in 'Protected' mode if out of scope.

--- a/src/org/zaproxy/zap/extension/api/ApiGeneratorUtils.java
+++ b/src/org/zaproxy/zap/extension/api/ApiGeneratorUtils.java
@@ -75,8 +75,7 @@ public class ApiGeneratorUtils {
 		api.addApiOptions(new SpiderParam());
 		imps.add(api);
 
-		api = new CoreAPI();
-        api.addApiOptions(new ConnectionParam());
+		api = new CoreAPI(new ConnectionParam());
 		imps.add(api);
 
 		imps.add(new ParamsAPI(null));

--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -123,6 +123,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 	private static final String ACTION_OPTION_MAXIMUM_ALERT_INSTANCES = "setOptionMaximumAlertInstances";
 	private static final String ACTION_OPTION_MERGE_RELATED_ALERTS = "setOptionMergeRelatedAlerts";
 	private static final String ACTION_OPTION_ALERT_OVERRIDES_FILE_PATH = "setOptionAlertOverridesFilePath";
+	private static final String ACTION_OPTION_USE_PROXY_CHAIN = "setOptionUseProxyChain";
 	
 	private static final String VIEW_ALERT = "alert";
 	private static final String VIEW_ALERTS = "alerts";
@@ -222,9 +223,12 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
     private SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd-HHmmss");
 	private boolean savingSession = false;
     private static ExtensionHistory extHistory;
+    private ConnectionParam connectionParam;
 
 
-	public CoreAPI() {
+	public CoreAPI(ConnectionParam connectionParam) {
+		this.connectionParam = connectionParam;
+
 		this.addApiAction(
 				new ApiAction(ACTION_ACCESS_URL, new String[] { PARAM_URL }, new String[] { PARAM_FOLLOW_REDIRECTS }));
 		this.addApiAction(new ApiAction(ACTION_SHUTDOWN));
@@ -316,6 +320,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 		this.addApiShortcut(OTHER_SET_PROXY);
 		this.addApiShortcut(OTHER_SCRIPT_JS);
 
+		addApiOptions(this.connectionParam);
 	}
 
 	@Override
@@ -701,6 +706,20 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 			throw new ApiException(ApiException.Type.BAD_ACTION);
 		}
 		return ApiResponseElement.OK;
+	}
+
+    @Override
+    public ApiResponse handleApiOptionAction(String name, JSONObject params) throws ApiException {
+        if (ACTION_OPTION_USE_PROXY_CHAIN.equals(name)) {
+            boolean enabled = params.getBoolean("Boolean");
+            if (enabled && (connectionParam.getProxyChainName() == null || connectionParam.getProxyChainName().isEmpty())) {
+                return ApiResponseElement.FAIL;
+            }
+
+            connectionParam.setUseProxyChain(enabled);
+            return ApiResponseElement.OK;
+        }
+        return super.handleApiOptionAction(name, params);
 	}
 
 	private void setProxyChainExcludedDomainsEnabled(boolean enabled) {

--- a/src/org/zaproxy/zap/extension/api/ExtensionAPI.java
+++ b/src/org/zaproxy/zap/extension/api/ExtensionAPI.java
@@ -64,8 +64,7 @@ public class ExtensionAPI extends ExtensionAdaptor {
 	    	extensionHook.getHookMenu().addToolsMenuItem(getMenuAPI());
 	    }
         
-        coreApi = new CoreAPI();
-        coreApi.addApiOptions(extensionHook.getModel().getOptionsParam().getConnectionParam());
+        coreApi = new CoreAPI(extensionHook.getModel().getOptionsParam().getConnectionParam());
 
         extensionHook.addApiImplementor(coreApi);
         extensionHook.addApiImplementor(new ContextAPI());


### PR DESCRIPTION
Change CoreAPI to not return OK if the outgoing proxy was not enabled
(e.g. a required address/hostname was not previously set).
Require ConnectionParam when instantiating a CoreAPI (now required to
directly set the outgoing proxy changes).