### PR TITLE
Issue 3818 - Rename resend

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1253,7 +1253,7 @@ history.panel.mnemonic		           = h
 history.panel.title                    = History
 history.purge.popup                    = Delete
 history.purge.warning                  = Are you sure you want to delete the record(s)?
-history.resend.popup                   = Resend...
+history.resend.popup                   = Open/Resend with Request Editor...
 history.scan.warning                   = Error getting History.
 history.scope.button.selected          = Show all URLs
 history.scope.button.unselected        = Show only URLs in Scope
@@ -1429,7 +1429,8 @@ manReq.checkBox.followRedirect = Follow redirect
 manReq.checkBox.useSession     = Use current tracking session
 manReq.dialog.title            = Manual Request Editor
 manReq.pullDown.method         = Method
-manReq.resend.popup            = Resend
+# TODO remove manReq.resend.popup once websockets addon is no longer using it
+manReq.resend.popup            = Manual Request Editor
 manReq.tab.request             = Request
 manReq.tab.response            = Response
 manReq.display.tabs            = Separate tabs for Request and Response
@@ -2022,7 +2023,7 @@ sites.panel.mnemonic	   = s
 sites.panel.title          = Sites
 sites.purge.popup          = Delete
 sites.purge.warning        = Are you sure you want to delete the node(s)?
-sites.resend.popup         = Resend...
+sites.resend.popup         = Open/Resend with Request Editor...
 sites.spider.popup         = Spider...
 sites.showinsites.popup    = Show in Sites Tab
 

--- a/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -538,7 +538,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
 	public ManualRequestEditorDialog getResendDialog() {
 		if (resendDialog == null) {
 			resendDialog = new ManualHttpRequestEditorDialog(true, "resend", "ui.dialogs.resend");
-			resendDialog.setTitle(Constant.messages.getString("manReq.resend.popup"));	// ZAP: i18n
+			resendDialog.setTitle(Constant.messages.getString("manReq.dialog.title"));	// ZAP: i18n
 		}
 		return resendDialog;
 	}


### PR DESCRIPTION
Rename context entries from "Resend..." to "Open/Resend with Request Editor..."

I chose "Request Editor" vs "Manual Editor" as mentioned in the ticket as I didn't think that 'Manual Editor' was specific enough for inexperienced/newer users.

Also standardize on the dialog title.
`manReq.resend.popup` resource key can't be removed because the websocket addon depends on it.

Fixes zaproxy/zaproxy#3818