### PR TITLE
added bare docker image file

### DIFF
--- a/build/docker/Dockerfile-bare
+++ b/build/docker/Dockerfile-bare
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
     rm -rf /var/lib/apt/lists/*
 
 # Download and expand the latest stable release 
-RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions-dev.xml | xmlstarlet sel -t -v //url |grep -i Linux | wget --content-disposition -i - -O - | tar zxv && \
+RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml | xmlstarlet sel -t -v //url |grep -i Linux | wget --content-disposition -i - -O - | tar zxv && \
     cp -R ZAP*/* . &&  \
     rm -R ZAP* 
 

--- a/build/docker/Dockerfile-bare
+++ b/build/docker/Dockerfile-bare
@@ -1,24 +1,23 @@
 # This dockerfile builds the zap stable release
 FROM ubuntu:16.04 as builder
-MAINTAINER Simon Bennetts "psiinon@gmail.com"
 
 WORKDIR /zap
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
-	wget \
-	curl \
-	xmlstarlet \
-	unzip && \
-	apt-get clean && \
-	rm -rf /var/lib/apt/lists/*
+    wget \
+    curl \
+    xmlstarlet \
+    unzip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Download and expand the latest stable release 
 RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions-dev.xml | xmlstarlet sel -t -v //url |grep -i Linux | wget --content-disposition -i - -O - | tar zxv && \
-	cp -R ZAP*/* . &&  \
-	rm -R ZAP* 
+    cp -R ZAP*/* . &&  \
+    rm -R ZAP* 
 
 FROM java:openjdk-8-jdk-alpine
-MAINTAINER Simon Bennetts "psiinon@gmail.com"
+LABEL maintainer="psiinon@gmail.com"
 
 WORKDIR /zap
 COPY --from=builder /zap .
@@ -27,7 +26,7 @@ RUN echo "http://dl-3.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
     adduser -h /home/zap -s /bin/bash zap -D zap && \
     rm -rf /var/cache/apk/* && \
     chown zap /zap && \
-	chgrp zap /zap && \
+    chgrp zap /zap && \
     chown -R zap:zap /zap
 
 #Change to the zap user so things get done as the right person (apart from copy)

--- a/build/docker/Dockerfile-bare
+++ b/build/docker/Dockerfile-bare
@@ -1,0 +1,41 @@
+# This dockerfile builds the zap stable release
+FROM ubuntu:16.04 as builder
+MAINTAINER Simon Bennetts "psiinon@gmail.com"
+
+WORKDIR /zap
+
+RUN apt-get update && apt-get install -q -y --fix-missing \
+	wget \
+	curl \
+	xmlstarlet \
+	unzip && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
+
+# Download and expand the latest stable release 
+RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions-dev.xml | xmlstarlet sel -t -v //url |grep -i Linux | wget --content-disposition -i - -O - | tar zxv && \
+	cp -R ZAP*/* . &&  \
+	rm -R ZAP* 
+
+FROM java:openjdk-8-jdk-alpine
+MAINTAINER Simon Bennetts "psiinon@gmail.com"
+
+WORKDIR /zap
+COPY --from=builder /zap .
+RUN echo "http://dl-3.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories &&\
+    apk add --update --no-cache bash netcat-openbsd && \
+    adduser -h /home/zap -s /bin/bash zap -D zap && \
+    rm -rf /var/cache/apk/* && \
+    chown zap /zap && \
+	chgrp zap /zap && \
+    chown -R zap:zap /zap
+
+#Change to the zap user so things get done as the right person (apart from copy)
+USER zap
+
+ENV PATH $JAVA_HOME/bin:/zap/:$PATH
+ENV ZAP_PATH /zap/zap.sh
+ENV HOME /home/zap/
+ENV ZAP_PORT 8080
+
+HEALTHCHECK --retries=15 --interval=5s CMD nc -vz 127.0.0.1 $ZAP_PORT


### PR DESCRIPTION
Added a new docker file, that is a lot smaller (569 MB instead of 1.3 GB). I removed a lot of things and used Alpine instead of Ubuntu. The idea is to have a very small image for CI, with only the required stuff - at least for us, this is the minimum required to run Zap. As I think this could help others too, I create a PR. If you think otherwise - I can push this image to our repo :)