### PR TITLE
Normalise API authentication methods' responses

### DIFF
--- a/src/org/zaproxy/zap/authentication/AuthenticationMethod.java
+++ b/src/org/zaproxy/zap/authentication/AuthenticationMethod.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.authentication;
 
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import org.apache.commons.httpclient.URIException;
@@ -26,12 +27,16 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.api.ApiResponse;
+import org.zaproxy.zap.extension.api.ApiResponseSet;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.SessionStructure;
 import org.zaproxy.zap.session.SessionManagementMethod;
 import org.zaproxy.zap.session.WebSession;
 import org.zaproxy.zap.users.User;
 import org.zaproxy.zap.utils.Stats;
+
+import net.sf.json.JSON;
+import net.sf.json.JSONObject;
 
 /**
  * The {@code AuthenticationMethod} represents an authentication method that can be used to authenticate an
@@ -331,4 +336,17 @@ public abstract class AuthenticationMethod {
 		}
 	}
 
+    static class AuthMethodApiResponseRepresentation<T> extends ApiResponseSet<T> {
+
+        public AuthMethodApiResponseRepresentation(Map<String, T> values) {
+            super("method", values);
+        }
+
+        @Override
+        public JSON toJSON() {
+            JSONObject response = new JSONObject();
+            response.put(getName(), super.toJSON());
+            return response;
+        }
+    }
 }

--- a/src/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
@@ -72,7 +72,6 @@ import org.zaproxy.zap.authentication.UsernamePasswordAuthenticationCredentials.
 import org.zaproxy.zap.extension.api.ApiDynamicActionImplementor;
 import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiResponse;
-import org.zaproxy.zap.extension.api.ApiResponseSet;
 import org.zaproxy.zap.extension.authentication.AuthenticationAPI;
 import org.zaproxy.zap.extension.authentication.ContextAuthenticationPanel;
 import org.zaproxy.zap.extension.users.ExtensionUserManagement;
@@ -374,7 +373,7 @@ public class FormBasedAuthenticationMethodType extends AuthenticationMethodType 
 			values.put("methodName", API_METHOD_NAME);
 			values.put("loginUrl", loginRequestURL);
 			values.put("loginRequestData", this.loginRequestBody);
-			return new ApiResponseSet<String>("method", values);
+			return new AuthMethodApiResponseRepresentation<>(values);
 		}
 
 		@Override

--- a/src/org/zaproxy/zap/authentication/HttpAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/HttpAuthenticationMethodType.java
@@ -27,7 +27,6 @@ import org.zaproxy.zap.authentication.UsernamePasswordAuthenticationCredentials.
 import org.zaproxy.zap.extension.api.ApiDynamicActionImplementor;
 import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiResponse;
-import org.zaproxy.zap.extension.api.ApiResponseSet;
 import org.zaproxy.zap.extension.authentication.AuthenticationAPI;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.session.SessionManagementMethod;
@@ -139,7 +138,7 @@ public class HttpAuthenticationMethodType extends AuthenticationMethodType {
 			values.put("host", this.hostname);
 			values.put("port", Integer.toString(this.port));
 			values.put("realm", this.realm);
-			return new ApiResponseSet<String>("method", values);
+			return new AuthMethodApiResponseRepresentation<>(values);
 		}
 
 	}

--- a/src/org/zaproxy/zap/authentication/ManualAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/ManualAuthenticationMethodType.java
@@ -47,7 +47,6 @@ import org.zaproxy.zap.extension.api.ApiDynamicActionImplementor;
 import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiException.Type;
 import org.zaproxy.zap.extension.api.ApiResponse;
-import org.zaproxy.zap.extension.api.ApiResponseElement;
 import org.zaproxy.zap.extension.api.ApiResponseSet;
 import org.zaproxy.zap.extension.authentication.AuthenticationAPI;
 import org.zaproxy.zap.extension.httpsessions.ExtensionHttpSessions;
@@ -145,7 +144,9 @@ public class ManualAuthenticationMethodType extends AuthenticationMethodType {
 
 		@Override
 		public ApiResponse getApiResponseRepresentation() {
-			return new ApiResponseElement("methodName", API_METHOD_NAME);
+			Map<String, String> values = new HashMap<>();
+			values.put("methodName", API_METHOD_NAME);
+			return new AuthMethodApiResponseRepresentation<>(values);
 		}
 
 		@Override

--- a/src/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
@@ -45,7 +45,6 @@ import org.zaproxy.zap.authentication.GenericAuthenticationCredentials.GenericAu
 import org.zaproxy.zap.extension.api.ApiDynamicActionImplementor;
 import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiResponse;
-import org.zaproxy.zap.extension.api.ApiResponseSet;
 import org.zaproxy.zap.extension.authentication.AuthenticationAPI;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.extension.script.ScriptType;
@@ -266,7 +265,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
 			values.put("methodName", API_METHOD_NAME);
 			values.put("scriptName", script.getName());
 			values.putAll(paramValues);
-			return new ApiResponseSet<String>("method", values);
+			return new AuthMethodApiResponseRepresentation<>(values);
 		}
 
 	}


### PR DESCRIPTION
Change authentication methods to return the JSON API responses wrapped
in an object instead of returning the data directly, so that the Python
ZAP API client is able to correctly read the data (expects and removes
the wrapper object).

The data returned is now, for example:
```JSON
{
  "method": {
    "port": "443",
    "host": "example.com",
    "methodName": "httpAuthentication",
    "realm": "example"
  }
}
```

instead of:
```JSON
{
  "port": "443",
  "host": "example.com",
  "methodName": "httpAuthentication",
  "realm": "example"
}
```

This change breaks existing custom clients that consume the JSON format.
The structure of XML format is unchanged for all methods except "manual"
(normalised with the other methods).

Fix #4097 - python api returns the wrong content for
authentication.get_authentication_method()