### PR TITLE
Reserve plugin ID for Zest's Action - Fail stmt

### DIFF
--- a/src/doc/scanners.md
+++ b/src/doc/scanners.md
@@ -153,6 +153,7 @@ Scanners:
 50001   Passive Scan scripts
 50002   Fuzzer HTTP Processor scripts
 50003   Stats passive scan rule
+50004   Zest scripts (Action - Fail)
 
 60000   Example simple passive rule 
 60001   Example file passive rule 


### PR DESCRIPTION
Reserve the plugin ID for Action - Fail statement in Zest scripts,
which is using the ID of another scanner (0, Directory browsing).