### PR TITLE
Use raw address for main proxy address option

### DIFF
--- a/src/org/zaproxy/zap/extension/proxies/ProxiesParam.java
+++ b/src/org/zaproxy/zap/extension/proxies/ProxiesParam.java
@@ -81,7 +81,7 @@ public class ProxiesParam extends AbstractParam {
 
     public ProxiesParamProxy getMainProxy() {
         ProxyParam mainProxyParam = Model.getSingleton().getOptionsParam().getProxyParam();
-        ProxiesParamProxy mainProxy = new ProxiesParamProxy(mainProxyParam.getProxyIp(), mainProxyParam.getProxyPort(), true);
+        ProxiesParamProxy mainProxy = new ProxiesParamProxy(mainProxyParam.getRawProxyIP(), mainProxyParam.getProxyPort(), true);
         mainProxy.setAlwaysDecodeGzip(mainProxyParam.isAlwaysDecodeGzip());
         mainProxy.setBehindNat(mainProxyParam.isBehindNat());
         mainProxy.setProxyIpAnyLocalAddress(mainProxyParam.isProxyIpAnyLocalAddress());


### PR DESCRIPTION
Change ProxiesParam to use the raw address for the main proxy, otherwise
it would change to an exact IP address when listening on all addresses.