### PR TITLE
Do not validate cookie path

### DIFF
--- a/src/org/parosproxy/paros/network/HttpSender.java
+++ b/src/org/parosproxy/paros/network/HttpSender.java
@@ -66,6 +66,7 @@
 // ZAP: 2017/06/12 Allow to ignore listeners.
 // ZAP: 2017/06/19 Allow to send a request with custom socket timeout.
 // ZAP: 2017/11/20 Add initiator constant for Token Generator requests.
+// ZAP: 2017/11/27 Use custom CookieSpec (ZapCookieSpec).
 
 package org.parosproxy.paros.network;
 
@@ -103,6 +104,7 @@ import org.apache.log4j.Logger;
 import org.zaproxy.zap.ZapGetMethod;
 import org.zaproxy.zap.ZapHttpConnectionManager;
 import org.zaproxy.zap.network.HttpSenderListener;
+import org.zaproxy.zap.network.ZapCookieSpec;
 import org.zaproxy.zap.network.HttpRedirectionValidator;
 import org.zaproxy.zap.network.HttpRequestConfig;
 import org.zaproxy.zap.network.ZapNTLMScheme;
@@ -145,6 +147,8 @@ public class HttpSender {
 		}
 
 		AuthPolicy.registerAuthScheme(AuthPolicy.NTLM, ZapNTLMScheme.class);
+		CookiePolicy.registerCookieSpec(CookiePolicy.DEFAULT, ZapCookieSpec.class);
+		CookiePolicy.registerCookieSpec(CookiePolicy.BROWSER_COMPATIBILITY, ZapCookieSpec.class);
 	}
 
 	private static HttpMethodHelper helper = new HttpMethodHelper();
