### PR TITLE
copy python scripts to docker image

### DIFF
--- a/build/docker/Dockerfile-bare
+++ b/build/docker/Dockerfile-bare
@@ -31,4 +31,6 @@ ENV ZAP_PATH /zap/zap.sh
 ENV HOME /home/zap/
 ENV ZAP_PORT 8080
 
+COPY zap* /zap/
+
 HEALTHCHECK --retries=15 --interval=5s CMD nc -vz 127.0.0.1 $ZAP_PORT


### PR DESCRIPTION
All the python scripts are not copied to the bare image, this PR fixed it.
I'm closing this PR - there is no Python installed, and it is intentionally...