### PR TITLE
Update minimum Java version in zap.sh script

### DIFF
--- a/src/zap.sh
+++ b/src/zap.sh
@@ -45,10 +45,10 @@ JAVA_VERSION=$(java -version 2>&1 | awk -F\" '/version/ { print $2 }')
 JAVA_MAJOR_VERSION=${JAVA_VERSION%%.*}
 JAVA_MINOR_VERSION=$(echo $JAVA_VERSION | awk -F\. '{ print $2 }')
 
-if [ $JAVA_MAJOR_VERSION -ge 1 ] && [ $JAVA_MINOR_VERSION -ge 7 ]; then
+if [ $JAVA_MAJOR_VERSION -ge 1 ] && [ $JAVA_MINOR_VERSION -ge 8 ]; then
   echo "Found Java version $JAVA_VERSION"
 else
-  echo "Exiting: ZAP requires a minimum of Java 7 to run, found $JAVA_VERSION"
+  echo "Exiting: ZAP requires a minimum of Java 8 to run, found $JAVA_VERSION"
   exit 1
 fi
 


### PR DESCRIPTION
Change zap.sh script to check that the minimum Java version is greater
than or equal to 8.

Part of #3470 - Move to using Java 8