### PR TITLE
Ascan API - Return alert count for each scanner

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/HostProcess.java
+++ b/src/org/parosproxy/paros/core/scanner/HostProcess.java
@@ -72,6 +72,7 @@
 // ZAP: 2017/06/15 Initialise the plugin factory immediately after starting the scan.
 // ZAP: 2017/06/15 Do not start following plugin if the scanner is paused.
 // ZAP: 2017/06/20 Log number of alerts raised by each scanner.
+// ZAP: 2017/07/06 Expose plugin stats.
 // ZAP: 2017/07/12 Tweak the method used when initialising the PluginFactory.
 // ZAP: 2017/07/13 Automatically skip dependent scanners (Issue 3784)
 
@@ -754,13 +755,13 @@ public class HostProcess implements Runnable {
             return;
         }
 
-        pluginStats.skipped();
+        pluginStats.skip();
         pluginStats.setSkippedReason(reason);
 
         for (Plugin dependent : pluginFactory.getDependentPlugins(plugin)) {
             pluginStats = mapPluginStats.get(dependent.getId());
             if (pluginStats != null && !pluginStats.isSkipped() && !pluginFactory.getCompleted().contains(dependent)) {
-                pluginStats.skipped();
+                pluginStats.skip();
                 pluginStats.setSkippedReason(
                         Constant.messages.getString(
                                 "ascan.progress.label.skipped.reason.dependency"));
@@ -1014,6 +1015,19 @@ public class HostProcess implements Runnable {
     }
 
     /**
+     * Gets the stats of the {@code Plugin} with the given ID.
+     *
+     * @param pluginId the ID of the plugin.
+     * @return the stats of the plugin, or {@code null} if not found.
+     * @since TODO add version
+     */
+    public PluginStats getPluginStats(int pluginId) {
+        synchronized (mapPluginStats) {
+            return mapPluginStats.get(pluginId);
+        }
+    }
+
+    /**
      * An action to be executed for each node traversed during the scan.
      *
      * @see #apply(StructuralNode)
@@ -1027,150 +1041,6 @@ public class HostProcess implements Runnable {
          * @param node the node being traversed
          */
         void apply(StructuralNode node);
-    }
-
-    /**
-     * The stats (and skip state and reason) of a {@link Plugin}, when the {@code Plugin} was started, how many messages were
-     * sent and its scan progress.
-     */
-    private static class PluginStats {
-
-        private long startTime;
-        private int messageCount;
-        private int alertCount;
-        private int progress;
-        private boolean skipped;
-        private String skippedReason;
-
-        /**
-         * Constructs a {@code PluginStats}.
-         * 
-         * @see #start()
-         */
-        public PluginStats() {
-        }
-
-        /**
-         * Tells whether or not the plugin was skipped.
-         *
-         * @return {@code true} if the plugin was skipped, {@code false} otherwise
-         * @see #skipped()
-         */
-        public boolean isSkipped() {
-            return skipped;
-        }
-
-        /**
-         * Skips the plugin.
-         *
-         * @see #isSkipped()
-         * @see #setSkippedReason(String)
-         */
-        public void skipped() {
-            this.skipped = true;
-        }
-
-        /**
-         * Gets the reason why the plugin was skipped.
-         *
-         * @param reason the reason why the plugin was skipped, might be {@code null}
-         * @see #getSkippedReason()
-         * @see #isSkipped()
-         */
-        public void setSkippedReason(String reason) {
-            this.skippedReason = reason;
-        }
-
-        /**
-         * Gets the reason why the plugin was skipped.
-         *
-         * @return the reason why the plugin was skipped, might be {@code null}
-         * @see #setSkippedReason(String)
-         * @see #isSkipped()
-         */
-        public String getSkippedReason() {
-            return skippedReason;
-        }
-
-        /**
-         * Starts the plugin stats.
-         */
-        void start() {
-            startTime = System.currentTimeMillis();
-        }
-
-        /**
-         * Gets the time when the plugin was started, in milliseconds.
-         *
-         * @return time when the plugin was started
-         * @see System#currentTimeMillis()
-         */
-        public long getStartTime() {
-            return startTime;
-        }
-
-        /**
-         * Gets the count of messages sent by the plugin.
-         *
-         * @return the count of messages sent
-         */
-        public int getMessageCount() {
-            return messageCount;
-        }
-
-        /**
-         * Increments the count of messages sent by the plugin.
-         * <p>
-         * Should be called when the plugin notifies that a message was sent.
-         */
-        public void incMessageCount() {
-            messageCount++;
-        }
-
-        /**
-         * Gets the count of alerts raised by the plugin.
-         *
-         * @return the count of alerts raised.
-         */
-        public int getAlertCount() {
-            return alertCount;
-        }
-
-        /**
-         * Increments the count of alerts raised by the plugin.
-         * <p>
-         * Should be called when the plugin notifies that an alert was found.
-         */
-        public void incAlertCount() {
-            alertCount++;
-        }
-
-        /**
-         * Gets the scan progress of the plugin.
-         *
-         * @return the scan progress
-         */
-        public int getProgress() {
-            return progress;
-        }
-
-        /**
-         * Increments the scan progress of the plugin.
-         * <p>
-         * Should be called after scanning a message.
-         */
-        public void incProgress() {
-            this.progress++;
-        }
-
-        /**
-         * Sets the scan progress of the plugin.
-         *
-         * @param progress the progress to set
-         */
-        public void setProgress(int progress) {
-            this.progress = progress;
-        }
     }
 
 }

