### PR TITLE
fix HttpSender icon

### DIFF
--- a/src/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/src/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -172,7 +172,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 		this.registerScriptType(new ScriptType(TYPE_STANDALONE, "script.type.standalone", createIcon("/resource/icon/16/script-standalone.png"), false,
 				new String[] {ScriptType.CAPABILITY_APPEND}));
 		this.registerScriptType(new ScriptType(TYPE_TARGETED, "script.type.targeted", createIcon("/resource/icon/16/script-targeted.png"), false));
-		this.registerScriptType(new ScriptType(TYPE_HTTP_SENDER, "script.type.httpsender", createIcon("/resource/icon/16/script-targeted.png"), true));
+		this.registerScriptType(new ScriptType(TYPE_HTTP_SENDER, "script.type.httpsender", createIcon("/resource/icon/16/script-httpsender.png"), true));
 
 		extensionHook.addSessionListener(new ClearScriptVarsOnSessionChange());
 


### PR DESCRIPTION
The HttpSender type of script has the Trageted icon, this mixup was probably a mistake in refactoring the way icons are referenced...

https://github.com/zaproxy/zaproxy/commit/c7fdfa3a#diff-73436761b2495559af7b08826c94d69cR175