### PR TITLE
Correct license header comment in forked class

### DIFF
--- a/src/org/zaproxy/zap/spider/URLResolver.java
+++ b/src/org/zaproxy/zap/spider/URLResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This class is adopted from Htmlunit with the following copyright:
  * 
  * Copyright (c) 2002-2012 Gargoyle Software Inc.


### PR DESCRIPTION
Change URLResolver to use plain comment for the license header (instead
of JavaDoc).