### PR TITLE
Correct add-on version used in warning messages

### DIFF
--- a/src/org/zaproxy/zap/control/AddOn.java
+++ b/src/org/zaproxy/zap/control/AddOn.java
@@ -476,6 +476,17 @@ public class AddOn  {
 		return version;
 	}
 
+	/**
+	 * Gets the semantic version declared in the manifest file.
+	 * <p>
+	 * To be replaced by {@link #getVersion()}.
+	 *
+	 * @return the semantic version declared in the manifest file, might be {@code null}.
+	 */
+	Version getSemVer() {
+		return semVer;
+	}
+
 	public Status getStatus() {
 		return status;
 	}

--- a/src/org/zaproxy/zap/control/AddOnRunIssuesUtils.java
+++ b/src/org/zaproxy/zap/control/AddOnRunIssuesUtils.java
@@ -213,7 +213,7 @@ public final class AddOnRunIssuesUtils {
                         Constant.messages.getString("cfu.warn.addon.with.missing.requirements.addon.version"),
                         addOn.getName(),
                         issueDetails.get(1),
-                        addOn.getVersion());
+                        addOn.getSemVer() != null ? addOn.getSemVer() : addOn.getVersion());
                 break;
             default:
                 message = Constant.messages.getString("cfu.warn.addon.with.missing.requirements.unknown");
@@ -349,7 +349,7 @@ public final class AddOnRunIssuesUtils {
                     "Add-on \"{0}\" with version matching {1} (found version {2})",
                     addOn.getName(),
                     issueDetails.get(1),
-                    addOn.getVersion());
+                    addOn.getSemVer() != null ? addOn.getSemVer() : addOn.getVersion());
         default:
             LOGGER.warn("Failed to handle dependency issue with name \"" + requirements.getDependencyIssue().name()
                     + "\" and details: " + issueDetails);


### PR DESCRIPTION
Change AddOnRunIssuesUtils to use the semantic version (if/when)
declared in the manifest file in the warning messages about mismatch
version of the dependencies, the add-ons are not yet using semantic
version as the main version (which would lead to wrong version being
shown).
Change AddOn to expose the semantic version declared in the manifest
file (just for use in warning messages).