### PR TITLE
Spider New Scan UI Consistency

### DIFF
--- a/src/org/zaproxy/zap/extension/spider/SpiderDialog.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderDialog.java
@@ -114,6 +114,7 @@ public class SpiderDialog extends StandardFieldsDialog {
         this.addTargetSelectField(0, FIELD_START, this.target, true, false);
         this.addComboField(0, FIELD_CONTEXT, new String[] {}, "");
         this.addComboField(0, FIELD_USER, new String[] {}, "");
+        setUsers();
         this.addCheckBoxField(0, FIELD_RECURSE, true);
         this.addCheckBoxField(0, FIELD_SUBTREE_ONLY, subtreeOnlyPreviousCheckedState);
         // This option is always read from the 'global' options
@@ -423,5 +424,11 @@ public class SpiderDialog extends StandardFieldsDialog {
     void reset() {
         target = null;
         reset(true);
+    }
+
+    @Override
+    public void cancelPressed() {
+        this.target=null;
+        super.cancelPressed();
     }
 }

--- a/src/org/zaproxy/zap/extension/spider/SpiderPanel.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderPanel.java
@@ -49,6 +49,7 @@ import org.jdesktop.swingx.renderer.IconValues;
 import org.jdesktop.swingx.renderer.MappedValue;
 import org.jdesktop.swingx.renderer.StringValues;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.model.ScanController;
 import org.zaproxy.zap.model.ScanListenner2;
@@ -495,7 +496,7 @@ public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderSca
 			scanButton.addActionListener(new ActionListener () {
 				@Override
 				public void actionPerformed(ActionEvent e) {
-					extension.showSpiderDialog(null);
+					extension.showSpiderDialog(getSiteTreeTarget());
 				}
 			});
 		}
@@ -540,5 +541,13 @@ public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderSca
 		protected boolean isHighlighted(final Object cellItem) {
 			return true;
 		}
+	}
+	
+	private SiteNode getSiteTreeTarget() {
+		if (!extension.getView().getSiteTreePanel().getTreeSite().isSelectionEmpty()) {
+			return (SiteNode) extension.getView().getSiteTreePanel().getTreeSite().getSelectionPath()
+					.getLastPathComponent();
+		}
+		return null;
 	}
 }


### PR DESCRIPTION
Minor changes to SpiderDialog so that when the "New Scan" button is clicked the target (and associated context(s)/user(s)) combo fields are populated based on site tree selection (if any) instead of blank.
Cancelling the dialog now resets the target to nothing.