### PR TITLE
Use getExtension(Class) to obtain extensions

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/AbstractAppParamPlugin.java
+++ b/src/org/parosproxy/paros/core/scanner/AbstractAppParamPlugin.java
@@ -32,6 +32,7 @@
 // ZAP: 2014/02/09 Add custom input vector scripting capabilities
 // ZAP: 2014/08/14 Issue 1279: Active scanner excluded parameters not working when "Where" is "Any"
 // ZAP: 2016/06/15 Add VariantHeader based on the current scan options
+// ZAP: 2017/10/31 Use ExtensionLoader.getExtension(Class).
 package org.parosproxy.paros.core.scanner;
 
 import java.util.ArrayList;
@@ -294,7 +295,7 @@ public abstract class AbstractAppParamPlugin extends AbstractAppPlugin {
 
     private ExtensionScript getExtension() {
         if (extension == null) {
-            extension = (ExtensionScript) Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.NAME);
+            extension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
         }
         return extension;
     }

--- a/src/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/src/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -54,6 +54,7 @@
 // ZAP: 2016/07/12 Do not allow techSet to be null
 // ZAP: 2017/03/27 Use HttpRequestConfig.
 // ZAP: 2017/05/31 Remove re-declaration of methods.
+// ZAP: 2017/10/31 Use ExtensionLoader.getExtension(Class).
 
 package org.parosproxy.paros.core.scanner;
 
