### PR TITLE
Remove unnecessary ZAP comments

### DIFF
--- a/src/org/parosproxy/paros/db/DbUtils.java
+++ b/src/org/parosproxy/paros/db/DbUtils.java
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and 
  * limitations under the License. 
  */
-// ZAP: 2014/03/27 Issue 1072: Allow the request and response body sizes to be user-specifiable as far as possible
 
 package org.parosproxy.paros.db;
 

--- a/src/org/parosproxy/paros/extension/history/HistoryFilter.java
+++ b/src/org/parosproxy/paros/extension/history/HistoryFilter.java
@@ -17,7 +17,6 @@
  * See the License for the specific language governing permissions and 
  * limitations under the License. 
  */
-// ZAP: 2014/05/23 Issue 1209: Reliability becomes Confidence and add levels
 
 package org.parosproxy.paros.extension.history;
 

--- a/src/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
+++ b/src/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and 
  * limitations under the License. 
  */
-// ZAP: 2017/02/20 Issue 2699: Make SSLException handling more user friendly
 package org.parosproxy.paros.extension.manualrequest.http.impl;
 
 import java.awt.EventQueue;

--- a/src/org/parosproxy/paros/extension/option/DatabaseParam.java
+++ b/src/org/parosproxy/paros/extension/option/DatabaseParam.java
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and 
  * limitations under the License. 
  */
-// ZAP: 2014/03/27 Issue 1072: Allow the request and response body sizes to be user-specifiable as far as possible
 
 package org.parosproxy.paros.extension.option;
 

--- a/src/org/parosproxy/paros/extension/option/OptionsDatabasePanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsDatabasePanel.java
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and 
  * limitations under the License. 
  */
-// ZAP: 2014/03/27 Issue 1072: Allow the request and response body sizes to be user-specifiable as far as possible
 
 package org.parosproxy.paros.extension.option;
 

--- a/src/org/parosproxy/paros/extension/option/OptionsJvmPanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsJvmPanel.java
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and 
  * limitations under the License. 
  */
-// ZAP: 2014/03/27 Issue 1072: Allow the request and response body sizes to be user-specifiable as far as possible
 
 package org.parosproxy.paros.extension.option;
 

--- a/src/org/parosproxy/paros/network/HtmlParameter.java
+++ b/src/org/parosproxy/paros/network/HtmlParameter.java
@@ -17,7 +17,6 @@
  * See the License for the specific language governing permissions and 
  * limitations under the License. 
  * 
- * ZAP - 2013/09/09: Cleanup and lazy initialization of flags (speed-up)
  */
 package org.parosproxy.paros.network;
 

--- a/src/org/zaproxy/zap/utils/HirshbergMatcher.java
+++ b/src/org/zaproxy/zap/utils/HirshbergMatcher.java
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// ZAP: 2014/01/08 Created an helper component for common use inside plugins
 
 package org.zaproxy.zap.utils;
 


### PR DESCRIPTION
Remove ZAP comments from ZAP classes, they are not needed.