### PR TITLE
Use %USERPROFILE% in zap.bat

### DIFF
--- a/src/zap.bat
+++ b/src/zap.bat
@@ -1,5 +1,5 @@
-if exist "%HOMEDRIVE%%HOMEPATH%\OWASP ZAP\.ZAP_JVM.properties" (
-	set /p jvmopts=< "%HOMEDRIVE%%HOMEPATH%\OWASP ZAP\.ZAP_JVM.properties"
+if exist "%USERPROFILE%\OWASP ZAP\.ZAP_JVM.properties" (
+	set /p jvmopts=< "%USERPROFILE%\OWASP ZAP\.ZAP_JVM.properties"
 ) else (
 	set jvmopts=-Xmx512m
 )


### PR DESCRIPTION
Change zap.bat to use %USERPROFILE% to check for the ZAP_JVM.properties,
that's the (default) variable used to set the property "user.home" (used
for the path of (default) ZAP home and the properties file).

Fix #4004 - zap.bat should use %USERPROFILE% instead of
%HOMEDRIVE%%HOMEPATH%