### PR TITLE
Fix NPE when saving manual authentication data

### DIFF
--- a/src/org/zaproxy/zap/authentication/ManualAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/ManualAuthenticationMethodType.java
@@ -200,6 +200,9 @@ public class ManualAuthenticationMethodType extends AuthenticationMethodType {
 
 		@Override
 		public String encode(String parentStringSeparator) {
+			if (selectedSession == null) {
+				return "";
+			}
 			return Base64.encodeBase64String(selectedSession.getName().getBytes());
 		}
 


### PR DESCRIPTION
Change ManualAuthenticationMethodType to skip session's encoding if
none was set, preventing the NullPointerException.

Fix #3854 - Error whilst using Api - ERROR ExtensionUserManagement -
Unable to persist Users