### PR TITLE
Focus API key field on validation error

### DIFF
--- a/src/org/zaproxy/zap/extension/api/OptionsApiPanel.java
+++ b/src/org/zaproxy/zap/extension/api/OptionsApiPanel.java
@@ -281,6 +281,7 @@ public class OptionsApiPanel extends AbstractParamPanel {
 	@Override
 	public void validateParam(Object obj) throws Exception {
 	    if (! getDisableKey().isSelected() && getKeyField().getText().length() == 0) {
+	    	getKeyField().requestFocusInWindow();
 	    	throw new Exception (Constant.messages.getString("api.options.nokey.error"));
 	    }
 	}


### PR DESCRIPTION
Change OptionsApiPanel to request focus to the API key field when
there's a validation error (i.e. missing key when enabled).