### PR TITLE
Include body size in Large Response HTTP views

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1335,18 +1335,18 @@ http.panel.view.image.ext.name = HTTP Panel Image View Extension
 http.panel.view.image.name       = Image
 http.panel.view.largerequest.name = Large Request
 http.panel.view.largerequest.ext.name = HTTP Panel Large Request View Extension
-http.panel.view.largerequest.split.warning = <html><p>Very large request body - switch views (using the pulldown currently showing 'Body: Large Request' above) to display.</p>\
+http.panel.view.largerequest.split.warning = <html><p>Very large request body ({0} bytes) - switch views (using the pulldown currently showing 'Body: Large Request' above) to display.</p>\
 <p>Be aware that this message may take some time to load.</p>\
 <p>You can change the minimum message size used for the 'Large Request' view via Options / Display.</p></html> 
-http.panel.view.largerequest.all.warning = <html><p>Very large request body - switch views (using the pulldown currently showing 'Body: Large Request' above)to display.</p>\
+http.panel.view.largerequest.all.warning = <html><p>Very large request body ({0} bytes) - switch views (using the pulldown currently showing 'Body: Large Request' above)to display.</p>\
 <p>Be aware that this message may take some time to load.</p>\
 <p>You can change the minimum message size used for the 'Large Request' view via Options / Display.</p></html> 
 http.panel.view.largeresponse.ext.name = HTTP Panel Large Response View Extension
 http.panel.view.largeresponse.name = Large Response
-http.panel.view.largeresponse.split.warning = <html><p>Very large response body - switch views (using the pulldown currently showing 'Body: Large Response' above) to display.</p>\
+http.panel.view.largeresponse.split.warning = <html><p>Very large response body ({0} bytes) - switch views (using the pulldown currently showing 'Body: Large Response' above) to display.</p>\
 <p>Be aware that this message may take some time to load.</p>\
 <p>You can change the minimum message size used for the 'Large Response' view via Options / Display.</p></html> 
-http.panel.view.largeresponse.all.warning = <html><p>Very large response body - switch views (using the pulldown currently showing 'Body: Large Response' above) to display.</p>\
+http.panel.view.largeresponse.all.warning = <html><p>Very large response body ({0} bytes) - switch views (using the pulldown currently showing 'Body: Large Response' above) to display.</p>\
 <p>Be aware that this message may take some time to load.</p>\
 <p>You can change the minimum message size used for the 'Large Response' view via Options / Display.</p></html>
 http.panel.view.posttable.ext.name = HTTP Panel Post Table View Extension

--- a/src/org/zaproxy/zap/extension/httppanel/view/largerequest/LargeRequestStringHttpPanelViewModel.java
+++ b/src/org/zaproxy/zap/extension/httppanel/view/largerequest/LargeRequestStringHttpPanelViewModel.java
@@ -32,7 +32,7 @@ public class LargeRequestStringHttpPanelViewModel extends RequestStringHttpPanel
         }
 
         return httpMessage.getRequestHeader().toString().replaceAll(HttpHeader.CRLF, HttpHeader.LF)
-                + Constant.messages.getString("http.panel.view.largerequest.all.warning");
+                + Constant.messages.getString("http.panel.view.largerequest.all.warning", httpMessage.getRequestBody().length());
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/httppanel/view/largerequest/RequestLargeRequestSplitView.java
+++ b/src/org/zaproxy/zap/extension/httppanel/view/largerequest/RequestLargeRequestSplitView.java
@@ -30,19 +30,40 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.httppanel.Message;
 import org.zaproxy.zap.extension.httppanel.view.HttpPanelView;
 import org.zaproxy.zap.extension.httppanel.view.HttpPanelViewModel;
-import org.zaproxy.zap.extension.httppanel.view.ImmutableHttpPanelViewModel;
+import org.zaproxy.zap.extension.httppanel.view.HttpPanelViewModelEvent;
+import org.zaproxy.zap.extension.httppanel.view.HttpPanelViewModelListener;
+import org.zaproxy.zap.extension.httppanel.view.impl.models.http.AbstractHttpStringHttpPanelViewModel;
 
