### PR TITLE
Remove usage of java.awt.Event

### DIFF
--- a/src/org/parosproxy/paros/extension/history/LogPanel.java
+++ b/src/org/parosproxy/paros/extension/history/LogPanel.java
@@ -42,11 +42,11 @@
 // ZAP: 2017/01/30 Use HistoryTable.
 // ZAP: 2017/03/03 Tweak filter label.
 // ZAP: 2017/05/12 Support table export.
+// ZAP: 2017/09/02 Use KeyEvent instead of Event (deprecated in Java 9).
 
 package org.parosproxy.paros.extension.history;
 
 import java.awt.BorderLayout;
-import java.awt.Event;
 import java.awt.GridBagConstraints;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
@@ -131,7 +131,7 @@ public class LogPanel extends AbstractPanel {
 	    }
 		this.add(getHistoryPanel(), java.awt.BorderLayout.CENTER);
 		
-		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_H, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.SHIFT_MASK, false));
+		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_H, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("history.panel.mnemonic"));
 		
 	}

--- a/src/org/parosproxy/paros/view/MainMenuBar.java
+++ b/src/org/parosproxy/paros/view/MainMenuBar.java
@@ -31,12 +31,12 @@
 // ZAP: 2015/02/05 Issue 1524: New Persist Session dialog
 // ZAP: 2017/05/10 Issue 3460: Add Show Support Info help menuitem
 // ZAP: 2017/06/27 Issue 2375: Added option to change ZAP mode in edit menu
+// ZAP: 2017/09/02 Use KeyEvent instead of Event (deprecated in Java 9).
 
 package org.parosproxy.paros.view;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.awt.Event;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
