### PR TITLE
Hook ContextDataFactory and ContextPanelFactory

### DIFF
--- a/src/org/zaproxy/zap/extension/authentication/ExtensionAuthentication.java
+++ b/src/org/zaproxy/zap/extension/authentication/ExtensionAuthentication.java
@@ -37,7 +37,6 @@ import org.parosproxy.paros.db.RecordContext;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.zaproxy.zap.authentication.AuthenticationMethod;
 import org.zaproxy.zap.authentication.AuthenticationMethodType;
@@ -100,14 +99,14 @@ public class ExtensionAuthentication extends ExtensionAdaptor implements Context
 	public void hook(ExtensionHook extensionHook) {
 		super.hook(extensionHook);
 		// Register this as a context data factory
-		Model.getSingleton().addContextDataFactory(this);
+		extensionHook.addContextDataFactory(this);
 
 		if (getView() != null) {
 			extensionHook.getHookMenu().addPopupMenuItem(getPopupFlagLoggedInIndicatorMenu());
 			extensionHook.getHookMenu().addPopupMenuItem(getPopupFlagLoggedOutIndicatorMenu());
 
 			// Factory for generating Session Context UserAuth panels
-			getView().addContextPanelFactory(this);
+			extensionHook.getHookView().addContextPanelFactory(this);
 		}
 
 		// Load the Authentication and Session Management methods

--- a/src/org/zaproxy/zap/extension/authorization/ExtensionAuthorization.java
+++ b/src/org/zaproxy/zap/extension/authorization/ExtensionAuthorization.java
@@ -33,7 +33,6 @@ import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.db.RecordContext;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.ContextDataFactory;
@@ -82,11 +81,11 @@ public class ExtensionAuthorization extends ExtensionAdaptor implements ContextP
 		super.hook(extensionHook);
 
 		// Register this where needed
-		Model.getSingleton().addContextDataFactory(this);
+		extensionHook.addContextDataFactory(this);
 
 		if (getView() != null) {
 			// Factory for generating Session Context UserAuth panels
-			getView().addContextPanelFactory(this);
+			extensionHook.getHookView().addContextPanelFactory(this);
 		}
 
 		extensionHook.addApiImplementor(new AuthorizationAPI());

--- a/src/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
+++ b/src/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
@@ -122,11 +122,11 @@ public class ExtensionForcedUser extends ExtensionAdaptor implements ContextPane
 		super.hook(extensionHook);
 
 		// Register this where needed
-		Model.getSingleton().addContextDataFactory(this);
+		extensionHook.addContextDataFactory(this);
 
 		if (getView() != null) {
 			// Factory for generating Session Context UserAuth panels
-			getView().addContextPanelFactory(this);
+			extensionHook.getHookView().addContextPanelFactory(this);
 
 			View.getSingleton().addMainToolbarButton(getForcedUserModeToggleButton());
 		}

--- a/src/org/zaproxy/zap/extension/sessions/ExtensionSessionManagement.java
+++ b/src/org/zaproxy/zap/extension/sessions/ExtensionSessionManagement.java
@@ -34,7 +34,6 @@ import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.db.RecordContext;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.ContextDataFactory;
@@ -90,11 +89,11 @@ public class ExtensionSessionManagement extends ExtensionAdaptor implements Cont
 	public void hook(ExtensionHook extensionHook) {
 		super.hook(extensionHook);
 		// Register this as a context data factory
-		Model.getSingleton().addContextDataFactory(this);
+		extensionHook.addContextDataFactory(this);
 
 		if (getView() != null) {
 			// Factory for generating Session Context UserAuth panels
-			getView().addContextPanelFactory(this);
+			extensionHook.getHookView().addContextPanelFactory(this);
 		}
 
 		// Load the Session Management methods

--- a/src/org/zaproxy/zap/extension/users/ExtensionUserManagement.java
+++ b/src/org/zaproxy/zap/extension/users/ExtensionUserManagement.java
@@ -37,7 +37,6 @@ import org.parosproxy.paros.db.RecordContext;
 import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.zaproxy.zap.authentication.AuthenticationMethodType;
 import org.zaproxy.zap.control.ExtensionFactory;
@@ -146,11 +145,11 @@ public class ExtensionUserManagement extends ExtensionAdaptor implements Context
 	public void hook(ExtensionHook extensionHook) {
 		super.hook(extensionHook);
 		// Register this as a context data factory
-		Model.getSingleton().addContextDataFactory(this);
+		extensionHook.addContextDataFactory(this);
 
 		if (getView() != null) {
 			// Factory for generating Session Context Users panels
-			getView().addContextPanelFactory(this);
+			extensionHook.getHookView().addContextPanelFactory(this);
 		}
 
 		// Prepare API


### PR DESCRIPTION
Change authentication/authorisation related extensions to hook its
ContextDataFactory and ContextPanelFactory, instead of adding them
directly using core classes (less changes required when moved to
add-ons).