### PR TITLE
Allow to delete a Context with keyboard shortcut

### DIFF
--- a/src/org/parosproxy/paros/view/SiteMapPanel.java
+++ b/src/org/parosproxy/paros/view/SiteMapPanel.java
@@ -40,6 +40,7 @@
 // ZAP: 2016/07/01 Issue 2642: Slow mouse wheel scrolling in site tree
 // ZAP: 2017/03/28 Issue 3253: Facilitate exporting URLs by context (add getSelectedContext)
 // ZAP: 2017/09/02 Use KeyEvent instead of Event (deprecated in Java 9).
+// ZAP: 2017/11/01 Delete context with keyboard shortcut.
 
 package org.parosproxy.paros.view;
 
@@ -89,6 +90,7 @@ import org.zaproxy.zap.view.ContextCreateDialog;
 import org.zaproxy.zap.view.ContextGeneralPanel;
 import org.zaproxy.zap.view.ContextsSitesPanel;
 import org.zaproxy.zap.view.ContextsTreeCellRenderer;
+import org.zaproxy.zap.view.DeleteContextAction;
 import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.SiteMapListener;
 import org.zaproxy.zap.view.SiteMapTreeCellRenderer;
@@ -449,6 +451,19 @@ public class SiteMapPanel extends AbstractPanel {
 	        treeContext.setComponentPopupMenu(new ContextsCustomPopupMenu());
 
 			treeContext.setCellRenderer(new ContextsTreeCellRenderer());
+			DeleteContextAction delContextAction = new DeleteContextAction() {
+
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				protected Context getContext() {
+					return getSelectedContext();
+				}
+			};
+			treeContext.getInputMap().put(
+					(KeyStroke) delContextAction.getValue(DeleteContextAction.ACCELERATOR_KEY),
+					DeleteContextAction.ACTION_NAME);
+			treeContext.getActionMap().put(DeleteContextAction.ACTION_NAME, delContextAction);
 		}
 		return treeContext;
 	}

--- a/src/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
+++ b/src/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
@@ -29,7 +29,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import javax.swing.ImageIcon;
-import javax.swing.JOptionPane;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -45,6 +44,7 @@ import org.zaproxy.zap.extension.history.PopupMenuExportContextURLs;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.ContextExportDialog;
+import org.zaproxy.zap.view.DeleteContextAction;
 import org.zaproxy.zap.view.popup.PopupMenuItemContextDataDriven;
 import org.zaproxy.zap.view.popup.PopupMenuItemContextExclude;
 import org.zaproxy.zap.view.popup.PopupMenuItemContextInclude;
@@ -195,17 +195,16 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
 	private PopupContextTreeMenu getPopupContextTreeMenuDelete() {
 		if (popupContextTreeMenuDelete == null) {
 			popupContextTreeMenuDelete = new PopupContextTreeMenu(); 
+			popupContextTreeMenuDelete.setAction(new DeleteContextAction() {
+
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				protected Context getContext() {
+					return Model.getSingleton().getSession().getContext(popupContextTreeMenuOutScope.getContextId());
+				}
+			});
 			popupContextTreeMenuDelete.setText(Constant.messages.getString("context.delete.popup"));
-            popupContextTreeMenuDelete.addActionListener(new java.awt.event.ActionListener() {
-                @Override
-                public void actionPerformed(java.awt.event.ActionEvent e) {
-                	Context ctx = Model.getSingleton().getSession().getContext(popupContextTreeMenuOutScope.getContextId());
-                	if (View.getSingleton().showConfirmDialog(Constant.messages.getString("context.delete.warning"))
-                			== JOptionPane.OK_OPTION) {
-                		Model.getSingleton().getSession().deleteContext(ctx);
-                	}
-                }
-            });
 		}
 		return popupContextTreeMenuDelete;
 	}

--- a/src/org/zaproxy/zap/view/DeleteContextAction.java
+++ b/src/org/zaproxy/zap/view/DeleteContextAction.java
@@ -1,0 +1,77 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.view;
+
+import java.awt.event.ActionEvent;
+
+import javax.swing.AbstractAction;
+import javax.swing.JOptionPane;
+
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.model.Context;
+
+/**
+ * An {@link AbstractAction} that allows to delete a {@link Context}.
+ * <p>
+ * The (default) accelerator for the action is given by {@link View#getDefaultDeleteKeyStroke()}.
+ * 
+ * @since TODO add version
+ */
+public abstract class DeleteContextAction extends AbstractAction {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The name of the action.
+     */
+    public static final String ACTION_NAME = "zap.delete.context";
+
+    /**
+     * Constructs a {@code DeleteContextAction}.
+     *
+     */
+    public DeleteContextAction() {
+        super(ACTION_NAME);
+
+        putValue(ACCELERATOR_KEY, View.getSingleton().getDefaultDeleteKeyStroke());
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        Context context = getContext();
+        if (context == null) {
+            return;
+        }
+
+        if (View.getSingleton()
+                .showConfirmDialog(Constant.messages.getString("context.delete.warning")) == JOptionPane.OK_OPTION) {
+            Model.getSingleton().getSession().deleteContext(context);
+        }
+    }
+
+    /**
+     * Called when the action is performed, to delete the returned context.
+     *
+     * @return the {@code Context} to delete, or {@code null} if none.
+     */
+    protected abstract Context getContext();
+}


### PR DESCRIPTION
Extract an action to delete a context (DeleteContextAction) and change
ExtensionStdMenus and SiteMapPanel to use it and be accessible with
default delete keyboard key.