### PR TITLE
Do not refresh history/spider entries by default

### DIFF
--- a/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/src/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -909,9 +909,9 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
                 notifyHistoryItemChanged(Integer.valueOf(event.getParameters().get(AlertEventPublisher.HISTORY_REFERENCE_ID)));
                 break;
             case AlertEventPublisher.ALL_ALERTS_REMOVED_EVENT:
-            default:
                 notifyHistoryItemsChanged();
                 break;
+            default:
             }
         }
     }

--- a/src/org/zaproxy/zap/extension/spider/SpiderMessagesTableModel.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderMessagesTableModel.java
@@ -355,9 +355,9 @@ class SpiderMessagesTableModel
                 refreshEntry(Integer.valueOf(event.getParameters().get(AlertEventPublisher.HISTORY_REFERENCE_ID)));
                 break;
             case AlertEventPublisher.ALL_ALERTS_REMOVED_EVENT:
-            default:
                 refreshEntries();
                 break;
+            default:
             }
         }
 


### PR DESCRIPTION
Change ExtensionHistory and SpiderMessagesTableModel to not refresh the
existing entries by default, it would create unnecessary workload when a
HistoryReference is removed.