### PR TITLE
rename function removeRequestDefaultViewSelectorFactoryAndDefaultView…

### DIFF
--- a/src/org/zaproxy/zap/extension/httppanel/view/largerequest/ExtensionHttpPanelLargeRequestView.java
+++ b/src/org/zaproxy/zap/extension/httppanel/view/largerequest/ExtensionHttpPanelLargeRequestView.java
@@ -79,7 +79,7 @@ public class ExtensionHttpPanelLargeRequestView extends ExtensionAdaptor {
             panelManager.removeRequestDefaultViewSelectorFactory(
                     RequestSplitComponent.NAME,
                     LargeRequestDefaultSplitViewSelectorFactory.NAME);
-            panelManager.removeRequestDefaultViewSelectorFactoryAndDefaultViewSelectorsAdded(
+            panelManager.removeRequestDefaultViewSelectors(
                     RequestSplitComponent.NAME,
                     LargeRequestDefaultSplitViewSelector.NAME,
                     RequestSplitComponent.ViewComponent.BODY);
@@ -89,7 +89,7 @@ public class ExtensionHttpPanelLargeRequestView extends ExtensionAdaptor {
             panelManager.removeRequestDefaultViewSelectorFactory(
                     RequestAllComponent.NAME,
                     LargeRequestDefaultAllViewSelectorFactory.NAME);
-            panelManager.removeRequestDefaultViewSelectorFactoryAndDefaultViewSelectorsAdded(
+            panelManager.removeRequestDefaultViewSelectors(
                     RequestAllComponent.NAME,
                     LargeRequestDefaultAllViewSelector.NAME,
                     null);

--- a/src/org/zaproxy/zap/view/HttpPanelManager.java
+++ b/src/org/zaproxy/zap/view/HttpPanelManager.java
@@ -112,7 +112,15 @@ public class HttpPanelManager {
 	public void removeRequestDefaultViewSelectorFactory(String componentName, String defaultViewSelectorFactoryName) {
 		requestPanels.removeDefaultViewSelectorFactory(componentName, defaultViewSelectorFactoryName);
 	}
-	
+
+	public void removeRequestDefaultViewSelectors(String componentName, String defaultViewSelectorName, Object options) {
+		requestPanels.removeDefaultViewSelectors(componentName, defaultViewSelectorName, options);
+	}
+
+	/**
+	 * @deprecated (TODO add version) Use {@link #removeRequestDefaultViewSelectors(String, String, Object)} instead
+	 * */
+	@Deprecated
 	public void removeRequestDefaultViewSelectorFactoryAndDefaultViewSelectorsAdded(String componentName, String defaultViewSelectorName, Object options) {
 		requestPanels.removeDefaultViewSelectors(componentName, defaultViewSelectorName, options);
 	}


### PR DESCRIPTION
The removeRequestDefaultViewSelectorFactoryAndDefaultViewSelectorsAdded does not do what it says, but does what removeRequestDefaultViewSelectors would be expected to do.

This deprecates the old function but does not fix it to do what it should, because that would require the function arguments to include the name of the DefaultViewSelectorFactory to be deleted.