### PR TITLE
Use ZapVersions.xml file in Docker images

### DIFF
--- a/build/docker/Dockerfile-stable
+++ b/build/docker/Dockerfile-stable
@@ -48,7 +48,7 @@ RUN mkdir /home/zap/.vnc
 
 
 # Download and expand the latest stable release 
-RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions-dev.xml | xmlstarlet sel -t -v //url |grep -i Linux | wget --content-disposition -i - -O - | tar zxv && \
+RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml | xmlstarlet sel -t -v //url |grep -i Linux | wget --content-disposition -i - -O - | tar zxv && \
 	cp -R ZAP*/* . &&  \
 	rm -R ZAP* && \
 	curl -s -L https://bitbucket.org/meszarv/webswing/downloads/webswing-2.3-distribution.zip > webswing.zip && \

--- a/build/docker/Dockerfile-weekly
+++ b/build/docker/Dockerfile-weekly
@@ -47,7 +47,7 @@ RUN mkdir /home/zap/.vnc
 
 
 # Download and expand the latest weekly release 
-RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions-dev.xml | xmlstarlet sel -t -v //url |grep -i weekly | wget --content-disposition -i - && \
+RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml | xmlstarlet sel -t -v //url |grep -i weekly | wget --content-disposition -i - && \
 	unzip *.zip && \
 	rm *.zip && \
 	cp -R ZAP*/* . &&  \


### PR DESCRIPTION
Change Dockerfile-stable and Dockerfile-weekly to use ZapVersions.xml
instead of ZapVersions-dev.xml, the latter also contains the URLs of
the add-ons which were being picked and downloaded (unnecessarily) when
building the (stable) image.