### PR TITLE
Clear dockerfiles 🐋

### DIFF
--- a/build/docker/Dockerfile-live
+++ b/build/docker/Dockerfile-live
@@ -1,6 +1,6 @@
 # This dockerfile builds a 'live' zap docker image using the latest files in the repos
 FROM ubuntu:16.04
-MAINTAINER Simon Bennetts "psiinon@gmail.com"
+LABEL maintainer="psiinon@gmail.com"
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
 	make \
@@ -15,8 +15,6 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	xmlstarlet \
 	unzip \
 	git \
-	x11vnc \
-	xvfb \
 	openbox \
 	xterm \
 	net-tools \
@@ -28,12 +26,10 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	x11vnc && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*  && \
-	
-	pip install --upgrade pip && \
+
 	gem install zapr && \
-	pip install zapcli && \
-	pip install python-owasp-zap-v2.4 && \
-	useradd -d /home/zap -m -s /bin/bash zap && \ 
+	pip install --upgrade pip zapcli python-owasp-zap-v2.4 && \
+	useradd -d /home/zap -m -s /bin/bash zap && \
 	echo zap:zap | chpasswd && \
 	mkdir /zap  && \
 	chown zap /zap && \
@@ -72,15 +68,14 @@ RUN git clone --depth 1 https://github.com/zaproxy/zaproxy.git && \
 	unzip webswing.zip && \
 	rm webswing.zip && \
 	touch AcceptedLicense
-	
+
 ENV ZAP_PATH /zap/zap.sh
 # Default port for use with zapcli
 ENV ZAP_PORT 8080
 ENV HOME /home/zap/
 
-COPY zap-*.* /zap/ 
-COPY zap_*.* /zap/ 
-COPY webswing.config /zap/webswing-2.3/ 
+COPY zap* /zap/
+COPY webswing.config /zap/webswing-2.3/
 COPY policies /home/zap/.ZAP_D/policies/
 COPY scripts /home/zap/.ZAP_D/scripts/
 COPY .xinitrc /home/zap/
@@ -97,8 +92,8 @@ RUN chown zap:zap /zap/zap-x.sh && \
 	chmod a+x /home/zap/.xinitrc && \
 	chmod +x /zap/zap.sh && \
 	rm -rf /zap-src
-	
+
 WORKDIR /zap
-	
+
 USER zap
 HEALTHCHECK --retries=5 --interval=5s CMD zap-cli status

--- a/build/docker/Dockerfile-stable
+++ b/build/docker/Dockerfile-stable
@@ -1,6 +1,6 @@
 # This dockerfile builds the zap stable release
 FROM ubuntu:16.04
-MAINTAINER Simon Bennetts "psiinon@gmail.com"
+LABEL maintainer="psiinon@gmail.com"
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
 	make \
@@ -14,8 +14,6 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	xmlstarlet \
 	unzip \
 	git \
-	x11vnc \
-	xvfb \
 	openbox \
 	xterm \
 	net-tools \
@@ -27,28 +25,22 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip
 RUN gem install zapr
-RUN pip install zapcli
-# Install latest dev version of the python API
-RUN pip install python-owasp-zap-v2.4
+RUN pip install --upgrade pip zapcli python-owasp-zap-v2.4
 
-RUN useradd -d /home/zap -m -s /bin/bash zap 
+RUN useradd -d /home/zap -m -s /bin/bash zap
 RUN echo zap:zap | chpasswd
-RUN mkdir /zap 
+RUN mkdir /zap && chown zap:zap /zap
+
 WORKDIR /zap
-RUN chown zap /zap && \
-	chgrp zap /zap
 
 #Change to the zap user so things get done as the right person (apart from copy)
 USER zap
 
 RUN mkdir /home/zap/.vnc
 
-
-
 # Download and expand the latest stable release 
-RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml | xmlstarlet sel -t -v //url |grep -i Linux | wget --content-disposition -i - -O - | tar zxv && \
+RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml | xmlstarlet sel -t -v //url |grep -i Linux | wget -nv --content-disposition -i - -O - | tar zxv && \
 	cp -R ZAP*/* . &&  \
 	rm -R ZAP* && \
 	curl -s -L https://bitbucket.org/meszarv/webswing/downloads/webswing-2.3-distribution.zip > webswing.zip && \
@@ -65,14 +57,10 @@ ENV ZAP_PATH /zap/zap.sh
 ENV ZAP_PORT 8080
 ENV HOME /home/zap/
 
-
-COPY zap-x.sh /zap/ 
-COPY zap-* /zap/ 
-COPY zap_* /zap/ 
-COPY webswing.config /zap/webswing-2.3/ 
+COPY zap* /zap/
+COPY webswing.config /zap/webswing-2.3/
 COPY policies /home/zap/.ZAP/policies/
 COPY .xinitrc /home/zap/
-
 
 #Copy doesn't respect USER directives so we need to chown and to do that we need to be root
 USER root
@@ -84,6 +72,8 @@ RUN chown zap:zap /zap/zap-x.sh && \
 	chown zap:zap -R /home/zap/.ZAP/ && \
 	chown zap:zap /home/zap/.xinitrc && \
 	chmod a+x /home/zap/.xinitrc
+
 #Change back to zap at the end
 USER zap
+
 HEALTHCHECK --retries=5 --interval=5s CMD zap-cli status

--- a/build/docker/Dockerfile-weekly
+++ b/build/docker/Dockerfile-weekly
@@ -1,6 +1,6 @@
 # This dockerfile builds the zap weekly release
 FROM ubuntu:16.04
-MAINTAINER Simon Bennetts "psiinon@gmail.com"
+LABEL maintainer="psiinon@gmail.com"
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
 	make \
@@ -14,8 +14,6 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	xmlstarlet \
 	unzip \
 	git \
-	x11vnc \
-	xvfb \
 	openbox \
 	xterm \
 	net-tools \
@@ -27,26 +25,20 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip
 RUN gem install zapr
-RUN pip install zapcli
-RUN pip install python-owasp-zap-v2.4
+RUN pip install --upgrade pip zapcli python-owasp-zap-v2.4
 
-RUN useradd -d /home/zap -m -s /bin/bash zap 
+RUN useradd -d /home/zap -m -s /bin/bash zap
 RUN echo zap:zap | chpasswd
-RUN mkdir /zap 
+RUN mkdir /zap && chown zap:zap /zap
+
 WORKDIR /zap
-RUN chown zap /zap && \
-	chgrp zap /zap
 
 #Change to the zap user so things get done as the right person (apart from copy)
 USER zap
 
 RUN mkdir /home/zap/.vnc
 
-
-
-# Download and expand the latest weekly release 
 RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml | xmlstarlet sel -t -v //url |grep -i weekly | wget --content-disposition -i - && \
 	unzip *.zip && \
 	rm *.zip && \
@@ -66,14 +58,10 @@ ENV ZAP_PATH /zap/zap.sh
 ENV ZAP_PORT 8080
 ENV HOME /home/zap/
 
-
-COPY zap-x.sh /zap/ 
-COPY zap-*.* /zap/ 
-COPY zap_*.* /zap/ 
-COPY webswing.config /zap/webswing-2.3/ 
+COPY zap* /zap/
+COPY webswing.config /zap/webswing-2.3/
 COPY policies /home/zap/.ZAP_D/policies/
 COPY .xinitrc /home/zap/
-
 
 #Copy doesn't respect USER directives so we need to chown and to do that we need to be root
 USER root
@@ -85,7 +73,8 @@ RUN chown zap:zap /zap/zap-x.sh && \
 	chown zap:zap -R /home/zap/.ZAP_D/ && \
 	chown zap:zap /home/zap/.xinitrc && \
 	chmod a+x /home/zap/.xinitrc
+
 #Change back to zap at the end
 USER zap
-HEALTHCHECK --retries=5 --interval=5s CMD zap-cli status
 
+HEALTHCHECK --retries=5 --interval=5s CMD zap-cli status

--- a/build/docker/zap-webswing.sh
+++ b/build/docker/zap-webswing.sh
@@ -1,42 +1,41 @@
 #!/bin/sh
 #
 # Startup script for the Webswing
-# 
+#
 # Customised for ZAP running in Docker - just call with no parameters for webswing to start and leave
 # the docker container running
 #
 # Set environment.
 export HOME=/zap/webswing-2.3/
 export OPTS="-h 0.0.0.0 -j $HOME/jetty.properties -u $HOME/user.properties -c $HOME/webswing.config"
-export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 export JAVA_OPTS="-Xmx128M"
 export LOG=$HOME/webswing.out
 export PID_PATH_NAME=$HOME/webswing.pid
 
-if [ -z `command -v $0` ]; then 
+if [ -z `command -v $0` ]; then
     CURRENTDIR=`pwd`
     cd `dirname $0` > /dev/null
     SCRIPTPATH=`pwd`/
     cd $CURRENTDIR
 else
-    SCRIPTPATH="" 
+    SCRIPTPATH=""
 fi
 
 if [ ! -f $HOME/webswing-server.war ]; then
-    echo "Webswing executable not found in $HOME folder" 
+    echo "Webswing executable not found in $HOME folder"
     exit 1
 fi
 
 if [ ! -f $JAVA_HOME/bin/java ]; then
-    echo "Java installation not found in $JAVA_HOME folder" 
+    echo "Java installation not found in $JAVA_HOME folder"
     exit 1
 fi
 if [ -z `command -v xvfb-run` ]; then
-    echo "Unable to locate xvfb-run command. Please install Xvfb before starting Webswing." 
+    echo "Unable to locate xvfb-run command. Please install Xvfb before starting Webswing."
     exit 1
 fi
 if [ ! -z `command -v ldconfig` ]; then
-    if [ `ldconfig -p | grep -i libXext | wc -l` -lt 1 ]; then 
+    if [ `ldconfig -p | grep -i libXext | wc -l` -lt 1 ]; then
         echo "Missing dependent library libXext."
         exit 1
     fi


### PR DESCRIPTION
List of changes : 
- Remove `MAINTAINER` because it's deprecated
- 2 dependencies were duplicated (`x11vnc` and `xvfb`)
- `pip install python-owasp-zap-v2.4` was already satisfied by `zapcli`
- add `-na` flag to `wget` for a better output
- remove `export JAVA_HOME` from script because it's already defined in Dockerfile
- remove whitespaces at end of lines