### PR TITLE
Reserve scanner ID used by Retire.js

### DIFF
--- a/src/doc/scanners.md
+++ b/src/doc/scanners.md
@@ -174,4 +174,6 @@ Scanners:
 100000  Client/Server HTTP Error Response Codes [Script]
 100001  Unexpected Content Types [Script]
 
+322420463 Retire.js
+
 ```


### PR DESCRIPTION
Add the ID currently used by the passive scanner Retire.js.