### PR TITLE
Prevent multiple find dialogs per parent

### DIFF
--- a/src/org/parosproxy/paros/extension/edit/ExtensionEdit.java
+++ b/src/org/parosproxy/paros/extension/edit/ExtensionEdit.java
@@ -26,6 +26,7 @@
 // ZAP: 2015/03/16 Issue 1525: Further database independence changes
 // ZAP: 2016/06/20 Removed unnecessary/unused constructor
 // ZAP: 2017/04/07 Added name constants and getUIName()
+// ZAP: 2017/07/22 Added KeyStroke constant for consistency with other FindDialog usage
 
 package org.parosproxy.paros.extension.edit;
 
@@ -45,8 +46,8 @@ import org.zaproxy.zap.view.ZapMenuItem;
 public class ExtensionEdit extends ExtensionAdaptor {
 	
 	private static final String NAME = "ExtensionEdit";
+	public static final KeyStroke FIND_DEFAULT_KEYSTROKE = KeyStroke.getKeyStroke(KeyEvent.VK_F, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false);
 
-    private FindDialog findDialog = null;
     private ZapMenuItem menuFind = null;
     private PopupFindMenu popupFindMenu = null;
 
@@ -73,10 +74,7 @@ public class ExtensionEdit extends ExtensionAdaptor {
 	}
     
     private void showFindDialog(JFrame frame, JTextComponent lastInvoker) {
-        if (findDialog == null || findDialog.getParent() != frame) {
-            findDialog = new FindDialog(frame, false);            
-        }
-        
+        FindDialog findDialog = FindDialog.getDialog(frame, false);            
         findDialog.setLastInvoker(lastInvoker);
         findDialog.setVisible(true);
     }
@@ -88,8 +86,7 @@ public class ExtensionEdit extends ExtensionAdaptor {
      */
     private ZapMenuItem getMenuFind() {
         if (menuFind == null) {
-            menuFind = new ZapMenuItem("menu.edit.find", 
-            		KeyStroke.getKeyStroke(KeyEvent.VK_F, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
+            menuFind = new ZapMenuItem("menu.edit.find", FIND_DEFAULT_KEYSTROKE);
 
             menuFind.addActionListener(new java.awt.event.ActionListener() {
                 @Override

--- a/src/org/parosproxy/paros/extension/edit/PopupFindMenu.java
+++ b/src/org/parosproxy/paros/extension/edit/PopupFindMenu.java
@@ -24,6 +24,7 @@
 // ZAP: 2012/10/23 Changed to prevent a NullPointerException when there's no
 // parent JFrame (changed to use SwingUtilities.getAncestorOfClass(...)).
 // ZAP: 2016/04/05 Issue 2458: Fix xlint warning messages 
+// ZAP: 2017/07/22 Leverage KeyStroke constant for consistency with other FindDialog usage
 
 package org.parosproxy.paros.extension.edit;
 
@@ -62,6 +63,7 @@ public class PopupFindMenu extends ExtensionPopupMenuItem {
 	 */
 	private void initialize() {
         this.setText(Constant.messages.getString("edit.find.popup"));	// ZAP: i18n
+        this.setAccelerator(ExtensionEdit.FIND_DEFAULT_KEYSTROKE);
 	}
 	
     @Override

--- a/src/org/parosproxy/paros/view/FindDialog.java
+++ b/src/org/parosproxy/paros/view/FindDialog.java
@@ -23,6 +23,7 @@
 // ZAP: 2012/05/03 Changed the method find to check if txtComp is null.
 // ZAP: 2014/01/30 Issue 996: Ensure all dialogs close when the escape key is pressed (copy tidy up)
 // ZAP: 2017/07/12 Issue 765: Add constructor with window parent, to facilitate ctrl-F in various HttpPanels
+// ZAP: 2017/07/17: Prevent opening multiple dialogs per parent.
 
 package org.parosproxy.paros.view;
 
@@ -33,6 +34,9 @@ import java.awt.GridBagLayout;
 import java.awt.HeadlessException;
 import java.awt.Toolkit;
 import java.awt.Window;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.Map;
 
 import javax.swing.JButton;
 import javax.swing.JFrame;
@@ -40,6 +44,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.text.JTextComponent;
 
+import org.apache.commons.collections.map.ReferenceMap;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractDialog;
 import org.parosproxy.paros.model.Model;
@@ -48,6 +53,9 @@ import org.zaproxy.zap.utils.ZapTextField;
 public class FindDialog extends AbstractDialog {
 
 	private static final long serialVersionUID = -3223449799557586758L;
+	
+	@SuppressWarnings("unchecked")
+	private static Map<Object, FindDialog> parentsMap = new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.HARD);
 
 	private JPanel jPanel = null;
 	private JButton btnFind = null;
@@ -65,7 +73,10 @@ public class FindDialog extends AbstractDialog {
 
     /**
      * @throws HeadlessException
+     * @deprecated TODO add version, use #FindDialog(Window, boolean) instead
+     * @see #getDialog(Window, boolean)
      */
+    @Deprecated
     public FindDialog() throws HeadlessException {
         super();
  		initialize();
@@ -75,7 +86,10 @@ public class FindDialog extends AbstractDialog {
      * @param arg0
      * @param arg1
      * @throws HeadlessException
+     * @deprecated TODO add version, use #FindDialog(Window, boolean) instead 
+     * @see #getDialog(Window, boolean)
      */
+    @Deprecated
     public FindDialog(Frame arg0, boolean arg1) throws HeadlessException {
         super(arg0, arg1);
         initialize();
@@ -87,6 +101,8 @@ public class FindDialog extends AbstractDialog {
      * @param parent the parent window of the FindDialog.
      * @param modal whether or not this FindDialog should be modal
      * @throws HeadlessException
+     * @see #getDialog(Window, boolean)
+     * @since TODO add version
      */
     public FindDialog(Window parent, boolean modal) throws HeadlessException {
     	super(parent, modal);
@@ -108,6 +124,42 @@ public class FindDialog extends AbstractDialog {
         txtFind.requestFocus();
         this.getRootPane().setDefaultButton(btnFind);
         pack();
+        this.setVisible(true);
+	}
+	
+	private static Map<Object, FindDialog> getParentsMap() {
+		return parentsMap;
+	}
+	
+	/**
+	 * Get the FindDialog for the parent if there is one or creates and returns a new one.
+	 * 
+	 * @param parent the parent Window (or Frame) for this FindDialog
+	 * @param modal a boolean indicating whether the FindDialog should ({@code true}), 
+	 * or shouldn't ({@code false}) be modal.
+	 * @return The existing FindDialog for the parent (if there is one), or a new FindDialog.
+	 * @since TODO add version
+	 */
+	public static FindDialog getDialog(Window parent, boolean modal) {
+		FindDialog activeDialog = getParentsMap().get(parent);
+		if (activeDialog != null) {
+			activeDialog.getTxtFind().requestFocus();
+			return activeDialog;
+		}
+		FindDialog newDialog = new FindDialog(parent, modal); 
+		getParentsMap().put(parent, newDialog);
+		newDialog.addWindowListener(new WindowAdapter() {
+			@Override
+			public void windowClosed(WindowEvent e) {
+				getParentsMap().remove(parent);
+			}
+		});
+		return newDialog;
+	}
+
+	private void discard() {
+		this.setVisible(false);
+		this.dispose();
 	}
 	
 	private void find() {
@@ -224,7 +276,8 @@ public class FindDialog extends AbstractDialog {
 				@Override
 				public void actionPerformed(java.awt.event.ActionEvent e) {
 
-				    FindDialog.this.setVisible(false);
+					FindDialog.this.discard();
+					FindDialog.this.dispatchEvent(new WindowEvent(FindDialog.this, WindowEvent.WINDOW_CLOSING));
 				}
 			});
 

--- a/src/org/zaproxy/zap/extension/httppanel/HttpPanel.java
+++ b/src/org/zaproxy/zap/extension/httppanel/HttpPanel.java
@@ -22,10 +22,8 @@ import java.awt.CardLayout;
 import java.awt.Component;
 import java.awt.FlowLayout;
 import java.awt.KeyboardFocusManager;
-import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.KeyEvent;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -45,7 +43,6 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
-import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import javax.swing.text.JTextComponent;
 
@@ -53,6 +50,7 @@ import org.apache.commons.configuration.FileConfiguration;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
+import org.parosproxy.paros.extension.edit.ExtensionEdit;
 import org.parosproxy.paros.view.FindDialog;
 import org.zaproxy.zap.extension.httppanel.component.HttpPanelComponentInterface;
 import org.zaproxy.zap.extension.httppanel.view.HttpPanelDefaultViewSelector;
@@ -153,7 +151,7 @@ public abstract class HttpPanel extends AbstractPanel implements Tab {
         toolBarMoreOptions.setBorder(BorderFactory.createEmptyBorder());
         toolBarMoreOptions.setRollover(true);
         toolBarMoreOptions.getActionMap().put("findAction", getFindAction());
-        toolBarMoreOptions.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_F, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "findAction");
+        toolBarMoreOptions.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(ExtensionEdit.FIND_DEFAULT_KEYSTROKE, "findAction");
         
         endAllOptions = new JPanel();
         
@@ -208,9 +206,8 @@ public abstract class HttpPanel extends AbstractPanel implements Tab {
                 public void actionPerformed(ActionEvent e) {
                     Component focusOwner = KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner();
                     if (focusOwner instanceof JTextComponent) {
-                        FindDialog findDialog = new FindDialog(SwingUtilities.getWindowAncestor(focusOwner), false);
+                        FindDialog findDialog = FindDialog.getDialog(SwingUtilities.getWindowAncestor(focusOwner), false);
                         findDialog.setLastInvoker((JTextComponent) focusOwner);
-                        findDialog.setVisible(true);
                     }
                 }
             }; 


### PR DESCRIPTION
FindDialog add functionality to track find dialogs & parents, only allowing one open per parent. Deprecate no params constructor (searching code base [incl. extensions] it does not seem used anyway). Set dialog
visible in initialize method.
HttpPanel remove setting visibility.
ExtensionEdit align handling of FindDialog, add FIND_DEFAULT_KEYSTROKE to be used in various locations.
PopupFindMenu updated to leverage new KeyStroke constant.