### PR TITLE
Prevent Commas in Port Number Strings

### DIFF
--- a/src/org/zaproxy/zap/extension/proxies/DialogAddProxy.java
+++ b/src/org/zaproxy/zap/extension/proxies/DialogAddProxy.java
@@ -93,7 +93,8 @@ class DialogAddProxy extends AbstractFormDialog {
             if (!extension.canListenOn(testProxy.getAddress(), testProxy.getPort())) {
                 JOptionPane.showMessageDialog(
                         this,
-                        Constant.messages.getString("options.proxy.dialog.proxy.warning.fail.message", testProxy.getAddress(), testProxy.getPort()),
+                        Constant.messages.getString("options.proxy.dialog.proxy.warning.fail.message",
+                                testProxy.getAddress(), Integer.toString(testProxy.getPort())),
                         Constant.messages.getString("options.proxy.dialog.proxy.warning.fail.title"),
                         JOptionPane.ERROR_MESSAGE);
                 return false;

--- a/src/org/zaproxy/zap/extension/proxies/OptionsProxiesPanel.java
+++ b/src/org/zaproxy/zap/extension/proxies/OptionsProxiesPanel.java
@@ -86,7 +86,8 @@ public class OptionsProxiesPanel extends AbstractParamPanel {
             // Only check if they've changed, otherwise we'll still be listening on them
             if (!extension.canListenOn(newAddress, newPort) || extension.getAdditionalProxy(newAddress, newPort) != null) {
                 throw new Exception(
-                        Constant.messages.getString("options.proxy.dialog.proxy.warning.fail.message", newAddress, newPort));
+                        Constant.messages.getString("options.proxy.dialog.proxy.warning.fail.message", newAddress,
+                                Integer.toString(newPort)));
             }
         }
     }


### PR DESCRIPTION
Just tested the new multi proxy functionality out quickly, noticed that when you try to create a
duplicate entry the error message port number had commas.