### PR TITLE
Correct key used when adding proxy through the API

### DIFF
--- a/src/org/zaproxy/zap/extension/proxies/ExtensionProxies.java
+++ b/src/org/zaproxy/zap/extension/proxies/ExtensionProxies.java
@@ -110,7 +110,7 @@ public class ExtensionProxies extends ExtensionAdaptor implements OptionsChanged
         for (ProxiesParamProxy proxyParam : proxyParams) {
             if (proxyParam.isEnabled()) {
                 // Treat disabled proxies as if they dont really exist
-                String key = proxyParam.getAddress() + ":" + proxyParam.getPort();
+                String key = createProxyKey(proxyParam.getAddress(), proxyParam.getPort());
                 ProxyServer proxy = currentProxies.remove(key);
                 if (proxy == null) {
                     // Its a new one
@@ -125,9 +125,20 @@ public class ExtensionProxies extends ExtensionAdaptor implements OptionsChanged
         }
     }
 
+    /**
+     * Creates a key that identifies a proxy, to be used with {@link #proxyServers}.
+     *
+     * @param address the address of the proxy.
+     * @param port the port of the proxy.
+     * @return a key that identifies the proxy.
+     */
+    private static String createProxyKey(String address, int port) {
+        return address + ":" + port;
+    }
+
     private ProxyServer startProxyServer(String address, int port) {
         // Note that if this is _not_ set then the proxy will go into a nasty loop if you point a browser at it
-        String key = address + ":" + port;
+        String key = createProxyKey(address, port);
         log.info("Starting alt proxy server: " + key);
         ProxyServer proxyServer = new ProxyServer(ZAP_PROXY_THREAD_PREFIX + key);
         proxyServer.setEnableApi(true);
@@ -159,23 +170,24 @@ public class ExtensionProxies extends ExtensionAdaptor implements OptionsChanged
     }
 
     public void addProxy(ProxiesParamProxy proxy) {
+        String key = createProxyKey(proxy.getAddress(), proxy.getPort());
         if (this.getAdditionalProxy(proxy.getAddress(), proxy.getPort()) != null) {
-            throw new IllegalArgumentException("Proxy already exists " + proxy.getAddress() + ":" + proxy.getPort());
+            throw new IllegalArgumentException("Proxy already exists: " + key);
         }
         if (!this.canListenOn(proxy.getAddress(), proxy.getPort())) {
-            throw new IllegalArgumentException("Cannot listen on " + proxy.getAddress() + ":" + proxy.getPort());
+            throw new IllegalArgumentException("Cannot listen on: " + key);
         }
 
         ProxyServer proxyServer = startProxyServer(proxy.getAddress(), proxy.getPort());
-        proxyServers.put(proxy.getAddress() + proxy.getPort(), proxyServer);
+        proxyServers.put(key, proxyServer);
         this.getParam().addProxy(proxy);
     }
 
     public void removeProxy(String address, int port) {
-        String key = address + ":" + port;
+        String key = createProxyKey(address, port);
         ProxyServer proxyServer = proxyServers.remove(key);
         if (proxyServer == null) {
-            throw new IllegalArgumentException("Proxy not found");
+            throw new IllegalArgumentException("Proxy not found: " + key);
         }
         this.stopProxyServer(proxyServer);
         this.getParam().removeProxy(address, port);


### PR DESCRIPTION
Change ExtensionProxies.addProxy to use the same key as the other
methods (it was missing a colon between the address and the port), which
prevented the proxies from being removed through the API.
Extract a method that creates a key for the proxies and change the code
to use it.