### PR TITLE
Allow to enable code folding in body text views

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1364,6 +1364,7 @@ http.panel.view.tableparam.functions = Functions
 http.panel.view.syntaxtext.popup.view.label                    = View
 http.panel.view.syntaxtext.popup.view.antiAliasing             = Anti-Aliasing
 http.panel.view.syntaxtext.popup.view.showLineNumbers          = Show Line Numbers
+http.panel.view.syntaxtext.popup.view.codeFolding = Code Folding
 http.panel.view.syntaxtext.popup.view.wordWrap                 = Word Wrap
 http.panel.view.syntaxtext.popup.view.highlightCurrentLine     = Highlight Current Line
 http.panel.view.syntaxtext.popup.view.fadeCurrentHighlightLine = Fade Current Highlight Line

--- a/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/HttpPanelSyntaxHighlightTextArea.java
+++ b/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/HttpPanelSyntaxHighlightTextArea.java
@@ -65,6 +65,7 @@ public abstract class HttpPanelSyntaxHighlightTextArea extends RSyntaxTextArea i
 
 	private static final String ANTI_ALIASING = "aa";
 	private static final String SHOW_LINE_NUMBERS = "linenumbers";
+	private static final String CODE_FOLDING = "codefolding";
 	private static final String WORD_WRAP = "wordwrap";
 	private static final String HIGHLIGHT_CURRENT_LINE = "highlightline";
 	private static final String FADE_CURRENT_HIGHLIGHT_LINE = "fadehighlightline";
@@ -77,6 +78,7 @@ public abstract class HttpPanelSyntaxHighlightTextArea extends RSyntaxTextArea i
 	
 	private Message message;
 	private Vector<SyntaxStyle> syntaxStyles;
+	private boolean codeFoldingAllowed;
 	
 	private static SyntaxMenu syntaxMenu = null;
 	private static ViewMenu viewMenu = null;
@@ -135,6 +137,29 @@ public abstract class HttpPanelSyntaxHighlightTextArea extends RSyntaxTextArea i
 		this.setFont(font);
 		
 		initHighlighter();
+	}
+
+	/**
+	 * Sets whether or not code folding is allowed, to show or not a context menu item to enable/disable code folding.
+	 * <p>
+	 * Default is {@code false}.
+	 *
+	 * @param codeFoldingAllowed {@code true} if code folding is allowed, {@code false} otherwise.
+	 * @since TODO add version
+	 * @see RSyntaxTextArea#setCodeFoldingEnabled(boolean)
+	 */
+	protected void setCodeFoldingAllowed(boolean codeFoldingAllowed) {
+		this.codeFoldingAllowed = codeFoldingAllowed;
+	}
+
+	/**
+	 * Tells whether or not code folding is allowed.
+	 *
+	 * @return {@code true} if code folding is allowed, {@code false} otherwise.
+	 * @since TODO add version
+	 */
+	public boolean isCodeFoldingAllowed() {
+		return codeFoldingAllowed;
 	}
 	
 	@Override
@@ -264,6 +289,11 @@ public abstract class HttpPanelSyntaxHighlightTextArea extends RSyntaxTextArea i
 			if (c instanceof RTextScrollPane) {
 				final RTextScrollPane scrollPane = (RTextScrollPane)c;
 				scrollPane.setLineNumbersEnabled(fileConfiguration.getBoolean(key + SHOW_LINE_NUMBERS, scrollPane.getLineNumbersEnabled()));
+
+				if (isCodeFoldingAllowed()) {
+					setCodeFoldingEnabled(fileConfiguration.getBoolean(key + CODE_FOLDING, this.isCodeFoldingEnabled()));
+					scrollPane.setFoldIndicatorEnabled(this.isCodeFoldingEnabled());
+				}
 			}
 		}
 		
@@ -292,6 +322,10 @@ public abstract class HttpPanelSyntaxHighlightTextArea extends RSyntaxTextArea i
 			if (c instanceof RTextScrollPane) {
 				final RTextScrollPane scrollPane = (RTextScrollPane)c;
 				fileConfiguration.setProperty(key + SHOW_LINE_NUMBERS, Boolean.valueOf(scrollPane.getLineNumbersEnabled()));
+
+				if (isCodeFoldingAllowed()) {
+					fileConfiguration.setProperty(key + CODE_FOLDING, Boolean.valueOf(this.isCodeFoldingEnabled()));
+				}
 			}
 		}
 		

--- a/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/split/request/HttpRequestBodyPanelSyntaxHighlightTextView.java
+++ b/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/split/request/HttpRequestBodyPanelSyntaxHighlightTextView.java
@@ -104,6 +104,8 @@ public class HttpRequestBodyPanelSyntaxHighlightTextView extends HttpPanelSyntax
 			addSyntaxStyle(XML, SyntaxConstants.SYNTAX_STYLE_XML);
 			
 			caretVisiblityEnforcer = new CaretVisibilityEnforcerOnFocusGain(this);
+
+			setCodeFoldingAllowed(true);
 		}
 		
         @Override

