### PR TITLE
Include spider messages when comparing sessions

### DIFF
--- a/src/org/zaproxy/zap/extension/compare/ExtensionCompare.java
+++ b/src/org/zaproxy/zap/extension/compare/ExtensionCompare.java
@@ -142,7 +142,12 @@ public class ExtensionCompare extends ExtensionAdaptor implements SessionChanged
     	}
 
         List<Integer> hIds = th.getHistoryIdsOfHistType(
-                rh.getSessionId(), HistoryReference.TYPE_PROXIED, HistoryReference.TYPE_ZAP_USER);
+                rh.getSessionId(),
+                HistoryReference.TYPE_PROXIED,
+                HistoryReference.TYPE_ZAP_USER,
+                HistoryReference.TYPE_SPIDER,
+                HistoryReference.TYPE_SPIDER_AJAX);
+
     	for (Integer hId : hIds) {
     		RecordHistory recH = th.read(hId);
     		URI uri = recH.getHttpMessage().getRequestHeader().getURI();


### PR DESCRIPTION
Change ExtensionCompare to also include (normal and AJAX) spider
messages when creating the map for session comparisons.