### PR TITLE
Use main connection settings in additional proxies

### DIFF
--- a/src/org/zaproxy/zap/extension/proxies/ExtensionProxies.java
+++ b/src/org/zaproxy/zap/extension/proxies/ExtensionProxies.java
@@ -141,6 +141,7 @@ public class ExtensionProxies extends ExtensionAdaptor implements OptionsChanged
         String key = createProxyKey(address, port);
         log.info("Starting alt proxy server: " + key);
         ProxyServer proxyServer = new ProxyServer(ZAP_PROXY_THREAD_PREFIX + key);
+        proxyServer.setConnectionParam(getModel().getOptionsParam().getConnectionParam());
         proxyServer.setEnableApi(true);
         if (proxyServer.startServer(address, port, false) > 0) {
             Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class).registerProxy(proxyServer);


### PR DESCRIPTION
Change ExtensionProxies to set the connection settings (for example,
connection timeout, outgoing proxy) into the additional proxies created,
otherwise it would use default values.