--- a/src/org/parosproxy/paros/core/scanner/PluginStats.java
+++ b/src/org/parosproxy/paros/core/scanner/PluginStats.java
@@ -1,0 +1,165 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.core.scanner;
+
+/**
+ * The stats of a {@link Plugin}, when the {@code Plugin} was started, how many messages were sent, number of alerts raised, and
+ * its scan progress.
+ * 
+ * @since TODO add version
+ */
+public class PluginStats {
+
+    private long startTime;
+    private int messageCount;
+    private int alertCount;
+    private int progress;
+    private boolean skipped;
+    private String skippedReason;
+
+    /**
+     * Constructs a {@code PluginStats}.
+     * 
+     * @see #start()
+     */
+    PluginStats() {
+    }
+
+    /**
+     * Tells whether or not the plugin was skipped.
+     *
+     * @return {@code true} if the plugin was skipped, {@code false} otherwise
+     */
+    public boolean isSkipped() {
+        return skipped;
+    }
+
+    /**
+     * Skips the plugin.
+     *
+     * @see #isSkipped()
+     * @see #setSkippedReason(String)
+     */
+    void skip() {
+        this.skipped = true;
+    }
+
+    /**
+     * Sets the reason why the plugin was skipped.
+     *
+     * @param reason the reason why the plugin was skipped, might be {@code null}
+     * @see #getSkippedReason()
+     * @see #isSkipped()
+     */
+    void setSkippedReason(String reason) {
+        this.skippedReason = reason;
+    }
+
+    /**
+     * Gets the reason why the plugin was skipped.
+     *
+     * @return the reason why the plugin was skipped, might be {@code null}
+     * @see #setSkippedReason(String)
+     * @see #isSkipped()
+     */
+    public String getSkippedReason() {
+        return skippedReason;
+    }
+
+    /**
+     * Starts the plugin stats.
+     */
+    void start() {
+        startTime = System.currentTimeMillis();
+    }
+
+    /**
+     * Gets the time when the plugin was started, in milliseconds.
+     *
+     * @return time when the plugin was started
+     * @see System#currentTimeMillis()
+     */
+    public long getStartTime() {
+        return startTime;
+    }
+
+    /**
+     * Gets the count of messages sent by the plugin.
+     *
+     * @return the count of messages sent
+     */
+    public int getMessageCount() {
+        return messageCount;
+    }
+
+    /**
+     * Increments the count of messages sent by the plugin.
+     * <p>
+     * Should be called when the plugin notifies that a message was sent.
+     */
+    void incMessageCount() {
+        messageCount++;
+    }
+
+    /**
+     * Gets the count of alerts raised by the plugin.
+     *
+     * @return the count of alerts raised.
+     */
+    public int getAlertCount() {
+        return alertCount;
+    }
+
+    /**
+     * Increments the count of alerts raised by the plugin.
+     * <p>
+     * Should be called when the plugin notifies that an alert was found.
+     */
+    void incAlertCount() {
+        alertCount++;
+    }
+
+    /**
+     * Gets the scan progress of the plugin.
+     *
+     * @return the scan progress
+     */
+    public int getProgress() {
+        return progress;
+    }
+
+    /**
+     * Increments the scan progress of the plugin.
+     * <p>
+     * Should be called after scanning a message.
+     */
+    void incProgress() {
+        this.progress++;
+    }
+
+    /**
+     * Sets the scan progress of the plugin.
+     *
+     * @param progress the progress to set
+     */
+    void setProgress(int progress) {
+        this.progress = progress;
+    }
+}

