### PR TITLE
Allow to unload ContextPanelUsersSelectComboBox

### DIFF
--- a/src/org/zaproxy/zap/view/widgets/ContextPanelUsersSelectComboBox.java
+++ b/src/org/zaproxy/zap/view/widgets/ContextPanelUsersSelectComboBox.java
@@ -13,6 +13,8 @@ import org.zaproxy.zap.view.renderer.UserListCellRenderer;
  * currently being edited in Users Context Panel. This class should be used when displaying a
  * combo-box for selecting a user in a Context Panel, as it uses the right list of Users: the latest
  * list of Users as being defined in the Users Panel.
+ * 
+ * @see #unload()
  */
 public class ContextPanelUsersSelectComboBox extends JComboBox<User> {
 
@@ -30,6 +32,8 @@ public class ContextPanelUsersSelectComboBox extends JComboBox<User> {
 		}
 	}
 
+	private final UsersListModel usersListModel;
+
 	/**
 	 * Instantiates a new user select combo box.
 	 * 
@@ -41,8 +45,20 @@ public class ContextPanelUsersSelectComboBox extends JComboBox<User> {
 		// Force loading the UserManagement extension to make sure it's enabled.
 		loadUsersManagementExtension();
 		UsersTableModel usersTableModel = usersExtension.getUIConfiguredUsersModel(contextId);
-		this.setModel(new UsersListModel(usersTableModel));
+		this.usersListModel = new UsersListModel(usersTableModel);
+		this.setModel(usersListModel);
 		this.setRenderer(new UserListCellRenderer());
+	}
+
+	/**
+	 * Unloads the combo box model.
+	 * <p>
+	 * This method should be called once the combo box is no longer needed, to detach it from core (persistent) classes.
+	 * 
+	 * @since TODO add version
+	 */
+	public void unload() {
+		this.usersListModel.unload();
 	}
 
 	/**

--- a/src/org/zaproxy/zap/view/widgets/UsersListModel.java
+++ b/src/org/zaproxy/zap/view/widgets/UsersListModel.java
@@ -31,6 +31,7 @@ import org.zaproxy.zap.users.User;
 class UsersListModel extends AbstractListModel<User> implements ComboBoxModel<User> {
 
 	private static final long serialVersionUID = 5648260449088479312L;
+	private final TableModelListenerImpl tableModelListenerImpl;
 	private User selectedItem;
 	private UsersTableModel tableModel;
 	private User[] customUsers;
@@ -38,7 +39,15 @@ class UsersListModel extends AbstractListModel<User> implements ComboBoxModel<Us
 	UsersListModel(UsersTableModel tableModel) {
 		super();
 		this.tableModel = tableModel;
-		this.tableModel.addTableModelListener(new TableModelListenerImpl());
+		this.tableModelListenerImpl = new TableModelListenerImpl();
+		this.tableModel.addTableModelListener(tableModelListenerImpl);
+	}
+
+	/**
+	 * Unloads this instance, by removing the listener previously added to the table model.
+	 */
+	public void unload() {
+		this.tableModel.removeTableModelListener(tableModelListenerImpl);
 	}
 
 	@Override


### PR DESCRIPTION
Change ContextPanelUsersSelectComboBox to allow to unload it, to be
GC'ed when no longer needed.
Change UsersListModel to allow to unload it (helper class used by the
previous class, this class adds itself to "core" table model to get the
latest users available, thus needs to be removed when no longer needed).