### PR TITLE
Edit menu allows ZAP mode change

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1455,6 +1455,7 @@ menu.edit.previous            = Previous
 menu.edit.previous.mnemonic   = p
 menu.edit.search              = Search...
 menu.edit.search.mnemonic     = s
+menu.edit.zapmode	       = ZAP Mode
 menu.file                     = File
 menu.file.mnemonic            = f
 menu.file.closeSession        = The current session will be closed.  Create new session?

--- a/src/org/parosproxy/paros/control/Control.java
+++ b/src/org/parosproxy/paros/control/Control.java
@@ -546,8 +546,10 @@ public class Control extends AbstractControl implements SessionListener {
 		return mode;
 	}
 	public void setMode(Mode mode) {
-		this.mode = mode;
-		getExtensionLoader().sessionModeChangedAllPlugin(mode);
-		model.getOptionsParam().getViewParam().setMode(mode.name());
+		if (this.mode != mode) {
+			this.mode = mode;
+			getExtensionLoader().sessionModeChangedAllPlugin(mode);
+			model.getOptionsParam().getViewParam().setMode(mode.name());
+		}
 	}
 }

--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -515,6 +515,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 				Mode mode = Mode.valueOf(params.getString(PARAM_MODE).toLowerCase());
 		    	if (View.isInitialised()) {
 	    			View.getSingleton().getMainFrame().getMainToolbarPanel().setMode(mode);
+	    			View.getSingleton().getMainFrame().getMainMenuBar().setMode(mode);
 		    	} else {
 	    			Control.getSingleton().setMode(mode);
 		    	}

--- a/src/org/zaproxy/zap/view/MainToolbarPanel.java
+++ b/src/org/zaproxy/zap/view/MainToolbarPanel.java
@@ -227,6 +227,7 @@ public class MainToolbarPanel extends JPanel {
 						default: return;	// Not recognised
 					}
 					Control.getSingleton().setMode(mode);
+					View.getSingleton().getMainFrame().getMainMenuBar().setMode(mode);
 				}
 			});
 		}


### PR DESCRIPTION
This is a core dev pickup of #2837 which has been abandon and we've been unable to get in-touch with the original submitter (@rajiv65).

Edit menu now has an option to change ZAP mode. Mode can now be changed even if the main toolbar is hidden.

Fixes zaproxy/zaproxy#2375