### PR TITLE
Reduce HTTP Sessions log level on token changes

### DIFF
--- a/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
@@ -369,7 +369,11 @@ public class ExtensionHttpSessions extends ExtensionAdaptor implements SessionCh
 			siteTokens = new HttpSessionTokensSet();
 			sessionTokens.put(site, siteTokens);
 		}
-		log.info("Added new session token for site '" + site + "': " + token);
+
+		if (log.isDebugEnabled()) {
+			log.debug("Added new session token for site '" + site + "': " + token);
+		}
+
 		siteTokens.addToken(token);
 		// If the session token is a default token and was previously marked as remove, undo that
 		unmarkRemovedDefaultSessionToken(site, token);
@@ -410,7 +414,10 @@ public class ExtensionHttpSessions extends ExtensionAdaptor implements SessionCh
 		// be detected again and added as a session token
 		if (isDefaultSessionToken(token))
 			markRemovedDefaultSessionToken(site, token);
-		log.info("Removed session token for site '" + site + "': " + token);
+
+		if (log.isDebugEnabled()) {
+			log.debug("Removed session token for site '" + site + "': " + token);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Change ExtensionHttpSessions to log the tokens added/removed to a site
with DEBUG level, those are not outstanding events that require the use
of INFO level.