### PR TITLE
Address Java 9 deprecation in StatsdClient

### DIFF
--- a/src/org/zaproxy/zap/extension/stats/StatsdClient.java
+++ b/src/org/zaproxy/zap/extension/stats/StatsdClient.java
@@ -105,6 +105,9 @@ public class StatsdClient extends TimerTask {
         setBufferSize((short) 1500);
 	}
 
+    @Override
+    @SuppressWarnings("deprecation")
+    // XXX Deprecated in Java 9, use Cleaner instead?
     protected void finalize() {
             flush();
     }


### PR DESCRIPTION
Suppress the deprecation warning in StatsdClient of the override of
finalize method and add a task to resolve it when targeting Java 9.

Part of #2602 - Java 9