### PR TITLE
Do not allow to open a FindDialog with null parent

### DIFF
--- a/src/org/parosproxy/paros/extension/edit/ExtensionEdit.java
+++ b/src/org/parosproxy/paros/extension/edit/ExtensionEdit.java
@@ -28,14 +28,16 @@
 // ZAP: 2017/04/07 Added name constants and getUIName()
 // ZAP: 2017/07/22 Added KeyStroke constant for consistency with other FindDialog usage
 // ZAP: 2017/08/10 Issue 3798: java.awt.Toolkit initialised in daemon mode
+// ZAP: 2017/10/18 Use Window for parent of invoked component.
 
 package org.parosproxy.paros.extension.edit;
 
 import java.awt.Toolkit;
+import java.awt.Window;
 import java.awt.event.KeyEvent;
 
-import javax.swing.JFrame;
 import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
 import javax.swing.text.JTextComponent;
 
 import org.parosproxy.paros.Constant;
@@ -82,8 +84,8 @@ public class ExtensionEdit extends ExtensionAdaptor {
 
 	}
     
-    private void showFindDialog(JFrame frame, JTextComponent lastInvoker) {
-        FindDialog findDialog = FindDialog.getDialog(frame, false);            
+    private void showFindDialog(Window window, JTextComponent lastInvoker) {
+        FindDialog findDialog = FindDialog.getDialog(window, false);
         findDialog.setLastInvoker(lastInvoker);
         findDialog.setVisible(true);
     }
@@ -135,12 +137,28 @@ public class ExtensionEdit extends ExtensionAdaptor {
             popupFindMenu.addActionListener(new java.awt.event.ActionListener() {
                 @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
-                    showFindDialog(popupFindMenu.getParentFrame(), popupFindMenu.getLastInvoker());
-                    
+                    JTextComponent component = popupFindMenu.getLastInvoker();
+                    Window window = getWindowAncestor(component);
+                    if (window != null) {
+                        showFindDialog(window, component);
+                    }
                 }
             });
         }
         return popupFindMenu;
+    }
+
+    /**
+     * Gets the ancestor {@code Window} where the given {@code component} is contained.
+     *
+     * @param component the component.
+     * @return the {@code Window}, or {@code null} if the component is {@code null} or if not contained inside a {@code Window}.
+     */
+    private static Window getWindowAncestor(JTextComponent component) {
+        if (component == null) {
+            return null;
+        }
+        return SwingUtilities.getWindowAncestor(component);
     }
 	
 	@Override

--- a/src/org/parosproxy/paros/extension/edit/PopupFindMenu.java
+++ b/src/org/parosproxy/paros/extension/edit/PopupFindMenu.java
@@ -26,6 +26,7 @@
 // ZAP: 2016/04/05 Issue 2458: Fix xlint warning messages 
 // ZAP: 2017/07/22 Leverage KeyStroke constant for consistency with other FindDialog usage
 // ZAP: 2017/08/10 Issue 3798: java.awt.Toolkit initialised in daemon mode
+// ZAP: 2017/10/18 Drop support of JFrame as parent (that might not be the case, e.g. parentless JDialog).
 
 package org.parosproxy.paros.extension.edit;
 
@@ -41,7 +42,6 @@ import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 public class PopupFindMenu extends ExtensionPopupMenuItem {
     private static final long serialVersionUID = 1L;
     private JTextComponent lastInvoker = null;
-    private JFrame parentFrame = null;
     
 	/**
      * @return Returns the lastInvoker.
@@ -71,7 +71,6 @@ public class PopupFindMenu extends ExtensionPopupMenuItem {
     public boolean isEnableForComponent(Component invoker) {
         if (invoker instanceof JTextComponent) {
             setLastInvoker((JTextComponent) invoker);
-            setParentFrame((JFrame) SwingUtilities.getAncestorOfClass(JFrame.class, invoker));
             return true;
         } else {
             setLastInvoker(null);
@@ -82,16 +81,24 @@ public class PopupFindMenu extends ExtensionPopupMenuItem {
 
     /**
      * @return Returns the parentFrame.
+     * @deprecated (TODO add version) No longer supported, the invoker might not be contained in a {@code JFrame}. It should be
+     *             obtained its {@link SwingUtilities#getWindowAncestor(Component) ancestor Window} instead.
      */
+    @Deprecated
     public JFrame getParentFrame() {
-        return parentFrame;
+        if (lastInvoker != null) {
+            return (JFrame) SwingUtilities.getAncestorOfClass(JFrame.class, lastInvoker);
+        }
+        return null;
     }
 
     /**
      * @param parentFrame The parentFrame to set.
+     * @deprecated (TODO add version) No longer supported, the parent component is obtained from the invoker moreover the
+     *             invoker might not be contained in a {@code JFrame}.
      */
+    @Deprecated
     public void setParentFrame(JFrame parentFrame) {
-        this.parentFrame = parentFrame;
     }
 
     /**

--- a/src/org/parosproxy/paros/view/FindDialog.java
+++ b/src/org/parosproxy/paros/view/FindDialog.java
@@ -24,6 +24,7 @@
 // ZAP: 2014/01/30 Issue 996: Ensure all dialogs close when the escape key is pressed (copy tidy up)
 // ZAP: 2017/07/12 Issue 765: Add constructor with window parent, to facilitate ctrl-F in various HttpPanels
 // ZAP: 2017/07/17: Prevent opening multiple dialogs per parent.
+// ZAP: 2017/10/18 Do not allow to obtain the FindDialog with a null parent.
 
 package org.parosproxy.paros.view;
 
@@ -138,9 +139,14 @@ public class FindDialog extends AbstractDialog {
 	 * @param modal a boolean indicating whether the FindDialog should ({@code true}), 
 	 * or shouldn't ({@code false}) be modal.
 	 * @return The existing FindDialog for the parent (if there is one), or a new FindDialog.
+	 * @throws IllegalArgumentException if the {@code parent} is {@code null}.
 	 * @since TODO add version
 	 */
 	public static FindDialog getDialog(Window parent, boolean modal) {
+		if (parent == null) {
+			throw new IllegalArgumentException("The parent must not be null.");
+		}
+
 		FindDialog activeDialog = getParentsMap().get(parent);
 		if (activeDialog != null) {
 			activeDialog.getTxtFind().requestFocus();


### PR DESCRIPTION
Change FindDialog to throw an exception if the parent is null, as
there's no parent to cache to.
Change PopupFindMenu to drop the use of parent JFrame, the text
component might not have one (e.g. contained in parentless JDialog).
Change ExtensionEdit to obtain the ancestor Window and use it as the
parent of the text component, it correctly handles the cases of a parent
JDialog and JFrame.