### PR TITLE
Correct command line args shown on error

### DIFF
--- a/src/org/zaproxy/zap/ZAP.java
+++ b/src/org/zaproxy/zap/ZAP.java
@@ -83,7 +83,7 @@ public class ZAP {
     public static void main(String[] args) throws Exception {
         CommandLine cmdLine = null;
         try {
-            cmdLine = new CommandLine(args);
+            cmdLine = new CommandLine(args != null ? Arrays.copyOf(args, args.length) : null);
 
         } catch (final Exception e) {
         	// Cant use the CommandLine help here as the 


### PR DESCRIPTION
Change ZAP class to pass a copy of the arguments to CommandLine, the
latter changes the arguments to null which makes the info when an error
occurs harder to read/understand:
For example, if the port was wrong it would output:
 Failed due to invalid parameters: [null, null]

instead of:
 Failed due to invalid parameters: [-port, a]