### PR TITLE
Use selected font in Request/Response panels

### DIFF
--- a/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/HttpPanelSyntaxHighlightTextArea.java
+++ b/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/HttpPanelSyntaxHighlightTextArea.java
@@ -19,6 +19,7 @@ package org.zaproxy.zap.extension.httppanel.view.syntaxhighlight;
 
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Font;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Observable;
@@ -124,8 +125,14 @@ public abstract class HttpPanelSyntaxHighlightTextArea extends RSyntaxTextArea i
 		setCloseMarkupTags(false);
 		setClearWhitespaceLinesEnabled(false);
 		
-		// Correct the font size
-		this.setFont(FontUtils.getFont(this.getFont().getFontName()));
+		Font font;
+		if (!FontUtils.isDefaultFontSet()) {
+			// Use default RSyntaxTextArea font instead but with correct font size.
+			font = FontUtils.getFont(this.getFont().getFontName());
+		} else {
+			font = FontUtils.getFont(Font.PLAIN);
+		}
+		this.setFont(font);
 		
 		initHighlighter();
 	}

--- a/src/org/zaproxy/zap/utils/FontUtils.java
+++ b/src/org/zaproxy/zap/utils/FontUtils.java
@@ -29,6 +29,7 @@ public class FontUtils {
 	public static enum Size {smallest, much_smaller, smaller, standard, larger, much_larger, huge};	
 	private static float scale = -1;
 	private static Font defaultFont;
+	private static boolean defaultFontSet;
 	private static Font systemDefaultFont;
 	
 	public static Font getSystemDefaultFont() {
@@ -65,6 +66,7 @@ public class FontUtils {
 			size = getDefaultFont().getSize();
 		}
 
+		defaultFontSet = name != null && !name.isEmpty();
 		setDefaultFont(new Font(name, Font.PLAIN, size));
 	}
 
@@ -117,5 +119,18 @@ public class FontUtils {
 			scale = getDefaultFont().getSize2D() / getSystemDefaultFont().getSize2D(); 
 		}
 		return scale;
+	}
+
+	/**
+	 * Tells whether or not a custom default font was set.
+	 * <p>
+	 * If no custom font was set it's used the system default font.
+	 *
+	 * @return {@code true} if a custom font was set, {@code false} otherwise.
+	 * @since TODO Add version
+	 * @see #getSystemDefaultFont()
+	 */
+	public static boolean isDefaultFontSet() {
+		return defaultFontSet;
 	}
 }


### PR DESCRIPTION
Change HttpPanelSyntaxHighlightTextArea to use the font selected in the
options or use default font of the component (e.g. monospaced).
Change FontUtils to allow to check if a custom font was set.

Fix #3490 - Poor font rendering on linux