### PR TITLE
Update JavaScript templates to Java 8

### DIFF
--- a/src/scripts/templates/active/Active default template.js
+++ b/src/scripts/templates/active/Active default template.js
@@ -1,10 +1,6 @@
 // Note that new active scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"  
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 /**
  * Scans a "node", i.e. an individual entry in the Sites Tree.
  * The scanNode function will typically be called once for every page. 
@@ -16,7 +12,7 @@ if (typeof println == 'undefined') this.println = print;
  */
 function scanNode(as, msg) {
 	// Debugging can be done using println like this
-	println('scan called for url=' + msg.getRequestHeader().getURI().toString());
+	print('scan called for url=' + msg.getRequestHeader().getURI().toString());
 
 	// Copy requests before reusing them
 	msg = msg.cloneRequest();
@@ -58,7 +54,7 @@ function scanNode(as, msg) {
  */
 function scan(as, msg, param, value) {
 	// Debugging can be done using println like this
-	println('scan called for url=' + msg.getRequestHeader().getURI().toString() + 
+	print('scan called for url=' + msg.getRequestHeader().getURI().toString() + 
 		' param=' + param + ' value=' + value);
 	
 	// Copy requests before reusing them

--- a/src/scripts/templates/authentication/Authentication default template.js
+++ b/src/scripts/templates/authentication/Authentication default template.js
@@ -1,7 +1,3 @@
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 // The authenticate function will be called for authentications made via ZAP.
 
 // The authenticate function is called whenever ZAP requires to authenticate, for a Context for which this script
@@ -19,7 +15,7 @@ if (typeof println == 'undefined') this.println = print;
 //					The credential values can be obtained via calls to the getParam(paramName) method. The param names are the ones
 //					returned by the getCredentialsParamsNames() below
 function authenticate(helper, paramsValues, credentials) {
-	println("Authenticating via JavaScript script...");
+	print("Authenticating via JavaScript script...");
 	msg = helper.prepareMessage();
 	
 	// TODO: Process message to match the authentication needs

--- a/src/scripts/templates/authentication/BodgeIt Store Authentication.js
+++ b/src/scripts/templates/authentication/BodgeIt Store Authentication.js
@@ -1,7 +1,3 @@
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 // The authenticate function is called whenever ZAP requires to authenticate, for a Context for which this script
 // was selected as the Authentication Method. The function should send any messages that are required to do the authentication
 // and should return a message with an authenticated response so the calling method.
@@ -18,12 +14,12 @@ if (typeof println == 'undefined') this.println = print;
 //					returned by the getCredentialsParamsNames() below
 
 function authenticate(helper, paramsValues, credentials) {
-	println("Authenticating via JavaScript script...");
+	print("Authenticating via JavaScript script...");
 	
 	// Make sure any Java classes used explicitly are imported
-	importClass(org.parosproxy.paros.network.HttpRequestHeader)
-	importClass(org.parosproxy.paros.network.HttpHeader)
-	importClass(org.apache.commons.httpclient.URI)
+	var HttpRequestHeader = Java.type("org.parosproxy.paros.network.HttpRequestHeader")
+	var HttpHeader = Java.type("org.parosproxy.paros.network.HttpHeader")
+	var URI = Java.type("org.apache.commons.httpclient.URI")
 
 	// Prepare the login request details
 	requestUri = new URI("http://localhost:8080/bodgeit/login.jsp", false);
@@ -39,7 +35,7 @@ function authenticate(helper, paramsValues, credentials) {
 
 	// Send the authentication message and return it
 	helper.sendAndReceive(msg);
-	println("Received BodgeIt response status code: "+ msg.getResponseHeader().getStatusCode());
+	print("Received BodgeIt response status code: "+ msg.getResponseHeader().getStatusCode());
 
 	return msg;
 }

--- a/src/scripts/templates/authentication/Simple Form-Based Authentication.js
+++ b/src/scripts/templates/authentication/Simple Form-Based Authentication.js
@@ -1,7 +1,3 @@
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 // This authentication script can be used to authenticate in a webapplication via forms.
 // The submit target for the form, the name of the username field, the name of the password field
 // and, optionally, any extra POST Data fields need to be specified after loading the script.
@@ -23,12 +19,12 @@ if (typeof println == 'undefined') this.println = print;
 //					returned by the getCredentialsParamsNames() below
 
 function authenticate(helper, paramsValues, credentials) {
-	println("Authenticating via JavaScript script...");
+	print("Authenticating via JavaScript script...");
 
 	// Make sure any Java classes used explicitly are imported
-	importClass(org.parosproxy.paros.network.HttpRequestHeader)
-	importClass(org.parosproxy.paros.network.HttpHeader)
-	importClass(org.apache.commons.httpclient.URI)
+	var HttpRequestHeader = Java.type("org.parosproxy.paros.network.HttpRequestHeader")
+	var HttpHeader = Java.type("org.parosproxy.paros.network.HttpHeader")
+	var URI = Java.type("org.apache.commons.httpclient.URI")
 
 	// Prepare the login request details
 	requestUri = new URI(paramsValues.get("Target URL"), false);
@@ -42,14 +38,14 @@ function authenticate(helper, paramsValues, credentials) {
 		requestBody += "&" + extraPostData.trim();
 
 	// Build the actual message to be sent
-	println("Sending " + requestMethod + " request to " + requestUri + " with body: " + requestBody);
+	print("Sending " + requestMethod + " request to " + requestUri + " with body: " + requestBody);
 	msg = helper.prepareMessage();
 	msg.setRequestHeader(new HttpRequestHeader(requestMethod, requestUri, HttpHeader.HTTP10));
 	msg.setRequestBody(requestBody);
 
 	// Send the authentication message and return it
 	helper.sendAndReceive(msg);
-	println("Received response status code: " + msg.getResponseHeader().getStatusCode());
+	print("Received response status code: " + msg.getResponseHeader().getStatusCode());
 
 	return msg;
 }

--- a/src/scripts/templates/authentication/Wordpress Authentication.js
+++ b/src/scripts/templates/authentication/Wordpress Authentication.js
@@ -4,10 +4,6 @@
 //	Path: The path, with a '/' at the end, in which the app is found. E.g.: /wp/
 // The parameters must chosen such that: "http://" + domain + path + "wp-login.php"  is the uri of the login page. In case https is used,modify the script below.
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 // The authenticate function is called whenever ZAP requires to authenticate, for a Context for which this script
 // was selected as the Authentication Method. The function should send any messages that are required to do the authentication
 // and should return a message with an authenticated response so the calling method.
@@ -23,18 +19,18 @@ if (typeof println == 'undefined') this.println = print;
 //					The credential values can be obtained via calls to the getParam(paramName) method. The param names are the ones
 //					returned by the getCredentialsParamsNames() below
 function authenticate(helper, paramsValues, credentials) {
-	println("Wordpress Authenticating via JavaScript script...");
+	print("Wordpress Authenticating via JavaScript script...");
 
 	// Make sure any Java classes used explicitly are imported
-	importClass(org.parosproxy.paros.network.HttpRequestHeader)
-	importClass(org.parosproxy.paros.network.HttpHeader)
-	importClass(org.apache.commons.httpclient.URI)
-	importClass(org.apache.commons.httpclient.Cookie)
+	var HttpRequestHeader = Java.type("org.parosproxy.paros.network.HttpRequestHeader")
+	var HttpHeader = Java.type("org.parosproxy.paros.network.HttpHeader")
+	var URI = Java.type("org.apache.commons.httpclient.URI")
+	var Cookie = Java.type("org.apache.commons.httpclient.Cookie")
 
 	// Prepare the login request details
 	var domain = paramsValues.get("Domain");
 	var path = paramsValues.get("Path");
-	println("Logging in to domain " + domain + " and path " + path);
+	print("Logging in to domain " + domain + " and path " + path);
 
 	var requestUri = new URI("http://"+domain + path + "wp-login.php", false);
 	var requestMethod = HttpRequestHeader.POST;
@@ -49,26 +45,26 @@ function authenticate(helper, paramsValues, credentials) {
 	requestHeader.setHeader(HttpHeader.COOKIE, "wordpress_test_cookie=WP+Cookie+check");
 
 	// Build the actual message to be sent
-	println("Sending " + requestMethod + " request to " + requestUri + " with body: " + requestBody);
+	print("Sending " + requestMethod + " request to " + requestUri + " with body: " + requestBody);
 	var msg = helper.prepareMessage();
 	msg.setRequestHeader(requestHeader);
 	msg.setRequestBody(requestBody);
 
 	// Send the authentication message and return it
 	helper.sendAndReceive(msg);
-	println("Received response status code for authentication request: " + msg.getResponseHeader().getStatusCode());
+	print("Received response status code for authentication request: " + msg.getResponseHeader().getStatusCode());
 
 	// The path Wordpress sets on the session cookies is illegal according to the standard. The web browsers ignore this and use the cookies anyway, but the Apache Commons HttpClient used in ZAP really cares about this (probably the only one who does it) and simply ignores the "invalid" cookies [0] , [1],so we must make sure we MANUALLY add the response cookies
 	if(path != "/" && path.charAt(path.length() - 1) == '/')	{
-		path = path.splice(0, path.length() - 2);
+		path = path.substring(0, path.length() - 1);
 	}
-	println("Cleaned cookie path: " + path);
+	print("Cleaned cookie path: " + path);
 
 	var cookies = msg.getResponseHeader().getCookieParams();
 	var state = helper.getCorrespondingHttpState();
 	for(var iterator = cookies.iterator(); iterator.hasNext();){
 		var cookie = iterator.next();
-		println("Manually adding cookie: " + cookie.getName() + " = " + cookie.getValue());
+		print("Manually adding cookie: " + cookie.getName() + " = " + cookie.getValue());
 		state.addCookie(new Cookie(domain, cookie.getName(), cookie.getValue(), path, 999999, false));
 	}
 

--- a/src/scripts/templates/httpsender/HttpSender default template.js
+++ b/src/scripts/templates/httpsender/HttpSender default template.js
@@ -23,18 +23,14 @@
 // New requests can be made like this:
 // msg2 = msg.cloneAll() // msg2 can then be safely changed as required without affecting msg
 // helper.getHttpSender().sendAndReceive(msg2, false);
-// println('msg2 response=' + msg2.getResponseHeader().getStatusCode())
-
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
+// print('msg2 response=' + msg2.getResponseHeader().getStatusCode())
 
 function sendingRequest(msg, initiator, helper) {
 	// Debugging can be done using println like this
-	println('sendingRequest called for url=' + msg.getRequestHeader().getURI().toString())
+	print('sendingRequest called for url=' + msg.getRequestHeader().getURI().toString())
 }
 
 function responseReceived(msg, initiator, helper) {
 	// Debugging can be done using println like this
-	println('responseReceived called for url=' + msg.getRequestHeader().getURI().toString())
+	print('responseReceived called for url=' + msg.getRequestHeader().getURI().toString())
 }

--- a/src/scripts/templates/passive/Passive default template.js
+++ b/src/scripts/templates/passive/Passive default template.js
@@ -3,9 +3,7 @@
 // Note that new passive scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"  
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
+var PluginPassiveScanner = Java.type("org.zaproxy.zap.extension.pscan.PluginPassiveScanner");
 
 /**
  * Passively scans an HTTP message. The scan function will be called for 
@@ -52,5 +50,5 @@ function appliesToHistoryType(historyType) {
 	// return historyType == org.parosproxy.paros.model.HistoryReference.TYPE_SPIDER;
 
 	// Default behaviour scans default types.
-	return org.zaproxy.zap.extension.pscan.PluginPassiveScanner.getDefaultHistoryTypes().contains(historyType);
+	return PluginPassiveScanner.getDefaultHistoryTypes().contains(historyType);
 }

--- a/src/scripts/templates/proxy/Proxy default template.js
+++ b/src/scripts/templates/proxy/Proxy default template.js
@@ -6,10 +6,6 @@
 // Note that new proxy scripts will initially be disabled
 // Right click the script in the Scripts tree and select "enable"  
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 /**
  * This function allows interaction with proxy requests (i.e.: outbound from the browser/client to the server).
  * 
@@ -17,7 +13,7 @@ if (typeof println == 'undefined') this.println = print;
  */
 function proxyRequest(msg) {
 	// Debugging can be done using println like this
-	println('proxyRequest called for url=' + msg.getRequestHeader().getURI().toString())
+	print('proxyRequest called for url=' + msg.getRequestHeader().getURI().toString())
 	
 	return true
 }
@@ -29,6 +25,6 @@ function proxyRequest(msg) {
  */
 function proxyResponse(msg) {
 	// Debugging can be done using println like this
-	println('proxyResponse called for url=' + msg.getRequestHeader().getURI().toString())
+	print('proxyResponse called for url=' + msg.getRequestHeader().getURI().toString())
 	return true
 }

--- a/src/scripts/templates/standalone/Loop through history table.js
+++ b/src/scripts/templates/standalone/Loop through history table.js
@@ -3,10 +3,6 @@
 // Standalone scripts have no template.
 // They are only evaluated when you run them. 
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 extHist = org.parosproxy.paros.control.Control.getSingleton().
     getExtensionLoader().getExtension(
         org.parosproxy.paros.extension.history.ExtensionHistory.NAME) 
@@ -16,7 +12,7 @@ if (extHist != null) {
     while (hr = extHist.getHistoryReference(i), hr) {
         if (hr) { 
             url = hr.getHttpMessage().getRequestHeader().getURI().toString();
-            println('Got History record id ' + hr.getHistoryId() + ' URL=' + url); 
+            print('Got History record id ' + hr.getHistoryId() + ' URL=' + url); 
         }
         i++
     }

--- a/src/scripts/templates/standalone/Standalone default template.js
+++ b/src/scripts/templates/standalone/Standalone default template.js
@@ -1,6 +1,3 @@
 // Standalone scripts have no template.
 // They are only evaluated when you run them. 
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;

--- a/src/scripts/templates/standalone/Traverse sites tree.js
+++ b/src/scripts/templates/standalone/Traverse sites tree.js
@@ -3,14 +3,10 @@
 // Standalone scripts have no template.
 // They are only evaluated when you run them. 
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 function listChildren(node, level) {
     var j;
     for (j=0;j<node.getChildCount();j++) {
-        println(Array(level+1).join("    ") + node.getChildAt(j).getNodeName());
+        print(Array(level+1).join("    ") + node.getChildAt(j).getNodeName());
         listChildren(node.getChildAt(j), level+1);
     }
 }

--- a/src/scripts/templates/targeted/Find HTML comments.js
+++ b/src/scripts/templates/targeted/Find HTML comments.js
@@ -1,12 +1,8 @@
 // Targeted scripts can only be invoked by you, the user, eg via a right-click option on the Sites or History tabs
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 function invokeWith(msg) {
 	// Debugging can be done using println like this
-	println('Finding comments under ' + msg.getRequestHeader().getURI().toString()); 
+	print('Finding comments under ' + msg.getRequestHeader().getURI().toString()); 
 	prefix = msg.getRequestHeader().getURI().toString();
 
 	extHist = org.parosproxy.paros.control.Control.getSingleton().
@@ -22,11 +18,11 @@ function invokeWith(msg) {
 				body = hr.getHttpMessage().getResponseBody().toString()
 				// Look for html comments
 				if (body.indexOf('<!--') > 0) {
-		           	println(hr.getHttpMessage().getRequestHeader().getURI()) 
+		           	print(hr.getHttpMessage().getRequestHeader().getURI()) 
 					o = body.indexOf('<!--');
 					while (o > 0) {
 						e = body.indexOf('-->', o);
-			           	println("\t" + body.substr(o,e-o+3)) 
+			           	print("\t" + body.substr(o,e-o+3)) 
 						o = body.indexOf('<!--', e);
 					}
 				}

--- a/src/scripts/templates/targeted/Targeted default template.js
+++ b/src/scripts/templates/targeted/Targeted default template.js
@@ -1,9 +1,5 @@
 // Targeted scripts can only be invoked by you, the user, eg via a right-click option on the Sites or History tabs
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 /**
  * A function which will be invoked against a specific "targeted" message.
  *
@@ -11,5 +7,5 @@ if (typeof println == 'undefined') this.println = print;
  */
 function invokeWith(msg) {
 	// Debugging can be done using println like this
-	println('invokeWith called for url=' + msg.getRequestHeader().getURI().toString()); 
+	print('invokeWith called for url=' + msg.getRequestHeader().getURI().toString()); 
 }

--- a/src/scripts/templates/variant/Input Vector default template.js
+++ b/src/scripts/templates/variant/Input Vector default template.js
@@ -8,16 +8,12 @@
 // in VariantCustom 
 // https://github.com/zaproxy/zaproxy/blob/develop/src/org/parosproxy/paros/core/scanner/VariantCustom.java
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 var B64STATE = 'b64';
 var paramStates = [];
 
 function parseParameters(helper, msg) {
     // Debugging can be done using println like this
-    println('Custom input vector handler called for url=' + msg.getRequestHeader().getURI().toString());
+    print('Custom input vector handler called for url=' + msg.getRequestHeader().getURI().toString());
 
     // Sample scan of a query string object
     // searching for Base64 encoded parameters


### PR DESCRIPTION
Update the JavaScript templates to Nashorn (e.g. use print, import
classes with Java.type...), all scripts are now running without errors
(most of them already were).

Part of #3470 - Move to using Java 8