### PR TITLE
Fix exception in VariantAbstractQuery

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/VariantAbstractQuery.java
+++ b/src/org/parosproxy/paros/core/scanner/VariantAbstractQuery.java
@@ -144,8 +144,10 @@ public abstract class VariantAbstractQuery implements Variant {
             i++;
         }
         if (i == 0) {
+            String param = "query";
         	// No query params, lets add one just to make sure
-            listParam.add(new NameValuePair(type, "query", "query", i));
+            listParam.add(new NameValuePair(type, param, param, i));
+            originalNames.add(param);
         }
     }
 

--- a/test/org/parosproxy/paros/core/scanner/VariantAbstractQueryUnitTest.java
+++ b/test/org/parosproxy/paros/core/scanner/VariantAbstractQueryUnitTest.java
@@ -286,6 +286,35 @@ public class VariantAbstractQueryUnitTest {
     }
 
     @Test
+    public void shouldSetNameAndValueOfDummyParameter() {
+        // Given
+        List<String> names = new ArrayList<>();
+        List<String> values = new ArrayList<>();
+        VariantAbstractQuery variantAbstractQuery = new VariantAbstractQueryImpl() {
+
+            @Override
+            protected String getEscapedName(HttpMessage msg, String name) {
+                names.add(name);
+                return name;
+            }
+
+            @Override
+            protected String getEscapedValue(HttpMessage msg, String value) {
+                values.add(value);
+                return value;
+            }
+        };
+        List<org.zaproxy.zap.model.NameValuePair> noParameters = parameters();
+        variantAbstractQuery.setParameters(NAME_VALUE_PAIR_TYPE, noParameters);
+        HttpMessage message = createMessage();
+        // When
+        variantAbstractQuery.setParameter(message, param("query", "query", 0), "y", "z");
+        // Then
+        assertThat(names, contains("y"));
+        assertThat(values, contains("z"));
+    }
+
+    @Test
     public void shouldCallBuildMessageWhenSettingParameter() {
         // Given
         MutableBoolean buildMessageCalled = new MutableBoolean();


### PR DESCRIPTION
Change VariantAbstractQuery to also add the original name for the dummy
parameter, preventing a IndexOutOfBoundsException when getting its name
while setting the parameter.
Add test to assert the expected behaviour.

Caused by #4011 - Differentiate GET/POST array parameters