### PR TITLE
Correct default font used in FontUtils

### DIFF
--- a/src/org/zaproxy/zap/utils/FontUtils.java
+++ b/src/org/zaproxy/zap/utils/FontUtils.java
@@ -81,7 +81,7 @@ public class FontUtils {
 	}
 	
 	public static Font getFont (String name) {
-		return new Font(name, Font.PLAIN, getDefaultFont().getSize());
+		return getFont(name, Font.PLAIN);
 	}
 	
 	public static Font getFont (int style) {
@@ -89,8 +89,7 @@ public class FontUtils {
 	}
 	
 	public static Font getFont (String name, int style) {
-		Font font = (Font) UIManager.getLookAndFeelDefaults().get("defaultFont");
-		return new Font(name, style, font.getSize());
+		return new Font(name, style, getDefaultFont().getSize());
 	}
 	
 	public static Font getFont (int style, Size size) {


### PR DESCRIPTION
Change FontUtils.getFont(String, int) to use getDefaultFont() instead of
UIManager.getLookAndFeelDefaults().get("defaultFont"), the latter might
not be always defined while the font from the former method is. Also,
change the method getFont(String) to delegate to getFont(String, int) to
reduce code duplication (the former was already using getDefaultFont()).

Fix #3779 - Can't open the Resend window because of missing font