### PR TITLE
Remove ant-optional workaround in Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ env:
    - secure: "KYrFpaQbUrRWI+BcWwRQR0tqQnO5oOx+ZwF0GtvBqMB7QDKR6I9rxV5Kx5FrHY/qVKIo3leF18GJlJvwHoVRO+oXldhPsifeQju5OhXSyqA9pLmttn9WnGiHJXp/wxh2JCepzIx9ggNCDW60ZFIkZpI5T2qgAILdpTPFybIImEzVFyQHdD02+UQ2c7kmIpYkUau28G9Powb2Xvg11HWDj3TodA5zDcLinTKVkehDSB4/1s7zGcvlLfSnJcfmDQon6+ZckkBgdkGcpxqNaDe3SZ6QEQQqBELpwhFAIU2ApjUgKI7xvWy+FV4XsdpNYGuoYrh33vEDC8K1nTqkbWIEDa6LhNxEs9eChghlqsliTC1f5fz06Bk63Wv5XVGOIXzlJHdX1z3NXEggFolK1ZszpicoI5WdXyBHtefNupXnOjkGGvuBT1QqFGwkac73MVYhKa0CEf0pe8b4G6pd1xTPtSFWp4Gpvbl7v/z+OVB7tNllhwQxLykXe0RKyBf8r1084DnUcRR+gAozgbvdcLji1hU6A0GrhPnV0mYVHWfXR8aEH1iwf0q2W0kizk02+/WL1ktSP7AjTaJRg02koOgCJZLb842E6opNuDFvCZpvn0543l+jhga1SCKVfJ7M53W3VV4fRBLoSqYaZ265lOUsA3d511PNH87zQi+FjNdurnE="
 
 addons:
-  # Issue travis-ci/travis-ci#7706
-  apt:
-    packages:
-      - ant-optional
   coverity_scan:
     project:
       name: "zaproxy/zaproxy"


### PR DESCRIPTION
Change .travis.yml to remove the manual installation of the package
ant-optional, it's now (update 2017-09-06) installed by default.