### PR TITLE
Return API alerts summary in a JSON object

### DIFF
--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -40,6 +40,7 @@ import java.util.regex.PatternSyntaxException;
 
 import javax.swing.tree.TreeNode;
 
+import net.sf.json.JSON;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 
@@ -977,7 +978,15 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 			for (int i = 0; i < riskSummary.length; i++) {
 				alertData.put(Alert.MSG_RISK[i], riskSummary[i]);
 			}
-			result = new ApiResponseSet<Object>("risk", alertData);
+			result = new ApiResponseSet<Object>("risk", alertData) {
+
+				@Override
+				public JSON toJSON() {
+					JSONObject response = new JSONObject();
+					response.put(name, super.toJSON());
+					return response;
+				}
+			};
 		} else if (VIEW_MESSAGE.equals(name)) {
 			TableHistory tableHistory = Model.getSingleton().getDb().getTableHistory();
 			RecordHistory recordHistory = getRecordHistory(tableHistory, getParam(params, PARAM_ID, -1));


### PR DESCRIPTION
Change CoreAPI to return the JSON API response of alerts summary wrapped
in an object instead of returning the data directly, so that the Python
ZAP API client is able to correctly read the data (expects and removes
the wrapper object).

The data returned is now, for example:
```JSON
{
  "alertsSummary": {
    "High": 0,
    "Low": 3,
    "Medium": 1,
    "Informational": 1
  }
}
```

instead of:
```JSON
{
  "High": 0,
  "Low": 3,
  "Medium": 1,
  "Informational": 1
}
```

This change breaks existing custom clients that consume the JSON format.

Fix #4111 - ZAP Python API: zap.context.alerts_summary() returns 0