### PR TITLE
Use helper methods to read configurations

### DIFF
--- a/src/ch/csnc/extension/util/OptionsParamExperimentalSliSupport.java
+++ b/src/ch/csnc/extension/util/OptionsParamExperimentalSliSupport.java
@@ -31,7 +31,7 @@ public class OptionsParamExperimentalSliSupport extends AbstractParam {
 
     @Override
     protected void parse() {
-	    expSliSupportEnabled = getConfig().getBoolean(EXPERIMENTAL_SLOT_LIST_INDEXES, false);
+	    expSliSupportEnabled = getBoolean(EXPERIMENTAL_SLOT_LIST_INDEXES, false);
     }
 
 	public boolean isExerimentalSliSupportEnabled() {

--- a/src/org/parosproxy/paros/core/proxy/ProxyParam.java
+++ b/src/org/parosproxy/paros/core/proxy/ProxyParam.java
@@ -33,6 +33,7 @@
 // ZAP: 2016/06/13 Change option "Accept-Encoding" request-header to Remove Unsupported Encodings
 // ZAP: 2017/03/26 Allow to configure if the proxy is behind NAT.
 // ZAP: 2017/04/14 Validate that the SSL/TLS versions persisted can be set/used.
+// ZAP: 2017/09/26 Use helper methods to read the configurations.
 
 package org.parosproxy.paros.core.proxy;
 
@@ -41,7 +42,6 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.configuration.ConversionException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.common.AbstractParam;
@@ -131,14 +131,10 @@ public class ProxyParam extends AbstractParam {
 
     @Override
     protected void parse() {
-        proxyIp = getConfig().getString(PROXY_IP, "localhost");
+        proxyIp = getString(PROXY_IP, "localhost");
         determineProxyIpAnyLocalAddress();
         
-        try {
-            proxyPort = getConfig().getInt(PROXY_PORT, 8080);
-
-        } catch (Exception e) {
-        }
+        proxyPort = getInt(PROXY_PORT, 8080);
 
         try {
             proxySSLPort = 8443;	//getConfig().getInt(PROXY_SSL_PORT, 8443);
@@ -155,20 +151,16 @@ public class ProxyParam extends AbstractParam {
             }
         }
 
-        reverseProxyHttpPort = getConfig().getInt(REVERSE_PROXY_HTTP_PORT, 80);
-        reverseProxyHttpsPort = getConfig().getInt(REVERSE_PROXY_HTTPS_PORT, 443);
-        useReverseProxy = getConfig().getInt(USE_REVERSE_PROXY, 0);
+        reverseProxyHttpPort = getInt(REVERSE_PROXY_HTTP_PORT, 80);
+        reverseProxyHttpsPort = getInt(REVERSE_PROXY_HTTPS_PORT, 443);
+        useReverseProxy = getInt(USE_REVERSE_PROXY, 0);
 
-        removeUnsupportedEncodings = getConfig().getBoolean(REMOVE_UNSUPPORTED_ENCODINGS, true);
-        alwaysDecodeGzip = getConfig().getBoolean(ALWAYS_DECODE_GZIP, true);
+        removeUnsupportedEncodings = getBoolean(REMOVE_UNSUPPORTED_ENCODINGS, true);
+        alwaysDecodeGzip = getBoolean(ALWAYS_DECODE_GZIP, true);
 
         loadSecurityProtocolsEnabled();
 
-        try {
-            behindNat = getConfig().getBoolean(PROXY_BEHIND_NAT, false);
-        } catch (ConversionException e) {
-            logger.error("Failed to read '" + PROXY_BEHIND_NAT + "'", e);
-        }
+        behindNat = getBoolean(PROXY_BEHIND_NAT, false);
     }
 
     public String getProxyIp() {

--- a/src/org/parosproxy/paros/core/scanner/ScannerParam.java
+++ b/src/org/parosproxy/paros/core/scanner/ScannerParam.java
@@ -43,6 +43,7 @@
 // ZAP: 2016/01/20 Issue 1959: Allow to active scan headers of all requests
 // ZAP: 2016/10/24 Issue 2951:  Support active scan rule and scan max duration
 // ZAP: 2017/01/13 Exclude getExcludedParamList from the ZAP API 
+// ZAP: 2017/09/26 Use helper methods to read the configurations.
 
 package org.parosproxy.paros.core.scanner;
 
@@ -171,105 +172,45 @@ public class ScannerParam extends AbstractParam {
     protected void parse() {
         removeOldOptions();
 
-        try {
-            this.threadPerHost = getConfig().getInt(THREAD_PER_HOST, 1);
-        } catch (Exception e) {
-        }
+        this.threadPerHost = getInt(THREAD_PER_HOST, 1);
 
-        try {
-            this.hostPerScan = getConfig().getInt(HOST_PER_SCAN, 2);
-        } catch (Exception e) {
-        }
+        this.hostPerScan = getInt(HOST_PER_SCAN, 2);
 
-        try {
-            this.delayInMs = getConfig().getInt(DELAY_IN_MS, 0);
-        } catch (Exception e) {
-        }
+        this.delayInMs = getInt(DELAY_IN_MS, 0);
 
-        try {
-            this.maxResultsToList = getConfig().getInt(MAX_RESULTS_LIST, 1000);
-        } catch (Exception e) {
-        }
+        this.maxResultsToList = getInt(MAX_RESULTS_LIST, 1000);
 
-        try {
-            this.maxRuleDurationInMins = getConfig().getInt(MAX_RULE_DURATION_IN_MINS, 0);
-        } catch (Exception e) {
-        }
+        this.maxRuleDurationInMins = getInt(MAX_RULE_DURATION_IN_MINS, 0);
 
-        try {
-            this.maxScanDurationInMins = getConfig().getInt(MAX_SCAN_DURATION_IN_MINS, 0);
-        } catch (Exception e) {
-        }
+        this.maxScanDurationInMins = getInt(MAX_SCAN_DURATION_IN_MINS, 0);
 
-        try {
-            this.maxScansInUI = getConfig().getInt(MAX_SCANS_IN_UI, 5);
-        } catch (Exception e) {
-        }
+        this.maxScansInUI = getInt(MAX_SCANS_IN_UI, 5);
         
-        try {
-        	this.injectPluginIdInHeader = getConfig().getBoolean(INJECT_PLUGIN_ID_IN_HEADER, false);
-        } catch (Exception e) {	
-        }
+        this.injectPluginIdInHeader = getBoolean(INJECT_PLUGIN_ID_IN_HEADER, false);
         
-        try {
-            this.handleAntiCSRFTokens = getConfig().getBoolean(HANDLE_ANTI_CSRF_TOKENS, false);
-        } catch (Exception e) {
-        }
+        this.handleAntiCSRFTokens = getBoolean(HANDLE_ANTI_CSRF_TOKENS, false);
 
-        try {
-            this.promptInAttackMode = getConfig().getBoolean(PROMPT_IN_ATTACK_MODE, true);
-        } catch (Exception e) {
-        }
+        this.promptInAttackMode = getBoolean(PROMPT_IN_ATTACK_MODE, true);
 
-        try {
-            this.rescanInAttackMode = getConfig().getBoolean(RESCAN_IN_ATTACK_MODE, true);
-        } catch (Exception e) {
-        }
+        this.rescanInAttackMode = getBoolean(RESCAN_IN_ATTACK_MODE, true);
 
-        try {
-            this.promptToClearFinishedScans = getConfig().getBoolean(PROMPT_TO_CLEAR_FINISHED, true);
-        } catch (Exception e) {
-        }
+        this.promptToClearFinishedScans = getBoolean(PROMPT_TO_CLEAR_FINISHED, true);
 
-        try {
-            this.showAdvancedDialog = getConfig().getBoolean(SHOW_ADV_DIALOG, false);
-        } catch (Exception e) {
-        }
+        this.showAdvancedDialog = getBoolean(SHOW_ADV_DIALOG, false);
 
-        try {
-            this.defaultPolicy = getConfig().getString(DEFAULT_POLICY, null);
-        } catch (Exception e) {
-        }
+        this.defaultPolicy = getString(DEFAULT_POLICY, null);
 
-        try {
-            this.attackPolicy = getConfig().getString(ATTACK_POLICY, null);
-        } catch (Exception e) {
-        }
+        this.attackPolicy = getString(ATTACK_POLICY, null);
 
-        try {
-            this.targetParamsInjectable = getConfig().getInt(TARGET_INJECTABLE, TARGET_INJECTABLE_DEFAULT);
-        } catch (Exception e) {
-        }
+        this.targetParamsInjectable = getInt(TARGET_INJECTABLE, TARGET_INJECTABLE_DEFAULT);
 
-        try {
-            this.targetParamsEnabledRPC = getConfig().getInt(TARGET_ENABLED_RPC, TARGET_ENABLED_RPC_DEFAULT);
-        } catch (Exception e) {
-        }
+        this.targetParamsEnabledRPC = getInt(TARGET_ENABLED_RPC, TARGET_ENABLED_RPC_DEFAULT);
 
-        try {
-            this.allowAttackOnStart = getConfig().getBoolean(ALLOW_ATTACK_ON_START, false);
-        } catch (Exception e) {
-        }
+        this.allowAttackOnStart = getBoolean(ALLOW_ATTACK_ON_START, false);
 
-        try {
-            this.maxChartTimeInMins = getConfig().getInt(MAX_CHART_TIME_IN_MINS, DEFAULT_MAX_CHART_TIME_IN_MINS);
-        } catch (Exception e) {
-        }
+        this.maxChartTimeInMins = getInt(MAX_CHART_TIME_IN_MINS, DEFAULT_MAX_CHART_TIME_IN_MINS);
 
-        try {
-            this.scanHeadersAllRequests = getConfig().getBoolean(SCAN_HEADERS_ALL_REQUESTS, false);
-        } catch (Exception e) {
-        }
+        this.scanHeadersAllRequests = getBoolean(SCAN_HEADERS_ALL_REQUESTS, false);
 
         // Parse the parameters that need to be excluded
         // ------------------------------------------------

--- a/src/org/parosproxy/paros/extension/option/OptionsParamCertificate.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsParamCertificate.java
@@ -23,12 +23,12 @@
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
 // ZAP: 2014/03/23 Issue 412: Enable unsafe SSL/TLS renegotiation option not saved
 // ZAP: 2014/08/14 Issue 1184: Improve support for IBM JDK
+// ZAP: 2017/09/26 Use helper methods to read the configurations.
 
 package org.parosproxy.paros.extension.option;
 
 import java.io.File;
 
-import org.apache.commons.configuration.ConversionException;
 import org.apache.commons.httpclient.protocol.Protocol;
 import org.apache.commons.httpclient.protocol.ProtocolSocketFactory;
 import org.apache.log4j.Logger;
@@ -64,12 +64,8 @@ public class OptionsParamCertificate extends AbstractParam {
         setUseClientCert(false);
         setClientCertLocation("");
         
-        try {
-            allowUnsafeSslRenegotiation = getConfig().getBoolean(ALLOW_UNSAFE_SSL_RENEGOTIATION, false);
-            setAllowUnsafeSslRenegotiationSystemProperty(allowUnsafeSslRenegotiation);
-        } catch (ConversionException e) {
-            logger.error("Error while loading the option Allow Unsafe SSL Renegotiation: " + e.getMessage(), e);
-        }
+        allowUnsafeSslRenegotiation = getBoolean(ALLOW_UNSAFE_SSL_RENEGOTIATION, false);
+        setAllowUnsafeSslRenegotiationSystemProperty(allowUnsafeSslRenegotiation);
     }
 
     /**

--- a/src/org/parosproxy/paros/extension/option/OptionsParamView.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsParamView.java
@@ -35,13 +35,12 @@
 // ZAP: 2016/04/27 Save, always, the Locale as String
 // ZAP: 2016/05/13 Add options to confirm removal of exclude from proxy, scanner and spider regexes
 // ZAP: 2017/05/29 Add option to use system's locale for formatting.
+// ZAP: 2017/09/26 Use helper methods to read the configurations.
 
 package org.parosproxy.paros.extension.option;
 
 import java.util.Locale;
 
-import org.apache.commons.configuration.ConversionException;
-import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.common.AbstractParam;
 import org.parosproxy.paros.control.Control.Mode;
@@ -53,8 +52,6 @@ import org.zaproxy.zap.extension.httppanel.view.largeresponse.LargeResponseUtil;
 
 public class OptionsParamView extends AbstractParam {
 	
-	private static final Logger LOGGER = Logger.getLogger(OptionsParamView.class);
-
 	private static final String DEFAULT_TIME_STAMP_FORMAT =  Constant.messages.getString("timestamp.format.default");
 	
 	public static final String BASE_VIEW_KEY = "view";
@@ -151,64 +148,42 @@ public class OptionsParamView extends AbstractParam {
     @Override
 	protected void parse() {
 	    // use temp variable to check.  Exception will be flagged if any error.
-      	showTabNames = getConfig().getBoolean(SHOW_TEXT_ICONS, true);
-	    processImages = getConfig().getInt(PROCESS_IMAGES, 0);
-	    configLocale = getConfig().getString(LOCALE, null);	// No default
-	    locale = getConfig().getString(LOCALE, DEFAULT_LOCALE);
-	    try {
-	        useSystemsLocaleForFormat = getConfig().getBoolean(USE_SYSTEMS_LOCALE_FOR_FORMAT_KEY, true);
-	    } catch (ConversionException e) {
-	        LOGGER.error("Failed to load " + USE_SYSTEMS_LOCALE_FOR_FORMAT_KEY, e);
-	        useSystemsLocaleForFormat = true;
-	    }
-	    displayOption = getConfig().getInt(DISPLAY_OPTION, 0);
-        responsePanelPosition = getConfig()
-                .getString(RESPONSE_PANEL_POS_KEY, WorkbenchPanel.ResponsePanelPosition.TABS_SIDE_BY_SIDE.name());
-	    brkPanelViewOption = getConfig().getInt(BRK_PANEL_VIEW_OPTION, 0);
-	    showMainToolbar = getConfig().getInt(SHOW_MAIN_TOOLBAR_OPTION, 1);
-	    advancedViewEnabled = getConfig().getInt(ADVANCEDUI_OPTION, 0);
-	    wmUiHandlingEnabled = getConfig().getInt(WMUIHANDLING_OPTION, 0);
-	    askOnExitEnabled = getConfig().getInt(ASKONEXIT_OPTION, 1);
-	    warnOnTabDoubleClick = getConfig().getBoolean(WARN_ON_TAB_DOUBLE_CLICK_OPTION, true);
-	    mode = getConfig().getString(MODE_OPTION, Mode.standard.name());
-	    outputTabTimeStampingEnabled = getConfig().getBoolean(OUTPUT_TAB_TIMESTAMPING_OPTION, false); 
-	    outputTabTimeStampFormat = getConfig().getString(OUTPUT_TAB_TIMESTAMP_FORMAT, DEFAULT_TIME_STAMP_FORMAT);
+      	showTabNames = getBoolean(SHOW_TEXT_ICONS, true);
+	    processImages = getInt(PROCESS_IMAGES, 0);
+	    configLocale = getString(LOCALE, null);	// No default
+	    locale = getString(LOCALE, DEFAULT_LOCALE);
+	    useSystemsLocaleForFormat = getBoolean(USE_SYSTEMS_LOCALE_FOR_FORMAT_KEY, true);
+	    displayOption = getInt(DISPLAY_OPTION, 0);
+        responsePanelPosition = getString(RESPONSE_PANEL_POS_KEY, WorkbenchPanel.ResponsePanelPosition.TABS_SIDE_BY_SIDE.name());
+	    brkPanelViewOption = getInt(BRK_PANEL_VIEW_OPTION, 0);
+	    showMainToolbar = getInt(SHOW_MAIN_TOOLBAR_OPTION, 1);
+	    advancedViewEnabled = getInt(ADVANCEDUI_OPTION, 0);
+	    wmUiHandlingEnabled = getInt(WMUIHANDLING_OPTION, 0);
+	    askOnExitEnabled = getInt(ASKONEXIT_OPTION, 1);
+	    warnOnTabDoubleClick = getBoolean(WARN_ON_TAB_DOUBLE_CLICK_OPTION, true);
+	    mode = getString(MODE_OPTION, Mode.standard.name());
+	    outputTabTimeStampingEnabled = getBoolean(OUTPUT_TAB_TIMESTAMPING_OPTION, false); 
+	    outputTabTimeStampFormat = getString(OUTPUT_TAB_TIMESTAMP_FORMAT, DEFAULT_TIME_STAMP_FORMAT);
 
-        try {
-            showLocalConnectRequests = getConfig().getBoolean(SHOW_LOCAL_CONNECT_REQUESTS, false);
-        } catch (ConversionException e) {
-            LOGGER.error("Error while parsing config file: " + e.getMessage(), e);
-        }
+        showLocalConnectRequests = getBoolean(SHOW_LOCAL_CONNECT_REQUESTS, false);
 
-	    showSplashScreen = getConfig().getBoolean(SPLASHSCREEN_OPTION, true);
-	    largeRequestSize = getConfig().getInteger(LARGE_REQUEST_SIZE, LargeRequestUtil.DEFAULT_MIN_CONTENT_LENGTH);
-	    largeResponseSize = getConfig().getInteger(LARGE_RESPONSE_SIZE, LargeResponseUtil.DEFAULT_MIN_CONTENT_LENGTH);
-	    fontSize = getConfig().getInteger(FONT_SIZE, -1);
-	    fontName = getConfig().getString(FONT_NAME, "");
-	    scaleImages = getConfig().getBoolean(SCALE_IMAGES, true);
-	    showDevWarning = getConfig().getBoolean(SHOW_DEV_WARNING, true);
+	    showSplashScreen = getBoolean(SPLASHSCREEN_OPTION, true);
+	    largeRequestSize = getInt(LARGE_REQUEST_SIZE, LargeRequestUtil.DEFAULT_MIN_CONTENT_LENGTH);
+	    largeResponseSize = getInt(LARGE_RESPONSE_SIZE, LargeResponseUtil.DEFAULT_MIN_CONTENT_LENGTH);
+	    fontSize = getInt(FONT_SIZE, -1);
+	    fontName = getString(FONT_NAME, "");
+	    scaleImages = getBoolean(SCALE_IMAGES, true);
+	    showDevWarning = getBoolean(SHOW_DEV_WARNING, true);
 	    
 	    // Special cases - set via static methods
 	    LargeRequestUtil.setMinContentLength(largeRequestSize);
 	    LargeResponseUtil.setMinContentLength(largeResponseSize);
 
-        try {
-            this.confirmRemoveProxyExcludeRegex = getConfig().getBoolean(CONFIRM_REMOVE_PROXY_EXCLUDE_REGEX_KEY, false);
-        } catch (ConversionException e) {
-            LOGGER.error("Error while parsing config file: " + e.getMessage(), e);
-        }
+        this.confirmRemoveProxyExcludeRegex = getBoolean(CONFIRM_REMOVE_PROXY_EXCLUDE_REGEX_KEY, false);
 
-        try {
-            this.confirmRemoveScannerExcludeRegex = getConfig().getBoolean(CONFIRM_REMOVE_SCANNER_EXCLUDE_REGEX_KEY, false);
-        } catch (ConversionException e) {
-            LOGGER.error("Error while parsing config file: " + e.getMessage(), e);
-        }
+        this.confirmRemoveScannerExcludeRegex = getBoolean(CONFIRM_REMOVE_SCANNER_EXCLUDE_REGEX_KEY, false);
 
-        try {
-            this.confirmRemoveSpiderExcludeRegex = getConfig().getBoolean(CONFIRM_REMOVE_SPIDER_EXCLUDE_REGEX_KEY, false);
-        } catch (ConversionException e) {
-            LOGGER.error("Error while parsing config file: " + e.getMessage(), e);
-        }
+        this.confirmRemoveSpiderExcludeRegex = getBoolean(CONFIRM_REMOVE_SPIDER_EXCLUDE_REGEX_KEY, false);
     }
 
 	/**

--- a/src/org/zaproxy/zap/extension/alert/AlertParam.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertParam.java
@@ -19,13 +19,9 @@
  */
 package org.zaproxy.zap.extension.alert;
 
-import org.apache.commons.configuration.ConversionException;
-import org.apache.log4j.Logger;
 import org.parosproxy.paros.common.AbstractParam;
 
 public class AlertParam extends AbstractParam {
-
-    private static final Logger LOGGER = Logger.getLogger(AlertParam.class);
 
     /**
      * The base configuration key for all alert configurations.
@@ -64,21 +60,9 @@ public class AlertParam extends AbstractParam {
      */
     @Override
     protected void parse() {
-        try {
-            maximumInstances = getConfig().getInt(PARAM_MAXIMUM_INSTANCES, DEFAULT_MAXIMUM_INSTANCES);
-        } catch (ConversionException e) {
-            LOGGER.error("Failed to load the \"Maximum instances\" configuration: " + e.getMessage(), e);
-        }
-        try {
-        	mergeRelatedIssues = getConfig().getBoolean(PARAM_MERGE_RELATED_ISSUES, true);
-        } catch (ConversionException e) {
-            LOGGER.error("Failed to load the \"old format\" configuration: " + e.getMessage(), e);
-        }
-        try {
-            overridesFilename = getConfig().getString(PARAM_OVERRIDES_FILENAME, "");
-        } catch (ConversionException e) {
-            LOGGER.error("Failed to load the \"Overrides filename\" configuration: " + e.getMessage(), e);
-        }
+        maximumInstances = getInt(PARAM_MAXIMUM_INSTANCES, DEFAULT_MAXIMUM_INSTANCES);
+        mergeRelatedIssues = getBoolean(PARAM_MERGE_RELATED_ISSUES, true);
+        overridesFilename = getString(PARAM_OVERRIDES_FILENAME, "");
     }
 
     /**

--- a/src/org/zaproxy/zap/extension/anticsrf/AntiCsrfParam.java
+++ b/src/org/zaproxy/zap/extension/anticsrf/AntiCsrfParam.java
@@ -84,11 +84,7 @@ public class AntiCsrfParam extends AbstractParam {
             }
         }
 
-        try {
-            this.confirmRemoveToken = getConfig().getBoolean(CONFIRM_REMOVE_TOKEN_KEY, true);
-        } catch (ConversionException e) {
-            logger.error("Error while loading the confirm remove token option: " + e.getMessage(), e);
-        }
+        this.confirmRemoveToken = getBoolean(CONFIRM_REMOVE_TOKEN_KEY, true);
     }
 
     @ZapApiIgnore

--- a/src/org/zaproxy/zap/extension/api/OptionsParamApi.java
+++ b/src/org/zaproxy/zap/extension/api/OptionsParamApi.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.ConversionException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.common.AbstractParam;
@@ -79,46 +78,19 @@ public class OptionsParamApi extends AbstractParam {
     @Override
     protected void parse() {
         
-		enabled = getBooleanFromConfig(ENABLED, true);
-		uiEnabled = getBooleanFromConfig(UI_ENABLED, true);
-		secureOnly = getBooleanFromConfig(SECURE_ONLY, false);
-		disableKey = getBooleanFromConfig(DISABLE_KEY, false);
-		incErrorDetails = getBooleanFromConfig(INC_ERROR_DETAILS, false);
-		autofillKey = getBooleanFromConfig(AUTOFILL_KEY, false);
-		enableJSONP = getBooleanFromConfig(ENABLE_JSONP, false);
-		noKeyForSafeOps = getBooleanFromConfig(NO_KEY_FOR_SAFE_OPS, false);
-		reportPermErrors = getBooleanFromConfig(REPORT_PERM_ERRORS, false);
-		nonceTimeToLiveInSecs = getIntFromConfig(NONCE_TTL_IN_SECS, DEFAULT_NONCE_TTL_IN_SECS);
-		try {
-			key = getConfig().getString(API_KEY, "");
-		} catch (ConversionException e) {
-			LOGGER.warn("Failed to load the option '" + key + "' caused by:", e);
-			key = "";
-		}
+		enabled = getBoolean(ENABLED, true);
+		uiEnabled = getBoolean(UI_ENABLED, true);
+		secureOnly = getBoolean(SECURE_ONLY, false);
+		disableKey = getBoolean(DISABLE_KEY, false);
+		incErrorDetails = getBoolean(INC_ERROR_DETAILS, false);
+		autofillKey = getBoolean(AUTOFILL_KEY, false);
+		enableJSONP = getBoolean(ENABLE_JSONP, false);
+		noKeyForSafeOps = getBoolean(NO_KEY_FOR_SAFE_OPS, false);
+		reportPermErrors = getBoolean(REPORT_PERM_ERRORS, false);
+		nonceTimeToLiveInSecs = getInt(NONCE_TTL_IN_SECS, DEFAULT_NONCE_TTL_IN_SECS);
+		key = getString(API_KEY, "");
 		loadPermittedAddresses();
-        try {
-            this.confirmRemovePermittedAddress = getConfig().getBoolean(CONFIRM_REMOVE_ADDRESS, true);
-        } catch (ConversionException e) {
-            LOGGER.error("Error while loading the confirm remove permitted address option: " + e.getMessage(), e);
-        }
-    }
-
-	private boolean getBooleanFromConfig(String key, boolean defaultValue) {
-		try {
-			return getConfig().getBoolean(key, defaultValue);
-		} catch (ConversionException e) {
-			LOGGER.warn("Failed to load the option '" + key + "' caused by:", e);
-			return defaultValue;
-		}
-	}
-
-    private int getIntFromConfig(String key, int defaultValue) {
-        try {
-            return getConfig().getInteger(key, defaultValue);
-        } catch (ConversionException e) {
-            LOGGER.warn("Failed to load the option '" + key + "' caused by:", e);
-            return defaultValue;
-        }
+		this.confirmRemovePermittedAddress = getBoolean(CONFIRM_REMOVE_ADDRESS, true);
     }
 
 	@Override

--- a/src/org/zaproxy/zap/extension/autoupdate/OptionsParamCheckForUpdates.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/OptionsParamCheckForUpdates.java
@@ -76,18 +76,18 @@ public class OptionsParamCheckForUpdates extends AbstractParam {
     protected void parse() {
         updateOldOptions();
         
-	    checkOnStart = getConfig().getBoolean(CHECK_ON_START, true);
-	    dayLastChecked = getConfig().getString(DAY_LAST_CHECKED, "");
-	    dayLastInstallWarned = getConfig().getString(DAY_LAST_INSTALL_WARNED, "");
-	    dayLastUpdateWarned = getConfig().getString(DAY_LAST_UPDATE_WARNED, "");
+	    checkOnStart = getBoolean(CHECK_ON_START, true);
+	    dayLastChecked = getString(DAY_LAST_CHECKED, "");
+	    dayLastInstallWarned = getString(DAY_LAST_INSTALL_WARNED, "");
+	    dayLastUpdateWarned = getString(DAY_LAST_UPDATE_WARNED, "");
 		
-		downloadNewRelease = getConfig().getBoolean(DOWNLOAD_NEW_RELEASE, false);
-		checkAddonUpdates = getConfig().getBoolean(CHECK_ADDON_UPDATES, true);
-		installAddonUpdates = getConfig().getBoolean(INSTALL_ADDON_UPDATES, false);
-		installScannerRules = getConfig().getBoolean(INSTALL_SCANNER_RULES, false);
-		reportReleaseAddons = getConfig().getBoolean(REPORT_RELEASE_ADDON, false);
-		reportBetaAddons = getConfig().getBoolean(REPORT_BETA_ADDON, false);
-		reportAlphaAddons = getConfig().getBoolean(REPORT_ALPHA_ADDON, false);
+		downloadNewRelease = getBoolean(DOWNLOAD_NEW_RELEASE, false);
+		checkAddonUpdates = getBoolean(CHECK_ADDON_UPDATES, true);
+		installAddonUpdates = getBoolean(INSTALL_ADDON_UPDATES, false);
+		installScannerRules = getBoolean(INSTALL_SCANNER_RULES, false);
+		reportReleaseAddons = getBoolean(REPORT_RELEASE_ADDON, false);
+		reportBetaAddons = getBoolean(REPORT_BETA_ADDON, false);
+		reportAlphaAddons = getBoolean(REPORT_ALPHA_ADDON, false);
 		for (Object dir : getConfig().getList(ADDON_DIRS)) {
 			File f = new File(dir.toString());
 			if (!f.exists()) {
@@ -100,7 +100,7 @@ public class OptionsParamCheckForUpdates extends AbstractParam {
 				this.addonDirectories.add(f);
 			}
 		}
-		setDownloadDirectory(new File(getConfig().getString(DOWNLOAD_DIR, Constant.FOLDER_LOCAL_PLUGIN)), false);
+		setDownloadDirectory(new File(getString(DOWNLOAD_DIR, Constant.FOLDER_LOCAL_PLUGIN)), false);
     }
 
 	private void updateOldOptions() {

--- a/src/org/zaproxy/zap/extension/brk/BreakpointsParam.java
+++ b/src/org/zaproxy/zap/extension/brk/BreakpointsParam.java
@@ -69,10 +69,10 @@ public class BreakpointsParam extends AbstractParam {
      */
     @Override
     protected void parse() {
-        confirmDropMessage = getConfig().getBoolean(PARAM_CONFIRM_DROP_MESSAGE_KEY, false);
-        buttonMode = getConfig().getInt(PARAM_UI_BUTTON_MODE, BUTTON_MODE_SIMPLE);
+        confirmDropMessage = getBoolean(PARAM_CONFIRM_DROP_MESSAGE_KEY, false);
+        buttonMode = getInt(PARAM_UI_BUTTON_MODE, BUTTON_MODE_SIMPLE);
         alwaysOnTop = getConfig().getBoolean(PARAM_BRK_ALWAYS_ON_TOP, null);
-        inScopeOnly = getConfig().getBoolean(PARAM_BRK_IN_SCOPE_ONLY, false);
+        inScopeOnly = getBoolean(PARAM_BRK_IN_SCOPE_ONLY, false);
     }
 
     /**

--- a/src/org/zaproxy/zap/extension/callback/CallbackParam.java
+++ b/src/org/zaproxy/zap/extension/callback/CallbackParam.java
@@ -54,22 +54,9 @@ public class CallbackParam extends AbstractParam {
 
     @Override
     protected void parse() {
-        try {
-            localAddress = getConfig().getString(LOCAL_ADDRESS_KEY, "0.0.0.0");
-        } catch (Exception e) {
-            logger.error(e.getMessage(), e);
-        }
-        try {
-            remoteAddress = getConfig().getString(REMOTE_ADDRESS_KEY,
-                    getDefaultAddress());
-        } catch (Exception e) {
-            logger.error(e.getMessage(), e);
-        }
-        try {
-            port = getConfig().getInt(PORT_KEY, 0);
-        } catch (Exception e) {
-            logger.error(e.getMessage(), e);
-        }
+        localAddress = getString(LOCAL_ADDRESS_KEY, "0.0.0.0");
+        remoteAddress = getString(REMOTE_ADDRESS_KEY, getDefaultAddress());
+        port = getInt(PORT_KEY, 0);
     }
 
     private String getDefaultAddress() {

--- a/src/org/zaproxy/zap/extension/encoder2/EncodeDecodeParam.java
+++ b/src/org/zaproxy/zap/extension/encoder2/EncodeDecodeParam.java
@@ -34,9 +34,9 @@ class EncodeDecodeParam extends AbstractParam {
 	
 	@Override
 	protected void parse() {
-		base64Charset = getConfig().getString(PARAM_BASE64_CHARSET, base64Charset);
+		base64Charset = getString(PARAM_BASE64_CHARSET, base64Charset);
 		
-		base64DoBreakLines = getConfig().getBoolean(PARAM_BASE64_DO_BREAK_LINES, base64DoBreakLines);
+		base64DoBreakLines = getBoolean(PARAM_BASE64_DO_BREAK_LINES, base64DoBreakLines);
 	}
 
 	public String getBase64Charset() {

--- a/src/org/zaproxy/zap/extension/globalexcludeurl/GlobalExcludeURLParam.java
+++ b/src/org/zaproxy/zap/extension/globalexcludeurl/GlobalExcludeURLParam.java
@@ -200,11 +200,7 @@ public class GlobalExcludeURLParam extends AbstractParam {
             }
         }
 
-        try {
-            this.confirmRemoveToken = getConfig().getBoolean(CONFIRM_REMOVE_TOKEN_KEY, true);
-        } catch (ConversionException e) {
-            logger.error("Error while loading the confirm remove token option: " + e.getMessage(), e);
-        }
+        this.confirmRemoveToken = getBoolean(CONFIRM_REMOVE_TOKEN_KEY, true);
     }
 
     public List<GlobalExcludeURLParamToken> getTokens() {

--- a/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsParam.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsParam.java
@@ -103,17 +103,8 @@ public class HttpSessionsParam extends AbstractParam {
 			}
 		}
 
-		try {
-			this.enabledProxyOnly = getConfig().getBoolean(PROXY_ONLY_KEY, false);
-		} catch (ConversionException e) {
-			log.error("Error while parsing config file: " + e.getMessage(), e);
-		}
-
-		try {
-			this.confirmRemove = getConfig().getBoolean(CONFIRM_REMOVE_TOKEN_KEY, true);
-		} catch (ConversionException e) {
-			log.error("Error while parsing config file: " + e.getMessage(), e);
-		}
+		this.enabledProxyOnly = getBoolean(PROXY_ONLY_KEY, false);
+		this.confirmRemove = getBoolean(CONFIRM_REMOVE_TOKEN_KEY, true);
 	}
 
 	/**

--- a/src/org/zaproxy/zap/extension/pscan/PassiveScanParam.java
+++ b/src/org/zaproxy/zap/extension/pscan/PassiveScanParam.java
@@ -92,17 +92,8 @@ public class PassiveScanParam extends AbstractParam {
             logger.error("Error while loading the auto tag scanners: " + e.getMessage(), e);
         }
 
-        try {
-            this.confirmRemoveAutoTagScanner = getConfig().getBoolean(CONFIRM_REMOVE_AUTO_TAG_SCANNER_KEY, true);
-        } catch (ConversionException e) {
-            logger.error("Error while loading the confirm remove option: " + e.getMessage(), e);
-        }
-
-        try {
-            this.scanOnlyInScope = getConfig().getBoolean(SCAN_ONLY_IN_SCOPE_KEY, false);
-        } catch (ConversionException e) {
-            logger.error("Error while loading \"scanOnlyInScope\" option: " + e.getMessage(), e);
-        }
+        this.confirmRemoveAutoTagScanner = getBoolean(CONFIRM_REMOVE_AUTO_TAG_SCANNER_KEY, true);
+        this.scanOnlyInScope = getBoolean(SCAN_ONLY_IN_SCOPE_KEY, false);
     }
 
     public void setAutoTagScanners(List<RegexAutoTagScanner> scanners) {

--- a/src/org/zaproxy/zap/extension/script/ScriptParam.java
+++ b/src/org/zaproxy/zap/extension/script/ScriptParam.java
@@ -61,8 +61,8 @@ public class ScriptParam extends AbstractParam {
 
 	@Override
 	protected void parse() {
-		defaultScript = getConfig().getString(PARAM_DEFAULT_SCRIPT, "");
-		defaultDir = getConfig().getString(PARAM_DEFAULT_DIR, "");
+		defaultScript = getString(PARAM_DEFAULT_SCRIPT, "");
+		defaultDir = getString(PARAM_DEFAULT_DIR, "");
 		
         try {
             List<HierarchicalConfiguration> fields = ((HierarchicalConfiguration) getConfig()).configurationsAt(ALL_SCRIPTS_KEY);
@@ -114,7 +114,7 @@ public class ScriptParam extends AbstractParam {
         } catch (Exception e) {
             logger.error("Error while loading the script dirs: " + e.getMessage(), e);
         }
-        confirmRemoveDir = getConfig().getBoolean(SCRIPT_CONFIRM_REMOVE_DIR, true);
+        confirmRemoveDir = getBoolean(SCRIPT_CONFIRM_REMOVE_DIR, true);
 
 	}
 	

--- a/src/org/zaproxy/zap/extension/search/SearchParam.java
+++ b/src/org/zaproxy/zap/extension/search/SearchParam.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.search;
 
-import org.apache.commons.configuration.ConversionException;
-import org.apache.log4j.Logger;
 import org.parosproxy.paros.common.AbstractParam;
 
 /**
@@ -35,8 +33,6 @@ import org.parosproxy.paros.common.AbstractParam;
  * @see #getMaximumSearchResultsGUI()
  */
 public class SearchParam extends AbstractParam {
-
-    private static final Logger LOGGER = Logger.getLogger(SearchParam.class);
 
     /**
      * The base configuration key for all search configurations.
@@ -74,12 +70,7 @@ public class SearchParam extends AbstractParam {
      */
     @Override
     protected void parse() {
-        try {
-            maximumSearchResultsGUI = getConfig().getInt(PARAM_MAXIMUM_RESULTS_GUI, DEFAULT_MAXIMUM_RESULTS_GUI);
-        } catch (ConversionException e) {
-            LOGGER.error("Failed to load the \"Maximum search results in GUI\" configuration: " + e.getMessage(), e);
-            maximumSearchResultsGUI = DEFAULT_MAXIMUM_RESULTS_GUI;
-        }
+        maximumSearchResultsGUI = getInt(PARAM_MAXIMUM_RESULTS_GUI, DEFAULT_MAXIMUM_RESULTS_GUI);
     }
 
     /**

--- a/src/org/zaproxy/zap/extension/stats/StatsParam.java
+++ b/src/org/zaproxy/zap/extension/stats/StatsParam.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.stats;
 
-import org.apache.log4j.Logger;
 import org.parosproxy.paros.common.AbstractParam;
 
 /**
@@ -28,8 +27,6 @@ import org.parosproxy.paros.common.AbstractParam;
  * @since 2.5.0
  */
 public class StatsParam extends AbstractParam {
-
-    private static final Logger LOGGER = Logger.getLogger(StatsParam.class);
 
     /**
      * The base configuration key for all stats configurations.
@@ -109,14 +106,10 @@ public class StatsParam extends AbstractParam {
 
 	@Override
     protected void parse() {
-		try {
-			inMemory = getConfig().getBoolean(IN_MEMORY_STATS_KEY, true);
-			statsdHost = getConfig().getString(STATSD_HOST_KEY, "");
-			statsdPort = getConfig().getInt(STATSD_PORT_KEY, DEFAULT_STATSD_PORT);
-			statsdPrefix = getConfig().getString(STATSD_PREFIX_KEY, DEFAULT_STATSD_PREFIX);
-		} catch (Exception e) {
-			LOGGER.error(e.getMessage(), e);
-		}
+		inMemory = getBoolean(IN_MEMORY_STATS_KEY, true);
+		statsdHost = getString(STATSD_HOST_KEY, "");
+		statsdPort = getInt(STATSD_PORT_KEY, DEFAULT_STATSD_PORT);
+		statsdPrefix = getString(STATSD_PREFIX_KEY, DEFAULT_STATSD_PREFIX);
     }
 
 }


### PR DESCRIPTION
Change classes extending AbstractParam to use the helper methods to read
the (boolean, int, String) configurations, as those methods already
handle conversion exceptions and fallback always to default value.