### PR TITLE
Warn when check for updates fails

### DIFF
--- a/src/org/zaproxy/zap/extension/autoupdate/CheckForUpdateCallback.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/CheckForUpdateCallback.java
@@ -24,6 +24,11 @@ import org.zaproxy.zap.control.AddOnCollection;
 
 public interface CheckForUpdateCallback {
 
+	/**
+	 * Called when the check for updates finishes without {@link #insecureUrl(String, Exception) insecure URL errors}.
+	 *
+	 * @param aoc the latest {@code AddOnCollection}, or {@code null} if not obtained (e.g. I/O errors).
+	 */
 	void gotLatestData (AddOnCollection aoc);
 	
 	void insecureUrl(String url, Exception cause);

--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -952,6 +952,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 							shortUrl = ZAP_VERSIONS_REL_XML_SHORT;
 							longUrl = ZAP_VERSIONS_REL_XML_FULL;
 						}
+						boolean noInsecureUrlErrors = true;
 						logger.debug("Getting latest version info from " + shortUrl);
 			    		try {
 							latestVersionInfo = new AddOnCollection(getRemoteConfigurationUrl(shortUrl), getPlatform(), false);
@@ -961,11 +962,12 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 				    		try {
 				    			latestVersionInfo = new AddOnCollection(getRemoteConfigurationUrl(longUrl), getPlatform(), false);
 				    		} catch (SSLHandshakeException | InvalidCfuUrlException e2) {
+								noInsecureUrlErrors = false;
 					    		if (callback != null) {
 					    			callback.insecureUrl(longUrl, e2);
 					    		}
 							} catch (Exception e2) {
-								logger.debug("Failed to access " + longUrl, e2);
+								logger.warn("Failed to check for updates using: " + longUrl, e2);
 							}
 						}
 						if (latestVersionInfo != null) {
@@ -975,11 +977,11 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 									addOn.setInstallationStatus(localAddOn.getInstallationStatus());
 								}
 							}
-							if (callback != null) {
-								logger.debug("Calling callback with  " + latestVersionInfo);
-								callback.gotLatestData(latestVersionInfo);
-							}
 			    		}
+						if (noInsecureUrlErrors && callback != null) {
+							logger.debug("Calling callback with " + latestVersionInfo);
+							callback.gotLatestData(latestVersionInfo);
+						}
 						logger.debug("Done");
 	    			}
     			};


### PR DESCRIPTION
Change ExtensionAutoUpdate to notify the callback even if failed to
obtain the latest information (e.g. because of I/O errors or other non
insecure related errors), to have the manage add-ons dialogue show a
warning dialogue saying that the check for updates failed. Also, change
to log the (last) exception as warning (instead of debug) to show/log
the cause of the issue by default.
Add JavaDoc to CheckForUpdateCallback.