@@ -265,7 +266,7 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
 
         if (parent.handleAntiCsrfTokens() && handleAntiCSRF) {
             if (extAntiCSRF == null) {
-                extAntiCSRF = (ExtensionAntiCSRF) Control.getSingleton().getExtensionLoader().getExtension(ExtensionAntiCSRF.NAME);
+                extAntiCSRF = Control.getSingleton().getExtensionLoader().getExtension(ExtensionAntiCSRF.class);
             }
             if (extAntiCSRF != null) {
                 List<AntiCsrfToken> tokens = extAntiCSRF.getTokens(message);

--- a/src/org/parosproxy/paros/extension/ExtensionLoader.java
+++ b/src/org/parosproxy/paros/extension/ExtensionLoader.java
@@ -70,6 +70,7 @@
 // ZAP: 2017/06/07 Allow to notify of changes in the session's properties (e.g. name, description).
 // ZAP: 2017/07/25 Hook HttpSenderListener.
 // ZAP: 2017/10/11 Include add-on in extensions' initialisation errors.
+// ZAP: 2017/10/31 Add JavaDoc to ExtensionLoader.getExtension(String).
 
 package org.parosproxy.paros.extension;
 
@@ -158,6 +159,13 @@ public class ExtensionLoader {
         return extensionList.get(i);
     }
 
+    /**
+     * Gets the {@code Extension} with the given name.
+     *
+     * @param name the name of the {@code Extension}.
+     * @return the {@code Extension} or {@code null} if not found/enabled.
+     * @see #getExtension(Class)
+     */
     public Extension getExtension(String name) {
         if (name != null) {
             for (int i = 0; i < extensionList.size(); i++) {
@@ -188,7 +196,7 @@ public class ExtensionLoader {
      * Gets the {@code Extension} with the given class.
      *
      * @param clazz the class of the {@code Extension}
-     * @return the {@code Extension} or {@code null} if not found.
+     * @return the {@code Extension} or {@code null} if not found/enabled.
      */
     public <T extends Extension> T getExtension(Class<T> clazz) {
         if (clazz != null) {

--- a/src/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
+++ b/src/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
@@ -189,8 +189,7 @@ public class HttpPanelSender implements MessageSender {
 
     protected ExtensionHistory getHistoryExtension() {
         if (extension == null) {
-            extension = ((ExtensionHistory) Control.getSingleton()
-                    .getExtensionLoader().getExtension(ExtensionHistory.NAME));
+            extension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
         }
         return extension;
     }

--- a/src/org/parosproxy/paros/view/View.java
+++ b/src/org/parosproxy/paros/view/View.java
@@ -74,6 +74,7 @@
 // ZAP: 2017/08/31 Use helper method I18N.getString(String, Object...).
 // ZAP: 2017/09/02 Use KeyEvent instead of Event (deprecated in Java 9).
 // ZAP: 2017/10/20 Implement method to expose default delete keyboard shortcut (Issue 3626).
+// ZAP: 2017/10/31 Use ExtensionLoader.getExtension(Class).
 
 package org.parosproxy.paros.view;
 
@@ -368,7 +369,7 @@ public class View implements ViewDelegate {
         menuShowTabs = new JMenu(Constant.messages.getString("menu.view.showtab"));
         mainFrame.getMainMenuBar().getMenuView().add(menuShowTabs);
 
-        ExtensionKeyboard extKey = (ExtensionKeyboard) Control.getSingleton().getExtensionLoader().getExtension(ExtensionKeyboard.NAME);
+        ExtensionKeyboard extKey = Control.getSingleton().getExtensionLoader().getExtension(ExtensionKeyboard.class);
 
         for (AbstractPanel panel : getWorkbench().getSortedPanels(WorkbenchPanel.PanelType.SELECT)) {
             registerMenu(extKey, panel);

--- a/src/org/zaproxy/zap/GuiBootstrap.java
+++ b/src/org/zaproxy/zap/GuiBootstrap.java
@@ -232,9 +232,8 @@ public class GuiBootstrap extends ZapBootstrap {
                 } else {
                     // Dont auto check for updates the first time, no chance of any
                     // proxy having been set
-                    final ExtensionAutoUpdate eau = (ExtensionAutoUpdate) Control.getSingleton()
-                            .getExtensionLoader()
-                            .getExtension("ExtensionAutoUpdate");
+                    final ExtensionAutoUpdate eau = Control.getSingleton()
+                            .getExtensionLoader().getExtension(ExtensionAutoUpdate.class);
                     if (eau != null) {
                         eau.alertIfNewVersions();
                     }

--- a/src/org/zaproxy/zap/authentication/AuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/AuthenticationMethodType.java
@@ -224,8 +224,7 @@ public abstract class AuthenticationMethodType {
 	protected static void apiChangedAuthenticationMethodForContext(int contextId) {
 		// Make sure the Users are wiped so the authentication credentials for them match the
 		// Method.
-		ExtensionUserManagement usersExtension = (ExtensionUserManagement) Control.getSingleton()
-				.getExtensionLoader().getExtension(ExtensionUserManagement.NAME);
+		ExtensionUserManagement usersExtension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionUserManagement.class);
 		if (usersExtension != null) {
 			if (usersExtension.getContextUserAuthManager(contextId).getUsers().size() > 0) {
 				usersExtension.removeContextUsers(contextId);

--- a/src/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
@@ -586,7 +586,7 @@ public class FormBasedAuthenticationMethodType extends AuthenticationMethodType 
 		
 		private ExtensionUserManagement getUserExt() {
 			if (userExt == null) {
-				userExt = (ExtensionUserManagement) Control.getSingleton().getExtensionLoader().getExtension(ExtensionUserManagement.NAME);
+				userExt = Control.getSingleton().getExtensionLoader().getExtension(ExtensionUserManagement.class);
 				
 			}
 			return userExt;
@@ -777,8 +777,7 @@ public class FormBasedAuthenticationMethodType extends AuthenticationMethodType 
 					 * @return true, if successful
 					 */
 					private boolean confirmUsersDeletion(Context uiSharedContext) {
-						usersExtension = (ExtensionUserManagement) Control.getSingleton()
-								.getExtensionLoader().getExtension(ExtensionUserManagement.NAME);
+						usersExtension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionUserManagement.class);
 						if (usersExtension != null) {
 							if (usersExtension.getSharedContextUsers(uiSharedContext).size() > 0) {
 								int choice = JOptionPane.showConfirmDialog(this, Constant.messages

--- a/src/org/zaproxy/zap/authentication/GenericAuthenticationCredentials.java
+++ b/src/org/zaproxy/zap/authentication/GenericAuthenticationCredentials.java
@@ -139,8 +139,8 @@ public class GenericAuthenticationCredentials implements AuthenticationCredentia
 
 				// NOTE: no need to check if extension is loaded as this method is called only if
 				// the Users extension is loaded
-				ExtensionUserManagement extensionUserManagement = (ExtensionUserManagement) Control
-						.getSingleton().getExtensionLoader().getExtension(ExtensionUserManagement.NAME);
+				ExtensionUserManagement extensionUserManagement = Control.getSingleton()
+						.getExtensionLoader().getExtension(ExtensionUserManagement.class);
 				User user = extensionUserManagement.getContextUserAuthManager(context.getIndex())
 						.getUserById(userId);
 				if (user == null)

--- a/src/org/zaproxy/zap/authentication/ManualAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/ManualAuthenticationMethodType.java
@@ -279,8 +279,8 @@ public class ManualAuthenticationMethodType extends AuthenticationMethodType {
 
 		private JComboBox<HttpSession> getSessionsComboBox() {
 			if (sessionsComboBox == null) {
-				ExtensionHttpSessions extensionHttpSessions = (ExtensionHttpSessions) Control.getSingleton().getExtensionLoader()
-						.getExtension(ExtensionHttpSessions.NAME);
+				ExtensionHttpSessions extensionHttpSessions = Control.getSingleton().getExtensionLoader()
+						.getExtension(ExtensionHttpSessions.class);
 				List<HttpSession> sessions = extensionHttpSessions.getHttpSessionsForContext(uiSharedContext);
 				if (log.isDebugEnabled())
 					log.debug("Found sessions for Manual Authentication Config: " + sessions);
@@ -417,8 +417,8 @@ public class ManualAuthenticationMethodType extends AuthenticationMethodType {
 				// is called only if
 				// the Users
 				// extension is loaded
-				ExtensionUserManagement extensionUserManagement = (ExtensionUserManagement) Control.getSingleton()
-						.getExtensionLoader().getExtension(ExtensionUserManagement.NAME);
+				ExtensionUserManagement extensionUserManagement = Control.getSingleton()
+						.getExtensionLoader().getExtension(ExtensionUserManagement.class);
 				User user = extensionUserManagement.getContextUserAuthManager(context.getIndex()).getUserById(userId);
 				if (user == null) {
 					throw new ApiException(Type.USER_NOT_FOUND, UsersAPI.PARAM_USER_ID);
@@ -426,8 +426,8 @@ public class ManualAuthenticationMethodType extends AuthenticationMethodType {
 				String sessionName = ApiUtils.getNonEmptyStringParam(params, PARAM_SESSION_NAME);
 
 				// Get the matching session
-				ExtensionHttpSessions extensionHttpSessions = (ExtensionHttpSessions) Control.getSingleton().getExtensionLoader()
-						.getExtension(ExtensionHttpSessions.NAME);
+				ExtensionHttpSessions extensionHttpSessions = Control.getSingleton().getExtensionLoader()
+						.getExtension(ExtensionHttpSessions.class);
 				if (extensionHttpSessions == null) {
 					throw new ApiException(Type.NO_IMPLEMENTOR, "HttpSessions extension is not loaded.");
 				}

--- a/src/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
@@ -648,8 +648,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
 
 	private ExtensionScript getScriptsExtension() {
 		if (extensionScript == null)
-			extensionScript = (ExtensionScript) Control.getSingleton().getExtensionLoader()
-					.getExtension(ExtensionScript.NAME);
+			extensionScript = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
 		return extensionScript;
 	}
 

--- a/src/org/zaproxy/zap/authentication/UsernamePasswordAuthenticationCredentials.java
+++ b/src/org/zaproxy/zap/authentication/UsernamePasswordAuthenticationCredentials.java
@@ -213,8 +213,8 @@ class UsernamePasswordAuthenticationCredentials implements AuthenticationCredent
 				// NOTE: no need to check if extension is loaded as this method is called only if
 				// the Users
 				// extension is loaded
-				ExtensionUserManagement extensionUserManagement = (ExtensionUserManagement) Control
-						.getSingleton().getExtensionLoader().getExtension(ExtensionUserManagement.NAME);
+				ExtensionUserManagement extensionUserManagement = Control
+						.getSingleton().getExtensionLoader().getExtension(ExtensionUserManagement.class);
 				User user = extensionUserManagement.getContextUserAuthManager(context.getIndex())
 						.getUserById(userId);
 				if (user == null)

--- a/src/org/zaproxy/zap/control/AddOnInstaller.java
+++ b/src/org/zaproxy/zap/control/AddOnInstaller.java
@@ -302,9 +302,7 @@ public final class AddOnInstaller {
 
     private static void installAddOnPassiveScanRules(AddOn addOn, AddOnClassLoader addOnClassLoader) {
         List<PluginPassiveScanner> pscanrules = AddOnLoaderUtils.getPassiveScanRules(addOn, addOnClassLoader);
-        ExtensionPassiveScan extPscan = (ExtensionPassiveScan) Control.getSingleton()
-                .getExtensionLoader()
-                .getExtension(ExtensionPassiveScan.NAME);
+        ExtensionPassiveScan extPscan = Control.getSingleton().getExtensionLoader().getExtension(ExtensionPassiveScan.class);
 
         if (!pscanrules.isEmpty() && extPscan != null) {
             for (PluginPassiveScanner pscanrule : pscanrules) {
@@ -321,9 +319,7 @@ public final class AddOnInstaller {
         boolean uninstalledWithoutErrors = true;
 
         List<PluginPassiveScanner> loadedPscanrules = addOn.getLoadedPscanrules();
-        ExtensionPassiveScan extPscan = (ExtensionPassiveScan) Control.getSingleton()
-                .getExtensionLoader()
-                .getExtension(ExtensionPassiveScan.NAME);
+        ExtensionPassiveScan extPscan = Control.getSingleton().getExtensionLoader().getExtension(ExtensionPassiveScan.class);
         if (!loadedPscanrules.isEmpty()) {
             logger.debug("Uninstall pscanrules: " + addOn.getPscanrules());
             callback.passiveScanRulesWillBeRemoved(loadedPscanrules.size());

--- a/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -484,9 +484,7 @@ public class ExtensionAlert extends ExtensionAdaptor implements
         //Vector<Integer> v = tableAlert.getAlertListBySession(Model.getSingleton().getSession().getSessionId());
         Vector<Integer> v = tableAlert.getAlertList();
 
-        final ExtensionHistory extensionHistory = (ExtensionHistory) Control.getSingleton()
-                .getExtensionLoader()
-                .getExtension(ExtensionHistory.NAME);
+        final ExtensionHistory extensionHistory = Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
 
         for (int i = 0; i < v.size(); i++) {
             int alertId = v.get(i).intValue();

--- a/src/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRF.java
+++ b/src/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRF.java
@@ -99,9 +99,7 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
 	public void hook(ExtensionHook extensionHook) {
 	    super.hook(extensionHook);
 
-		final ExtensionHistory extensionHistory = (ExtensionHistory) Control.getSingleton()
-				.getExtensionLoader()
-				.getExtension(ExtensionHistory.NAME);
+		final ExtensionHistory extensionHistory = Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
 		if (extensionHistory != null) {
 			historyReferenceFactory = new HistoryReferenceFactory() {
 
@@ -128,9 +126,7 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
 	        extensionHook.getHookMenu().addPopupMenuItem(this.getPopupMenuGenerateForm());
 	    }
 
-        ExtensionPassiveScan extensionPassiveScan = (ExtensionPassiveScan) Control.getSingleton()
-                .getExtensionLoader()
-                .getExtension(ExtensionPassiveScan.NAME);
+        ExtensionPassiveScan extensionPassiveScan = Control.getSingleton().getExtensionLoader().getExtension(ExtensionPassiveScan.class);
         if (extensionPassiveScan != null) {
             extensionPassiveScan.addPassiveScanner(antiCsrfDetectScanner);
         }
@@ -143,9 +139,7 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
 	
 	@Override
 	public void unload() {
-		ExtensionPassiveScan extensionPassiveScan = (ExtensionPassiveScan) Control.getSingleton()
-				.getExtensionLoader()
-				.getExtension(ExtensionPassiveScan.NAME);
+		ExtensionPassiveScan extensionPassiveScan = Control.getSingleton().getExtensionLoader().getExtension(ExtensionPassiveScan.class);
 		if (extensionPassiveScan != null) {
 			extensionPassiveScan.removePassiveScanner(antiCsrfDetectScanner);
 		}
@@ -398,7 +392,7 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
 	}
 
 	public String generateForm(int hrefId) throws Exception {
-		ExtensionHistory extHist = (ExtensionHistory) Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.NAME);
+		ExtensionHistory extHist = Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
 		if (extHist != null) {
 			HistoryReference hr = extHist.getHistoryReference(hrefId);
 			if (hr != null) {

--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -528,8 +528,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_MODE);
 			}
 		} else if (ACTION_GENERATE_ROOT_CA.equals(name)) {
-			ExtensionDynSSL extDyn = (ExtensionDynSSL) 
-					Control.getSingleton().getExtensionLoader().getExtension(ExtensionDynSSL.EXTENSION_ID);
+			ExtensionDynSSL extDyn = Control.getSingleton().getExtensionLoader().getExtension(ExtensionDynSSL.class);
 			if (extDyn != null) {
 				try {
 					extDyn.createNewRootCa();
@@ -547,9 +546,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 			validateForCurrentMode(request);
 			return sendHttpMessage(request, getParam(params, PARAM_FOLLOW_REDIRECTS, false), name);
 		} else if (ACTION_DELETE_ALL_ALERTS.equals(name)) {
-            final ExtensionAlert extAlert = (ExtensionAlert) Control.getSingleton()
-                    .getExtensionLoader()
-                    .getExtension(ExtensionAlert.NAME);
+            final ExtensionAlert extAlert = Control.getSingleton().getExtensionLoader().getExtension(ExtensionAlert.class);
             if (extAlert != null) {
                 extAlert.deleteAllAlerts();
             } else {
@@ -579,9 +576,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 				throw new ApiException(ApiException.Type.DOES_NOT_EXIST, PARAM_ID);
 			}
 
-			final ExtensionAlert extAlert = (ExtensionAlert) Control.getSingleton()
-					.getExtensionLoader()
-					.getExtension(ExtensionAlert.NAME);
+			final ExtensionAlert extAlert = Control.getSingleton().getExtensionLoader().getExtension(ExtensionAlert.class);
 			if (extAlert != null) {
 				extAlert.deleteAlert(new Alert(recAlert));
 			} else {
@@ -1165,8 +1160,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 
 			return msg;
 		} else if (OTHER_ROOT_CERT.equals(name)) {
-			ExtensionDynSSL extDynSSL = 
-					(ExtensionDynSSL) Control.getSingleton().getExtensionLoader().getExtension(ExtensionDynSSL.EXTENSION_ID);
+			ExtensionDynSSL extDynSSL =  Control.getSingleton().getExtensionLoader().getExtension(ExtensionDynSSL.class);
 			if (extDynSSL != null) {
 				try {
 					Certificate rootCA = extDynSSL.getRootCA();

--- a/src/org/zaproxy/zap/extension/ascan/AttackModeScanner.java
+++ b/src/org/zaproxy/zap/extension/ascan/AttackModeScanner.java
@@ -218,7 +218,7 @@ public class AttackModeScanner implements EventConsumer {
 
 	private ExtensionAlert getExtensionAlert() {
 		if (extAlert == null) {
-			extAlert = (ExtensionAlert) Control.getSingleton().getExtensionLoader().getExtension(ExtensionAlert.NAME);
+			extAlert = Control.getSingleton().getExtensionLoader().getExtension(ExtensionAlert.class);
 		}
 		return extAlert;
 	}

--- a/src/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
+++ b/src/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
@@ -103,9 +103,7 @@ public class CustomScanDialog extends StandardFieldsDialog {
     private JButton[] extraButtons = null;
     private ExtensionActiveScan extension = null;
 
-    private final ExtensionUserManagement extUserMgmt = 
-            (ExtensionUserManagement) Control.getSingleton().getExtensionLoader()
-            .getExtension(ExtensionUserManagement.NAME);
+    private final ExtensionUserManagement extUserMgmt = Control.getSingleton().getExtensionLoader().getExtension(ExtensionUserManagement.class);
 
     private int headerLength = -1;
     // The index of the start of the URL path eg after https://www.example.com:1234/ - no point attacking this

--- a/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -166,7 +166,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
         // TODO this isnt currently implemented
         //extensionHook.addCommandLine(getCommandLineArguments());
 
-        ExtensionScript extScript = (ExtensionScript) Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.NAME);
+        ExtensionScript extScript = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
         if (extScript != null) {
             extScript.registerScriptType(
                     new ScriptType(SCRIPT_TYPE_ACTIVE, "ascan.scripts.type.active", createIcon("script-ascan.png"), true));
@@ -174,7 +174,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
                     new ScriptType(SCRIPT_TYPE_VARIANT, "variant.scripts.type.variant", createIcon("script-variant.png"), true));
         }
 
-        this.ascanController.setExtAlert((ExtensionAlert) Control.getSingleton().getExtensionLoader().getExtension(ExtensionAlert.NAME));
+        this.ascanController.setExtAlert(Control.getSingleton().getExtensionLoader().getExtension(ExtensionAlert.class));
         this.activeScanApi = new ActiveScanAPI(this);
         this.activeScanApi.addApiOptions(getScannerParam());
         extensionHook.addApiImplementor(activeScanApi);

--- a/src/org/zaproxy/zap/extension/ascan/OptionsVariantPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/OptionsVariantPanel.java
@@ -212,7 +212,7 @@ public class OptionsVariantPanel extends AbstractParamPanel {
         this.getChkRPCDWR().setSelected((rpcEnabled & ScannerParam.RPC_DWR) != 0);
         this.getChkRPCCustom().setSelected((rpcEnabled & ScannerParam.RPC_CUSTOM) != 0);
         
-        ExtensionScript extension = (ExtensionScript)Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.NAME);
+        ExtensionScript extension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
         this.getChkRPCCustom().setEnabled((extension != null));
 
         this.getExcludedParameterModel().setTokens(param.getExcludedParamList());

--- a/src/org/zaproxy/zap/extension/ascan/ScriptsActiveScanner.java
+++ b/src/org/zaproxy/zap/extension/ascan/ScriptsActiveScanner.java
@@ -131,7 +131,7 @@ public class ScriptsActiveScanner extends AbstractAppParamPlugin {
 
 	private ExtensionScript getExtension() {
 		if (extension == null) {
-			extension = (ExtensionScript) Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.NAME);
+			extension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
 		}
 		return extension;
 	}

--- a/src/org/zaproxy/zap/extension/authentication/ContextAuthenticationPanel.java
+++ b/src/org/zaproxy/zap/extension/authentication/ContextAuthenticationPanel.java
@@ -246,8 +246,7 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
 	 * @return true, if successful
 	 */
 	private boolean confirmAndExecuteUsersDeletion() {
-		ExtensionUserManagement usersExtension = (ExtensionUserManagement) Control.getSingleton()
-				.getExtensionLoader().getExtension(ExtensionUserManagement.NAME);
+		ExtensionUserManagement usersExtension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionUserManagement.class);
 		if (usersExtension != null) {
 			if (usersExtension.getSharedContextUsers(getUISharedContext()).size() > 0) {
 				authenticationMethodsComboBox.transferFocus();

--- a/src/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
+++ b/src/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
@@ -216,8 +216,7 @@ public class ExtensionForcedUser extends ExtensionAdaptor implements ContextPane
 
 	protected ExtensionUserManagement getUserManagementExtension() {
 		if (extensionUserManagement == null) {
-			extensionUserManagement = (ExtensionUserManagement) Control.getSingleton().getExtensionLoader()
-					.getExtension(ExtensionUserManagement.NAME);
+			extensionUserManagement = Control.getSingleton().getExtensionLoader().getExtension(ExtensionUserManagement.class);
 		}
 		return extensionUserManagement;
 	}

--- a/src/org/zaproxy/zap/extension/httpsessions/PopupMenuFactoryAddUserFromSession.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/PopupMenuFactoryAddUserFromSession.java
@@ -54,8 +54,7 @@ public class PopupMenuFactoryAddUserFromSession extends PopupContextMenuItemFact
 	 */
 	private ExtensionAuthentication getExtensionAuthentication() {
 		if (extensionAuth == null) {
-			extensionAuth = (ExtensionAuthentication) Control.getSingleton().getExtensionLoader()
-					.getExtension(ExtensionAuthentication.NAME);
+			extensionAuth = Control.getSingleton().getExtensionLoader().getExtension(ExtensionAuthentication.class);
 		}
 		return extensionAuth;
 	}
@@ -67,8 +66,7 @@ public class PopupMenuFactoryAddUserFromSession extends PopupContextMenuItemFact
 	 */
 	private ExtensionUserManagement getExtensionUserManagement() {
 		if (extensionUsers == null) {
-			extensionUsers = (ExtensionUserManagement) Control.getSingleton().getExtensionLoader()
-					.getExtension(ExtensionUserManagement.NAME);
+			extensionUsers = Control.getSingleton().getExtensionLoader().getExtension(ExtensionUserManagement.class);
 		}
 		return extensionUsers;
 	}

--- a/src/org/zaproxy/zap/extension/params/ExtensionParams.java
+++ b/src/org/zaproxy/zap/extension/params/ExtensionParams.java
@@ -118,9 +118,7 @@ public class ExtensionParams extends ExtensionAdaptor
 	        ExtensionHelp.enableHelpKey(getParamsPanel(), "ui.tabs.params");
 	    }
 
-        ExtensionPassiveScan extensionPassiveScan = (ExtensionPassiveScan) Control.getSingleton()
-                .getExtensionLoader()
-                .getExtension(ExtensionPassiveScan.NAME);
+        ExtensionPassiveScan extensionPassiveScan = Control.getSingleton().getExtensionLoader().getExtension(ExtensionPassiveScan.class);
         if (extensionPassiveScan != null) {
             paramScanner = new ParamScanner(this);
             extensionPassiveScan.addPassiveScanner(new ParamScanner(this));
@@ -129,9 +127,7 @@ public class ExtensionParams extends ExtensionAdaptor
 	
 	@Override
 	public void unload() {
-		ExtensionPassiveScan extensionPassiveScan = (ExtensionPassiveScan) Control.getSingleton()
-				.getExtensionLoader()
-				.getExtension(ExtensionPassiveScan.NAME);
+		ExtensionPassiveScan extensionPassiveScan = Control.getSingleton().getExtensionLoader().getExtension(ExtensionPassiveScan.class);
 		if (extensionPassiveScan != null) {
 			extensionPassiveScan.removePassiveScanner(paramScanner);
 		}
@@ -212,8 +208,7 @@ public class ExtensionParams extends ExtensionAdaptor
 	 */
 	protected ExtensionHttpSessions getExtensionHttpSessions() {
 		if(extensionHttpSessions==null){
-			extensionHttpSessions = (ExtensionHttpSessions) Control.getSingleton().getExtensionLoader()
-					.getExtension(ExtensionHttpSessions.NAME);
+			extensionHttpSessions = Control.getSingleton().getExtensionLoader().getExtension(ExtensionHttpSessions.class);
 		}
 		return extensionHttpSessions;
 		
@@ -292,8 +287,7 @@ public class ExtensionParams extends ExtensionAdaptor
 		// Form Parameters
 		// TODO flag anti csrf url ones too?
 		
-		ExtensionAntiCSRF extAntiCSRF = 
-			(ExtensionAntiCSRF) Control.getSingleton().getExtensionLoader().getExtension(ExtensionAntiCSRF.NAME);
+		ExtensionAntiCSRF extAntiCSRF = Control.getSingleton().getExtensionLoader().getExtension(ExtensionAntiCSRF.class);
 		
 		params = msg.getFormParams();
 		iter = params.iterator();
@@ -403,8 +397,7 @@ public class ExtensionParams extends ExtensionAdaptor
 
 		HtmlParameterStats item = this.getParamsPanel().getSelectedParam();
 		if (item != null) {
-			ExtensionSearch extSearch = 
-				(ExtensionSearch) Control.getSingleton().getExtensionLoader().getExtension(ExtensionSearch.NAME);
+			ExtensionSearch extSearch = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSearch.class);
 
 			if (extSearch != null) {
 				if (HtmlParameter.Type.url.equals(item.getType())) {
@@ -424,8 +417,7 @@ public class ExtensionParams extends ExtensionAdaptor
 	public void addAntiCsrfToken() {
 		HtmlParameterStats item = this.getParamsPanel().getSelectedParam();
 		
-		ExtensionAntiCSRF extAntiCSRF = 
-			(ExtensionAntiCSRF) Control.getSingleton().getExtensionLoader().getExtension(ExtensionAntiCSRF.NAME);
+		ExtensionAntiCSRF extAntiCSRF = Control.getSingleton().getExtensionLoader().getExtension(ExtensionAntiCSRF.class);
 
 		if (extAntiCSRF != null && item != null) {
 			extAntiCSRF.addAntiCsrfTokenName(item.getName());
@@ -443,8 +435,7 @@ public class ExtensionParams extends ExtensionAdaptor
 	public void removeAntiCsrfToken() {
 		HtmlParameterStats item = this.getParamsPanel().getSelectedParam();
 		
-		ExtensionAntiCSRF extAntiCSRF = 
-			(ExtensionAntiCSRF) Control.getSingleton().getExtensionLoader().getExtension(ExtensionAntiCSRF.NAME);
+		ExtensionAntiCSRF extAntiCSRF = Control.getSingleton().getExtensionLoader().getExtension(ExtensionAntiCSRF.class);
 
 		if (extAntiCSRF != null && item != null) {
 			extAntiCSRF.removeAntiCsrfTokenName(item.getName());

--- a/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -108,7 +108,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
             extensionHook.getHookView().addOptionPanel(getPolicyPanel());
         }
 
-        ExtensionScript extScript = (ExtensionScript) Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.NAME);
+        ExtensionScript extScript = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
         if (extScript != null) {
             extScript.registerScriptType(
                     new ScriptType(SCRIPT_TYPE_PASSIVE, "pscan.scripts.type.passive", createScriptIcon(), true));
@@ -426,8 +426,8 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
     private PassiveScanThread getPassiveScanThread() {
         if (pst == null) {
             final ExtensionLoader extensionLoader = Control.getSingleton().getExtensionLoader();
-            final ExtensionHistory extHist = (ExtensionHistory) extensionLoader.getExtension(ExtensionHistory.NAME);
-            final ExtensionAlert extAlert = (ExtensionAlert) extensionLoader.getExtension(ExtensionAlert.NAME);
+            final ExtensionHistory extHist = extensionLoader.getExtension(ExtensionHistory.class);
+            final ExtensionAlert extAlert = extensionLoader.getExtension(ExtensionAlert.class);
 
             pst = new PassiveScanThread(getPassiveScannerList(), extHist, extAlert, getPassiveScanParam());
 

--- a/src/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
+++ b/src/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
@@ -57,7 +57,7 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
 
 	private ExtensionScript getExtension() {
 		if (extension == null) {
-			extension = (ExtensionScript) Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.NAME);
+			extension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
 		}
 		return extension;
 	}

--- a/src/org/zaproxy/zap/extension/spider/SpiderAPI.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderAPI.java
@@ -230,8 +230,8 @@ public class SpiderAPI extends ApiImplementor {
 			// The action is to start a new Scan from the perspective of a user
 			String urlUserScan = ApiUtils.getOptionalStringParam(params, PARAM_URL);
 			int userID = ApiUtils.getIntParam(params, PARAM_USER_ID);
-			ExtensionUserManagement usersExtension = (ExtensionUserManagement) Control.getSingleton()
-					.getExtensionLoader().getExtension(ExtensionUserManagement.NAME);
+			ExtensionUserManagement usersExtension = Control.getSingleton()
+					.getExtensionLoader().getExtension(ExtensionUserManagement.class);
 			if (usersExtension == null) {
 				throw new ApiException(Type.NO_IMPLEMENTOR, ExtensionUserManagement.NAME);
 			}

--- a/src/org/zaproxy/zap/extension/spider/SpiderDialog.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderDialog.java
@@ -86,8 +86,8 @@ public class SpiderDialog extends StandardFieldsDialog {
 	 */
 	private boolean subtreeOnlyPreviousCheckedState;
     
-    private ExtensionUserManagement extUserMgmt = (ExtensionUserManagement) Control.getSingleton().getExtensionLoader()
-			.getExtension(ExtensionUserManagement.NAME);
+    private ExtensionUserManagement extUserMgmt = Control.getSingleton().getExtensionLoader()
+			.getExtension(ExtensionUserManagement.class);
     
     private Target target = null;
 

--- a/src/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
@@ -345,7 +345,7 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
 		if (popupMenuResendMessage == null) {
 			popupMenuResendMessage = new PopupMenuResendMessage(
 					Constant.messages.getString("history.resend.popup"),
-					(ExtensionHistory) Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.NAME));
+					Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class));
 			popupMenuResendMessage.setMenuIndex(menuIndex);
 		}
 		return popupMenuResendMessage;
@@ -363,7 +363,7 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
 		if (popupMenuShowInHistory == null) {
 			popupMenuShowInHistory = new PopupMenuShowInHistory(
 					Constant.messages.getString("history.showinhistory.popup"),
-					(ExtensionHistory) Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.NAME));
+					Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class));
 			popupMenuShowInHistory.setMenuIndex(menuIndex);
 		}
 		return popupMenuShowInHistory;

--- a/src/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanCustom.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanCustom.java
@@ -42,7 +42,7 @@ public class PopupMenuActiveScanCustom extends PopupMenuItemSiteNodeContainer {
     
     private ExtensionActiveScan getExtensionActiveScan() {
     	if (extension == null) {
-    		extension = (ExtensionActiveScan) Control.getSingleton().getExtensionLoader().getExtension(ExtensionActiveScan.NAME);
+    		extension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionActiveScan.class);
     	}
     	return extension;
     }

--- a/src/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanNode.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanNode.java
@@ -42,7 +42,7 @@ public class PopupMenuActiveScanNode extends PopupMenuItemSiteNodeContainer {
     
     private ExtensionActiveScan getExtensionActiveScan() {
     	if (extension == null) {
-    		extension = (ExtensionActiveScan) Control.getSingleton().getExtensionLoader().getExtension(ExtensionActiveScan.NAME);
+    		extension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionActiveScan.class);
     	}
     	return extension;
     }

--- a/src/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanScope.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanScope.java
@@ -42,7 +42,7 @@ public class PopupMenuActiveScanScope extends PopupMenuItemSiteNodeContainer {
     
     private ExtensionActiveScan getExtensionActiveScan() {
     	if (extension == null) {
-    		extension = (ExtensionActiveScan) Control.getSingleton().getExtensionLoader().getExtension(ExtensionActiveScan.NAME);
+    		extension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionActiveScan.class);
     	}
     	return extension;
     }

--- a/src/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanSite.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanSite.java
@@ -42,7 +42,7 @@ public class PopupMenuActiveScanSite extends PopupMenuItemSiteNodeContainer {
     
     private ExtensionActiveScan getExtensionActiveScan() {
     	if (extension == null) {
-    		extension = (ExtensionActiveScan) Control.getSingleton().getExtensionLoader().getExtension(ExtensionActiveScan.NAME);
+    		extension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionActiveScan.class);
     	}
     	return extension;
     }

--- a/src/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanURL.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanURL.java
@@ -42,7 +42,7 @@ public class PopupMenuActiveScanURL extends PopupMenuItemSiteNodeContainer {
     
     private ExtensionActiveScan getExtensionActiveScan() {
     	if (extension == null) {
-    		extension = (ExtensionActiveScan) Control.getSingleton().getExtensionLoader().getExtension(ExtensionActiveScan.NAME);
+    		extension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionActiveScan.class);
     	}
     	return extension;
     }

--- a/src/org/zaproxy/zap/extension/stdmenus/PopupMenuSpiderContext.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/PopupMenuSpiderContext.java
@@ -60,8 +60,7 @@ public class PopupMenuSpiderContext extends PopupContextMenuItemHolder {
 	 */
 	private ExtensionSpider getExtensionSpider() {
 		if (extension == null) {
-			extension = (ExtensionSpider) Control.getSingleton().getExtensionLoader()
-					.getExtension(ExtensionSpider.NAME);
+			extension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSpider.class);
 		}
 		return extension;
 	}

--- a/src/org/zaproxy/zap/extension/stdmenus/PopupMenuSpiderContextAsUser.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/PopupMenuSpiderContextAsUser.java
@@ -57,8 +57,7 @@ public class PopupMenuSpiderContextAsUser extends PopupUserMenuItemHolder {
 	 */
 	private ExtensionSpider getExtensionSpider() {
 		if (extension == null) {
-			extension = (ExtensionSpider) Control.getSingleton().getExtensionLoader()
-					.getExtension(ExtensionSpider.NAME);
+			extension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSpider.class);
 		}
 		return extension;
 	}

--- a/src/org/zaproxy/zap/extension/stdmenus/PopupMenuSpiderDialog.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/PopupMenuSpiderDialog.java
@@ -47,7 +47,7 @@ public class PopupMenuSpiderDialog extends PopupMenuItemSiteNodeContainer {
     
     private ExtensionSpider getExtensionActiveScan() {
     	if (extension == null) {
-    		extension = (ExtensionSpider) Control.getSingleton().getExtensionLoader().getExtension(ExtensionSpider.NAME);
+    		extension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSpider.class);
     	}
     	return extension;
     }

--- a/src/org/zaproxy/zap/extension/stdmenus/PopupMenuSpiderScope.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/PopupMenuSpiderScope.java
@@ -46,7 +46,7 @@ public class PopupMenuSpiderScope extends PopupMenuItemSiteNodeContainer {
     
     private ExtensionSpider getExtensionSpider() {
     	if (extension == null) {
-    		extension = (ExtensionSpider) Control.getSingleton().getExtensionLoader().getExtension(ExtensionSpider.NAME);
+    		extension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSpider.class);
     	}
     	return extension;
     }

--- a/src/org/zaproxy/zap/extension/stdmenus/PopupMenuSpiderSite.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/PopupMenuSpiderSite.java
@@ -46,7 +46,7 @@ public class PopupMenuSpiderSite extends PopupMenuItemSiteNodeContainer {
     
     private ExtensionSpider getExtensionSpider() {
     	if (extension == null) {
-    		extension = (ExtensionSpider) Control.getSingleton().getExtensionLoader().getExtension(ExtensionSpider.NAME);
+    		extension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSpider.class);
     	}
     	return extension;
     }

--- a/src/org/zaproxy/zap/extension/stdmenus/PopupMenuSpiderSubtree.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/PopupMenuSpiderSubtree.java
@@ -46,7 +46,7 @@ public class PopupMenuSpiderSubtree extends PopupMenuItemSiteNodeContainer {
     
     private ExtensionSpider getExtensionSpider() {
     	if (extension == null) {
-    		extension = (ExtensionSpider) Control.getSingleton().getExtensionLoader().getExtension(ExtensionSpider.NAME);
+    		extension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSpider.class);
     	}
     	return extension;
     }

--- a/src/org/zaproxy/zap/extension/stdmenus/PopupMenuSpiderURL.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/PopupMenuSpiderURL.java
@@ -46,7 +46,7 @@ public class PopupMenuSpiderURL extends PopupMenuItemSiteNodeContainer {
     
     private ExtensionSpider getExtensionSpider() {
     	if (extension == null) {
-    		extension = (ExtensionSpider) Control.getSingleton().getExtensionLoader().getExtension(ExtensionSpider.NAME);
+    		extension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSpider.class);
     	}
     	return extension;
     }

--- a/src/org/zaproxy/zap/extension/stdmenus/PopupMenuSpiderURLAsUser.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/PopupMenuSpiderURLAsUser.java
@@ -57,8 +57,7 @@ public class PopupMenuSpiderURLAsUser extends PopupUserMenuItemHolder {
 	 */
 	private ExtensionSpider getExtensionSpider() {
 		if (extension == null) {
-			extension = (ExtensionSpider) Control.getSingleton().getExtensionLoader()
-					.getExtension(ExtensionSpider.NAME);
+			extension = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSpider.class);
 		}
 		return extension;
 	}

--- a/src/org/zaproxy/zap/extension/stdmenus/PopupUserMenuItemHolder.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/PopupUserMenuItemHolder.java
@@ -74,8 +74,7 @@ public abstract class PopupUserMenuItemHolder extends ExtensionPopupMenuMessageC
 		this.parentName = parentName;
 		this.visibleItself = true;
 		// Check whether the User Authentication extension is enabled
-		extensionUserAuth = (ExtensionUserManagement) Control.getSingleton().getExtensionLoader()
-				.getExtension(ExtensionUserManagement.NAME);
+		extensionUserAuth = Control.getSingleton().getExtensionLoader().getExtension(ExtensionUserManagement.class);
 		if (extensionUserAuth == null || !extensionUserAuth.isEnabled()) {
 			Logger.getLogger(PopupUserMenuItemHolder.class).warn(
 					ExtensionUserManagement.class

--- a/src/org/zaproxy/zap/extension/users/ExtensionUserManagement.java
+++ b/src/org/zaproxy/zap/extension/users/ExtensionUserManagement.java
@@ -111,8 +111,7 @@ public class ExtensionUserManagement extends ExtensionAdaptor implements Context
 	 */
 	protected ExtensionHttpSessions getExtensionHttpSessions() {
 		if (extensionHttpSessions == null) {
-			extensionHttpSessions = (ExtensionHttpSessions) Control.getSingleton().getExtensionLoader()
-					.getExtension(ExtensionHttpSessions.NAME);
+			extensionHttpSessions = Control.getSingleton().getExtensionLoader().getExtension(ExtensionHttpSessions.class);
 			if (extensionHttpSessions == null)
 				log.error("Http Sessions Extension should be enabled for the "
 						+ ExtensionUserManagement.class.getSimpleName() + " to work.");

--- a/src/org/zaproxy/zap/extension/users/UsersAPI.java
+++ b/src/org/zaproxy/zap/extension/users/UsersAPI.java
@@ -99,8 +99,8 @@ public class UsersAPI extends ApiImplementor {
 
 		// Load the authentication method actions
 		if (Control.getSingleton() != null) {
-			ExtensionAuthentication authenticationExtension = (ExtensionAuthentication) Control
-					.getSingleton().getExtensionLoader().getExtension(ExtensionAuthentication.NAME);
+			ExtensionAuthentication authenticationExtension = Control
+					.getSingleton().getExtensionLoader().getExtension(ExtensionAuthentication.class);
 			this.loadedAuthenticationMethodActions = new HashMap<>();
 			if (authenticationExtension != null) {
 				for (AuthenticationMethodType t : authenticationExtension.getAuthenticationMethodTypes()) {

--- a/src/org/zaproxy/zap/model/StructuralTableNode.java
+++ b/src/org/zaproxy/zap/model/StructuralTableNode.java
@@ -113,7 +113,7 @@ public class StructuralTableNode implements StructuralNode {
 
 	private static ExtensionHistory getExtensionHistory() {
 		if (extHistory == null) {
-			extHistory = (ExtensionHistory) Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.NAME);
+			extHistory = Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
 		}
 		return extHistory;
 	}

--- a/src/org/zaproxy/zap/spider/SpiderTask.java
+++ b/src/org/zaproxy/zap/spider/SpiderTask.java
@@ -404,7 +404,7 @@ public class SpiderTask implements Runnable {
 
 	private ExtensionHistory getExtensionHistory() {
 		if (this.extHistory == null) {
-			this.extHistory = (ExtensionHistory) Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.NAME);
+			this.extHistory = Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
 		}
 		return this.extHistory;
 	}

--- a/src/org/zaproxy/zap/users/User.java
+++ b/src/org/zaproxy/zap/users/User.java
@@ -268,8 +268,7 @@ public class User extends Enableable {
 	 */
 	private static ExtensionAuthentication getAuthenticationExtension() {
 		if (extensionAuth == null) {
-			extensionAuth = (ExtensionAuthentication) Control.getSingleton().getExtensionLoader()
-					.getExtension(ExtensionAuthentication.NAME);
+			extensionAuth = Control.getSingleton().getExtensionLoader().getExtension(ExtensionAuthentication.class);
 		}
 		return extensionAuth;
 	}


### PR DESCRIPTION
Replace use of method ExtensionLoader.getExtension(String) with
getExtension(Class), safer (returns the requested type) and less verbose
(does not require the explicit cast).