### PR TITLE
Differentiate GET/POST array parameters

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/VariantAbstractQuery.java
+++ b/src/org/parosproxy/paros/core/scanner/VariantAbstractQuery.java
@@ -30,24 +30,32 @@
 // ZAP: 2016/05/04 Changes to address issues related to ParameterParser
 // ZAP: 2016/05/26 Use non-null String for names and values of parameters, scanners might not handle null names/values well
 // ZAP: 2016/09/13 Issue 2863: Attack query string even if not originally specified
+// ZAP: 2017/11/06 Use indexed names for array parameters (Issue 2496).
 
 package org.parosproxy.paros.core.scanner;
 
 import java.net.URLEncoder;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.apache.commons.lang.mutable.MutableInt;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.model.ParameterParser;
+import org.zaproxy.zap.model.StandardParameterParser;
 
 public abstract class VariantAbstractQuery implements Variant {
 
-    private List<NameValuePair> listParam = new ArrayList<>();
+    private List<NameValuePair> listParam;
+    private List<String> originalNames;
 
     public VariantAbstractQuery() {
+        listParam = Collections.emptyList();
+        originalNames = Collections.emptyList();
     }
 
     /**
@@ -111,17 +119,28 @@ public abstract class VariantAbstractQuery implements Variant {
      *
      * @param type the type of parameters
      * @param parameters the actual parameters to add
+     * @throws IllegalArgumentException if {@code parameters} is {@code null}.
      * @since 2.5.0
      * @see #getParamList()
      * @see NameValuePair#TYPE_QUERY_STRING
      * @see NameValuePair#TYPE_POST_DATA
      */
     protected void setParameters(int type, List<org.zaproxy.zap.model.NameValuePair> parameters) {
-        listParam.clear();
+        if (parameters == null) {
+            throw new IllegalArgumentException("Parameter parameters must not be null.");
+        }
 
+        int size = parameters.isEmpty() ? 1 : parameters.size();
+        listParam = new ArrayList<>(size);
+        originalNames = new ArrayList<>(size);
+
+        Map<String, MutableInt> arraysMap = new HashMap<>();
         int i = 0;
         for (org.zaproxy.zap.model.NameValuePair parameter : parameters) {
-            listParam.add(new NameValuePair(type, nonNullString(parameter.getName()), nonNullString(parameter.getValue()), i));
+            String originalName = nonNullString(parameter.getName());
+            originalNames.add(originalName);
+            String name = isParamArray(originalName) ? getArrayName(originalName, arraysMap) : originalName;
+            listParam.add(new NameValuePair(type, name, nonNullString(parameter.getValue()), i));
             i++;
         }
         if (i == 0) {
@@ -137,9 +156,24 @@ public abstract class VariantAbstractQuery implements Variant {
         return string;
     }
 
+    private String getArrayName(String originalName, Map<String, MutableInt> arraysMap) {
+        MutableInt count = arraysMap.get(originalName);
+        if (count == null) {
+            count = new MutableInt();
+            arraysMap.put(originalName, count);
+        }
+        String arrayName = originalName.substring(0, originalName.length() - 2) + "[" + count + "]";
+        count.increment();
+        return arrayName;
+    }
+
+    private static boolean isParamArray(String name) {
+        return name.endsWith("[]");
+    }
+
     @Override
     public List<NameValuePair> getParamList() {
-        return listParam;
+        return Collections.unmodifiableList(listParam);
     }
 
     /**
@@ -161,8 +195,10 @@ public abstract class VariantAbstractQuery implements Variant {
         if (originalPair.getType() == NameValuePair.TYPE_POST_DATA) {
             parser = Model.getSingleton().getSession().getFormParamParser(msg.getRequestHeader().getURI().toString());
 
-        } else {
+        } else if (originalPair.getType() == NameValuePair.TYPE_QUERY_STRING) {
             parser = Model.getSingleton().getSession().getUrlParamParser(msg.getRequestHeader().getURI().toString());
+        } else {
+            parser = new StandardParameterParser();
         }
     	
         StringBuilder sb = new StringBuilder();
@@ -172,11 +208,12 @@ public abstract class VariantAbstractQuery implements Variant {
         
         for (int i = 0; i < getParamList().size(); i++) {
             pair = getParamList().get(i);
+            String origName = originalNames.get(i);
             if (i == originalPair.getPosition()) {
-                isAppended = paramAppend(sb, getEscapedName(msg, name), encodedValue, parser);
+                isAppended = paramAppend(sb, getEscapedName(msg, pair.getName() == name ? origName : name), encodedValue, parser);
 
             } else {
-                isAppended = paramAppend(sb, getEscapedName(msg, pair.getName()), getEscapedValue(msg, pair.getValue()), parser);
+                isAppended = paramAppend(sb, getEscapedName(msg, origName), getEscapedValue(msg, pair.getValue()), parser);
             }
 
             if (isAppended && i < getParamList().size() - 1) {

--- a/test/org/parosproxy/paros/core/scanner/VariantAbstractQueryUnitTest.java
+++ b/test/org/parosproxy/paros/core/scanner/VariantAbstractQueryUnitTest.java
@@ -1,0 +1,370 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.core.scanner;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.lang.mutable.MutableBoolean;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+
+/**
+ * Unit test for {@link VariantAbstractQuery}.
+ */
+public class VariantAbstractQueryUnitTest {
+
+    private static final int NAME_VALUE_PAIR_TYPE = -1;
+
+    @Test
+    public void shouldHaveParametersListEmptyByDefault() {
+        // Given
+        VariantAbstractQuery variantAbstractQuery = new VariantAbstractQueryImpl();
+        // When
+        List<NameValuePair> parameters = variantAbstractQuery.getParamList();
+        // Then
+        assertThat(parameters, is(empty()));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldNotAllowToModifyReturnedParametersList() {
+        // Given
+        VariantAbstractQuery variantAbstractQuery = new VariantAbstractQueryImpl();
+        // When
+        variantAbstractQuery.getParamList().add(param("Name", "Value", 0));
+        // Then = UnsupportedOperationException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToProcessUndefinedParameters() {
+        // Given
+        VariantAbstractQuery variantAbstractQuery = new VariantAbstractQueryImpl();
+        List<org.zaproxy.zap.model.NameValuePair> undefinedParameters = null;
+        // When
+        variantAbstractQuery.setParameters(NAME_VALUE_PAIR_TYPE, undefinedParameters);
+        // Then = IllegalArgumentException
+    }
+
+    @Test
+    public void shouldCreateOneDummyNameValuePairIfNoParametersProvided() {
+        // Given
+        VariantAbstractQuery variantAbstractQuery = new VariantAbstractQueryImpl();
+        List<org.zaproxy.zap.model.NameValuePair> noParameters = parameters();
+        // When
+        variantAbstractQuery.setParameters(NAME_VALUE_PAIR_TYPE, noParameters);
+        // Then
+        assertThat(variantAbstractQuery.getParamList(), contains(param(NAME_VALUE_PAIR_TYPE, "query", "query", 0)));
+    }
+
+    @Test
+    public void shouldCreateNameValuePairsFromProvidedParameters() {
+        // Given
+        VariantAbstractQuery variantAbstractQuery = new VariantAbstractQueryImpl();
+        List<org.zaproxy.zap.model.NameValuePair> parameters = parameters(parameter("a", "b"), parameter("c", "d"));
+        // When
+        variantAbstractQuery.setParameters(NAME_VALUE_PAIR_TYPE, parameters);
+        // Then
+        assertThat(
+                variantAbstractQuery.getParamList(),
+                contains(param(NAME_VALUE_PAIR_TYPE, "a", "b", 0), param(NAME_VALUE_PAIR_TYPE, "c", "d", 1)));
+    }
+
+    @Test
+    public void shouldCreateNameValuePairsFromProvidedParametersWithNullNameOrValue() {
+        // Given
+        VariantAbstractQuery variantAbstractQuery = new VariantAbstractQueryImpl();
+        List<org.zaproxy.zap.model.NameValuePair> parameters = parameters(parameter(null, "b"), parameter("c", null));
+        // When
+        variantAbstractQuery.setParameters(NAME_VALUE_PAIR_TYPE, parameters);
+        // Then
+        assertThat(
+                variantAbstractQuery.getParamList(),
+                contains(param(NAME_VALUE_PAIR_TYPE, "", "b", 0), param(NAME_VALUE_PAIR_TYPE, "c", "", 1)));
+    }
+
+    @Test
+    public void shouldCreateNameValuePairsWithIndexedNamesFromProvidedArrayParameters() {
+        // Given
+        VariantAbstractQuery variantAbstractQuery = new VariantAbstractQueryImpl();
+        List<org.zaproxy.zap.model.NameValuePair> parameters = parameters(
+                parameter("a[]", "b"),
+                parameter("a[]", "d"),
+                parameter("e", "f"),
+                parameter("g[]", "h"),
+                parameter("i", "j"));
+        // When
+        variantAbstractQuery.setParameters(NAME_VALUE_PAIR_TYPE, parameters);
+        // Then
+        assertThat(
+                variantAbstractQuery.getParamList(),
+                contains(
+                        param(NAME_VALUE_PAIR_TYPE, "a[0]", "b", 0),
+                        param(NAME_VALUE_PAIR_TYPE, "a[1]", "d", 1),
+                        param(NAME_VALUE_PAIR_TYPE, "e", "f", 2),
+                        param(NAME_VALUE_PAIR_TYPE, "g[0]", "h", 3),
+                        param(NAME_VALUE_PAIR_TYPE, "i", "j", 4)));
+    }
+
+    @Test
+    public void shouldNotAccumulateProvidedParameters() {
+        // Given
+        VariantAbstractQuery variantAbstractQuery = new VariantAbstractQueryImpl();
+        List<org.zaproxy.zap.model.NameValuePair> parameters = parameters(parameter("a", "b"), parameter("c", "d"));
+        List<org.zaproxy.zap.model.NameValuePair> otherParameters = parameters(parameter("e", "f"), parameter("g", "h"));
+        int otherType = -2;
+        // When
+        variantAbstractQuery.setParameters(NAME_VALUE_PAIR_TYPE, parameters);
+        variantAbstractQuery.setParameters(otherType, otherParameters);
+        // Then
+        assertThat(variantAbstractQuery.getParamList(), contains(param(otherType, "e", "f", 0), param(otherType, "g", "h", 1)));
+    }
+
+    @Test
+    public void shouldNotCallGetEscapedValueForInjectedValueIfEscapedWhenSettingParameter() {
+        // Given
+        List<String> values = new ArrayList<>();
+        VariantAbstractQuery variantAbstractQuery = new VariantAbstractQueryImpl() {
+
+            @Override
+            protected String getEscapedValue(HttpMessage msg, String value) {
+                values.add(value);
+                return value;
+            }
+        };
+        List<org.zaproxy.zap.model.NameValuePair> parameters = parameters(
+                parameter("a", "b"),
+                parameter("c", "d"),
+                parameter("e", "f"));
+        variantAbstractQuery.setParameters(NAME_VALUE_PAIR_TYPE, parameters);
+        HttpMessage message = createMessage();
+        // When
+        variantAbstractQuery.setEscapedParameter(message, param("a", "b", 0), "y", "escaped");
+        // Then
+        assertThat(values, contains("d", "f"));
+    }
+
+    @Test
+    public void shouldCallGetEscapedValueForInjectedValueIfNotEscapedWhenSettingParameter() {
+        // Given
+        List<String> values = new ArrayList<>();
+        VariantAbstractQuery variantAbstractQuery = new VariantAbstractQueryImpl() {
+
+            @Override
+            protected String getEscapedValue(HttpMessage msg, String value) {
+                values.add(value);
+                return value;
+            }
+        };
+        List<org.zaproxy.zap.model.NameValuePair> parameters = parameters(
+                parameter("a", "b"),
+                parameter("c", "d"),
+                parameter("e", "f"));
+        variantAbstractQuery.setParameters(NAME_VALUE_PAIR_TYPE, parameters);
+        HttpMessage message = createMessage();
+        // When
+        variantAbstractQuery.setParameter(message, param("a", "b", 0), "y", "not-escaped");
+        // Then
+        assertThat(values, contains("not-escaped", "d", "f"));
+    }
+
+    @Test
+    public void shouldCallGetEscapedNameForEachNameWhenSettingParameter() {
+        // Given
+        List<String> names = new ArrayList<>();
+        VariantAbstractQuery variantAbstractQuery = new VariantAbstractQueryImpl() {
+
+            @Override
+            protected String getEscapedName(HttpMessage msg, String name) {
+                names.add(name);
+                return name;
+            }
+        };
+        List<org.zaproxy.zap.model.NameValuePair> parameters = parameters(
+                parameter("a", "b"),
+                parameter("c", "d"),
+                parameter("e", "f"));
+        variantAbstractQuery.setParameters(NAME_VALUE_PAIR_TYPE, parameters);
+        HttpMessage message = createMessage();
+        // When
+        variantAbstractQuery.setParameter(message, param("a", "b", 0), "y", "z");
+        // Then
+        assertThat(names, contains("y", "c", "e"));
+    }
+
+    @Test
+    public void shouldUseOriginalNamesForArraysWhenSettingParameter() {
+        // Given
+        List<String> names = new ArrayList<>();
+        VariantAbstractQuery variantAbstractQuery = new VariantAbstractQueryImpl() {
+
+            @Override
+            protected String getEscapedName(HttpMessage msg, String name) {
+                names.add(name);
+                return name;
+            }
+        };
+        List<org.zaproxy.zap.model.NameValuePair> parameters = parameters(
+                parameter("a[]", "b"),
+                parameter("a[]", "d"),
+                parameter("e", "f"),
+                parameter("g[]", "h"),
+                parameter("i", "j"));
+        variantAbstractQuery.setParameters(NAME_VALUE_PAIR_TYPE, parameters);
+        HttpMessage message = createMessage();
+        // When
+        variantAbstractQuery.setParameter(message, param("e", "f", 2), "e", "f");
+        // Then
+        assertThat(names, contains("a[]", "a[]", "e", "g[]", "i"));
+    }
+
+    @Test
+    public void shouldUseInjectedNameWhenSettingArrayParameter() {
+        // Given
+        List<String> names = new ArrayList<>();
+        VariantAbstractQuery variantAbstractQuery = new VariantAbstractQueryImpl() {
+
+            @Override
+            protected String getEscapedName(HttpMessage msg, String name) {
+                names.add(name);
+                return name;
+            }
+        };
+        List<org.zaproxy.zap.model.NameValuePair> parameters = parameters(parameter("a[]", "b"));
+        variantAbstractQuery.setParameters(NAME_VALUE_PAIR_TYPE, parameters);
+        HttpMessage message = createMessage();
+        // When
+        variantAbstractQuery.setParameter(message, param("a[]", "b", 0), "y", "z");
+        // Then
+        assertThat(names, contains("y"));
+    }
+
+    @Test
+    public void shouldUseInjectedNameEvenIfEqualToIndexedNameWhenSettingArrayParameter() {
+        // Given
+        List<String> names = new ArrayList<>();
+        VariantAbstractQuery variantAbstractQuery = new VariantAbstractQueryImpl() {
+
+            @Override
+            protected String getEscapedName(HttpMessage msg, String name) {
+                names.add(name);
+                return name;
+            }
+        };
+        List<org.zaproxy.zap.model.NameValuePair> parameters = parameters(parameter("a[]", "b"));
+        variantAbstractQuery.setParameters(NAME_VALUE_PAIR_TYPE, parameters);
+        HttpMessage message = createMessage();
+        // When
+        variantAbstractQuery.setParameter(message, param("a[]", "b", 0), "a[0]", "z");
+        // Then
+        assertThat(names, contains("a[0]"));
+    }
+
+    @Test
+    public void shouldCallBuildMessageWhenSettingParameter() {
+        // Given
+        MutableBoolean buildMessageCalled = new MutableBoolean();
+        VariantAbstractQuery variantAbstractQuery = new VariantAbstractQueryImpl() {
+
+            @Override
+            protected void buildMessage(HttpMessage msg, String query) {
+                buildMessageCalled.setValue(true);
+            }
+        };
+        List<org.zaproxy.zap.model.NameValuePair> parameters = parameters(parameter("a", "b"), parameter("c", "d"));
+        variantAbstractQuery.setParameters(NAME_VALUE_PAIR_TYPE, parameters);
+        HttpMessage message = createMessage();
+        // When
+        variantAbstractQuery.setParameter(message, param("a", "b", 0), "y", "z");
+        // Then
+        assertTrue(buildMessageCalled.isTrue());
+    }
+
+    private static HttpMessage createMessage() {
+        HttpMessage message = new HttpMessage();
+        try {
+            message.setRequestHeader("GET / HTTP/1.1\r\nHost: example.com\r\n");
+        } catch (HttpMalformedHeaderException e) {
+            throw new RuntimeException(e);
+        }
+        return message;
+    }
+
+    private static NameValuePair param(String name, String value, int position) {
+        return param(NAME_VALUE_PAIR_TYPE, name, value, position);
+    }
+
+    private static NameValuePair param(int type, String name, String value, int position) {
+        return new NameValuePair(type, name, value, position);
+    }
+
+    private static org.zaproxy.zap.model.NameValuePair parameter(String name, String value) {
+        return new org.zaproxy.zap.model.NameValuePair() {
+
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public String getValue() {
+                return value;
+            }
+        };
+    }
+
+    private static List<org.zaproxy.zap.model.NameValuePair> parameters(org.zaproxy.zap.model.NameValuePair... parameters) {
+        if (parameters == null || parameters.length == 0) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList(parameters);
+    }
+
+    private static class VariantAbstractQueryImpl extends VariantAbstractQuery {
+
+        @Override
+        public void setMessage(HttpMessage msg) {
+            // Nothing to do.
+        }
+
+        @Override
+        protected void buildMessage(HttpMessage msg, String query) {
+            // Nothing to do.
+        }
+
+        @Override
+        protected String getEscapedValue(HttpMessage msg, String value) {
+            return value;
+        }
+
+        @Override
+        protected String getUnescapedValue(String value) {
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
Change VariantAbstractQuery to use indexed names for array parameters,
for example, if param[]=x&param[]=y use as names param[0] and param[1],
respectively.
Add tests to assert the expected behaviour of VariantAbstractQuery and
normalise some of its behaviour (that is, validate that valid parameters
are set, prevent modifications to internal parameter list, and do not
accumulate parameters on successive calls).

Fix #2496 - ZAP only report the first alert in array