### PR TITLE
Add IPv6 loopback to default API allowed addresses

### DIFF
--- a/src/org/zaproxy/zap/extension/api/OptionsParamApi.java
+++ b/src/org/zaproxy/zap/extension/api/OptionsParamApi.java
@@ -54,6 +54,8 @@ public class OptionsParamApi extends AbstractParam {
     
     private static final int DEFAULT_NONCE_TTL_IN_SECS = 5 * 60; // 5 mins
 
+    private static final String IPV6_LOOPBACK_ADDRS = "0:0:0:0:0:0:0:1";
+
 	private boolean enabled = true;
 	private boolean uiEnabled = true;
 	private boolean secureOnly;
@@ -371,7 +373,11 @@ public class OptionsParamApi extends AbstractParam {
             permittedAddresses.add(addr);
             addrsEnabled.add(addr);
 
-            addr = new DomainMatcher("zap");
+            addr = new DomainMatcher(API.API_DOMAIN);
+            permittedAddresses.add(addr);
+            addrsEnabled.add(addr);
+
+            addr = new DomainMatcher(IPV6_LOOPBACK_ADDRS);
             permittedAddresses.add(addr);
             addrsEnabled.add(addr);
         }


### PR DESCRIPTION
Change OptionsParamApi to include the IPv6 loopback address when adding
the default addresses that can access the API. Also, replace literal
"zap" address with the constant.

Fix #3836 - Allow IPv6 loopback address to access the API by default