### PR TITLE
Declare ExtensionDynSSL as supporting low mem

### DIFF
--- a/src/org/zaproxy/zap/extension/dynssl/ExtensionDynSSL.java
+++ b/src/org/zaproxy/zap/extension/dynssl/ExtensionDynSSL.java
@@ -153,6 +153,11 @@ public class ExtensionDynSSL extends ExtensionAdaptor {
     	return true;
     }
 	
+	@Override
+	public boolean supportsLowMemory() {
+		return true;
+	}
+
 	/**
 	 * Gets ZAPs current Root CA Certificate in X.509 format. 
 	 * Could return {@code null} if there is a problem getting the certificate.


### PR DESCRIPTION
Change ExtensionDynSSL to declare that it supports low mem option, it
only caches the SSL certs.

 ---

Per OWASP ZAP Developer Group thread: https://groups.google.com/d/topic/zaproxy-develop/Nq5VpK7-EO0/discussion