### PR TITLE
Allow to import a Scan Policy through the API

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -176,6 +176,7 @@ ascan.api.action.excludeFromScan = Adds a regex of URLs that should be excluded 
 ascan.api.action.scan = Runs the active scanner against the given URL and/or Context. Optionally, the 'recurse' parameter can be used to scan URLs under the given URL, the parameter 'inScopeOnly' can be used to constrain the scan to URLs that are in scope (ignored if a Context is specified), the parameter 'scanPolicyName' allows to specify the scan policy (if none is given it uses the default scan policy), the parameters 'method' and 'postData' allow to select a given request in conjunction with the given URL.
 ascan.api.action.scanAsUser = Active Scans from the perspective of a User, obtained using the given Context ID and User ID. See 'scan' action for more details.
 ascan.api.action.setOptionInjectPluginIdInHeader = Sets whether or not the active scanner should inject the HTTP request header X-ZAP-Scan-ID, with the ID of the scanner that's sending the requests.
+ascan.api.action.importScanPolicy = Imports a Scan Policy using the given file system path.
 ascan.api.view.excludedParams = Gets all the parameters that are excluded. For each parameter the following are shown: the name, the URL, and the parameter type.
 ascan.api.view.excludedParamTypes = Gets all the types of excluded parameters. For each type the following are shown: the ID and the name.
 ascan.api.view.optionExcludedParamList = Use view excludedParams instead.


### PR DESCRIPTION
Change ActiveScanAPI to allow to import a scan policy from the file
system.

Fix #1604 - Import policy file via API