### PR TITLE
Make the .deb depend on java8-runtime not openjdk-7-jre

### DIFF
--- a/build/debian/control/control
+++ b/build/debian/control/control
@@ -5,6 +5,6 @@ Architecture: all
 Maintainer: Simon Bennetts <psiinon@gmail.com>
 Section: net
 Priority: extra
-Depends: openjdk-7-jre
+Depends: java8-runtime
 Homepage: https://github.com/zaproxy/zaproxy
 Description: OWASP Zed Attack Proxy -an easy to use tool for finding vulnerabilities in web applications.


### PR DESCRIPTION
This way, the sysadmin can decide which Java runtime to use.

The `java8-runtime` virtual package is provided by the OpenJDK packages, so this retains BC. This also allows sysadmins to attempt to run with newer versions of Java (because e.g. `openjdk-9-jre` still `Provides: java8-runtime`)