### PR TITLE
Skip dependent scanners

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -342,6 +342,7 @@ ascan.progress.label.pending    = Pending
 ascan.progress.label.running    = Running
 ascan.progress.label.skipped    = Skipped
 ascan.progress.label.skippedWithReason = Skipped, {0}.
+ascan.progress.label.skipped.reason.dependency = dependency skipped
 ascan.progress.label.skipped.reason.user = by user action
 ascan.progress.label.skipped.reason.techs = scanner does not target selected technologies
 ascan.progress.label.skipped.reason.maxRule = exceeded max rule time


### PR DESCRIPTION
Change HostProcess to skip dependents (if needed) of the plugin being
skipped.

Fix #3748 - Automatically skip dependent scanners