### PR TITLE
Validate that -cmd and -daemon are not both set

### DIFF
--- a/src/org/parosproxy/paros/CommandLine.java
+++ b/src/org/parosproxy/paros/CommandLine.java
@@ -38,6 +38,7 @@
 // ZAP: 2017/05/12 Issue 3460: Support -suppinfo 
 // ZAP: 2017/05/31 Handle null args and include a message in all exceptions.
 // ZAP: 2017/08/31 Use helper method I18N.getString(String, Object...).
+// ZAP: 2017/11/21 Validate that -cmd and -daemon are not set at the same time (they are mutually exclusive).
 
 package org.parosproxy.paros;
 
@@ -110,6 +111,12 @@ public class CommandLine {
     public CommandLine(String[] args) throws Exception {
         this.args = args == null ? new String[0] : args;
         parseFirst(this.args);
+
+        if (isEnabled(CommandLine.CMD) && isEnabled(CommandLine.DAEMON)) {
+            throw new IllegalArgumentException(
+                    "Command line arguments " + CommandLine.CMD + " and " + CommandLine.DAEMON
+                            + " cannot be used at the same time.");
+        }
     }
 
     private boolean checkPair(String[] args, String paramName, int i) throws Exception {

--- a/test/org/parosproxy/paros/CommandLineUnitTest.java
+++ b/test/org/parosproxy/paros/CommandLineUnitTest.java
@@ -132,6 +132,13 @@ public class CommandLineUnitTest {
         assertThat(cmdLine.isGUI(), is(equalTo(false)));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailIfDaemonAndCommandLineArgumentsAreSet() throws Exception {
+        // Given / When
+        cmdLine = new CommandLine(new String[] { CommandLine.CMD, CommandLine.DAEMON });
+        // Then = IllegalArgumentException.class
+    }
+
     @Test(expected = Exception.class)
     public void shouldFailIfSessionArgumentDoesNotHaveValue() throws Exception {
         // Given / When


### PR DESCRIPTION
Change CommandLine to validate that -cmd and -daemon are not set at the
same time, the arguments are mutually exclusive (the former stops ZAP
after executing the command line arguments and the latter keeps ZAP
running indefinitely).
Add test to assert the new behaviour.