--- a/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
@@ -839,7 +839,8 @@ public class ActiveScanAPI extends ApiImplementor {
 					for (Plugin plugin : hp.getCompleted()) {
 						long timeTaken = plugin.getTimeFinished().getTime() - plugin.getTimeStarted().getTime();
 						int reqs = hp.getPluginRequestCount(plugin.getId());
-						hpList.addItem(createPluginProgressEntry(plugin, getStatus(hp, plugin, "Complete"), timeTaken, reqs));
+						int alertCount = hp.getPluginStats(plugin.getId()).getAlertCount();
+						hpList.addItem(createPluginProgressEntry(plugin, getStatus(hp, plugin, "Complete"), timeTaken, reqs, alertCount));
 			        }
 
 			        for (Plugin plugin : hp.getRunning()) {
@@ -851,11 +852,12 @@ public class ActiveScanAPI extends ApiImplementor {
 						}
 						long timeTaken = new Date().getTime() - plugin.getTimeStarted().getTime();
 						int reqs = hp.getPluginRequestCount(plugin.getId());
-						hpList.addItem(createPluginProgressEntry(plugin, pc + "%", timeTaken, reqs));
+						int alertCount = hp.getPluginStats(plugin.getId()).getAlertCount();
+						hpList.addItem(createPluginProgressEntry(plugin, pc + "%", timeTaken, reqs, alertCount));
 			        }
 
 			        for (Plugin plugin : hp.getPending()) {
-						hpList.addItem(createPluginProgressEntry(plugin, getStatus(hp, plugin, "Pending"), 0, 0));
+						hpList.addItem(createPluginProgressEntry(plugin, getStatus(hp, plugin, "Pending"), 0, 0, 0));
 			        }
 					resultList.addItem(hpList);
 
@@ -967,7 +969,7 @@ public class ActiveScanAPI extends ApiImplementor {
 		return result;
 	}
 
-	private static ApiResponseList createPluginProgressEntry(Plugin plugin, String status, long timeTaken, int requestCount) {
+	private static ApiResponseList createPluginProgressEntry(Plugin plugin, String status, long timeTaken, int requestCount, int alertCount) {
 		ApiResponseList pList = new ApiResponseList("Plugin");
 		pList.addItem(new ApiResponseElement("name", plugin.getName()));
 		pList.addItem(new ApiResponseElement("id", Integer.toString(plugin.getId())));
@@ -975,6 +977,7 @@ public class ActiveScanAPI extends ApiImplementor {
 		pList.addItem(new ApiResponseElement("status", status));
 		pList.addItem(new ApiResponseElement("timeInMs", Long.toString(timeTaken)));
 		pList.addItem(new ApiResponseElement("reqCount", Integer.toString(requestCount)));
+		pList.addItem(new ApiResponseElement("alertCount", Integer.toString(alertCount)));
 		return pList;
 	}
 


### PR DESCRIPTION
Change ActiveScanAPI to return the count of alerts raised by each
scanner.
Change HostProcess to expose the PluginStats (allow consumers to obtain
all the data, instead of adding more methods to HostProcess).
Move PluginStats to a top level class.