### PR TITLE
Use realm as domain for NTLM authentication

### DIFF
--- a/src/org/zaproxy/zap/authentication/HttpAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/HttpAuthenticationMethodType.java
@@ -124,7 +124,7 @@ public class HttpAuthenticationMethodType extends AuthenticationMethodType {
 						(this.realm == null || this.realm.isEmpty()) ? AuthScope.ANY_REALM : this.realm);
 				stateCredentials = new NTCredentials(userCredentials.getUsername(),
 						userCredentials.getPassword(), InetAddress.getLocalHost().getCanonicalHostName(),
-						this.hostname);
+						this.realm);
 				session.getHttpState().setCredentials(stateAuthScope, stateCredentials);
 			} catch (UnknownHostException e1) {
 				log.error(e1.getMessage(), e1);


### PR DESCRIPTION
Change HttpAuthenticationMethodType to use the realm as domain for NTLM
authentication, instead of using the hostname of the server. If an
invalid domain is provided it might lead to an authentication failure
(which would most likely happen since the hostname is always set).