### PR TITLE
Address Toolkit initialisations in daemon mode

### DIFF
--- a/src/org/parosproxy/paros/extension/edit/ExtensionEdit.java
+++ b/src/org/parosproxy/paros/extension/edit/ExtensionEdit.java
@@ -27,6 +27,7 @@
 // ZAP: 2016/06/20 Removed unnecessary/unused constructor
 // ZAP: 2017/04/07 Added name constants and getUIName()
 // ZAP: 2017/07/22 Added KeyStroke constant for consistency with other FindDialog usage
+// ZAP: 2017/08/10 Issue 3798: java.awt.Toolkit initialised in daemon mode
 
 package org.parosproxy.paros.extension.edit;
 
@@ -46,7 +47,15 @@ import org.zaproxy.zap.view.ZapMenuItem;
 public class ExtensionEdit extends ExtensionAdaptor {
 	
 	private static final String NAME = "ExtensionEdit";
-	public static final KeyStroke FIND_DEFAULT_KEYSTROKE = KeyStroke.getKeyStroke(KeyEvent.VK_F, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false);
+
+	/**
+	 * The find default keyboard shortcut.
+	 * <p>
+	 * Lazily initialised.
+	 * 
+	 * @see #getFindDefaultKeyStroke()
+	 */
+	private static KeyStroke findDefaultKeyStroke;
 
     private ZapMenuItem menuFind = null;
     private PopupFindMenu popupFindMenu = null;
@@ -86,7 +95,7 @@ public class ExtensionEdit extends ExtensionAdaptor {
      */
     private ZapMenuItem getMenuFind() {
         if (menuFind == null) {
-            menuFind = new ZapMenuItem("menu.edit.find", FIND_DEFAULT_KEYSTROKE);
+            menuFind = new ZapMenuItem("menu.edit.find", getFindDefaultKeyStroke());
 
             menuFind.addActionListener(new java.awt.event.ActionListener() {
                 @Override
@@ -96,6 +105,22 @@ public class ExtensionEdit extends ExtensionAdaptor {
             });
         }
         return menuFind;
+    }
+
+    /**
+     * Gets the default keyboard shortcut for find functionality.
+     * <p>
+     * Should be called/used only when in view mode.
+     * 
+     * @return the keyboard shortcut, never {@code null}.
+     * @since TODO add version
+     */
+    public static KeyStroke getFindDefaultKeyStroke() {
+        if (findDefaultKeyStroke == null) {
+            findDefaultKeyStroke = KeyStroke
+                    .getKeyStroke(KeyEvent.VK_F, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false);
+        }
+        return findDefaultKeyStroke;
     }
 
     /**

--- a/src/org/parosproxy/paros/extension/edit/PopupFindMenu.java
+++ b/src/org/parosproxy/paros/extension/edit/PopupFindMenu.java
@@ -25,6 +25,7 @@
 // parent JFrame (changed to use SwingUtilities.getAncestorOfClass(...)).
 // ZAP: 2016/04/05 Issue 2458: Fix xlint warning messages 
 // ZAP: 2017/07/22 Leverage KeyStroke constant for consistency with other FindDialog usage
+// ZAP: 2017/08/10 Issue 3798: java.awt.Toolkit initialised in daemon mode
 
 package org.parosproxy.paros.extension.edit;
 
@@ -63,7 +64,7 @@ public class PopupFindMenu extends ExtensionPopupMenuItem {
 	 */
 	private void initialize() {
         this.setText(Constant.messages.getString("edit.find.popup"));	// ZAP: i18n
-        this.setAccelerator(ExtensionEdit.FIND_DEFAULT_KEYSTROKE);
+        this.setAccelerator(ExtensionEdit.getFindDefaultKeyStroke());
 	}
 	
     @Override

--- a/src/org/parosproxy/paros/extension/manualrequest/http/impl/ManualHttpRequestEditorDialog.java
+++ b/src/org/parosproxy/paros/extension/manualrequest/http/impl/ManualHttpRequestEditorDialog.java
@@ -23,6 +23,7 @@
 // ZAP: 2014/01/28 Issue 207: Support keyboard shortcuts 
 // ZAP: 2014/12/12 Issue 1449: Added help button
 // ZAP: 2015/08/07 Issue 1768: Update to use a more recent default user agent
+// ZAP: 2017/08/10 Issue 3798: java.awt.Toolkit initialised in daemon mode
 
 package org.parosproxy.paros.extension.manualrequest.http.impl;
 
@@ -174,7 +175,7 @@ public class ManualHttpRequestEditorDialog extends ManualRequestEditorDialog {
 			
 			if (helpKey != null) {
 				JButton helpButton = new JButton();
-				helpButton.setIcon(ExtensionHelp.HELP_ICON);
+				helpButton.setIcon(ExtensionHelp.getHelpIcon());
 				helpButton.setToolTipText(Constant.messages.getString("help.dialog.button.tooltip"));
 				helpButton.addActionListener(new java.awt.event.ActionListener() { 
 					@Override

--- a/src/org/zaproxy/zap/extension/help/ExtensionHelp.java
+++ b/src/org/zaproxy/zap/extension/help/ExtensionHelp.java
@@ -44,6 +44,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.ViewDelegate;
+import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.extension.AddOnInstallationStatusListener;
@@ -66,8 +67,20 @@ public class ExtensionHelp extends ExtensionAdaptor {
 	private static final String HELP_ID_PROPERTY = "HelpID";
 
 	private static final String HELP_SET_FILE_NAME = "helpset";
-	public static final ImageIcon HELP_ICON = DisplayUtils.getScaledIcon(
-			new ImageIcon(ExtensionHelp.class.getResource("/resource/icon/16/201.png")));
+	/**
+	 * @deprecated (TODO add version) Use {@link #getHelpIcon()} instead.
+	 */
+	@Deprecated
+	public static final ImageIcon HELP_ICON = View.isInitialised() ? getHelpIcon() : null;
+
+	/**
+	 * The help icon.
+	 * <p>
+	 * Lazily initialised.
+	 * 
+	 * @see #getHelpIcon()
+	 */
+	private static ImageIcon helpIcon;
 	
 	private static final String NAME = "ExtensionHelp";
 
@@ -380,6 +393,21 @@ public class ExtensionHelp extends ExtensionAdaptor {
                 setHelpEnabled(false);
             }
         }
+    }
+
+    /**
+     * Gets the help icon.
+     * <p>
+     * Should be called/used only when in view mode.
+     * 
+     * @return the help icon, never {@code null}.
+     * @since TODO add version
+     */
+    public static ImageIcon getHelpIcon() {
+        if (helpIcon == null) {
+            helpIcon = DisplayUtils.getScaledIcon(new ImageIcon(ExtensionHelp.class.getResource("/resource/icon/16/201.png")));
+        }
+        return helpIcon;
     }
 
 }

--- a/src/org/zaproxy/zap/extension/httppanel/HttpPanel.java
+++ b/src/org/zaproxy/zap/extension/httppanel/HttpPanel.java
@@ -151,7 +151,7 @@ public abstract class HttpPanel extends AbstractPanel implements Tab {
         toolBarMoreOptions.setBorder(BorderFactory.createEmptyBorder());
         toolBarMoreOptions.setRollover(true);
         toolBarMoreOptions.getActionMap().put("findAction", getFindAction());
-        toolBarMoreOptions.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(ExtensionEdit.FIND_DEFAULT_KEYSTROKE, "findAction");
+        toolBarMoreOptions.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(ExtensionEdit.getFindDefaultKeyStroke(), "findAction");
         
         endAllOptions = new JPanel();
         

--- a/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -43,7 +43,6 @@ import org.parosproxy.paros.extension.SessionChangedListener;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.control.CoreFunctionality;
 import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
@@ -54,8 +53,6 @@ import org.zaproxy.zap.extension.script.ScriptType;
 public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionChangedListener {
 
     public static final String NAME = "ExtensionPassiveScan";
-    private static final ImageIcon SCRIPT_ICON =
-            new ImageIcon(ZAP.class.getResource("/resource/icon/16/script-pscan.png"));
     public static final String SCRIPT_TYPE_PASSIVE = "passive";
     private static final Logger logger = Logger.getLogger(ExtensionPassiveScan.class);
     private PassiveScannerList scannerList;
@@ -113,11 +110,19 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
 
         ExtensionScript extScript = (ExtensionScript) Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.NAME);
         if (extScript != null) {
-            extScript.registerScriptType(new ScriptType(SCRIPT_TYPE_PASSIVE, "pscan.scripts.type.passive", SCRIPT_ICON, true));
+            extScript.registerScriptType(
+                    new ScriptType(SCRIPT_TYPE_PASSIVE, "pscan.scripts.type.passive", createScriptIcon(), true));
         }
 
 
         extensionHook.addApiImplementor(new PassiveScanAPI(this));
+    }
+
+    private ImageIcon createScriptIcon() {
+        if (getVersion() == null) {
+            return null;
+        }
+        return new ImageIcon(ExtensionPassiveScan.class.getResource("/resource/icon/16/script-pscan.png"));
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/src/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -69,14 +69,18 @@ import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.control.ExtensionFactory;
 
 public class ExtensionScript extends ExtensionAdaptor implements CommandLineListener {
 	
 	public static final int EXTENSION_ORDER = 60;
 	public static final String NAME = "ExtensionScript";
-	public static final ImageIcon ICON = new ImageIcon(ZAP.class.getResource("/resource/icon/16/059.png")); // Script icon
+
+	/**
+	 * @deprecated (TODO add version) Use {@link #getScriptIcon()} instead.
+	 */
+	@Deprecated
+	public static final ImageIcon ICON = View.isInitialised() ? getScriptIcon() : null;
 	
 	/**
 	 * The {@code Charset} used to load/save the scripts from/to the file.
@@ -90,6 +94,15 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 	 * @see #saveScript(ScriptWrapper)
 	 */
 	public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+
+	/**
+	 * The script icon.
+	 * <p>
+	 * Lazily initialised.
+	 * 
+	 * @see #getScriptIcon()
+	 */
+	private static ImageIcon scriptIcon;
 	
 	public static final String SCRIPTS_DIR = "scripts";
 	public static final String TEMPLATES_DIR = SCRIPTS_DIR + File.separator + "templates";
@@ -101,15 +114,6 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 	public static final String TYPE_PROXY = "proxy";
 	public static final String TYPE_STANDALONE = "standalone";
 	public static final String TYPE_TARGETED = "targeted";
-
-	private static final ImageIcon HTTP_SENDER_ICON = 
-			new ImageIcon(ZAP.class.getResource("/resource/icon/16/script-httpsender.png"));
-	private static final ImageIcon PROXY_ICON = 
-			new ImageIcon(ZAP.class.getResource("/resource/icon/16/script-proxy.png"));
-	private static final ImageIcon STANDALONE_ICON = 
-			new ImageIcon(ZAP.class.getResource("/resource/icon/16/script-standalone.png"));
-	private static final ImageIcon TARGETED_ICON = 
-			new ImageIcon(ZAP.class.getResource("/resource/icon/16/script-targeted.png"));
 	
 	private ScriptEngineManager mgr = new ScriptEngineManager();
 	private ScriptParam scriptParam = null;
@@ -164,11 +168,11 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 	public void hook(ExtensionHook extensionHook) {
 	    super.hook(extensionHook);
 
-		this.registerScriptType(new ScriptType(TYPE_PROXY, "script.type.proxy", PROXY_ICON, true));
-		this.registerScriptType(new ScriptType(TYPE_STANDALONE, "script.type.standalone", STANDALONE_ICON, false, 
+		this.registerScriptType(new ScriptType(TYPE_PROXY, "script.type.proxy", createIcon("/resource/icon/16/script-proxy.png"), true));
+		this.registerScriptType(new ScriptType(TYPE_STANDALONE, "script.type.standalone", createIcon("/resource/icon/16/script-standalone.png"), false,
 				new String[] {ScriptType.CAPABILITY_APPEND}));
-		this.registerScriptType(new ScriptType(TYPE_TARGETED, "script.type.targeted", TARGETED_ICON, false));
-		this.registerScriptType(new ScriptType(TYPE_HTTP_SENDER, "script.type.httpsender", HTTP_SENDER_ICON, true));
+		this.registerScriptType(new ScriptType(TYPE_TARGETED, "script.type.targeted", createIcon("/resource/icon/16/script-targeted.png"), false));
+		this.registerScriptType(new ScriptType(TYPE_HTTP_SENDER, "script.type.httpsender", createIcon("/resource/icon/16/script-targeted.png"), true));
 
 		extensionHook.addSessionListener(new ClearScriptVarsOnSessionChange());
 
@@ -187,6 +191,19 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 
 		extensionHook.addApiImplementor(new ScriptAPI(this));
 
+	}
+
+	/**
+	 * Creates an {@code ImageIcon} with the give resource path, if in view mode.
+	 *
+	 * @param resourcePath the resource path of the icon, must not be {@code null}.
+	 * @return the icon, or {@code null} if not in view mode.
+	 */
+	private ImageIcon createIcon(String resourcePath) {
+		if (getView() == null) {
+			return null;
+		}
+		return new ImageIcon(ExtensionScript.class.getResource(resourcePath));
 	}
 	
 	private OptionsScriptPanel getOptionsScriptPanel() {
@@ -1639,6 +1656,21 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 	public boolean supportsDb(String type) {
 		return true;
 	}
+
+    /**
+     * Gets the script icon.
+     * <p>
+     * Should be called/used only when in view mode.
+     * 
+     * @return the script icon, never {@code null}.
+     * @since TODO add version
+     */
+    public static ImageIcon getScriptIcon() {
+        if (scriptIcon == null) {
+            scriptIcon = new ImageIcon(ExtensionScript.class.getResource("/resource/icon/16/059.png"));
+        }
+        return scriptIcon;
+    }
 
 	private static class ClearScriptVarsOnSessionChange implements SessionChangedListener {
 

--- a/src/org/zaproxy/zap/extension/script/JavascriptEngineWrapper.java
+++ b/src/org/zaproxy/zap/extension/script/JavascriptEngineWrapper.java
@@ -24,12 +24,18 @@ import javax.script.ScriptEngine;
 import javax.swing.ImageIcon;
 
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
-import org.zaproxy.zap.ZAP;
+import org.parosproxy.paros.view.View;
 
 public class JavascriptEngineWrapper extends DefaultEngineWrapper {
 
-	private static final ImageIcon ICON = 
-			new ImageIcon(ZAP.class.getResource("/resource/icon/16/cup.png"));
+	/**
+	 * The icon of the engine.
+	 * <p>
+	 * Lazily initialised.
+	 * 
+	 * @see #getIcon()
+	 */
+	private static ImageIcon icon;
 
 	public JavascriptEngineWrapper(ScriptEngine engine) {
 		super(engine);
@@ -37,7 +43,20 @@ public class JavascriptEngineWrapper extends DefaultEngineWrapper {
 
 	@Override
 	public ImageIcon getIcon() {
-		return ICON;
+		if (!View.isInitialised()) {
+			return null;
+		}
+
+		if (icon == null) {
+			createIcon();
+		}
+		return icon;
+	}
+
+	private static synchronized void createIcon() {
+		if (icon == null) {
+			icon = new ImageIcon(JavascriptEngineWrapper.class.getResource("/resource/icon/16/cup.png"));
+		}
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/view/AbstractFormDialog.java
+++ b/src/org/zaproxy/zap/view/AbstractFormDialog.java
@@ -136,7 +136,7 @@ public abstract class AbstractFormDialog extends JDialog {
 	private JButton getHelpButton() {
 		if (helpButton == null) {
 			helpButton = new JButton();
-			helpButton.setIcon(ExtensionHelp.HELP_ICON);
+			helpButton.setIcon(ExtensionHelp.getHelpIcon());
 			helpButton.setToolTipText(Constant.messages.getString("help.dialog.button.tooltip"));
 			helpButton.setVisible(false);
 

--- a/src/org/zaproxy/zap/view/StandardFieldsDialog.java
+++ b/src/org/zaproxy/zap/view/StandardFieldsDialog.java
@@ -452,7 +452,7 @@ public abstract class StandardFieldsDialog extends AbstractDialog {
 	private JButton getHelpButton(final String helpIndex) {
 		if (helpButton == null) {
 			helpButton = new JButton();
-			helpButton.setIcon(ExtensionHelp.HELP_ICON);
+			helpButton.setIcon(ExtensionHelp.getHelpIcon());
 			helpButton.setToolTipText(Constant.messages.getString("help.dialog.button.tooltip"));
 
 			helpButton.addActionListener(new java.awt.event.ActionListener() { 


### PR DESCRIPTION
Change core extensions/classes to address Toolkit initialisations when
in daemon mode (e.g. caused by creation of icons or keyboard shortcuts).

Part of #3798 - java.awt.Toolkit initialised in daemon mode