### PR TITLE
Fix unicode encoding errors when writing reports

### DIFF
--- a/build/docker/zap-api-scan.py
+++ b/build/docker/zap-api-scan.py
@@ -465,18 +465,15 @@ def main(argv):
 
             if report_html:
                 # Save the report
-                with open(base_dir + report_html, 'w') as f:
-                    f.write(zap.core.htmlreport())
+                write_report(base_dir + report_html, zap.core.htmlreport())
 
             if report_md:
                 # Save the report
-                with open(base_dir + report_md, 'w') as f:
-                    f.write(zap.core.mdreport())
+                write_report(base_dir + report_md, zap.core.mdreport())
 
             if report_xml:
                 # Save the report
-                with open(base_dir + report_xml, 'w') as f:
-                    f.write(zap.core.xmlreport())
+                write_report(base_dir + report_xml, zap.core.xmlreport())
 
             print('FAIL-NEW: ' + str(fail_count) + '\tFAIL-INPROG: ' + str(fail_inprog_count) +
                 '\tWARN-NEW: ' + str(warn_count) + '\tWARN-INPROG: ' + str(warn_inprog_count) +

--- a/build/docker/zap-baseline.py
+++ b/build/docker/zap-baseline.py
@@ -377,18 +377,15 @@ def main(argv):
 
             if report_html:
                 # Save the report
-                with open(base_dir + report_html, 'w') as f:
-                    f.write(zap.core.htmlreport())
+                write_report(base_dir + report_html, zap.core.htmlreport())
 
             if report_md:
                 # Save the report
-                with open(base_dir + report_md, 'w') as f:
-                    f.write(zap.core.mdreport())
+                write_report(base_dir + report_md, zap.core.mdreport())
 
             if report_xml:
                 # Save the report
-                with open(base_dir + report_xml, 'w') as f:
-                    f.write(zap.core.xmlreport())
+                write_report(base_dir + report_xml, zap.core.xmlreport())
 
             print('FAIL-NEW: ' + str(fail_count) + '\tFAIL-INPROG: ' + str(fail_inprog_count) +
                 '\tWARN-NEW: ' + str(warn_count) + '\tWARN-INPROG: ' + str(warn_inprog_count) +

--- a/build/docker/zap-full-scan.py
+++ b/build/docker/zap-full-scan.py
@@ -418,18 +418,15 @@ def main(argv):
 
             if report_html:
                 # Save the report
-                with open(base_dir + report_html, 'w') as f:
-                    f.write(zap.core.htmlreport())
+                write_report(base_dir + report_html, zap.core.htmlreport())
 
             if report_md:
                 # Save the report
-                with open(base_dir + report_md, 'w') as f:
-                    f.write(zap.core.mdreport())
+                write_report(base_dir + report_md, zap.core.mdreport())
 
             if report_xml:
                 # Save the report
-                with open(base_dir + report_xml, 'w') as f:
-                    f.write(zap.core.xmlreport())
+                write_report(base_dir + report_xml, zap.core.xmlreport())
 
             print('FAIL-NEW: ' + str(fail_count) + '\tFAIL-INPROG: ' + str(fail_inprog_count) +
                 '\tWARN-NEW: ' + str(warn_count) + '\tWARN-INPROG: ' + str(warn_inprog_count) +

--- a/build/docker/zap_common.py
+++ b/build/docker/zap_common.py
@@ -32,6 +32,7 @@ import errno
 import zapv2
 from random import randint
 from six.moves.urllib.request import urlopen
+from six import binary_type
 
 try:
     import pkg_resources
@@ -376,3 +377,11 @@ def check_zap_client_version():
     # else:
     # we're up to date or ahead / running a development build
     # or latest_version is None and the user already got a warning
+
+
+def write_report(file_path, report):
+    with open(file_path, mode='wb') as f:
+        if not isinstance(report, binary_type):
+            report = report.encode('utf-8')
+
+        f.write(report)


### PR DESCRIPTION
Fix unicode encoding errors when writing reports in a way that supports
both Python 2.7 and Python 3.5. The string in Python 2.7 is a byte string,
and the default system encoding is ascii, which is why it breaks with just
mode w as it tries to encode a utf-8 string as ascii. Changing the mode to
wb fixes this as then it doesn't try to encode it further when writing. But,
in Python 3, the string is unicode so needs to be encoded as bytes before
being written with mode b.

Fixes #3780

/cc @omerlh 