### PR TITLE
Reduce log level in DialogModifyUser

### DIFF
--- a/src/org/zaproxy/zap/extension/users/DialogAddUser.java
+++ b/src/org/zaproxy/zap/extension/users/DialogAddUser.java
@@ -50,7 +50,7 @@ public class DialogAddUser extends AbstractFormDialog {
 	private static final long serialVersionUID = -7210879426146833234L;
 
 	/** The Constant logger. */
-	protected static final Logger log = Logger.getLogger(DialogAddUser.class);
+	protected final Logger log = Logger.getLogger(getClass());
 
 	private static final String DIALOG_TITLE = Constant.messages.getString("users.dialog.add.title");
 	private static final String CONFIRM_BUTTON_LABEL = Constant.messages

--- a/src/org/zaproxy/zap/extension/users/DialogModifyUser.java
+++ b/src/org/zaproxy/zap/extension/users/DialogModifyUser.java
@@ -26,7 +26,9 @@ public class DialogModifyUser extends DialogAddUser {
 
 	@Override
 	protected void init() {
-		log.info("Initializing modify user dialog for: " + user);
+		if (log.isDebugEnabled()) {
+			log.debug("Initializing modify user dialog for: " + user);
+		}
 		getNameTextField().setText(user.getName());
 		getEnabledCheckBox().setSelected(user.isEnabled());
 


### PR DESCRIPTION
Change DialogModifyUser to use debug level when logging that the
dialogue is being initialised (not of high relevance to log as info).
Change DialogAddUser to initialise the (protected) logger with the
instance's class, to log with correct class name.