### PR TITLE
Allow to delete History entries with keyboard

### DIFF
--- a/src/org/parosproxy/paros/extension/ViewDelegate.java
+++ b/src/org/parosproxy/paros/extension/ViewDelegate.java
@@ -25,8 +25,11 @@
 // ZAP: 2013/05/02 Removed redundant public modifiers from interface method declarations
 // ZAP: 2016/03/22 Allow to remove ContextPanelFactory
 // ZAP: 2016/04/14 Allow to display a message
+// ZAP: 2017/10/20 Allow to obtain default delete keyboard shortcut (Issue 3626).
 
 package org.parosproxy.paros.extension;
+
+import javax.swing.KeyStroke;
 
 import org.parosproxy.paros.view.MainFrame;
 import org.parosproxy.paros.view.MainPopupMenu;
@@ -102,4 +105,12 @@ public interface ViewDelegate {
      */
     void displayMessage(Message message);
 
+    /**
+     * Gets the default {@link KeyStroke} used to delete items (e.g. {@code HistoryReference}, {@code Alert}) show in the
+     * view (e.g. History tab, Alerts tree).
+     *
+     * @return the {@code KeyStroke} to delete items.
+     * @since TODO add version
+     */
+    KeyStroke getDefaultDeleteKeyStroke();
 }

--- a/src/org/parosproxy/paros/extension/history/LogPanel.java
+++ b/src/org/parosproxy/paros/extension/history/LogPanel.java
@@ -43,15 +43,18 @@
 // ZAP: 2017/03/03 Tweak filter label.
 // ZAP: 2017/05/12 Support table export.
 // ZAP: 2017/09/02 Use KeyEvent instead of Event (deprecated in Java 9).
+// ZAP: 2017/10/20 Add action/shortcut to delete history entries (Issue 3626).
 
 package org.parosproxy.paros.extension.history;
 
 import java.awt.BorderLayout;
 import java.awt.GridBagConstraints;
 import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.util.List;
 
+import javax.swing.AbstractAction;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -348,6 +351,17 @@ public class LogPanel extends AbstractPanel {
 				}
 			});
 
+			String deleteHrefKey = "zap.delete.href";
+			historyReferencesTable.getInputMap().put(view.getDefaultDeleteKeyStroke(), deleteHrefKey);
+			historyReferencesTable.getActionMap().put(deleteHrefKey, new AbstractAction() {
+
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				public void actionPerformed(ActionEvent e) {
+					extension.purgeHistory(historyReferencesTable.getSelectedHistoryReferences());
+				}
+			});
 		}
 		return historyReferencesTable;
 	}

--- a/src/org/parosproxy/paros/view/View.java
+++ b/src/org/parosproxy/paros/view/View.java
@@ -73,6 +73,7 @@
 // ZAP: 2017/02/20 Issue 3221: Some icons not scaled correctly
 // ZAP: 2017/08/31 Use helper method I18N.getString(String, Object...).
 // ZAP: 2017/09/02 Use KeyEvent instead of Event (deprecated in Java 9).
+// ZAP: 2017/10/20 Implement method to expose default delete keyboard shortcut (Issue 3626).
 
 package org.parosproxy.paros.view;
 
@@ -210,6 +211,13 @@ public class View implements ViewDelegate {
     private boolean postInitialisation;
 
     /**
+     * The default {@link KeyStroke} to delete view items.
+     * <p>
+     * Lazily initialised in {@link #getDefaultDeleteKeyStroke()}.
+     */
+    private KeyStroke defaultDeleteKeyStroke;
+
+    /**
      * @return Returns the mainFrame.
      */
     @Override
@@ -342,6 +350,14 @@ public class View implements ViewDelegate {
     @SuppressWarnings("javadoc")
     public org.zaproxy.zap.view.MessagePanelsPositionController getMessagePanelsPositionController() {
         return new org.zaproxy.zap.view.MessagePanelsPositionController(null, null, null, null);
+    }
+
+    @Override
+    public KeyStroke getDefaultDeleteKeyStroke() {
+        if (defaultDeleteKeyStroke == null) {
+            defaultDeleteKeyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0, false);
+        }
+        return defaultDeleteKeyStroke;
     }
 
     public void refreshTabViewMenus() {

--- a/src/org/zaproxy/zap/extension/history/PopupMenuPurgeHistory.java
+++ b/src/org/zaproxy/zap/extension/history/PopupMenuPurgeHistory.java
@@ -21,16 +21,9 @@ package org.zaproxy.zap.extension.history;
 
 import java.util.List;
 
-import javax.swing.JOptionPane;
-
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.HistoryReference;
-import org.parosproxy.paros.model.Model;
-import org.parosproxy.paros.model.SiteMap;
-import org.parosproxy.paros.model.SiteNode;
-import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer;
 
@@ -44,6 +37,7 @@ public class PopupMenuPurgeHistory extends PopupMenuItemHistoryReferenceContaine
         super(Constant.messages.getString("history.purge.popup"), true);
 
         this.extension = extension;
+        setAccelerator(extension.getView().getDefaultDeleteKeyStroke());
     }
 
     @Override
@@ -53,55 +47,12 @@ public class PopupMenuPurgeHistory extends PopupMenuItemHistoryReferenceContaine
 
     @Override
     public void performHistoryReferenceActions(List<HistoryReference> hrefs) {
-        if (hrefs.size() > 1) {
-            int result = extension.getView().showConfirmDialog(Constant.messages.getString("history.purge.warning"));
-            if (result != JOptionPane.YES_OPTION) {
-                return;
-            }
-        }
-        synchronized (extension) {
-            for (HistoryReference href : hrefs) {
-                purgeHistory(href);
-            }
-        }
+        extension.purgeHistory(hrefs);
     }
 
     @Override
     public void performAction(HistoryReference href) {
-    }
-
-    private void purgeHistory(HistoryReference ref) {
-        if (ref == null) {
-            return;
-        }
-
-        extension.removeFromHistoryList(ref);
-
-        ExtensionAlert extAlert = (ExtensionAlert) Control.getSingleton()
-                .getExtensionLoader()
-                .getExtension(ExtensionAlert.NAME);
-
-        if (extAlert != null) {
-            extAlert.deleteHistoryReferenceAlerts(ref);
-        }
-
-        extension.delete(ref);
-
-        SiteNode node = ref.getSiteNode();
-        if (node == null) {
-            return;
-        }
-
-        SiteMap map = Model.getSingleton().getSession().getSiteTree();
-
-        if (node.getHistoryReference() == ref) {
-            // same active Node
-            extension.purge(map, node);
-
-        } else {
-            node.getPastHistoryReference().remove(ref);
-            map.removeHistoryReference(ref.getHistoryId());
-        }
+        // Nothing to do, the action is performed on all the references.
     }
 
     @Override


### PR DESCRIPTION
Add an action to LogPanel (that is, the table that shows the history
entries) to allow to delete the history entries with keyboard shortcut.
Add a method to ViewDelegate to allow to obtain the default delete
keyboard shortcut (to be used/shared by all the UI components).
Implement the new method in View.
Move methods to delete/purge history entries from PopupMenuPurgeHistory
into ExtensionHistory and made the main method public, now used by the
pop up menu and LogPanel.
Set the default delete keyboard shortcut as accelerator of
PopupMenuPurgeHistory.

Fix #3626 - Allow to delete messages with keyboard shortcut