### PR TITLE
Validate configuration levels in Docker scripts

### DIFF
--- a/build/docker/zap-api-scan.py
+++ b/build/docker/zap-api-scan.py
@@ -64,7 +64,6 @@ from zap_common import *
 config_dict = {}
 config_msg = {}
 out_of_scope_dict = {}
-levels = ["PASS", "IGNORE", "INFO", "WARN", "FAIL"]
 min_level = 0
 
 # Scan rules that aren't really relevant, eg the examples rules in the alpha set
@@ -186,9 +185,9 @@ def main(argv):
             info_unspecified = True
         elif opt == '-l':
             try:
-                min_level = levels.index(arg)
+                min_level = zap_conf_lvls.index(arg)
             except ValueError:
-                logging.warning('Level must be one of ' + str(levels))
+                logging.warning('Level must be one of ' + str(zap_conf_lvls))
                 usage()
                 sys.exit(3)
         elif opt == '-z':
@@ -237,11 +236,18 @@ def main(argv):
     if config_file:
         # load config file from filestore
         with open(base_dir + config_file) as f:
-            load_config(f, config_dict, config_msg, out_of_scope_dict)
+            try:
+                load_config(f, config_dict, config_msg, out_of_scope_dict)
+            except ValueError as e:
+                logging.warning(e)
+                sys.exit(3)
     elif config_url:
         # load config file from url
         try:
             load_config(urllib2.urlopen(config_url), config_dict, config_msg, out_of_scope_dict)
+        except ValueError as e:
+            logging.warning(e)
+            sys.exit(3)
         except:
             logging.warning('Failed to read configs from ' + config_url)
             sys.exit(3)
@@ -440,7 +446,7 @@ def main(argv):
                 if not alert_dict.has_key(plugin_id) and not(config_dict.has_key(plugin_id) and config_dict[plugin_id] == 'IGNORE'):
                     pass_dict[plugin_id] = rule.get('name')
 
-            if min_level == levels.index("PASS") and detailed_output:
+            if min_level == zap_conf_lvls.index("PASS") and detailed_output:
                 for key, rule in sorted(pass_dict.iteritems()):
                     print('PASS: ' + rule + ' [' + key + ']')
 
@@ -456,19 +462,19 @@ def main(argv):
                         print('SKIP: ' + rule.get('name') + ' [' + plugin_id + ']')
 
             # print out the ignored rules
