### PR TITLE
docker: Check local zap python api client is up to date

### DIFF
--- a/build/docker/zap-api-scan.py
+++ b/build/docker/zap-api-scan.py
@@ -137,6 +137,8 @@ def main(argv):
     warn_inprog_count = 0
     fail_inprog_count = 0
 
+    check_zap_client_version()
+
     try:
         opts, args = getopt.getopt(argv, "t:f:c:u:g:m:n:r:w:x:l:daijp:sz:P:D:")
     except getopt.GetoptError as exc:

--- a/build/docker/zap-baseline.py
+++ b/build/docker/zap-baseline.py
@@ -48,17 +48,11 @@ import os
 import os.path
 import sys
 import time
-import zapv2
 from datetime import datetime
 from six.moves.urllib.request import urlopen
 from zapv2 import ZAPv2
 from zap_common import *
 
-try:
-    import pkg_resources
-except ImportError:
-    # don't hard fail since it's just used for the version check
-    logging.warning('Error importing pkg_resources. Is setuptools installed?')
 
 timeout = 120
 config_dict = {}
@@ -102,53 +96,6 @@ def usage():
     print ('    -z zap_options    ZAP command line options e.g. -z "-config aaa=bbb -config ccc=ddd"')
     print ('')
     print ('For more details see https://github.com/zaproxy/zaproxy/wiki/ZAP-Baseline-Scan')
-
-
-def get_latest_zap_client_version():
-    version_info = None
-
-    try:
-        version_info = urlopen('https://pypi.python.org/pypi/python-owasp-zap-v2.4/json')
-    except Exception, e:
-        logging.warning('Error fetching latest zap python API client version: %s' % e)
-        return None
-
-    if version_info is None:
-        logging.warning('Error fetching latest zap python API client version: %s' % e)
-        return None
-
-    version_json = json.loads(version_info.read())
-
-    if 'info' not in version_json:
-        logging.warning('No version found for latest zap python API client.')
-        return None
-    if 'version' not in version_json['info']:
-        logging.warning('No version found for latest zap python API client.')
-        return None
-
-    return version_json['info']['version']
-
-OLD_ZAP_CLIENT_WARNING = '''A newer version of python_owasp_zap_v2.4
- is available. Please run \'pip install -U python_owasp_zap_v2.4\' to update to
- the latest version.'''.replace('\n', '')
-
-def check_zap_client_version():
-    if 'pkg_resources' not in globals():  # import failed
-        logging.warning('Could not check zap python API client without pkg_resources.')
-        return
-
-    current_version = getattr(zapv2, '__version__', None)
-    latest_version = get_latest_zap_client_version()
-    parse_version = pkg_resources.parse_version
-    if current_version and latest_version and \
-       parse_version(current_version) < parse_version(latest_version):
-        logging.warning(OLD_ZAP_CLIENT_WARNING)
-    elif current_version is None:
-        # the latest versions >= 0.0.9 have a __version__
-        logging.warning(OLD_ZAP_CLIENT_WARNING)
-    # else:
-    # we're up to date or ahead / running a development build
-    # or latest_version is None and the user already got a warning
 
 
 def main(argv):

--- a/build/docker/zap-baseline.py
+++ b/build/docker/zap-baseline.py
@@ -48,11 +48,17 @@ import os
 import os.path
 import sys
 import time
-from six.moves.urllib.request import urlopen
-
+import zapv2
 from datetime import datetime
+from six.moves.urllib.request import urlopen
 from zapv2 import ZAPv2
 from zap_common import *
+
+try:
+    import pkg_resources
+except ImportError:
+    # don't hard fail since it's just used for the version check
+    logging.warning('Error importing pkg_resources. Is setuptools installed?')
 
 timeout = 120
 config_dict = {}
@@ -98,8 +104,54 @@ def usage():
     print ('For more details see https://github.com/zaproxy/zaproxy/wiki/ZAP-Baseline-Scan')
 
 
-def main(argv):
+def get_latest_zap_client_version():
+    version_info = None
 
+    try:
+        version_info = urlopen('https://pypi.python.org/pypi/python-owasp-zap-v2.4/json')
+    except Exception, e:
+        logging.warning('Error fetching latest zap python API client version: %s' % e)
+        return None
+
+    if version_info is None:
+        logging.warning('Error fetching latest zap python API client version: %s' % e)
+        return None
+
+    version_json = json.loads(version_info.read())
+
+    if 'info' not in version_json:
+        logging.warning('No version found for latest zap python API client.')
+        return None
+    if 'version' not in version_json['info']:
+        logging.warning('No version found for latest zap python API client.')
+        return None
+
+    return version_json['info']['version']
+
+OLD_ZAP_CLIENT_WARNING = '''A newer version of python_owasp_zap_v2.4
+ is available. Please run \'pip install -U python_owasp_zap_v2.4\' to update to
+ the latest version.'''.replace('\n', '')
+
+def check_zap_client_version():
+    if 'pkg_resources' not in globals():  # import failed
+        logging.warning('Could not check zap python API client without pkg_resources.')
+        return
+
+    current_version = getattr(zapv2, '__version__', None)
+    latest_version = get_latest_zap_client_version()
+    parse_version = pkg_resources.parse_version
+    if current_version and latest_version and \
+       parse_version(current_version) < parse_version(latest_version):
+        logging.warning(OLD_ZAP_CLIENT_WARNING)
+    elif current_version is None:
+        # the latest versions >= 0.0.9 have a __version__
+        logging.warning(OLD_ZAP_CLIENT_WARNING)
+    # else:
+    # we're up to date or ahead / running a development build
+    # or latest_version is None and the user already got a warning
+
+
+def main(argv):
     global min_level
     global in_progress_issues
     cid = ''
