### PR TITLE
Prevent NPE on script's content change

### DIFF
--- a/src/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/src/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -1372,13 +1372,15 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 	public void setChanged(ScriptWrapper script, boolean changed) {
 		script.setChanged(changed);
 		ScriptNode node = this.getTreeModel().getNodeForScript(script);
-		if (node.getNodeName().equals(script.getName())) {
-			// The name is the same
-			this.getTreeModel().nodeStructureChanged(script);
-		} else {
-			// The name has changed
-			node.setNodeName(script.getName());
-			this.getTreeModel().nodeStructureChanged(node.getParent());
+		if (node != null) {
+			if (node.getNodeName().equals(script.getName())) {
+				// The name is the same
+				this.getTreeModel().nodeStructureChanged(script);
+			} else {
+				// The name has changed
+				node.setNodeName(script.getName());
+				this.getTreeModel().nodeStructureChanged(node.getParent());
+			}
 		}
 		
 		notifyScriptChanged(script);


### PR DESCRIPTION
Change ExtensionScript to check that the ScriptNode for the given script
exists before changing it, the ScriptNode might not be found if the
script (ScriptWrapper) was replaced with a custom implementation (e.g.
Zest, Ruby).