### PR TITLE
Issue 3727 SiteTree Sorting Should Exclude Method

### DIFF
--- a/src/org/parosproxy/paros/model/SiteMap.java
+++ b/src/org/parosproxy/paros/model/SiteMap.java
@@ -52,6 +52,7 @@
 // ZAP: 2016/07/07 Do not add the message to past history if it already belongs to the node
 // ZAP: 2017/01/23: Issue 1800: Alpha sort the site tree
 // ZAP: 2017/06/29: Issue 3714: Added newOnly option to addPath
+// ZAP: 2017/07/09: Issue 3727: Sorting of SiteMap should not include HTTP method (verb) in the node's name
 
 package org.parosproxy.paros.model;
 
@@ -878,8 +879,16 @@ class SortedTreeModel extends DefaultTreeModel {
 
 class SiteNodeStringComparator implements Comparator<SiteNode> {
 	public int compare(SiteNode sn1, SiteNode sn2) {
-		String s1 = sn1.getNodeName();
-		String s2 = sn2.getNodeName();
-		return s1.compareToIgnoreCase(s2);
+		String s1 = sn1.getName();
+		String s2 = sn2.getName();
+		int initialComparison = s1.compareToIgnoreCase(s2);
+
+		if (initialComparison == 0) {
+			s1 = sn1.getNodeName();
+			s2 = sn2.getNodeName();
+			
+			return s1.compareToIgnoreCase(s2);
+		}
+		return initialComparison;
 	}
 }

--- a/src/org/parosproxy/paros/model/SiteNode.java
+++ b/src/org/parosproxy/paros/model/SiteNode.java
@@ -50,6 +50,7 @@
 // ZAP: 2016/04/12 Notify of changes when an alert is updated
 // ZAP: 2016/08/30 Use a Set instead of a List for the alerts
 // ZAP: 2017/02/22 Issue 3224: Use TreeCellRenderers to prevent HTML injection issues
+// ZAP: 2017/07/09: Issue 3727: Add getName() function, returning the node name without HTTP method (verb)
 
 package org.parosproxy.paros.model;
 
@@ -230,6 +231,27 @@ public class SiteNode extends DefaultMutableTreeNode {
     public String getNodeName() {
     	return this.nodeName;
     }
+    
+	/**
+	 * Returns the node's name without the HTTP Method (verb) prefixing the string.
+	 * 
+	 * @return the name of the site node
+	 * @see #getNodeName()
+	 * @see #getCleanNodeName()
+	 * @see #getCleanNodeName(boolean)
+	 * @since TODO add version
+	 */
+	public String getName() {
+		String name = this.getNodeName();
+		if (this.isLeaf()) {
+			int colonIndex = name.indexOf(":");
+			if (colonIndex > 0) {
+				// Strip the GET/POST etc off
+				name = name.substring(colonIndex+1);
+			}
+		}
+		return name; 
+	}
 
     public String getCleanNodeName() {
     	return getCleanNodeName(true);


### PR DESCRIPTION
SiteMap - Tweak embedded class SiteNodeStringComparator compare function so that if the node names match (without the method being included), they are then sorted based on method.
SiteNode - Added a getName() method which returns the node's name without the method (verb) prefixing the return string.

Fixes zaproxy/zaproxy#3727

Before:
![before](https://user-images.githubusercontent.com/7570458/27994193-93e0ecf2-6486-11e7-97f4-5ea0c661ed28.png)

After:
![after](https://user-images.githubusercontent.com/7570458/27994192-93df37a4-6486-11e7-9dec-911eaaac80e7.png)