-public class RequestLargeRequestSplitView implements HttpPanelView {
+public class RequestLargeRequestSplitView implements HttpPanelView, HttpPanelViewModelListener {
 
     public static final String NAME = "RequestLargeRequestSplitView";
 
     public static final String CAPTION_NAME = Constant.messages.getString("http.panel.view.largerequest.name");
 
     private JPanel mainPanel;
+    private JLabel label;
+
+    private AbstractHttpStringHttpPanelViewModel model;
 
     public RequestLargeRequestSplitView() {
+        label = new JLabel();
         mainPanel = new JPanel(new BorderLayout());
-        mainPanel.add(new JLabel(Constant.messages.getString("http.panel.view.largerequest.split.warning")));
+        mainPanel.add(label);
+
+        model = new AbstractHttpStringHttpPanelViewModel() {
+
+            @Override
+            public String getData() {
+                return Constant.messages
+                        .getString("http.panel.view.largerequest.split.warning", httpMessage.getRequestBody().length());
+            }
+
+            @Override
+            public void setData(String data) {
+                // Nothing to do, the view is immutable.
+            }
+        };
+        model.addHttpPanelViewModelListener(this);
     }
 
     @Override
@@ -114,7 +135,12 @@ public class RequestLargeRequestSplitView implements HttpPanelView {
 
     @Override
     public HttpPanelViewModel getModel() {
-        return ImmutableHttpPanelViewModel.getInstance();
+        return model;
+    }
+
+    @Override
+    public void dataChanged(HttpPanelViewModelEvent e) {
+        label.setText(model.getData());
     }
 
 }

--- a/src/org/zaproxy/zap/extension/httppanel/view/largeresponse/LargeResponseStringHttpPanelViewModel.java
+++ b/src/org/zaproxy/zap/extension/httppanel/view/largeresponse/LargeResponseStringHttpPanelViewModel.java
@@ -30,7 +30,7 @@ public class LargeResponseStringHttpPanelViewModel extends ResponseStringHttpPan
 		}
 		
 		return httpMessage.getResponseHeader().toString().replaceAll(HttpHeader.CRLF, HttpHeader.LF) +
-				Constant.messages.getString("http.panel.view.largeresponse.all.warning");
+				Constant.messages.getString("http.panel.view.largeresponse.all.warning", httpMessage.getResponseBody().length());
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/httppanel/view/largeresponse/ResponseLargeResponseSplitView.java
+++ b/src/org/zaproxy/zap/extension/httppanel/view/largeresponse/ResponseLargeResponseSplitView.java
@@ -28,19 +28,40 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.httppanel.Message;
 import org.zaproxy.zap.extension.httppanel.view.HttpPanelView;
 import org.zaproxy.zap.extension.httppanel.view.HttpPanelViewModel;
-import org.zaproxy.zap.extension.httppanel.view.ImmutableHttpPanelViewModel;
+import org.zaproxy.zap.extension.httppanel.view.HttpPanelViewModelEvent;
+import org.zaproxy.zap.extension.httppanel.view.HttpPanelViewModelListener;
+import org.zaproxy.zap.extension.httppanel.view.impl.models.http.AbstractHttpStringHttpPanelViewModel;
 
-public class ResponseLargeResponseSplitView implements HttpPanelView {
+public class ResponseLargeResponseSplitView implements HttpPanelView, HttpPanelViewModelListener {
 
 	public static final String NAME = "ResponseLargeResponseSplitView";
 	
 	public static final String CAPTION_NAME = Constant.messages.getString("http.panel.view.largeresponse.name");
 	
 	private JPanel mainPanel;
+	private JLabel label;
+
+	private AbstractHttpStringHttpPanelViewModel model;
 	
 	public ResponseLargeResponseSplitView() {
+		label = new JLabel();
 		mainPanel = new JPanel(new BorderLayout());
-		mainPanel.add(new JLabel(Constant.messages.getString("http.panel.view.largeresponse.split.warning")));
+		mainPanel.add(label);
+
+		model = new AbstractHttpStringHttpPanelViewModel() {
+
+			@Override
+			public String getData() {
+				return Constant.messages
+						.getString("http.panel.view.largeresponse.split.warning", httpMessage.getResponseBody().length());
+			}
+
+			@Override
+			public void setData(String data) {
+				// Nothing to do, the view is immutable.
+			}
+		};
+		model.addHttpPanelViewModelListener(this);
 	}
 	
 	@Override
@@ -112,7 +133,11 @@ public class ResponseLargeResponseSplitView implements HttpPanelView {
 
 	@Override
 	public HttpPanelViewModel getModel() {
-		return ImmutableHttpPanelViewModel.getInstance();
+		return model;
 	}
 	
+	@Override
+	public void dataChanged(HttpPanelViewModelEvent e) {
+		label.setText(model.getData());
+	}
 }


### PR DESCRIPTION
Change Large Response HTTP views to include the size of the body in the
information message shown.

Fix #3931 - Minor Enhancement to Very large response body message