@@ -224,7 +224,7 @@ public class MainMenuBar extends JMenuBar {
 	private ZapMenuItem getMenuToolsOptions() {
 		if (menuToolsOptions == null) {
 			menuToolsOptions = new ZapMenuItem("menu.tools.options",
-					KeyStroke.getKeyStroke(KeyEvent.VK_O, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK, false));
+					KeyStroke.getKeyStroke(KeyEvent.VK_O, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK, false));
 			menuToolsOptions.addActionListener(new java.awt.event.ActionListener() { 
 				@Override
 				public void actionPerformed(java.awt.event.ActionEvent e) {    
@@ -433,7 +433,7 @@ public class MainMenuBar extends JMenuBar {
 	private ZapMenuItem getMenuFileProperties() {
 		if (menuFileProperties == null) {
 			menuFileProperties = new ZapMenuItem("menu.file.properties",
-					KeyStroke.getKeyStroke(KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK, false));
+					KeyStroke.getKeyStroke(KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK, false));
 			menuFileProperties.setText(Constant.messages.getString("menu.file.properties")); // ZAP: i18n
 			menuFileProperties.addActionListener(new java.awt.event.ActionListener() { 
 				@Override

--- a/src/org/parosproxy/paros/view/OutputPanel.java
+++ b/src/org/parosproxy/paros/view/OutputPanel.java
@@ -27,12 +27,12 @@
 // ZAP: 2014/10/07 Issue 1357: Hide unused tabs
 // ZAP: 2015/02/10 Issue 1528: Support user defined font size
 // ZAP: 2017/02/20 Issue 3221: Some icons not scaled correctly
+// ZAP: 2017/09/02 Use KeyEvent instead of Event (deprecated in Java 9).
 
 package org.parosproxy.paros.view;
 
 
 import java.awt.BorderLayout;
-import java.awt.Event;
 import java.awt.EventQueue;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
@@ -84,7 +84,7 @@ public class OutputPanel extends AbstractPanel {
 	    }
         // ZAP: Added Output (doc) icon
 		this.setIcon(new ImageIcon(OutputPanel.class.getResource("/resource/icon/16/172.png")));	// 'doc' icon
-		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.SHIFT_MASK, false));
+		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("output.panel.mnemonic"));
 
         this.add(getMainPanel(), BorderLayout.CENTER);

--- a/src/org/parosproxy/paros/view/SiteMapPanel.java
+++ b/src/org/parosproxy/paros/view/SiteMapPanel.java
@@ -39,12 +39,12 @@
 // ZAP: 2016/04/14 Use View to display the HTTP messages
 // ZAP: 2016/07/01 Issue 2642: Slow mouse wheel scrolling in site tree
 // ZAP: 2017/03/28 Issue 3253: Facilitate exporting URLs by context (add getSelectedContext)
+// ZAP: 2017/09/02 Use KeyEvent instead of Event (deprecated in Java 9).
 
 package org.parosproxy.paros.view;
 
 import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.Event;
 import java.awt.EventQueue;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -146,7 +146,7 @@ public class SiteMapPanel extends AbstractPanel {
 		this.setHideable(false);
 	    this.setIcon(new ImageIcon(View.class.getResource("/resource/icon/16/094.png")));
 	    this.setName(Constant.messages.getString("sites.panel.title"));
-		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.SHIFT_MASK, false));
+		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("sites.panel.mnemonic"));
 
 	    if (Model.getSingleton().getOptionsParam().getViewParam().getWmUiHandlingOption() == 0) {

--- a/src/org/parosproxy/paros/view/View.java
+++ b/src/org/parosproxy/paros/view/View.java
@@ -72,11 +72,11 @@
 // ZAP: 2016/10/26 Create UI shared context in the session dialogue when adding a context
 // ZAP: 2017/02/20 Issue 3221: Some icons not scaled correctly
 // ZAP: 2017/08/31 Use helper method I18N.getString(String, Object...).
+// ZAP: 2017/09/02 Use KeyEvent instead of Event (deprecated in Java 9).
 
 package org.parosproxy.paros.view;
 
 import java.awt.Component;
-import java.awt.Event;
 import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
@@ -611,7 +611,7 @@ public class View implements ViewDelegate {
             requestPanel.setEnableViewSelect(true);
             requestPanel.loadConfig(Model.getSingleton().getOptionsParam().getConfig());
             requestPanel.setDefaultAccelerator(KeyStroke.getKeyStroke(
-                    KeyEvent.VK_R, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.SHIFT_MASK, false));
+                    KeyEvent.VK_R, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
             requestPanel.setMnemonic(Constant.messages.getChar("http.panel.request.mnemonic"));
 
         }
@@ -629,7 +629,7 @@ public class View implements ViewDelegate {
             responsePanel.setEnableViewSelect(false);
             responsePanel.loadConfig(Model.getSingleton().getOptionsParam().getConfig());
             responsePanel.setDefaultAccelerator(KeyStroke.getKeyStroke(
-                    KeyEvent.VK_R, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK | Event.SHIFT_MASK, false));
+                    KeyEvent.VK_R, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
             responsePanel.setMnemonic(Constant.messages.getChar("http.panel.response.mnemonic"));
         }
         return responsePanel;

--- a/src/org/zaproxy/zap/extension/alert/AlertPanel.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertPanel.java
@@ -23,7 +23,6 @@ package org.zaproxy.zap.extension.alert;
 import java.awt.CardLayout;
 import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.Event;
 import java.awt.EventQueue;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -155,7 +154,7 @@ public class AlertPanel extends AbstractPanel {
 
         this.add(getPanelCommand(), getPanelCommand().getName());
 			
-		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_A, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.SHIFT_MASK, false));
+		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_A, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("alerts.panel.mnemonic"));
 		this.setShowByDefault(true);
 	}

--- a/src/org/zaproxy/zap/extension/ascan/ActiveScanPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScanPanel.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.ascan;
 
-import java.awt.Event;
 import java.awt.EventQueue;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -93,7 +92,7 @@ public class ActiveScanPanel extends ScanPanel2<ActiveScan, ScanController<Activ
         super("ascan", new ImageIcon(ActiveScanPanel.class.getResource("/resource/icon/16/093.png")), extension);
         this.extension = extension;
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
-				KeyEvent.VK_A, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK | Event.SHIFT_MASK, false));
+				KeyEvent.VK_A, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("ascan.panel.mnemonic"));
     }
 

--- a/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.ascan;
 
 import java.awt.Dimension;
-import java.awt.Event;
 import java.awt.EventQueue;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
@@ -352,7 +351,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
     private ZapMenuItem getMenuItemCustomScan() {
         if (menuItemCustomScan == null) {
             menuItemCustomScan = new ZapMenuItem("menu.tools.ascanadv",
-                    KeyStroke.getKeyStroke(KeyEvent.VK_A, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK, false));
+                    KeyStroke.getKeyStroke(KeyEvent.VK_A, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK, false));
             menuItemCustomScan.setEnabled(Control.getSingleton().getMode() != Mode.safe);
 
             menuItemCustomScan.addActionListener(new java.awt.event.ActionListener() {

--- a/src/org/zaproxy/zap/extension/brk/BreakPanel.java
+++ b/src/org/zaproxy/zap/extension/brk/BreakPanel.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.extension.brk;
 
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
-import java.awt.Event;
 import java.awt.EventQueue;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
@@ -115,7 +114,7 @@ public class BreakPanel extends AbstractPanel implements Tab, BreakpointManageme
 		
 		this.setIcon(new ImageIcon(BreakPanel.class.getResource("/resource/icon/16/101grey.png")));	// 'grey X' icon
 
-		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_B, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.SHIFT_MASK, false));
+		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_B, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("brk.panel.mnemonic"));
 		
 		this.setLayout(new BorderLayout());

