### PR TITLE
Issue 765 - Ctrl-F doesn't work in Resend

### DIFF
--- a/src/org/parosproxy/paros/view/FindDialog.java
+++ b/src/org/parosproxy/paros/view/FindDialog.java
@@ -22,6 +22,7 @@
 // ZAP: 2012/04/23 Added @Override annotation to all appropriate methods.
 // ZAP: 2012/05/03 Changed the method find to check if txtComp is null.
 // ZAP: 2014/01/30 Issue 996: Ensure all dialogs close when the escape key is pressed (copy tidy up)
+// ZAP: 2017/07/12 Issue 765: Add constructor with window parent, to facilitate ctrl-F in various HttpPanels
 
 package org.parosproxy.paros.view;
 
@@ -31,6 +32,7 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.HeadlessException;
 import java.awt.Toolkit;
+import java.awt.Window;
 
 import javax.swing.JButton;
 import javax.swing.JFrame;
@@ -77,6 +79,18 @@ public class FindDialog extends AbstractDialog {
     public FindDialog(Frame arg0, boolean arg1) throws HeadlessException {
         super(arg0, arg1);
         initialize();
+    }
+    
+    /**
+     * Constructs a FindDialog. 
+     * 
+     * @param parent the parent window of the FindDialog.
+     * @param modal whether or not this FindDialog should be modal
+     * @throws HeadlessException
+     */
+    public FindDialog(Window parent, boolean modal) throws HeadlessException {
+    	super(parent, modal);
+    	initialize();
     }
 
 	/**
@@ -125,8 +139,8 @@ public class FindDialog extends AbstractDialog {
 		    int length = findText.length();
 		    if (startPos > -1) {
 		        txtComp.select(startPos,startPos+length);
-		        txtComp.requestFocus();
-                txtFind.requestFocus();
+		        txtComp.requestFocusInWindow();
+                txtFind.requestFocusInWindow();
 		    } else {
 		        Toolkit.getDefaultToolkit().beep();
 		    }

--- a/src/org/zaproxy/zap/extension/httppanel/HttpPanel.java
+++ b/src/org/zaproxy/zap/extension/httppanel/HttpPanel.java
@@ -21,8 +21,11 @@ import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Component;
 import java.awt.FlowLayout;
+import java.awt.KeyboardFocusManager;
+import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -33,17 +36,24 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
+import javax.swing.AbstractAction;
+import javax.swing.Action;
 import javax.swing.BorderFactory;
+import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+import javax.swing.text.JTextComponent;
 
 import org.apache.commons.configuration.FileConfiguration;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
+import org.parosproxy.paros.view.FindDialog;
 import org.zaproxy.zap.extension.httppanel.component.HttpPanelComponentInterface;
 import org.zaproxy.zap.extension.httppanel.view.HttpPanelDefaultViewSelector;
 import org.zaproxy.zap.extension.httppanel.view.HttpPanelView;
@@ -66,6 +76,7 @@ public abstract class HttpPanel extends AbstractPanel implements Tab {
     private static final String DEFAULT_COMPONENT_KEY = "defaultcomponent";
 
     private static Comparator<HttpPanelComponentInterface> componentsComparator;
+    private static Action findAction;
     
     private JPanel panelHeader;
     private JPanel panelContent;
@@ -141,6 +152,8 @@ public abstract class HttpPanel extends AbstractPanel implements Tab {
         toolBarMoreOptions.setFloatable(false);
         toolBarMoreOptions.setBorder(BorderFactory.createEmptyBorder());
         toolBarMoreOptions.setRollover(true);
+        toolBarMoreOptions.getActionMap().put("findAction", getFindAction());
+        toolBarMoreOptions.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_F, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "findAction");
         
         endAllOptions = new JPanel();
         
@@ -185,6 +198,24 @@ public abstract class HttpPanel extends AbstractPanel implements Tab {
             panelHeader = new JPanel(new BorderLayout());
         }
         return panelHeader;
+    }
+    
+    private static Action getFindAction() {
+        if (findAction == null) {
+            findAction = new AbstractAction("findAction") {  
+                private static final long serialVersionUID = 8365172573382425660L;
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    Component focusOwner = KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner();
+                    if (focusOwner instanceof JTextComponent) {
+                        FindDialog findDialog = new FindDialog(SwingUtilities.getWindowAncestor(focusOwner), false);
+                        findDialog.setLastInvoker((JTextComponent) focusOwner);
+                        findDialog.setVisible(true);
+                    }
+                }
+            }; 
+        }
+        return findAction;
     }
     
     


### PR DESCRIPTION
Added a Find action to the HttpPanel toolbar (activated by Ctrl-F). 
FindDialog added a constructor that accepts a parent window.

Fixes zaproxy/zaproxy#765