### PR TITLE
Do not try to read plugin dir if it does not exist

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnCollection.java
+++ b/src/org/zaproxy/zap/control/AddOnCollection.java
@@ -161,10 +161,12 @@ public class AddOnCollection {
     		return;
     	}
     	if (! dir.exists()) {
-    		logger.error("No such directory: " + dir.getAbsolutePath());
+    		logger.warn("No such directory: " + dir.getAbsolutePath());
+    		return;
     	}
     	if (! dir.isDirectory()) {
-    		logger.error("Not a directory: " + dir.getAbsolutePath());
+    		logger.warn("Not a directory: " + dir.getAbsolutePath());
+    		return;
     	}
 
     	// Load the addons


### PR DESCRIPTION
Change AddOnCollection to return if the provided plugin directory does
not exist or if it's not a directory, instead of continuing and try to
read it (leading to an exception). Also, change the log level to WARN,
it's not a ZAP error/issue if it does not exist or it's not a directory.