### PR TITLE
Support persistent connections in the API

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -84,6 +84,7 @@ api.error.bad_format        = Bad Format
 api.error.bad_type          = Bad Type
 api.error.bad_view          = Bad View
 api.error.bad_other         = Bad Other
+api.error.bad_pconn         = Bad Persistent Connection
 api.error.disabled          = Disabled
 api.error.does_not_exist    = Does Not Exist
 api.error.href_not_found    = Message Not Found
@@ -110,6 +111,8 @@ api.html.format             = Output format
 api.html.formMethod         = Form method
 api.html.other              = Other: 
 api.html.others             = Others
+api.html.pconn              = Persistent Connection: 
+api.html.pconns             = Persistent Connections
 api.html.shortcuts			= Shortcuts
 api.html.title              = ZAP API UI
 api.html.view               = View:
@@ -507,7 +510,10 @@ break.api.view.httpMessage = Returns the HTTP message currently intercepted (if 
 break.api.view.isBreakAll = Returns True if ZAP will break on both requests and responses
 break.api.view.isBreakRequest = Returns True if ZAP will break on requests
 break.api.view.isBreakResponse = Returns True if ZAP will break on responses
-
+break.api.pconn.waitForHttpBreak = Waits until an HTTP breakpoint has been hit, at which point it returns the message. \
+Poll is the number of milliseconds ZAP will pause between checking for breakpoints being hit (default 500). \
+If keepalive is zero or less then the response will be returned as a Server Sent Event, otherwise it is used as the frequency in seconds at which \
+'keepalive' events should be returned and the response is sent as a standard response.
 brk.add.button.add                = Add
 brk.add.button.cancel             = Cancel
 brk.add.error.history             = Error getting History

--- a/src/org/zaproxy/zap/extension/api/ApiException.java
+++ b/src/org/zaproxy/zap/extension/api/ApiException.java
@@ -51,7 +51,7 @@ public class ApiException extends Exception {
 		 * 
 		 * @see API.RequestType
 		 */
-		BAD_TYPE, NO_IMPLEMENTOR, BAD_ACTION, BAD_VIEW, BAD_OTHER, INTERNAL_ERROR, MISSING_PARAMETER, 
+		BAD_TYPE, NO_IMPLEMENTOR, BAD_ACTION, BAD_VIEW, BAD_OTHER, BAD_PCONN, INTERNAL_ERROR, MISSING_PARAMETER, 
 		URL_NOT_FOUND, HREF_NOT_FOUND, SCAN_IN_PROGRESS, DISABLED, ALREADY_EXISTS, DOES_NOT_EXIST,
 		/**
 		 * Indicates that the value of a parameter is illegal/invalid (for example, it's not of expected type (boolean,

--- a/src/org/zaproxy/zap/extension/api/ApiPersistentConnection.java
+++ b/src/org/zaproxy/zap/extension/api/ApiPersistentConnection.java
@@ -1,0 +1,46 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0 
+ *   
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package org.zaproxy.zap.extension.api;
+
+import java.util.List;
+
+public class ApiPersistentConnection extends ApiElement {
+
+    public ApiPersistentConnection(String name) {
+        super(name);
+    }
+
+    public ApiPersistentConnection(String name, List<String> paramNames) {
+        super(name, paramNames);
+    }
+
+    public ApiPersistentConnection(String name, String[] paramNames) {
+        super(name, paramNames);
+    }
+
+    public ApiPersistentConnection(String name,
+            List<String> mandatoryParamNames, List<String> optionalParamNames) {
+        super(name, mandatoryParamNames, optionalParamNames);
+    }
+
+    public ApiPersistentConnection(String name, String[] mandatoryParamNames,
+            String[] optionalParamNames) {
+        super(name, mandatoryParamNames, optionalParamNames);
+    }
+
+}

--- a/src/org/zaproxy/zap/extension/api/WebUI.java
+++ b/src/org/zaproxy/zap/extension/api/WebUI.java
@@ -79,6 +79,19 @@ public class WebUI {
 				throw new ApiException(ApiException.Type.BAD_VIEW);
 			}
 			return view;
+		} else if (RequestType.pconn.equals(reqType) && name != null) {
+			List<ApiPersistentConnection> pconnList = impl.getApiPersistentConnections();
+			ApiPersistentConnection pconn = null;
+			for (ApiPersistentConnection pc : pconnList) {
+				if (name.equals(pc.getName())) {
+					pconn = pc;
+					break;
+				}
+			}
+			if (pconn == null) {
+				throw new ApiException(ApiException.Type.BAD_PCONN);
+			}
+			return pconn;
 		} else {
 			throw new ApiException(ApiException.Type.BAD_TYPE);
 		}
@@ -378,6 +391,16 @@ public class WebUI {
 					elementList = new ArrayList<>();
 					elementList.addAll(otherList);
 					this.appendElements(sb, component, RequestType.other.name(), elementList);
+				}
+
+				List<ApiPersistentConnection> pconnList = impl.getApiPersistentConnections();
+				if (pconnList != null && pconnList.size() > 0) {
+					sb.append("<h3>");
+					sb.append(Constant.messages.getString("api.html.pconns"));
+					sb.append("</h3>\n");
+					elementList = new ArrayList<>();
+					elementList.addAll(pconnList);
+					this.appendElements(sb, component, RequestType.pconn.name(), elementList);
 				}
 
 				if (getOptionsParamApi().isDisableKey() || getOptionsParamApi().isAutofillKey() || 


### PR DESCRIPTION
Have also implemented an example endpoint break/waitForHttpBreak which
holds the connection open until a break point is hit.
The web UI will work with some browsers but I havnt updated the other
clients as I anticipate this only really being of use for web pages.