### PR TITLE
Add anoncsrf as anticsrf token name

### DIFF
--- a/src/org/zaproxy/zap/extension/anticsrf/AntiCsrfParam.java
+++ b/src/org/zaproxy/zap/extension/anticsrf/AntiCsrfParam.java
@@ -43,7 +43,7 @@ public class AntiCsrfParam extends AbstractParam {
     private static final String CONFIRM_REMOVE_TOKEN_KEY = ANTI_CSRF_BASE_KEY + ".confirmRemoveToken";
     
     private static final String[] DEFAULT_TOKENS_NAMES = { "anticsrf",
-            "CSRFToken", "__RequestVerificationToken", "csrfmiddlewaretoken", "authenticity_token", "OWASP_CSRFTOKEN" };
+            "CSRFToken", "__RequestVerificationToken", "csrfmiddlewaretoken", "authenticity_token", "OWASP_CSRFTOKEN", "anoncsrf" };
 
     private List<AntiCsrfParamToken> tokens = null;
     private List<String> enabledTokensNames = null;

--- a/src/xml/config.xml
+++ b/src/xml/config.xml
@@ -222,6 +222,11 @@
 				<enabled>true</enabled>
 				<name>authenticity_token</name>
 			</token>
+			<token>
+			        <!-- django-session-csrf default: https://github.com/mozilla/django-session-csrf#differences-from-django -->
+				<enabled>true</enabled>
+				<name>anoncsrf</name>
+			</token>
 		</tokens>
 	</anticsrf>
 


### PR DESCRIPTION
used by django-session-csrf: https://github.com/mozilla/django-session-csrf#differences-from-django