@@ -205,7 +209,14 @@ public class HttpSender {
 
 		if (useGlobalState) {
 			checkState();
+		} else {
+			setClientsCookiePolicy(CookiePolicy.BROWSER_COMPATIBILITY);
 		}
+	}
+
+	private void setClientsCookiePolicy(String policy) {
+		client.getParams().setCookiePolicy(policy);
+		clientViaProxy.getParams().setCookiePolicy(policy);
 	}
 
 	public static SSLConnector getSSLConnector() {
@@ -216,11 +227,9 @@ public class HttpSender {
 		if (param.isHttpStateEnabled()) {
 			client.setState(param.getHttpState());
 			clientViaProxy.setState(param.getHttpState());
-			client.getParams().setCookiePolicy(CookiePolicy.BROWSER_COMPATIBILITY);
-			clientViaProxy.getParams().setCookiePolicy(CookiePolicy.BROWSER_COMPATIBILITY);
+			setClientsCookiePolicy(CookiePolicy.BROWSER_COMPATIBILITY);
 		} else {
-			client.getParams().setCookiePolicy(CookiePolicy.IGNORE_COOKIES);
-			clientViaProxy.getParams().setCookiePolicy(CookiePolicy.IGNORE_COOKIES);
+			setClientsCookiePolicy(CookiePolicy.IGNORE_COOKIES);
 		}
 	}
 

--- a/src/org/zaproxy/zap/network/ZapCookieSpec.java
+++ b/src/org/zaproxy/zap/network/ZapCookieSpec.java
@@ -1,0 +1,92 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.network;
+
+import org.apache.commons.httpclient.Cookie;
+import org.apache.commons.httpclient.cookie.CookieSpecBase;
+import org.apache.commons.httpclient.cookie.MalformedCookieException;
+
+/**
+ * A {@link CookieSpecBase} that does not do any path validation.
+ * 
+ * @since TODO add version
+ */
+public class ZapCookieSpec extends CookieSpecBase {
+
+    // ZAP: Same implementation as base class but without the path validation.
+    @Override
+    public void validate(String host, int port, String path, boolean secure, Cookie cookie) throws MalformedCookieException {
+        LOG.trace("enter CookieSpecBase.validate("
+            + "String, port, path, boolean, Cookie)");
+        if (host == null) {
+            throw new IllegalArgumentException(
+                "Host of origin may not be null");
+        }
+        if (host.trim().equals("")) {
+            throw new IllegalArgumentException(
+                "Host of origin may not be blank");
+        }
+        if (port < 0) {
+            throw new IllegalArgumentException("Invalid port: " + port);
+        }
+        if (path == null) {
+            throw new IllegalArgumentException(
+                "Path of origin may not be null.");
+        }
+        host = host.toLowerCase();
+        // check version
+        if (cookie.getVersion() < 0) {
+            throw new MalformedCookieException ("Illegal version number " 
+                + cookie.getValue());
+        }
+
+        // security check... we musn't allow the server to give us an
+        // invalid domain scope
+
+        // Validate the cookies domain attribute.  NOTE:  Domains without 
+        // any dots are allowed to support hosts on private LANs that don't 
+        // have DNS names.  Since they have no dots, to domain-match the 
+        // request-host and domain must be identical for the cookie to sent 
+        // back to the origin-server.
+        if (host.indexOf(".") >= 0) {
+            // Not required to have at least two dots.  RFC 2965.
+            // A Set-Cookie2 with Domain=ajax.com will be accepted.
+
+            // domain must match host
+            if (!host.endsWith(cookie.getDomain())) {
+                String s = cookie.getDomain();
+                if (s.startsWith(".")) {
+                    s = s.substring(1, s.length());
+                }
+                if (!host.equals(s)) { 
+                    throw new MalformedCookieException(
+                        "Illegal domain attribute \"" + cookie.getDomain() 
+                        + "\". Domain of origin: \"" + host + "\"");
+                }
+            }
+        } else {
+            if (!host.equals(cookie.getDomain())) {
+                throw new MalformedCookieException(
+                    "Illegal domain attribute \"" + cookie.getDomain() 
+                    + "\". Domain of origin: \"" + host + "\"");
+            }
+        }
+    }
+}

--- a/test/org/zaproxy/zap/network/ZapCookieSpecUnitTest.java
+++ b/test/org/zaproxy/zap/network/ZapCookieSpecUnitTest.java
@@ -1,0 +1,122 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.network;
+
+import org.apache.commons.httpclient.Cookie;
+import org.apache.commons.httpclient.cookie.CookieSpec;
+import org.apache.commons.httpclient.cookie.MalformedCookieException;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link ZapCookieSpec}.
+ */
+public class ZapCookieSpecUnitTest {
+
+    private static final String HOST = "example.com";
+    private static final int PORT = 8443;
+    private static final String PATH = "/path/file";
+    private static final boolean SECURE = true;
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowWhenValidatingWithNullHost() throws MalformedCookieException {
+        // Given
+        CookieSpec cookieSpec = createCookieSpec();
+        String host = null;
+        // When
+        cookieSpec.validate(host, PORT, PATH, SECURE, new Cookie());
+        // Then = IllegalArgumentException.
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowWhenValidatingWithEmptyHost() throws MalformedCookieException {
+        // Given
+        CookieSpec cookieSpec = createCookieSpec();
+        String host = "";
+        // When
+        cookieSpec.validate(host, PORT, PATH, SECURE, new Cookie());
+        // Then = IllegalArgumentException.
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowWhenValidatingWithNegativePort() throws MalformedCookieException {
+        // Given
+        CookieSpec cookieSpec = createCookieSpec();
+        int port = -1;
+        // When
+        cookieSpec.validate(HOST, port, PATH, SECURE, new Cookie());
+        // Then = IllegalArgumentException.
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowWhenValidatingWithNullPath() throws MalformedCookieException {
+        // Given
+        CookieSpec cookieSpec = createCookieSpec();
+        String path = null;
+        // When
+        cookieSpec.validate(HOST, PORT, path, SECURE, new Cookie());
+        // Then = IllegalArgumentException.
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowWhenValidatingWithNullCookie() throws MalformedCookieException {
+        // Given
+        CookieSpec cookieSpec = createCookieSpec();
+        Cookie cookie = null;
+        // When
+        cookieSpec.validate(HOST, PORT, PATH, SECURE, cookie);
+        // Then = NullPointerException.
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowWhenValidatingWithNullCookieDomain() throws MalformedCookieException {
+        // Given
+        CookieSpec cookieSpec = createCookieSpec();
+        Cookie cookie = new Cookie(null, "name", "value");
+        // When
+        cookieSpec.validate(HOST, PORT, PATH, SECURE, cookie);
+        // Then = NullPointerException.
+    }
+
+    @Test(expected = MalformedCookieException.class)
+    public void shouldBeMalformedWhenValidatingWithNegativeCookieVersion() throws MalformedCookieException {
+        // Given
+        CookieSpec cookieSpec = createCookieSpec();
+        Cookie cookie = new Cookie(HOST, "name", "value");
+        cookie.setVersion(-1);
+        // When
+        cookieSpec.validate(HOST, PORT, PATH, SECURE, cookie);
+        // Then = MalformedCookieException.
+    }
+
+    @Test
+    public void shouldBeValidEvenIfCookiePathIsDifferentThanOrigin() throws MalformedCookieException {
+        // Given
+        CookieSpec cookieSpec = createCookieSpec();
+        Cookie cookie = new Cookie(HOST, "name", "value");
+        cookie.setPath("/other/path/");
+        // When
+        cookieSpec.validate(HOST, PORT, PATH, SECURE, cookie);
+        // Then = No exception.
+    }
+
+    private static CookieSpec createCookieSpec() {
+        return new ZapCookieSpec();
+    }
+}


### PR DESCRIPTION
Add ZapCookieSpec, same behaviour as CookieSpec already in use but
without the path validation. The path does not need to be validated (RFC
6265).
Change HttpSender to use the ZapCookieSpec as browser and default
CookieSpec.
Add some tests to assert the expected behaviour.

Fix #4079 - Cookie with unknown path is falsely rejected by ZAP