### PR TITLE
Reduce ScriptEngineFactory.getScriptEngine() calls

### DIFF
--- a/src/org/zaproxy/zap/extension/script/DefaultEngineWrapper.java
+++ b/src/org/zaproxy/zap/extension/script/DefaultEngineWrapper.java
@@ -23,7 +23,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import javax.script.ScriptEngine;
@@ -92,11 +91,6 @@ public class DefaultEngineWrapper extends ScriptEngineWrapper {
 			logger.error(e.getMessage(), e);
 			return "";
 		}
-	}
-
-	@Override
-	public List<String> getExtensions() {
-		return this.getEngine().getFactory().getExtensions();
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/src/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -233,7 +233,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 			engineNames.add(engine.getLanguageName() + LANG_ENGINE_SEP + engine.getEngineName());
 		}
 		for (ScriptEngineWrapper sew : this.engineWrappers) {
-			if (! engines.contains(sew.getEngine().getFactory())) {
+			if (! engines.contains(sew.getFactory())) {
 				engineNames.add(sew.getLanguageName() + LANG_ENGINE_SEP + sew.getEngineName());
 			}
 		}
@@ -954,7 +954,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 			if (this.getTreeModel().getTemplate(f.getName()) == null) {
 				String ext = f.getName().substring(f.getName().lastIndexOf(".") + 1);
 				String engineName = this.getEngineNameForExtension(ext);
-				if (engineName != null && (engine == null || engine.getEngine().getFactory().getExtensions().contains(ext))) {
+				if (engineName != null && (engine == null || engine.getExtensions().contains(ext))) {
 					try {
 						ScriptWrapper template = new ScriptWrapper(f.getName(), "", 
 								this.getEngineWrapper(engineName), type, false, f);

--- a/src/org/zaproxy/zap/extension/script/ScriptEngineWrapper.java
+++ b/src/org/zaproxy/zap/extension/script/ScriptEngineWrapper.java
@@ -23,32 +23,31 @@ package org.zaproxy.zap.extension.script;
 import java.util.List;
 
 import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
 import javax.swing.ImageIcon;
 
 public abstract class ScriptEngineWrapper {
 
-	private ScriptEngine engine;
-	private String languageName;
-	private String engineName;
-	
+	private final ScriptEngineFactory factory;
 	
 	public ScriptEngineWrapper(ScriptEngine engine) {
-		this.engine = engine;
-		this.engineName = engine.getFactory().getEngineName();
-		this.languageName = engine.getFactory().getLanguageName();
+		this.factory = engine.getFactory();
 	}
 	
 	public String getLanguageName() {
-		return languageName;
+		return factory.getLanguageName();
 	}
 
 	public String getEngineName() {
-		return engineName;
+		return factory.getEngineName();
 	}
 	
 	public ScriptEngine getEngine() {
-		// TODO Nasty hack!
-		return engine.getFactory().getScriptEngine();
+		return factory.getScriptEngine();
+	}
+	
+	ScriptEngineFactory getFactory() {
+		return factory;
 	}
 	
 	public abstract boolean isTextBased();
@@ -59,7 +58,9 @@ public abstract class ScriptEngineWrapper {
 	
 	public abstract ImageIcon getIcon();
 
-	public abstract List<String> getExtensions();
+	public List<String> getExtensions() {
+		return factory.getExtensions();
+	}
 	
 	public abstract boolean isRawEngine();
 	


### PR DESCRIPTION
Change ScriptEngineWrapper to keep a reference to ScriptEngineFactory
and use it when obtaining data related to the engine/factory (mainly
extensions (and to obtain the engines).
Change ExtensionScript to use the methods provided by the wrapper to
obtain the factory and the extensions, calls to
ScriptEngineWrapper.getEngine().getFactory() are costly with the newer
Jython engine, which makes ZAP slower to start and open the New Script
dialogue.
Change DefaultEngineWrapper to no longer override getExtensions(), now
done by base class.