### PR TITLE
Fix NPE when updating add-ons (command line flag)

### DIFF
--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -1692,16 +1692,20 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 	public void execute(CommandLineArgument[] args) {
         if (arguments[ARG_CFU_UPDATE_IDX].isEnabled()) {
         	AddOnCollection aoc = getLatestVersionInfo();
-        	// Create some temporary options with the settings we need
-        	OptionsParamCheckForUpdates options = new OptionsParamCheckForUpdates();
-        	options.load(new XMLPropertiesConfiguration());
-        	options.setCheckOnStart(true);
-        	options.setCheckAddonUpdates(true);
-        	options.setInstallAddonUpdates(true);
-			checkForAddOnUpdates(aoc, options);
+            if (aoc == null) {
+                CommandLine.error(Constant.messages.getString("cfu.cmdline.nocfu"));
+            } else {
+                // Create some temporary options with the settings we need
+                OptionsParamCheckForUpdates options = new OptionsParamCheckForUpdates();
+                options.load(new XMLPropertiesConfiguration());
+                options.setCheckOnStart(true);
+                options.setCheckAddonUpdates(true);
+                options.setInstallAddonUpdates(true);
+                checkForAddOnUpdates(aoc, options);
 
-			waitAndInstallDownloads();
-    		CommandLine.info(Constant.messages.getString("cfu.cmdline.updated"));
+                waitAndInstallDownloads();
+                CommandLine.info(Constant.messages.getString("cfu.cmdline.updated"));
+            }
         }
         if (arguments[ARG_CFU_INSTALL_ALL_IDX].isEnabled()) {
         	AddOnCollection aoc = getLatestVersionInfo();


### PR DESCRIPTION
Change ExtensionAutoUpdate to skip the update of the add-ons if not able
to get the latest info, preventing the NullPointerException.

Reported in #3902 - ZAP error messages when DNS is not working in docker
scripts could be more forth coming