### PR TITLE
Restore log dump on all IOError in Docker scripts

### DIFF
--- a/build/docker/zap-api-scan.py
+++ b/build/docker/zap-api-scan.py
@@ -491,7 +491,7 @@ def main(argv):
         else:
             print("ERROR %s" % e)
             logging.warning('I/O error: ' + str(e))
-            dump_log_file(cid)
+        dump_log_file(cid)
 
     except:
         print("ERROR " + str(sys.exc_info()[0]))

--- a/build/docker/zap-baseline.py
+++ b/build/docker/zap-baseline.py
@@ -404,7 +404,7 @@ def main(argv):
         else:
             print("ERROR %s" % e)
             logging.warning('I/O error: ' + str(e))
-            dump_log_file(cid)
+        dump_log_file(cid)
 
     except:
         print("ERROR " + str(sys.exc_info()[0]))

--- a/build/docker/zap-full-scan.py
+++ b/build/docker/zap-full-scan.py
@@ -444,7 +444,7 @@ def main(argv):
         else:
             print("ERROR %s" % e)
             logging.warning('I/O error: ' + str(e))
-            dump_log_file(cid)
+        dump_log_file(cid)
 
     except:
         print("ERROR " + str(sys.exc_info()[0]))


### PR DESCRIPTION
Change Docker scripts zap-api-scan.py, zap-baseline.py, and
zap-full-scan.py to dump the log on all IOError caught (a previous
change inadvertently moved the statement to the else branch).