@@ -130,6 +182,8 @@ def main(argv):
     ignore_count = 0
     warn_inprog_count = 0
     fail_inprog_count = 0
+
+    check_zap_client_version()
 
     try:
         opts, args = getopt.getopt(argv, "t:c:u:g:m:n:r:w:x:l:daijp:sz:P:D:")

--- a/build/docker/zap-full-scan.py
+++ b/build/docker/zap-full-scan.py
@@ -133,6 +133,8 @@ def main(argv):
     warn_inprog_count = 0
     fail_inprog_count = 0
 
+    check_zap_client_version()
+
     try:
         opts, args = getopt.getopt(argv, "t:c:u:g:m:n:r:w:x:l:daijp:sz:P:D:")
     except getopt.GetoptError as exc:

--- a/build/docker/zap_common.py
+++ b/build/docker/zap_common.py
@@ -347,7 +347,7 @@ def get_latest_zap_client_version():
         logging.warning('Error fetching latest ZAP Python API client version: %s' % e)
         return None
 
-    version_json = json.loads(version_info.read())
+    version_json = json.loads(version_info.read().decode('utf-8'))
 
     if 'info' not in version_json:
         logging.warning('No version found for latest ZAP Python API client.')

--- a/build/docker/zap_common.py
+++ b/build/docker/zap_common.py
@@ -339,21 +339,21 @@ def get_latest_zap_client_version():
 
     try:
         version_info = urlopen('https://pypi.python.org/pypi/python-owasp-zap-v2.4/json')
-    except Exception, e:
-        logging.warning('Error fetching latest zap python API client version: %s' % e)
+    except Exception as e:
+        logging.warning('Error fetching latest ZAP Python API client version: %s' % e)
         return None
 
     if version_info is None:
-        logging.warning('Error fetching latest zap python API client version: %s' % e)
+        logging.warning('Error fetching latest ZAP Python API client version: %s' % e)
         return None
 
     version_json = json.loads(version_info.read())
 
     if 'info' not in version_json:
-        logging.warning('No version found for latest zap python API client.')
+        logging.warning('No version found for latest ZAP Python API client.')
         return None
     if 'version' not in version_json['info']:
-        logging.warning('No version found for latest zap python API client.')
+        logging.warning('No version found for latest ZAP Python API client.')
         return None
 
     return version_json['info']['version']
@@ -361,7 +361,7 @@ def get_latest_zap_client_version():
 
 def check_zap_client_version():
     if 'pkg_resources' not in globals():  # import failed
-        logging.warning('Could not check zap python API client without pkg_resources.')
+        logging.warning('Could not check ZAP Python API client without pkg_resources.')
         return
 
     current_version = getattr(zapv2, '__version__', None)


### PR DESCRIPTION
Fixes: #3356 

The baseline script should work offline, so these checks should suppress errors that exit. 

Note: this adds setuptools as a dependency but it's usually installed already.

Functional Tests:

- [x] without a local zap client: `ImportError` (it might be nice to make this a more helpful warning)

```
~/zaproxy - [3356-baseline-check-python-api-version●] » pip freeze | grep -i zap
~/zaproxy - [3356-baseline-check-python-api-version●] » python build/docker/zap-baseline.py
Traceback (most recent call last):
  File "build/docker/zap-baseline.py", line 51, in <module>
    import zapv2
ImportError: No module named zapv2
```

- [x] with outdated local zap client: update warning

```
~/zaproxy - [3356-baseline-check-python-api-version●] » pip freeze | grep -i zap
python-owasp-zap-v2.4==0.0.9
~/zaproxy - [3356-baseline-check-python-api-version●] » python build/docker/zap-baseline.py
2017-07-11 17:47:08,158 A newer version of python_owasp_zap_v2.4 is available. Please run 'pip install -U python_owasp_zap_v2.4' to update to the latest version.
...
```

- [x] with updated local zap client: no warning

```
~/zaproxy - [3356-baseline-check-python-api-version●] » pip freeze | grep -i zap
python-owasp-zap-v2.4==0.0.11
~/zaproxy - [3356-baseline-check-python-api-version●] » python build/docker/zap-baseline.py
Usage: zap-baseline.py -t <target> [options]
```

- [x] with develop/HEAD local zap client version: no warning

```
~/zaproxy - [3356-baseline-check-python-api-version●] » pip freeze | grep -i zap
python-owasp-zap-v2.4==0.0.12
~/zaproxy - [3356-baseline-check-python-api-version●] » python build/docker/zap-baseline.py
Usage: zap-baseline.py -t <target> [options]
    -t target         target URL including the protocol, eg https://www.example.com
```

- [x] when offline: error loading current version

```
~/zaproxy - [3356-baseline-check-python-api-version●] » python build/docker/zap-baseline.py
2017-07-11 17:52:29,129 Error fetching latest zap python API client version: <urlopen error [Errno 8] nodename nor servname provided, or not known>
Usage: zap-baseline.py -t <target> [options]
...
```