--- a/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/split/response/HttpResponseBodyPanelSyntaxHighlightTextView.java
+++ b/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/split/response/HttpResponseBodyPanelSyntaxHighlightTextView.java
@@ -61,6 +61,8 @@ public class HttpResponseBodyPanelSyntaxHighlightTextView extends HttpPanelSynta
 			addSyntaxStyle(JAVASCRIPT, SyntaxConstants.SYNTAX_STYLE_JAVASCRIPT);
 			addSyntaxStyle(JSON, SyntaxConstants.SYNTAX_STYLE_JSON);
 			addSyntaxStyle(XML, SyntaxConstants.SYNTAX_STYLE_XML);
+
+			setCodeFoldingAllowed(true);
 		}
 
 		@Override

--- a/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/menus/ViewMenu.java
+++ b/src/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/menus/ViewMenu.java
@@ -38,6 +38,7 @@ public class ViewMenu extends ExtensionPopupMenu {
 	private static final String MENU_LABEL = Constant.messages.getString("http.panel.view.syntaxtext.popup.view.label");
 	private static final String ANTI_ALIASING = Constant.messages.getString("http.panel.view.syntaxtext.popup.view.antiAliasing");
 	private static final String SHOW_LINE_NUMBERS = Constant.messages.getString("http.panel.view.syntaxtext.popup.view.showLineNumbers");
+	private static final String CODE_FOLDING = Constant.messages.getString("http.panel.view.syntaxtext.popup.view.codeFolding");
 	private static final String WORD_WRAP = Constant.messages.getString("http.panel.view.syntaxtext.popup.view.wordWrap");
 	private static final String HIGHLIGHT_CURRENT_LINE = Constant.messages.getString("http.panel.view.syntaxtext.popup.view.highlightCurrentLine");
 	private static final String FADE_CURRENT_HIGHLIGHT_LINE = Constant.messages.getString("http.panel.view.syntaxtext.popup.view.fadeCurrentHighlightLine");
@@ -50,6 +51,7 @@ public class ViewMenu extends ExtensionPopupMenu {
 
 	private JCheckBoxMenuItem antiAliasingOption;
 	private JCheckBoxMenuItem lineNumbersOption;
+	private JCheckBoxMenuItem codeFoldingAction;
 	private JCheckBoxMenuItem wordWrapOption;
 	
 	private JCheckBoxMenuItem highlightCurrentLineOption;
@@ -70,6 +72,7 @@ public class ViewMenu extends ExtensionPopupMenu {
 
 		antiAliasingOption = createAndAddOption(new ChangeAntiAliasingAction(ANTI_ALIASING), this);
 		lineNumbersOption = createAndAddOption(new ChangeLineNumbersAction(SHOW_LINE_NUMBERS), this);
+		codeFoldingAction = createAndAddOption(new ChangeCodeFoldingAction(CODE_FOLDING), this);
 		wordWrapOption = createAndAddOption(new ChangeWordWrapAction(WORD_WRAP), this);
 		addSeparator();
 		highlightCurrentLineOption = createAndAddOption(new ChangeHighlightCurrentLineAction(HIGHLIGHT_CURRENT_LINE), this);
@@ -117,6 +120,9 @@ public class ViewMenu extends ExtensionPopupMenu {
 		lineNumbersOption.setSelected(selected);
 		
 		wordWrapOption.setSelected(httpPanelTextArea.getLineWrap());
+
+		codeFoldingAction.setVisible(enabled && httpPanelTextArea.isCodeFoldingAllowed());
+		codeFoldingAction.setSelected(httpPanelTextArea.isCodeFoldingEnabled());
 		
 		highlightCurrentLineOption.setSelected(httpPanelTextArea.getHighlightCurrentLine());
 		fadeCurrentHighlightLineOption.setSelected(httpPanelTextArea.getFadeCurrentLineHighlight());
@@ -176,6 +182,32 @@ public class ViewMenu extends ExtensionPopupMenu {
 					if (c instanceof RTextScrollPane) {
 						final RTextScrollPane scrollPane = (RTextScrollPane)c;
 						scrollPane.setLineNumbersEnabled(!scrollPane.getLineNumbersEnabled());
+					}
+				}
+			}
+		}
+	}
+
+	private static class ChangeCodeFoldingAction extends TextAction {
+
+		private static final long serialVersionUID = 8169545961043587586L;
+
+		public ChangeCodeFoldingAction(String text) {
+			super(text);
+		}
+
+		@Override
+		public void actionPerformed(ActionEvent e) {
+			JTextComponent textComponent = getTextComponent(e);
+			if (textComponent instanceof HttpPanelSyntaxHighlightTextArea) {
+				HttpPanelSyntaxHighlightTextArea httpPanelTextArea = (HttpPanelSyntaxHighlightTextArea) textComponent;
+				Component c = httpPanelTextArea.getParent();
+				if (c instanceof JViewport) {
+					c = c.getParent();
+					if (c instanceof RTextScrollPane) {
+						final RTextScrollPane scrollPane = (RTextScrollPane) c;
+						scrollPane.setFoldIndicatorEnabled(!httpPanelTextArea.isCodeFoldingEnabled());
+						httpPanelTextArea.setCodeFoldingEnabled(!httpPanelTextArea.isCodeFoldingEnabled());
 					}
 				}
 			}


### PR DESCRIPTION
Change request/response body (syntax highlight) text views to allow to
enable code folding, makes it easier to see big HTML/XML/JSON bodies.