### PR TITLE
Update version check in zap.sh script for Java 9

### DIFF
--- a/src/zap.sh
+++ b/src/zap.sh
@@ -42,10 +42,11 @@ if [ "`echo ${JAVA_OUTPUT} | grep "continuing with system-provided Java"`" ] ; t
 fi
 
 JAVA_VERSION=$(java -version 2>&1 | awk -F\" '/version/ { print $2 }')
-JAVA_MAJOR_VERSION=${JAVA_VERSION%%.*}
+JAVA_MAJOR_VERSION=${JAVA_VERSION%%[.|-]*}
 JAVA_MINOR_VERSION=$(echo $JAVA_VERSION | awk -F\. '{ print $2 }')
 
-if [ $JAVA_MAJOR_VERSION -ge 1 ] && [ $JAVA_MINOR_VERSION -ge 8 ]; then
+# JEP 223, newer Java versions (>= 9) no longer use 1 as major version
+if [ $JAVA_MAJOR_VERSION -ge 9 ] || ([ $JAVA_MAJOR_VERSION -ge 1 ] && [ $JAVA_MINOR_VERSION -ge 8 ]); then
   echo "Found Java version $JAVA_VERSION"
 else
   echo "Exiting: ZAP requires a minimum of Java 8 to run, found $JAVA_VERSION"


### PR DESCRIPTION
Change zap.sh script to also check that the major version (per JEP 223)
is greater than or equal to 9, also, drop early access suffixes from
the version when extracting the major version.

Related to #2602 - Java 9 (9-ea)