### PR TITLE
Refactor target access in docker scripts

### DIFF
--- a/build/docker/zap-baseline.py
+++ b/build/docker/zap-baseline.py
@@ -292,11 +292,7 @@ def main(argv):
             if res.startswith("ZAP Error"):
                 logging.error('Failed to load context file ' + context_file + ' : ' + res)
 
-        # Access the target
-        res = zap.urlopen(target)
-        if res.startswith("ZAP Error"):
-            # errno.EIO is 5, not sure why my atempts to import it failed;)
-            raise IOError(5, 'Failed to connect')
+        zap_access_target(zap, target)
 
         if target.count('/') > 2:
             # The url can include a valid path, but always reset to spider the host

--- a/build/docker/zap-full-scan.py
+++ b/build/docker/zap-full-scan.py
@@ -297,11 +297,7 @@ def main(argv):
             if res.startswith("ZAP Error"):
                 logging.error('Failed to load context file ' + context_file + ' : ' + res)
 
-        # Access the target
-        res = zap.urlopen(target)
-        if res.startswith("ZAP Error"):
-            # errno.EIO is 5, not sure why my atempts to import it failed;)
-            raise IOError(5, 'Failed to connect')
+        zap_access_target(zap, target)
 
         if target.count('/') > 2:
             # The url can include a valid path, but always reset to spider the host

--- a/build/docker/zap_common.py
+++ b/build/docker/zap_common.py
@@ -266,6 +266,12 @@ def stop_docker(cid):
         logging.warning('Docker rm failed')
 
 
+def zap_access_target(zap, target):
+    res = zap.urlopen(target)
+    if res.startswith("ZAP Error"):
+        raise IOError(errno.EIO, 'ZAP failed to access: {0}'.format(target))
+
+
 def zap_spider(zap, target):
     logging.debug('Spider ' + target)
     spider_scan_id = zap.spider.scan(target)


### PR DESCRIPTION
Extract a function into zap_common.py that accesses the target URL and
tweak the error message (to be more clear that's ZAP that failed to
access the target).
Change zap-baseline.py and zap-full-scan.py to use the new function.

Related to #3902 - ZAP error messages when DNS is not working in docker
scripts could be more forth coming