### PR TITLE
Update add-on files on newer versions

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnInstaller.java
+++ b/src/org/zaproxy/zap/control/AddOnInstaller.java
@@ -353,6 +353,17 @@ public final class AddOnInstaller {
         installAddOnFiles(addOnClassLoader, addOn, false);
     }
 
+    /**
+     * Updates the files declared by the given {@code addOn}.
+     *
+     * @param addOnClassLoader the class loader of the given {@code addOn}.
+     * @param addOn the add-on that will have the declared files updated.
+     * @since TODO add version
+     */
+    public static void updateAddOnFiles(AddOnClassLoader addOnClassLoader, AddOn addOn) {
+        installAddOnFiles(addOnClassLoader, addOn, true);
+    }
+
     private static void installAddOnFiles(AddOnClassLoader addOnClassLoader, AddOn addOn, boolean overwrite) {
         List<String> fileNames = addOn.getFiles();
 

--- a/src/org/zaproxy/zap/control/AddOnLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnLoader.java
@@ -36,11 +36,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.ResourceBundle;
+import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.jar.JarEntry;
@@ -167,18 +169,22 @@ public class AddOnLoader extends URLClassLoader {
     private void loadAllAddOns() {
         runnableAddOns = new HashMap<>();
         idsAddOnsWithRunningIssuesSinceLastRun = new ArrayList<>();
-        Map<AddOn, List<String>> oldRunnableAddOns = loadAddOnsRunState(aoc);
+        Map<AddOn, AddOnRunState> oldRunnableAddOns = loadAddOnsRunState(aoc);
         List<AddOn> runAddons = new ArrayList<>();
+        Set<AddOn> updatedAddOns = new HashSet<>();
         for (Iterator<AddOn> iterator = aoc.getAddOns().iterator(); iterator.hasNext();) {
             AddOn addOn = iterator.next();
             if (canLoadAddOn(addOn)) {
                 AddOnRunRequirements reqs = calculateRunRequirements(addOn, aoc.getAddOns());
                 if (reqs.isRunnable()) {
+                    AddOnRunState runState = oldRunnableAddOns.get(addOn);
                     List<String> runnableExtensions;
                     if (addOn.hasExtensionsWithDeps()) {
                         runnableExtensions = getRunnableExtensionsWithDeps(reqs);
-                        List<String> oldRunnableExtensions = oldRunnableAddOns.get(addOn);
-                        if (oldRunnableExtensions != null && !oldRunnableExtensions.isEmpty()) {
+                        List<String> oldRunnableExtensions = runState != null
+                                ? runState.getExtensions()
+                                : Collections.emptyList();
+                        if (!oldRunnableExtensions.isEmpty()) {
                             oldRunnableExtensions.removeAll(runnableExtensions);
                             if (!oldRunnableExtensions.isEmpty()) {
                                 idsAddOnsWithRunningIssuesSinceLastRun.add(addOn.getId());
@@ -190,6 +196,9 @@ public class AddOnLoader extends URLClassLoader {
 
                     runnableAddOns.put(addOn, runnableExtensions);
                     runAddons.add(addOn);
+                    if (runState != null && runState.hasNewerVersion()) {
+                        updatedAddOns.add(addOn);
+                    }
                 } else if (oldRunnableAddOns.get(addOn) != null) {
                     idsAddOnsWithRunningIssuesSinceLastRun.add(addOn.getId());
                 }
@@ -202,7 +211,10 @@ public class AddOnLoader extends URLClassLoader {
 
         for (AddOn addOn : runAddons) {
             addOn.setInstallationStatus(AddOn.InstallationStatus.INSTALLED);
-            createAndAddAddOnClassLoader(addOn);
+            AddOnClassLoader addOnClassLoader = createAndAddAddOnClassLoader(addOn);
+            if (updatedAddOns.contains(addOn)) {
+                AddOnInstaller.updateAddOnFiles(addOnClassLoader, addOn);
+            }
         }
     }
 
@@ -1027,12 +1039,12 @@ public class AddOnLoader extends URLClassLoader {
         }
     }
 
-    private static Map<AddOn, List<String>> loadAddOnsRunState(AddOnCollection addOnCollection) {
+    private static Map<AddOn, AddOnRunState> loadAddOnsRunState(AddOnCollection addOnCollection) {
         List<HierarchicalConfiguration> savedAddOns = ((HierarchicalConfiguration) Model.getSingleton()
                 .getOptionsParam()
                 .getConfig()).configurationsAt(ADDONS_RUNNABLE_KEY);
 
-        Map<AddOn, List<String>> runnableAddOns = new HashMap<>();
+        Map<AddOn, AddOnRunState> runnableAddOns = new HashMap<>();
         for (HierarchicalConfiguration savedAddOn : savedAddOns) {
             AddOn addOn = addOnCollection.getAddOn(savedAddOn.getString(ADDON_RUNNABLE_ID_KEY, ""));
             if (addOn == null) {
@@ -1044,10 +1056,20 @@ public class AddOnLoader extends URLClassLoader {
                 // Try read the old version, which was an integer.
                 version = savedAddOn.getString(ADDON_RUNNABLE_VERSION_KEY, "");
             }
-            if (version.isEmpty() || !addOn.getVersion().equals(createLegacyVersion(version, addOn.getName()))) {
-                // No version or not the same version, skip it.
+            if (version.isEmpty()) {
+                // No version, skip it.
                 continue;
             }
+
+            int result = addOn.getVersion().compareTo(createLegacyVersion(version, addOn.getName()));
+            if (result != 0) {
+                if (result > 1) {
+                    runnableAddOns.put(addOn, new AddOnRunState());
+                }
+                // Different version, nothing more to do.
+                continue;
+            }
+
             List<String> runnableExtensions = new ArrayList<>();
             List<String> currentExtensions = addOn.getExtensionsWithDeps();
             for (String savedExtension : savedAddOn.getStringArray(ADDON_RUNNABLE_ALL_EXTENSIONS_KEY)) {
@@ -1055,7 +1077,7 @@ public class AddOnLoader extends URLClassLoader {
                     runnableExtensions.add(savedExtension);
                 }
             }
-            runnableAddOns.put(addOn, runnableExtensions);
+            runnableAddOns.put(addOn, new AddOnRunState(runnableExtensions));
         }
 
         return runnableAddOns;
@@ -1158,6 +1180,30 @@ public class AddOnLoader extends URLClassLoader {
 
         @Override
         public void addOnUninstalled(boolean uninstalled) {
+        }
+    }
+
+    private static class AddOnRunState {
+
+        private final boolean newerVersion;
+        private final List<String> extensions;
+
+        public AddOnRunState() {
+            this.newerVersion = true;
+            this.extensions = Collections.emptyList();
+        }
+
+        public AddOnRunState(List<String> extensions) {
+            this.newerVersion = false;
+            this.extensions = extensions;
+        }
+
+        public boolean hasNewerVersion() {
+            return newerVersion;
+        }
+
+        public List<String> getExtensions() {
+            return extensions;
         }
     }
 }


### PR DESCRIPTION
Change AddOnLoader to check and update the files of add-ons that have
been implicitly updated (e.g. newer version bundled in ZAP or manually
copied to plugin directory).
Change AddOnInstaller to allow to update the files of an add-on.

Fix #3771 - Add-on files not updated when running newer ZAP/core version