### PR TITLE
Allow to delete alerts with keyboard shortcut

### DIFF
--- a/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -52,7 +52,6 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.OptionsChangedListener;
 import org.parosproxy.paros.extension.SessionChangedListener;
-import org.parosproxy.paros.extension.ViewDelegate;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
@@ -345,18 +344,11 @@ public class ExtensionAlert extends ExtensionAdaptor implements
     AlertPanel getAlertPanel() {
         if (alertPanel == null) {
             alertPanel = new AlertPanel(this);
-            alertPanel.setView(getView());
             alertPanel.setSize(345, 122);
             setMainTreeModel();
         }
 
         return alertPanel;
-    }
-
-    @Override
-    public void initView(ViewDelegate view) {
-        super.initView(view);
-        getAlertPanel().setView(view);
     }
 
     AlertTreeModel getTreeModel() {

--- a/src/org/zaproxy/zap/extension/alert/PopupMenuAlertDelete.java
+++ b/src/org/zaproxy/zap/extension/alert/PopupMenuAlertDelete.java
@@ -39,6 +39,7 @@ public class PopupMenuAlertDelete extends PopupMenuItemAlert {
 
     public PopupMenuAlertDelete() {
         super(Constant.messages.getString("scanner.delete.popup"), true);
+        setAccelerator(getExtensionAlert().getView().getDefaultDeleteKeyStroke());
 	}
 	
     @Override

--- a/src/org/zaproxy/zap/extension/alert/PopupMenuItemAlert.java
+++ b/src/org/zaproxy/zap/extension/alert/PopupMenuItemAlert.java
@@ -23,8 +23,6 @@ package org.zaproxy.zap.extension.alert;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.Component;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import javax.swing.JTree;
@@ -89,30 +87,10 @@ public abstract class PopupMenuItemAlert extends ExtensionPopupMenuItem {
     }
 
     private Set<Alert> getAlertNodes() {
-        TreePath[] paths = this.extAlert.getAlertPanel().getTreeAlert().getSelectionPaths();
-        if (paths == null || paths.length == 0) {
-            return Collections.emptySet();
-        }
-
-        HashSet<Alert> alertNodes = new HashSet<Alert>();
         if (!isMultiSelect()) {
-            DefaultMutableTreeNode alertNode = (DefaultMutableTreeNode) paths[0].getLastPathComponent();
-            alertNodes.add((Alert) alertNode.getUserObject());
-            return alertNodes;
+            return extAlert.getAlertPanel().getSelectedAlert();
         }
-
-        for(int i = 0; i < paths.length; i++ ) {
-            DefaultMutableTreeNode alertNode = (DefaultMutableTreeNode)paths[i].getLastPathComponent();
-            if(alertNode.getChildCount() == 0) {
-                alertNodes.add((Alert)alertNode.getUserObject());
-                continue;
-            }
-            for(int j = 0; j < alertNode.getChildCount(); j++ ) {
-                DefaultMutableTreeNode node = (DefaultMutableTreeNode)alertNode.getChildAt(j);
-                alertNodes.add((Alert)node.getUserObject());
-            }
-        }
-        return alertNodes;
+        return extAlert.getAlertPanel().getSelectedAlerts();
     }
 
     /**


### PR DESCRIPTION
Change AlertPanel to provide methods to get the selected alerts (moved
from PopupMenuItemAlert, they are now used by AlertPanel and the pop up
menu item) and set an action to the tree to allow to delete the alerts
with default delete keyboard shortcut.
Change PopupMenuAlertDelete to use the default delete keyboard key.
Change PopupMenuItemAlert to use the new methods from AlertPanel.
Remove code no longer needed in ExtensionAlert, the view used by
AlertPanel is now obtained from the extension itself.