### PR TITLE
Correct SQL queries used in experimental DB

### DIFF
--- a/src/db/hsqldb.properties
+++ b/src/db/hsqldb.properties
@@ -53,8 +53,8 @@ context.ps.read						= SELECT * FROM CONTEXT_DATA WHERE DATAID = ?
 context.ps.insert					= INSERT INTO CONTEXT_DATA (CONTEXTID, TYPE, DATA) VALUES (?, ?, ?)
 context.ps.lastinsert				= CALL IDENTITY()
 context.ps.delete					= DELETE FROM CONTEXT_DATA WHERE  CONTEXTID = ? AND  TYPE = ? AND DATA = ?
-context.ps.alldataforcontext		= DELETE FROM CONTEXT_DATA WHERE  CONTEXTID = ?
-context.ps.alldataforcontexttype	= DELETE FROM CONTEXT_DATA WHERE  CONTEXTID = ? AND  TYPE = ?
+context.ps.deletealldataforcontext = DELETE FROM CONTEXT_DATA WHERE  CONTEXTID = ?
+context.ps.deletealldataforcontexttype = DELETE FROM CONTEXT_DATA WHERE  CONTEXTID = ? AND  TYPE = ?
 context.ps.alldata					= SELECT * FROM CONTEXT_DATA
 context.ps.alldataforcontext		= SELECT * FROM CONTEXT_DATA WHERE  CONTEXTID = ?
 context.ps.alldataforcontexttype	= SELECT * FROM CONTEXT_DATA WHERE  CONTEXTID = ? AND  TYPE = ?

--- a/src/db/mysql.properties
+++ b/src/db/mysql.properties
@@ -53,8 +53,8 @@ context.ps.read						= SELECT * FROM CONTEXT_DATA WHERE DATAID = ?
 context.ps.insert					= INSERT INTO CONTEXT_DATA (CONTEXTID, TYPE, DATA) VALUES (?, ?, ?)
 context.ps.lastinsert				= SELECT LAST_INSERT_ID()
 context.ps.delete					= DELETE FROM CONTEXT_DATA WHERE  CONTEXTID = ? AND  TYPE = ? AND DATA = ?
-context.ps.alldataforcontext		= DELETE FROM CONTEXT_DATA WHERE  CONTEXTID = ?
-context.ps.alldataforcontexttype	= DELETE FROM CONTEXT_DATA WHERE  CONTEXTID = ? AND  TYPE = ?
+context.ps.deletealldataforcontext = DELETE FROM CONTEXT_DATA WHERE  CONTEXTID = ?
+context.ps.deletealldataforcontexttype = DELETE FROM CONTEXT_DATA WHERE  CONTEXTID = ? AND  TYPE = ?
 context.ps.alldata					= SELECT * FROM CONTEXT_DATA
 context.ps.alldataforcontext		= SELECT * FROM CONTEXT_DATA WHERE  CONTEXTID = ?
 context.ps.alldataforcontexttype	= SELECT * FROM CONTEXT_DATA WHERE  CONTEXTID = ? AND  TYPE = ?

--- a/src/db/mysql.schema
+++ b/src/db/mysql.schema
@@ -55,10 +55,11 @@ DROP TABLE IF EXISTS `CONTEXT_DATA`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `CONTEXT_DATA` (
-  `DATAID` bigint(20) NOT NULL,
+  `DATAID` bigint(20) NOT NULL AUTO_INCREMENT,
   `CONTEXTID` int(11) NOT NULL,
   `TYPE` int(11) NOT NULL,
-  `DATA` varchar(8192) DEFAULT ''''
+  `DATA` varchar(8192) DEFAULT '''',
+  PRIMARY KEY (`DATAID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -181,9 +182,10 @@ DROP TABLE IF EXISTS `SESSION_URL`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `SESSION_URL` (
-  `URLID` bigint(20) NOT NULL,
+  `URLID` bigint(20) NOT NULL AUTO_INCREMENT,
   `TYPE` int(11) NOT NULL,
-  `URL` varchar(8192) DEFAULT ''''
+  `URL` varchar(8192) DEFAULT '''',
+  PRIMARY KEY (`URLID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/src/org/zaproxy/zap/db/sql/SqlTableContext.java
+++ b/src/org/zaproxy/zap/db/sql/SqlTableContext.java
@@ -129,7 +129,7 @@ public class SqlTableContext extends SqlAbstractTable implements TableContext {
 	public synchronized void deleteAllDataForContextAndType(int contextId, int type) throws DatabaseException {
     	SqlPreparedStatementWrapper psDeleteAllDataForContextAndType = null;
     	try {
-        	psDeleteAllDataForContextAndType = DbSQL.getSingleton().getPreparedStatement("context.ps.alldataforcontexttype");
+        	psDeleteAllDataForContextAndType = DbSQL.getSingleton().getPreparedStatement("context.ps.deletealldataforcontexttype");
 			psDeleteAllDataForContextAndType.getPs().setInt(1, contextId);
 			psDeleteAllDataForContextAndType.getPs().setInt(2, type);
 			psDeleteAllDataForContextAndType.getPs().executeUpdate();
@@ -147,7 +147,7 @@ public class SqlTableContext extends SqlAbstractTable implements TableContext {
 	public synchronized void deleteAllDataForContext(int contextId) throws DatabaseException {
     	SqlPreparedStatementWrapper psDeleteAllDataForContext = null;
     	try {
-        	psDeleteAllDataForContext = DbSQL.getSingleton().getPreparedStatement("context.ps.alldataforcontext");
+        	psDeleteAllDataForContext = DbSQL.getSingleton().getPreparedStatement("context.ps.deletealldataforcontext");
 			psDeleteAllDataForContext.getPs().setInt(1, contextId);
 			psDeleteAllDataForContext.getPs().executeUpdate();
 		} catch (SQLException e) {


### PR DESCRIPTION
Change SqlTableContext to read the correct SQL queries when deleting all
context data (for a context and type).
Update name of the SQL query keys in the files hsqldb.properties and
mysqldb.properties.
Add missing primary keys in MySQL schema.

Fix #3703 - org.parosproxy.paros.db.DatabaseException:
java.sql.SQLException: Can not issue executeUpdate() or
executeLargeUpdate() for SELECTs