### PR TITLE
Fix a NPE in HttpRequestHeader.isImage()

### DIFF
--- a/src/org/parosproxy/paros/network/HttpRequestHeader.java
+++ b/src/org/parosproxy/paros/network/HttpRequestHeader.java
@@ -44,6 +44,7 @@
 // ZAP: 2017/02/23 Issue 3227: Limit API access to whitelisted IP addresses
 // ZAP: 2017/04/24 Added more HTTP methods
 // ZAP: 2017/10/19 Skip parsing of empty Cookie headers.
+// ZAP: 2017/11/22 Address a NPE in isImage().
 
 package org.parosproxy.paros.network;
 
@@ -499,6 +500,10 @@ public class HttpRequestHeader extends HttpHeader {
      */
     @Override
     public boolean isImage() {
+        if (getURI() == null) {
+            return false;
+        }
+
         try {
             // ZAP: prevents a NullPointerException when no path exists
             final String path = getURI().getPath();

--- a/test/org/parosproxy/paros/network/HttpRequestHeaderUnitTest.java
+++ b/test/org/parosproxy/paros/network/HttpRequestHeaderUnitTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import org.apache.commons.httpclient.URI;
 import org.junit.Test;
 
 /**
@@ -58,5 +59,40 @@ public class HttpRequestHeaderUnitTest {
         boolean empty = header.isEmpty();
         // Then
         assertThat(empty, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotBeImageIfItHasNoRequestUri() {
+        // Given
+        HttpRequestHeader header = new HttpRequestHeader();
+        // When
+        boolean image = header.isImage();
+        // Then
+        assertThat(image, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotBeImageIfRequestUriHasNoPath() throws Exception {
+        // Given
+        HttpRequestHeader header = new HttpRequestHeader();
+        header.setURI(new URI("http://example.com", true));
+        // When
+        boolean image = header.isImage();
+        // Then
+        assertThat(image, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldBeImageIfRequestUriHasPathWithImageExtension() throws Exception {
+        // Given
+        String[] extensions = { "bmp", "ico", "jpg", "jpeg", "gif", "tiff", "tif", "png" };
+        HttpRequestHeader header = new HttpRequestHeader();
+        for (String extension : extensions) {
+            header.setURI(new URI("http://example.com/image." + extension, true));
+            // When
+            boolean image = header.isImage();
+            // Then
+            assertThat(image, is(equalTo(true)));
+        }
     }
 }


### PR DESCRIPTION
Change HttpRequestHeader.isImage() to check that the request URI is set
before attempting to use it.
Add tests to assert the expected behaviour.