-            ignore_count, not_used = print_rules(alert_dict, 'IGNORE', config_dict, config_msg, min_level, levels,
+            ignore_count, not_used = print_rules(alert_dict, 'IGNORE', config_dict, config_msg, min_level,
                 inc_ignore_rules, True, detailed_output, {})
 
             # print out the info rules
-            info_count, not_used = print_rules(alert_dict, 'INFO', config_dict, config_msg, min_level, levels,
+            info_count, not_used = print_rules(alert_dict, 'INFO', config_dict, config_msg, min_level,
                 inc_info_rules, info_unspecified, detailed_output, in_progress_issues)
 
             # print out the warning rules
-            warn_count, warn_inprog_count = print_rules(alert_dict, 'WARN', config_dict, config_msg, min_level, levels,
+            warn_count, warn_inprog_count = print_rules(alert_dict, 'WARN', config_dict, config_msg, min_level,
                 inc_warn_rules, not info_unspecified, detailed_output, in_progress_issues)
 
             # print out the failing rules
-            fail_count, fail_inprog_count = print_rules(alert_dict, 'FAIL', config_dict, config_msg, min_level, levels,
+            fail_count, fail_inprog_count = print_rules(alert_dict, 'FAIL', config_dict, config_msg, min_level,
                 inc_fail_rules, True, detailed_output, in_progress_issues)
 
             if report_html:

--- a/build/docker/zap-full-scan.py
+++ b/build/docker/zap-full-scan.py
@@ -60,7 +60,6 @@ from zap_common import *
 config_dict = {}
 config_msg = {}
 out_of_scope_dict = {}
-levels = ["PASS", "IGNORE", "INFO", "WARN", "FAIL"]
 min_level = 0
 
 # Scan rules that aren't really relevant, eg the examples rules in the alpha set
@@ -184,9 +183,9 @@ def main(argv):
             ajax = True
         elif opt == '-l':
             try:
-                min_level = levels.index(arg)
+                min_level = zap_conf_lvls.index(arg)
             except ValueError:
-                logging.warning('Level must be one of ' + str(levels))
+                logging.warning('Level must be one of ' + str(zap_conf_lvls))
                 usage()
                 sys.exit(3)
         elif opt == '-z':
@@ -224,11 +223,18 @@ def main(argv):
     if config_file:
         # load config file from filestore
         with open(base_dir + config_file) as f:
-            load_config(f, config_dict, config_msg, out_of_scope_dict)
+            try:
+                load_config(f, config_dict, config_msg, out_of_scope_dict)
+            except ValueError as e:
+                logging.warning(e)
+                sys.exit(3)
     elif config_url:
         # load config file from url
         try:
             load_config(urllib2.urlopen(config_url), config_dict, config_msg, out_of_scope_dict)
+        except ValueError as e:
+            logging.warning(e)
+            sys.exit(3)
         except:
             logging.warning('Failed to read configs from ' + config_url)
             sys.exit(3)
@@ -389,7 +395,7 @@ def main(argv):
                 if not alert_dict.has_key(plugin_id) and not(config_dict.has_key(plugin_id) and config_dict[plugin_id] == 'IGNORE'):
                     pass_dict[plugin_id] = rule.get('name')
 
-            if min_level == levels.index("PASS") and detailed_output:
+            if min_level == zap_conf_lvls.index("PASS") and detailed_output:
                 for key, rule in sorted(pass_dict.iteritems()):
                     print('PASS: ' + rule + ' [' + key + ']')
 
@@ -405,19 +411,19 @@ def main(argv):
                         print('SKIP: ' + rule.get('name') + ' [' + plugin_id + ']')
 
             # print out the ignored rules
-            ignore_count, not_used = print_rules(alert_dict, 'IGNORE', config_dict, config_msg, min_level, levels,
+            ignore_count, not_used = print_rules(alert_dict, 'IGNORE', config_dict, config_msg, min_level,
                 inc_ignore_rules, True, detailed_output, {})
 
             # print out the info rules
-            info_count, not_used = print_rules(alert_dict, 'INFO', config_dict, config_msg, min_level, levels,
+            info_count, not_used = print_rules(alert_dict, 'INFO', config_dict, config_msg, min_level,
                 inc_info_rules, info_unspecified, detailed_output, in_progress_issues)
 
             # print out the warning rules
-            warn_count, warn_inprog_count = print_rules(alert_dict, 'WARN', config_dict, config_msg, min_level, levels,
+            warn_count, warn_inprog_count = print_rules(alert_dict, 'WARN', config_dict, config_msg, min_level,
                 inc_warn_rules, not info_unspecified, detailed_output, in_progress_issues)
 
             # print out the failing rules
-            fail_count, fail_inprog_count = print_rules(alert_dict, 'FAIL', config_dict, config_msg, min_level, levels,
+            fail_count, fail_inprog_count = print_rules(alert_dict, 'FAIL', config_dict, config_msg, min_level,
                 inc_fail_rules, True, detailed_output, in_progress_issues)
 
             if report_html:

--- a/build/docker/zap_common.py
+++ b/build/docker/zap_common.py
@@ -45,6 +45,8 @@ OLD_ZAP_CLIENT_WARNING = '''A newer version of python_owasp_zap_v2.4
  is available. Please run \'pip install -U python_owasp_zap_v2.4\' to update to
  the latest version.'''.replace('\n', '')
 
+zap_conf_lvls = ["PASS", "IGNORE", "INFO", "WARN", "FAIL"]
+
 
 def load_config(config, config_dict, config_msg, out_of_scope_dict):
     """ Loads the config file specified into:
@@ -60,6 +62,8 @@ def load_config(config, config_dict, config_msg, out_of_scope_dict):
                     if plugin_id not in out_of_scope_dict:
                         out_of_scope_dict[plugin_id] = []
                     out_of_scope_dict[plugin_id].append(re.compile(optional))
+            elif val not in zap_conf_lvls:
+                raise ValueError("Level {0} is not a supported level: {1}".format(val, zap_conf_lvls))
             else:
                 config_dict[key] = val
                 if '\t' in optional:
@@ -102,7 +106,7 @@ def print_rule(action, alert_list, detailed_output, user_msg, in_progress_issues
             print ('\t' + alert.get('url'))
 
 
-def print_rules(alert_dict, level, config_dict, config_msg, min_level, levels, inc_rule, inc_extra, detailed_output, in_progress_issues):
+def print_rules(alert_dict, level, config_dict, config_msg, min_level, inc_rule, inc_extra, detailed_output, in_progress_issues):
     # print out the ignored rules
     count = 0
     inprog_count = 0
@@ -112,7 +116,7 @@ def print_rules(alert_dict, level, config_dict, config_msg, min_level, levels, i
             user_msg = ''
             if key in config_msg:
                 user_msg = config_msg[key]
-            if min_level <= levels.index(level):
+            if min_level <= zap_conf_lvls.index(level):
                 print_rule(level, alert_list, detailed_output, user_msg, in_progress_issues)
             if key in in_progress_issues:
                 inprog_count += 1


### PR DESCRIPTION
Validate the levels provided in the configurations for the Docker
scripts, otherwise it would silently ignore the alerts when the level
was not valid.