### PR TITLE
Restore passive scan script icon

### DIFF
--- a/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -119,7 +119,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
     }
 
     private ImageIcon createScriptIcon() {
-        if (getVersion() == null) {
+        if (getView() == null) {
             return null;
         }
         return new ImageIcon(ExtensionPassiveScan.class.getResource("/resource/icon/16/script-pscan.png"));


### PR DESCRIPTION
Change ExtensionPassiveScan to call the correct method, getView() not
getVersion(), when checking if the icon should be created.