### PR TITLE
Do not attempt to parse empty Cookie headers

### DIFF
--- a/src/org/parosproxy/paros/network/HttpRequestHeader.java
+++ b/src/org/parosproxy/paros/network/HttpRequestHeader.java
@@ -43,6 +43,7 @@
 // ZAP: 2016/09/26 JavaDoc tweaks
 // ZAP: 2017/02/23 Issue 3227: Limit API access to whitelisted IP addresses
 // ZAP: 2017/04/24 Added more HTTP methods
+// ZAP: 2017/10/19 Skip parsing of empty Cookie headers.
 
 package org.parosproxy.paros.network;
 
@@ -722,6 +723,11 @@ public class HttpRequestHeader extends HttpHeader {
                     cookieLine = cookieLine.substring(HttpHeader.COOKIE.length() + 1);
                 }
                 
+                if (cookieLine.isEmpty()) {
+                    // Nothing to parse.
+                    continue;
+                }
+
                 // These can be comma separated type=value
                 String[] cookieArray = cookieLine.split(";");
                 for (String cookie : cookieArray) {

--- a/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
@@ -620,7 +620,14 @@ public class ExtensionHttpSessions extends ExtensionAdaptor implements SessionCh
 			return;
 
 		// Check for default tokens in request messages
-		List<HttpCookie> requestCookies = msg.getRequestHeader().getHttpCookies();
+		List<HttpCookie> requestCookies;
+		try {
+			requestCookies = msg.getRequestHeader().getHttpCookies();
+		} catch (IllegalArgumentException e) {
+			log.warn("Failed to obtain the cookies: " + e.getMessage(), e);
+			return;
+		}
+
 		for (HttpCookie cookie : requestCookies) {
 			// If it's a default session token and it is not already marked as session token and was
 			// not previously removed by the user

--- a/src/org/zaproxy/zap/extension/params/ExtensionParams.java
+++ b/src/org/zaproxy/zap/extension/params/ExtensionParams.java
@@ -278,8 +278,8 @@ public class ExtensionParams extends ExtensionAdaptor
 			while (iter.hasNext()) {
 				persist(sps.addParam(site, iter.next(), msg));
 			}
-		} catch (Exception e) {
-			logger.error(e.getMessage(), e);
+		} catch (IllegalArgumentException e) {
+			logger.warn("Failed to obtain the cookies: " + e.getMessage(), e);
 		}
 
 		// URL Parameters
@@ -354,10 +354,14 @@ public class ExtensionParams extends ExtensionAdaptor
 		SiteParameters sps = this.getSiteParameters(site);
 
 		// Cookie Parameters
-		TreeSet<HtmlParameter> params = msg.getResponseHeader().getCookieParams();
-		Iterator<HtmlParameter> iter = params.iterator();
-		while (iter.hasNext()) {
-			persist(sps.addParam(site, iter.next(), msg));
+		try {
+			TreeSet<HtmlParameter> params = msg.getResponseHeader().getCookieParams();
+			Iterator<HtmlParameter> iter = params.iterator();
+			while (iter.hasNext()) {
+				persist(sps.addParam(site, iter.next(), msg));
+			}
+		} catch (IllegalArgumentException e) {
+			logger.warn("Failed to obtain the cookies: " + e.getMessage(), e);
 		}
 
 		// Header "Parameters"


### PR DESCRIPTION
Change HttpRequestHeader to skip the parsing of empty Cookie headers
(there's nothing to parse).
Change the extensions that triggered the errors to handle the exception
thrown when the cookies are malformed and change the log level to
warn in the existing log statement (most likely not an error in ZAP).

Fix #3965 - Empty Cookie header causes errors