### PR TITLE
Allow to unload context select status panel

### DIFF
--- a/src/org/parosproxy/paros/model/Session.java
+++ b/src/org/parosproxy/paros/model/Session.java
@@ -71,6 +71,7 @@
 // ZAP: 2017/03/13 Remove global excluded URLs from Session's state.
 // ZAP: 2017/06/07 Allow to persist the session properties (e.g. name, description).
 // ZAP: 2017/09/03 Cope with Java 9 change to TreeNode.children().
+// ZAP: 2017/10/11 Make contextsChangedListeners static.
 
 package org.parosproxy.paros.model;
 
@@ -1568,7 +1569,7 @@ public class Session {
 	
 	// ZAP: Added listeners for contexts changed events.
 	// TODO: Might be better structured elsewhere, so maybe just a temporary solution.
-	private List<OnContextsChangedListener> contextsChangedListeners = new LinkedList<>();
+	private static List<OnContextsChangedListener> contextsChangedListeners = new LinkedList<>();
 
 	public void addOnContextsChangedListener(OnContextsChangedListener l) {
 		contextsChangedListeners.add(l);

--- a/src/org/zaproxy/zap/view/panels/AbstractContextSelectToolbarStatusPanel.java
+++ b/src/org/zaproxy/zap/view/panels/AbstractContextSelectToolbarStatusPanel.java
@@ -43,6 +43,8 @@ import org.zaproxy.zap.view.widgets.ContextSelectComboBox;
 /**
  * A base implementation for a status panel with a control toolbar that shows information/actions
  * based on a selected {@link Context}.
+ * 
+ * @see #unload()
  */
 public abstract class AbstractContextSelectToolbarStatusPanel extends AbstractPanel implements
 		OnContextsChangedListener {
@@ -244,6 +246,17 @@ public abstract class AbstractContextSelectToolbarStatusPanel extends AbstractPa
 		log.debug("Contexts changed...");
 		contextSelectBox.reloadContexts(false);
 		contextSelectBox.setSelectedIndex(-1);
+	}
+
+	/**
+	 * Unloads the status panel.
+	 * <p>
+	 * This method should be called once the panel is no longer needed, to detach it from core (persistent) classes.
+	 * 
+	 * @since TODO add version
+	 */
+	public void unload() {
+		Model.getSingleton().getSession().removeOnContextsChangedListener(this);
 	}
 
 	/**


### PR DESCRIPTION
Change AbstractContextSelectToolbarStatusPanel to allow to unload it.
Change Session to make the list of context listeners static, to apply to
all sessions created not just to the first the listeners were added to.