### PR TITLE
Address compilation errors with Java 9

### DIFF
--- a/src/org/parosproxy/paros/model/Session.java
+++ b/src/org/parosproxy/paros/model/Session.java
@@ -70,6 +70,7 @@
 // ZAP: 2017/01/26 Remove dependency on ExtensionActiveScan
 // ZAP: 2017/03/13 Remove global excluded URLs from Session's state.
 // ZAP: 2017/06/07 Allow to persist the session properties (e.g. name, description).
+// ZAP: 2017/09/03 Cope with Java 9 change to TreeNode.children().
 
 package org.parosproxy.paros.model;
 
@@ -88,6 +89,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
+
+import javax.swing.tree.TreeNode;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.httpclient.URI;
@@ -857,9 +860,9 @@ public class Session {
 		List<SiteNode> nodes = new LinkedList<>();
 		SiteNode rootNode = (SiteNode) getSiteTree().getRoot();
 		@SuppressWarnings("unchecked")
-		Enumeration<SiteNode> en = rootNode.children();
+		Enumeration<TreeNode> en = rootNode.children();
 		while (en.hasMoreElements()) {
-			SiteNode sn = en.nextElement();
+			SiteNode sn = (SiteNode) en.nextElement();
 			if (isContainsNodesInScope(sn)) {
 				nodes.add(sn);
 			}
@@ -872,9 +875,9 @@ public class Session {
 			return true;
 		}
 		@SuppressWarnings("unchecked")
-		Enumeration<SiteNode> en = node.children();
+		Enumeration<TreeNode> en = node.children();
 		while (en.hasMoreElements()) {
-			SiteNode sn = en.nextElement();
+			SiteNode sn = (SiteNode) en.nextElement();
 			if (isContainsNodesInScope(sn)) {
 				return true;
 			}
@@ -890,9 +893,9 @@ public class Session {
 	 */
 	private void fillNodesInScope(SiteNode rootNode, List<SiteNode> nodesList) {
 		@SuppressWarnings("unchecked")
-		Enumeration<SiteNode> en = rootNode.children();
+		Enumeration<TreeNode> en = rootNode.children();
 		while (en.hasMoreElements()) {
-			SiteNode sn = en.nextElement();
+			SiteNode sn = (SiteNode) en.nextElement();
 			if (isInScope(sn))
 				nodesList.add(sn);
 			fillNodesInScope(sn, nodesList);
@@ -923,9 +926,9 @@ public class Session {
 	 */
 	private void fillNodesInContext(SiteNode rootNode, List<SiteNode> nodesList, Context context) {
 		@SuppressWarnings("unchecked")
-		Enumeration<SiteNode> en = rootNode.children();
+		Enumeration<TreeNode> en = rootNode.children();
 		while (en.hasMoreElements()) {
-			SiteNode sn = en.nextElement();
+			SiteNode sn = (SiteNode) en.nextElement();
 			if (context.isInContext(sn))
 				nodesList.add(sn);
 			fillNodesInContext(sn, nodesList, context);

--- a/src/org/parosproxy/paros/view/AbstractParamContainerPanel.java
+++ b/src/org/parosproxy/paros/view/AbstractParamContainerPanel.java
@@ -24,6 +24,7 @@
 // ZAP: 2016/08/23 Respect sort parameter when adding intermediate panels
 // ZAP: 2016/10/27 Explicitly show other panel when the selected panel is removed.
 // ZAP: 2017/06/23 Ensure panel with validation errors is visible.
+// ZAP: 2017/09/03 Cope with Java 9 change to TreeNode.children().
 
 package org.parosproxy.paros.view;
 
@@ -50,6 +51,7 @@ import javax.swing.JTree;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeCellRenderer;
 import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
 
 import org.apache.log4j.Logger;
@@ -640,9 +642,9 @@ public class AbstractParamContainerPanel extends JSplitPane {
 
         // ZAP: Added @SuppressWarnings annotation.
         @SuppressWarnings("unchecked")
-        Enumeration<DefaultMutableTreeNode> children = parent.children();
+        Enumeration<TreeNode> children = parent.children();
         while (children.hasMoreElements()) {
-            DefaultMutableTreeNode child = children.nextElement();
+            DefaultMutableTreeNode child = (DefaultMutableTreeNode) children.nextElement();
             if (panel.equals(child.toString())) {
                 node = child;
                 break;
@@ -677,9 +679,9 @@ public class AbstractParamContainerPanel extends JSplitPane {
         System.out.println();
 
         @SuppressWarnings("unchecked")
-        Enumeration<DefaultMutableTreeNode> children = parent.children();
+        Enumeration<TreeNode> children = parent.children();
         while (children.hasMoreElements()) {
-            DefaultMutableTreeNode child = children.nextElement();
+            DefaultMutableTreeNode child = (DefaultMutableTreeNode) children.nextElement();
             this.printTree(child, level + 1);
         }
     }

--- a/src/org/zaproxy/zap/extension/alert/AlertNode.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertNode.java
@@ -31,7 +31,7 @@ import javax.swing.tree.TreeNode;
 public class AlertNode extends DefaultMutableTreeNode {
 	private static final long serialVersionUID = 1L;
 
-    private final Comparator<AlertNode> childComparator;
+    private final Comparator<TreeNode> childComparator;
 	private String nodeName = null;
     private int risk = -1;
     private Alert alert;
@@ -44,7 +44,7 @@ public class AlertNode extends DefaultMutableTreeNode {
         super();
         this.nodeName = nodeName;
         this.setRisk(risk);
-        this.childComparator = childComparator;
+        this.childComparator = new AlertNodeComparatorWrapper(childComparator);
     }
     
     @Override
@@ -137,4 +137,17 @@ public class AlertNode extends DefaultMutableTreeNode {
 		return risk;
 	}
 
+	private static class AlertNodeComparatorWrapper implements Comparator<TreeNode> {
+
+		private final Comparator<AlertNode> comparator;
+
+		public AlertNodeComparatorWrapper(Comparator<AlertNode> comparator) {
+			this.comparator = comparator;
+		}
+
+		@Override
+		public int compare(TreeNode o1, TreeNode o2) {
+			return comparator.compare((AlertNode) o1, (AlertNode) o2);
+		}
+	}
 }

--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -38,6 +38,8 @@ import java.util.Vector;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import javax.swing.tree.TreeNode;
+
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 
@@ -900,9 +902,9 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 			result = new ApiResponseList(name);
 			SiteNode root = (SiteNode) session.getSiteTree().getRoot();
 			@SuppressWarnings("unchecked")
-			Enumeration<SiteNode> en = root.children();
+			Enumeration<TreeNode> en = root.children();
 			while (en.hasMoreElements()) {
-				String site = en.nextElement().getNodeName();
+				String site = ((SiteNode) en.nextElement()).getNodeName();
 				if (site.indexOf("//") >= 0) {
 					site = site.substring(site.indexOf("//") + 2);
 				}
@@ -915,9 +917,9 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 			result = new ApiResponseList(name);
 			SiteNode root = (SiteNode) session.getSiteTree().getRoot();
 			@SuppressWarnings("unchecked")
-			Enumeration<SiteNode> en = root.children();
+			Enumeration<TreeNode> en = root.children();
 			while (en.hasMoreElements()) {
-				((ApiResponseList)result).addItem(new ApiResponseElement("site", en.nextElement().getNodeName()));
+				((ApiResponseList)result).addItem(new ApiResponseElement("site", ((SiteNode) en.nextElement()).getNodeName()));
 			}
 		} else if (VIEW_URLS.equals(name)) {
 			result = new ApiResponseList(name);
@@ -1446,9 +1448,9 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 
 	private void getURLs(String baseUrl, SiteNode parent, ApiResponseList list) {
 		@SuppressWarnings("unchecked")
-		Enumeration<SiteNode> en = parent.children();
+		Enumeration<TreeNode> en = parent.children();
 		while (en.hasMoreElements()) {
-			SiteNode child = en.nextElement();
+			SiteNode child = (SiteNode) en.nextElement();
 			String uri = child.getHistoryReference().getURI().toString();
 			if (baseUrl.isEmpty() || uri.startsWith(baseUrl)) {
 				list.addItem(new ApiResponseElement("url", uri));

--- a/src/org/zaproxy/zap/extension/params/ExtensionParams.java
+++ b/src/org/zaproxy/zap/extension/params/ExtensionParams.java
@@ -32,6 +32,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import javax.swing.tree.TreeNode;
+
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -230,9 +232,9 @@ public class ExtensionParams extends ExtensionAdaptor
 		// Repopulate
 		SiteNode root = (SiteNode)session.getSiteTree().getRoot();
 		@SuppressWarnings("unchecked")
-		Enumeration<SiteNode> en = root.children();
+		Enumeration<TreeNode> en = root.children();
 		while (en.hasMoreElements()) {
-			String site = en.nextElement().getNodeName();
+			String site = ((SiteNode) en.nextElement()).getNodeName();
 			if (getView() != null) {
 				this.getParamsPanel().addSite(site);
 			}

--- a/src/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/src/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -53,6 +53,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
 import javax.swing.table.AbstractTableModel;
+import javax.swing.tree.TreeNode;
 
 import org.apache.log4j.Logger;
 import org.jdesktop.swingx.JXTable;
@@ -285,8 +286,8 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 			ScriptEngineWrapper engineWrapper,
 			ScriptEngineWrapper newEngineWrapper) {
 		for (@SuppressWarnings("unchecked")
-		Enumeration<ScriptNode> e = baseNode.depthFirstEnumeration(); e.hasMoreElements();) {
-			ScriptNode node = e.nextElement();
+		Enumeration<TreeNode> e = baseNode.depthFirstEnumeration(); e.hasMoreElements();) {
+			ScriptNode node = (ScriptNode) e.nextElement();
 			if (node.getUserObject() != null && (node.getUserObject() instanceof ScriptWrapper)) {
 				ScriptWrapper scriptWrapper = (ScriptWrapper) node.getUserObject();
 				if (hasSameScriptEngine(scriptWrapper, engineWrapper)) {
@@ -393,8 +394,9 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 
 	private void processTemplatesOfRemovedEngine(ScriptNode baseNode, ScriptEngineWrapper engineWrapper) {
 		@SuppressWarnings("unchecked")
-		List<ScriptNode> templateNodes = Collections.list(baseNode.depthFirstEnumeration());
-		for (ScriptNode node : templateNodes) {
+		List<TreeNode> templateNodes = Collections.list(baseNode.depthFirstEnumeration());
+		for (TreeNode tpNode : templateNodes) {
+			ScriptNode node = (ScriptNode) tpNode;
 			if (node.getUserObject() != null && (node.getUserObject() instanceof ScriptWrapper)) {
 				ScriptWrapper scriptWrapper = (ScriptWrapper) node.getUserObject();
 				if (hasSameScriptEngine(scriptWrapper, engineWrapper)) {

--- a/src/org/zaproxy/zap/extension/spider/SpiderThread.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderThread.java
@@ -27,6 +27,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import javax.swing.DefaultListModel;
+import javax.swing.tree.TreeNode;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
@@ -394,9 +395,9 @@ public class SpiderThread extends ScanThread implements SpiderListener {
 		// If the "scanChildren" option is enabled, add them
 		if (scanChildren) {
 			@SuppressWarnings("unchecked")
-			Enumeration<SiteNode> en = node.children();
+			Enumeration<TreeNode> en = node.children();
 			while (en.hasMoreElements()) {
-				SiteNode sn = en.nextElement();
+				SiteNode sn = (SiteNode) en.nextElement();
 				addSeeds(sn);
 			}
 		}

--- a/src/org/zaproxy/zap/model/Context.java
+++ b/src/org/zaproxy/zap/model/Context.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import javax.swing.tree.TreeNode;
+
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.model.HistoryReference;
@@ -244,9 +246,9 @@ public class Context {
 	 */
 	private boolean hasNodesInContext(SiteNode node) {
 		@SuppressWarnings("unchecked")
-		Enumeration<SiteNode> en = node.children();
+		Enumeration<TreeNode> en = node.children();
 		while (en.hasMoreElements()) {
-			SiteNode sn = en.nextElement();
+			SiteNode sn = (SiteNode) en.nextElement();
 			if (isInContext(sn)) {
 				return true;
 			}
@@ -268,9 +270,9 @@ public class Context {
 		List<SiteNode> nodes = new LinkedList<>();
 		SiteNode rootNode = (SiteNode) session.getSiteTree().getRoot();
 		@SuppressWarnings("unchecked")
-		Enumeration<SiteNode> en = rootNode.children();
+		Enumeration<TreeNode> en = rootNode.children();
 		while (en.hasMoreElements()) {
-			SiteNode sn = en.nextElement();
+			SiteNode sn = (SiteNode) en.nextElement();
 			if (isContainsNodesInContext(sn)) {
 				nodes.add(sn);
 			}
@@ -286,9 +288,9 @@ public class Context {
 	 */
 	private void fillNodesInContext(SiteNode rootNode, List<SiteNode> nodesList) {
 		@SuppressWarnings("unchecked")
-		Enumeration<SiteNode> en = rootNode.children();
+		Enumeration<TreeNode> en = rootNode.children();
 		while (en.hasMoreElements()) {
-			SiteNode sn = en.nextElement();
+			SiteNode sn = (SiteNode) en.nextElement();
 			if (isInContext(sn)) {
 				nodesList.add(sn);
 			}
@@ -307,9 +309,9 @@ public class Context {
 			return true;
 		}
 		@SuppressWarnings("unchecked")
-		Enumeration<SiteNode> en = node.children();
+		Enumeration<TreeNode> en = node.children();
 		while (en.hasMoreElements()) {
-			SiteNode sn = en.nextElement();
+			SiteNode sn = (SiteNode) en.nextElement();
 			if (isContainsNodesInContext(sn)) {
 				return true;
 			}

--- a/src/org/zaproxy/zap/model/StructuralSiteNodeIterator.java
+++ b/src/org/zaproxy/zap/model/StructuralSiteNodeIterator.java
@@ -23,15 +23,18 @@ import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import javax.swing.tree.TreeNode;
+
 import org.parosproxy.paros.model.SiteNode;
 
 public class StructuralSiteNodeIterator implements Iterator<StructuralNode> {
 
-	private Enumeration<SiteNode> children;
+	private Enumeration<TreeNode> children;
 	
-	@SuppressWarnings("unchecked")
 	public StructuralSiteNodeIterator(StructuralSiteNode parent){
-		children = parent.getSiteNode().children();
+	    @SuppressWarnings("unchecked")
+	    Enumeration<TreeNode> children = parent.getSiteNode().children();
+	    this.children = children;
 	}
 	
 	@Override
@@ -44,7 +47,7 @@ public class StructuralSiteNodeIterator implements Iterator<StructuralNode> {
 		if (! hasNext()) {
 			throw new NoSuchElementException();
 		}
-		return new StructuralSiteNode(children.nextElement());
+		return new StructuralSiteNode((SiteNode) children.nextElement());
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/view/ScanPanel.java
+++ b/src/org/zaproxy/zap/view/ScanPanel.java
@@ -43,6 +43,7 @@ import javax.swing.JPanel;
 import javax.swing.JProgressBar;
 import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
+import javax.swing.tree.TreeNode;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -625,9 +626,9 @@ public abstract class ScanPanel extends AbstractPanel {
 		SiteNode rootNode = (SiteNode) siteTree.getRoot();
 		
 		@SuppressWarnings("unchecked")
-		Enumeration<SiteNode> en = rootNode.children();
+		Enumeration<TreeNode> en = rootNode.children();
 		while (en.hasMoreElements()) {
-			SiteNode sn = en.nextElement();
+			SiteNode sn = (SiteNode) en.nextElement();
 			String nodeName = sn.getNodeName();
 			if (nodeName.toLowerCase().startsWith("https:") && !hasPort(nodeName)) {
 				nodeName += ":443";

--- a/test/org/zaproxy/zap/view/JCheckBoxTreeUnitTest.java
+++ b/test/org/zaproxy/zap/view/JCheckBoxTreeUnitTest.java
@@ -621,7 +621,7 @@ public class JCheckBoxTreeUnitTest {
         }
 
         @Override
-        public Enumeration<?> children() {
+        public Enumeration<? extends TreeNode> children() {
             return null;
         }
     }
@@ -659,7 +659,7 @@ public class JCheckBoxTreeUnitTest {
         }
 
         @Override
-        public Enumeration<?> children() {
+        public Enumeration<? extends TreeNode> children() {
             return null;
         }
 
@@ -729,9 +729,9 @@ public class JCheckBoxTreeUnitTest {
             String nextNodeName = path[level];
 
             @SuppressWarnings("unchecked")
-            Enumeration<DefaultMutableTreeNode> children = currentNode.children();
+            Enumeration<TreeNode> children = currentNode.children();
             while (children.hasMoreElements()) {
-                DefaultMutableTreeNode childNode = children.nextElement();
+                DefaultMutableTreeNode childNode = (DefaultMutableTreeNode) children.nextElement();
                 if (childNode.getUserObject().equals(nextNodeName)) {
                     addNodes(childNode, nodes, path, level + 1);
                     return;
@@ -772,9 +772,9 @@ public class JCheckBoxTreeUnitTest {
             String nextNodeName = nodes[level];
 
             @SuppressWarnings("unchecked")
-            Enumeration<DefaultMutableTreeNode> children = node.children();
+            Enumeration<TreeNode> children = node.children();
             while (children.hasMoreElements()) {
-                DefaultMutableTreeNode childNode = children.nextElement();
+                DefaultMutableTreeNode childNode = (DefaultMutableTreeNode) children.nextElement();
                 if (childNode.getUserObject().equals(nextNodeName)) {
                     nextNode = childNode;
                     break;


### PR DESCRIPTION
Address compilation errors related to change in return type of method
DefaultMutableTreeNode.children​() and depthFirstEnumeration​(), with Java
9 it returns `Enumeration<TreeNode>`.

Part of #2602 - Java 9