--- a/src/org/zaproxy/zap/extension/brk/BreakpointsPanel.java
+++ b/src/org/zaproxy/zap/extension/brk/BreakpointsPanel.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.brk;
 
 import java.awt.CardLayout;
-import java.awt.Event;
 import java.awt.EventQueue;
 import java.awt.GridBagConstraints;
 import java.awt.Toolkit;
@@ -77,7 +76,7 @@ public class BreakpointsPanel extends AbstractPanel {
         this.setName(Constant.messages.getString("brk.panel.title"));
 		this.setIcon(new ImageIcon(BreakpointsPanel.class.getResource("/resource/icon/16/101.png")));	// 'red X' icon
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
-				KeyEvent.VK_B, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK | Event.SHIFT_MASK, false));
+				KeyEvent.VK_B, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("brk.panel.mnemonic"));
         this.add(getPanelCommand(), getPanelCommand().getName());
 	}

--- a/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
+++ b/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.brk;
 
 import java.awt.Component;
-import java.awt.Event;
 import java.awt.EventQueue;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
@@ -375,7 +374,7 @@ public class ExtensionBreak extends ExtensionAdaptor implements SessionChangedLi
     private ZapMenuItem getMenuToggleBreakOnResponses() {
         if (menuBreakOnResponses == null) {
             menuBreakOnResponses = new ZapMenuItem("menu.tools.brk.resp",
-            		KeyStroke.getKeyStroke(KeyEvent.VK_B, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK, false));
+            		KeyStroke.getKeyStroke(KeyEvent.VK_B, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK, false));
             menuBreakOnResponses.addActionListener(new java.awt.event.ActionListener() {
                 @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {

--- a/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsPanel.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsPanel.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.httpsessions;
 
 import java.awt.CardLayout;
-import java.awt.Event;
 import java.awt.EventQueue;
 import java.awt.GridBagConstraints;
 import java.awt.Toolkit;
@@ -109,7 +108,7 @@ public class HttpSessionsPanel extends AbstractPanel {
 		this.setName(Constant.messages.getString("httpsessions.panel.title"));
 		this.setIcon(new ImageIcon(HttpSessionsPanel.class.getResource("/resource/icon/16/session.png")));
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
-				KeyEvent.VK_H, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK | Event.SHIFT_MASK, false));
+				KeyEvent.VK_H, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("httpsessions.panel.mnemonic"));
 		this.add(getPanelCommand(), getPanelCommand().getName());
 	}

--- a/src/org/zaproxy/zap/extension/params/ParamsPanel.java
+++ b/src/org/zaproxy/zap/extension/params/ParamsPanel.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.extension.params;
 
 import java.awt.CardLayout;
 import java.awt.Component;
-import java.awt.Event;
 import java.awt.GridBagConstraints;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
@@ -82,7 +81,7 @@ public class ParamsPanel extends AbstractPanel{
         this.setSize(474, 251);
         this.setName(Constant.messages.getString("params.panel.title"));
 		this.setIcon(new ImageIcon(ParamsPanel.class.getResource("/resource/icon/16/179.png")));	// 'form' icon
-		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.SHIFT_MASK, false));
+		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("params.panel.mnemonic"));
         this.add(getPanelCommand(), getPanelCommand().getName());
 	}

--- a/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
+++ b/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
@@ -22,7 +22,6 @@
 package org.zaproxy.zap.extension.spider;
 
 import java.awt.Dimension;
-import java.awt.Event;
 import java.awt.EventQueue;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
@@ -804,7 +803,7 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
     private ZapMenuItem getMenuItemCustomScan() {
         if (menuItemCustomScan  == null) {
             menuItemCustomScan = new ZapMenuItem("menu.tools.spider",
-                    KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK, false));
+                    KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK, false));
             menuItemCustomScan.setEnabled(Control.getSingleton().getMode() != Mode.safe);
 
             menuItemCustomScan.addActionListener(new java.awt.event.ActionListener() {

--- a/src/org/zaproxy/zap/extension/spider/SpiderPanel.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderPanel.java
@@ -20,7 +20,6 @@ package org.zaproxy.zap.extension.spider;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
-import java.awt.Event;
 import java.awt.EventQueue;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -212,7 +211,7 @@ public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderSca
 
 		this.extension = extension;
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
-				KeyEvent.VK_D, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.SHIFT_MASK, false));
+				KeyEvent.VK_D, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("spider.panel.mnemonic"));
 
 	}


### PR DESCRIPTION
Replace usage of java.awt.Event with KeyEvent, the former is deprecated
in Java 9, also, update to recommended (non-deprecated) masks (e.g.
SHIFT_DOWN_MASK instead of SHIFT_MASK).

Part of #2602 - Java 9