### PR TITLE
Allow to set the status code and reason

### DIFF
--- a/src/org/parosproxy/paros/network/HttpResponseHeader.java
+++ b/src/org/parosproxy/paros/network/HttpResponseHeader.java
@@ -31,6 +31,7 @@
 // ZAP: 2015/02/26 Include json as a text content type
 // ZAP: 2016/06/17 Remove redundant initialisations of instance variables
 // ZAP: 2017/03/21 Add method to check if response type is json (isJson())
+// ZAP: 2017/11/10 Allow to set the status code and reason.
 
 package org.parosproxy.paros.network;
 
@@ -103,12 +104,54 @@ public class HttpResponseHeader extends HttpHeader {
 		mVersion = version.toUpperCase();
 	}
 
+    /**
+     * Gets the status code.
+     *
+     * @return the status code.
+     * @see #setStatusCode(int)
+     */
     public int getStatusCode() {
         return mStatusCode;
     }
 
+    /**
+     * Sets the status code.
+     * <p>
+     * <code>status-code = 3DIGIT</code>
+     *
+     * @param statusCode the new status code.
+     * @throws IllegalArgumentException if the given status code is not a (positive) 3 digit number.
+     * @see #getStatusCode()
+     * @since TODO add version
+     */
+    public void setStatusCode(int statusCode) {
+        if (statusCode < 100 || statusCode > 999) {
+            throw new IllegalArgumentException("The status code must be a (positive) 3 digit number.");
+        }
+        this.mStatusCode = statusCode;
+    }
+
+    /**
+     * Gets the reason phrase.
+     *
+     * @return the reason phrase.
+     * @see #setReasonPhrase(String)
+     */
     public String getReasonPhrase() {
         return mReasonPhrase;
+    }
+
+    /**
+     * Sets the reason phrase.
+     * <p>
+     * If {@code null} it's set an empty string.
+     *
+     * @param reasonPhrase the new reason phrase.
+     * @see #getReasonPhrase()
+     * @since TODO add version
+     */
+    public void setReasonPhrase(String reasonPhrase) {
+        this.mReasonPhrase = reasonPhrase != null ? reasonPhrase : "";
     }
 
     private void parse() throws HttpMalformedHeaderException {
@@ -121,9 +164,7 @@ public class HttpResponseHeader extends HttpHeader {
 		
 		mVersion 			= matcher.group(1);
 		mStatusCodeString	= matcher.group(2);
-		String tmp 			= matcher.group(3);
-
-		mReasonPhrase = (tmp != null) ? tmp : "";
+		setReasonPhrase(matcher.group(3));
 		 
         if (!mVersion.equalsIgnoreCase(HTTP10) && !mVersion.equalsIgnoreCase(HTTP11)) {
 			mMalformedHeader = true;

--- a/test/org/parosproxy/paros/network/HttpResponseHeaderUnitTest.java
+++ b/test/org/parosproxy/paros/network/HttpResponseHeaderUnitTest.java
@@ -59,4 +59,64 @@ public class HttpResponseHeaderUnitTest {
         // Then
         assertThat(empty, is(equalTo(false)));
     }
+
+    @Test
+    public void shouldSetValidStatusCode() throws Exception {
+        // Given
+        HttpResponseHeader header = new HttpResponseHeader("HTTP/1.1 200 OK\r\n\r\n");
+        // When
+        header.setStatusCode(100);
+        // Then
+        assertThat(header.getStatusCode(), is(equalTo(100)));
+        assertThat(header.getPrimeHeader(), is(equalTo("HTTP/1.1 100 OK")));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToSetNegative3DigitStatusCode() throws Exception {
+        // Given
+        HttpResponseHeader header = new HttpResponseHeader("HTTP/1.1 200 OK\r\n\r\n");
+        // When
+        header.setStatusCode(-200);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToSet2DigitStatusCode() throws Exception {
+        // Given
+        HttpResponseHeader header = new HttpResponseHeader("HTTP/1.1 200 OK\r\n\r\n");
+        // When
+        header.setStatusCode(99);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToSet4DigitStatusCode() throws Exception {
+        // Given
+        HttpResponseHeader header = new HttpResponseHeader("HTTP/1.1 200 OK\r\n\r\n");
+        // When
+        header.setStatusCode(1000);
+        // Then = IllegalArgumentException
+    }
+
+    @Test
+    public void shouldSetReasonPhrase() throws Exception {
+        // Given
+        HttpResponseHeader header = new HttpResponseHeader("HTTP/1.1 200 OK\r\n\r\n");
+        // When
+        header.setReasonPhrase("So So");
+        // Then
+        assertThat(header.getReasonPhrase(), is(equalTo("So So")));
+        assertThat(header.getPrimeHeader(), is(equalTo("HTTP/1.1 200 So So")));
+    }
+
+    @Test
+    public void shouldSetEmptyReasonPhraseIfNull() throws Exception {
+        // Given
+        HttpResponseHeader header = new HttpResponseHeader("HTTP/1.1 200 OK\r\n\r\n");
+        // When
+        header.setReasonPhrase(null);
+        // Then
+        assertThat(header.getReasonPhrase(), is(equalTo("")));
+        assertThat(header.getPrimeHeader(), is(equalTo("HTTP/1.1 200")));
+    }
 }


### PR DESCRIPTION
Change HttpResponseHeader to allow to set the status code and reason
phrase.
Add tests to assert the expected behaviour.

Makes use cases like #4022 more straightforward.