### PR TITLE
Hook extensions' main tool bar buttons

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -161,7 +161,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
             extensionHook.getHookView().addOptionPanel(getOptionsScannerPanel());
             extensionHook.getHookView().addOptionPanel(getOptionsVariantPanel());
 
-	        View.getSingleton().addMainToolbarButton(this.getPolicyButton());
+	        extensionHook.getHookView().addMainToolBarComponent(this.getPolicyButton());
 			View.getSingleton().getMainFrame().getMainFooterPanel().addFooterToolbarRightLabel(
 					attackModeScanner.getScanStatus().getCountLabel());
 

--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -536,8 +536,8 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 	        extensionHook.getHookMenu().addHelpMenuItem(getMenuItemCheckUpdate());
 	        extensionHook.getHookMenu().addFileMenuItem(getMenuItemLoadAddOn());
 	        
-			View.getSingleton().addMainToolbarButton(getAddonsButton());
-			View.getSingleton().addMainToolbarButton(getCheckForUpdatesButton());
+			extensionHook.getHookView().addMainToolBarComponent(getAddonsButton());
+			extensionHook.getHookView().addMainToolBarComponent(getCheckForUpdatesButton());
 
 			View.getSingleton().getMainFrame().getMainFooterPanel().addFooterToolbarRightLabel(getScanStatus().getCountLabel());
 	    }

--- a/src/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
+++ b/src/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
@@ -43,7 +43,6 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.users.ExtensionUserManagement;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.ContextDataFactory;
@@ -128,7 +127,7 @@ public class ExtensionForcedUser extends ExtensionAdaptor implements ContextPane
 			// Factory for generating Session Context UserAuth panels
 			extensionHook.getHookView().addContextPanelFactory(this);
 
-			View.getSingleton().addMainToolbarButton(getForcedUserModeToggleButton());
+			extensionHook.getHookView().addMainToolBarComponent(getForcedUserModeToggleButton());
 		}
 
 		// Register as Http Sender listener

--- a/src/org/zaproxy/zap/extension/help/ExtensionHelp.java
+++ b/src/org/zaproxy/zap/extension/help/ExtensionHelp.java
@@ -35,6 +35,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JRootPane;
+import javax.swing.JToolBar;
 import javax.swing.KeyStroke;
 import javax.swing.UIManager;
 
@@ -43,7 +44,6 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.ViewDelegate;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.extension.AddOnInstallationStatusListener;
@@ -122,8 +122,8 @@ public class ExtensionHelp extends ExtensionAdaptor {
 	    if (getView() != null) {	        
 	        extensionHook.getHookMenu().addHelpMenuItem(getMenuHelpZapUserGuide());
 
-	        View.getSingleton().addMainToolbarSeparator();
-	        View.getSingleton().addMainToolbarButton(this.getHelpButton());
+	        extensionHook.getHookView().addMainToolBarComponent(new JToolBar.Separator());
+	        extensionHook.getHookView().addMainToolBarComponent(this.getHelpButton());
 
             enableHelpKey(this.getView().getSiteTreePanel(), "ui.tabs.sites");
             enableHelpKey(this.getView().getRequestPanel(), "ui.tabs.request");


### PR DESCRIPTION
Change some of the extensions to hook its main tool bar buttons, instead
of adding them directly to the main tool bar.