### PR TITLE
Update docker scripts for latest Python API client

### DIFF
--- a/build/docker/zap-api-scan.py
+++ b/build/docker/zap-api-scan.py
@@ -341,11 +341,11 @@ def main(argv):
             if target_url:
                 logging.debug('Import OpenAPI URL ' + target_url)
                 res = zap.openapi.import_url(target)
-                urls = zap.core.urls
+                urls = zap.core.urls()
             else:
                 logging.debug('Import OpenAPI File ' + target_file)
                 res = zap.openapi.import_file(base_dir + target_file)
-                urls = zap.core.urls
+                urls = zap.core.urls()
                 if len(urls) > 0:
                     # Choose the first one - will be striping off the path below
                     target = urls[0]
@@ -355,11 +355,11 @@ def main(argv):
             if target_url:
                 logging.debug('Import SOAP URL ' + target_url)
                 res = zap._request(zap.base + 'soap/action/importUrl/', {'url':target})
-                urls = zap.core.urls
+                urls = zap.core.urls()
             else:
                 logging.debug('Import SOAP File ' + target_file)
                 res = zap._request(zap.base + 'soap/action/importFile/', {'file': base_dir + target_file})
-                urls = zap.core.urls
+                urls = zap.core.urls()
                 if len(urls) > 0:
                     # Choose the first one - will be striping off the path below
                     target = urls[0]
@@ -397,7 +397,7 @@ def main(argv):
         zap_wait_for_passive_scan(zap, timeout * 60)
 
         # Print out a count of the number of urls
-        num_urls = len(zap.core.urls)
+        num_urls = len(zap.core.urls())
         if num_urls == 0:
             logging.warning('No URLs found - is the target URL accessible? Local services may not be accessible from the Docker container')
         else:
@@ -483,7 +483,7 @@ def main(argv):
 
             if report_json:
                 # Save the report
-                write_report(base_dir + report_json, zap._request_other(zap.base_other + 'core/other/jsonreport/'))
+                write_report(base_dir + report_json, zap.core.jsonreport())
 
             if report_md:
                 # Save the report

--- a/build/docker/zap-baseline.py
+++ b/build/docker/zap-baseline.py
@@ -325,7 +325,7 @@ def main(argv):
         zap_wait_for_passive_scan(zap, timeout * 60)
 
         # Print out a count of the number of urls
-        num_urls = len(zap.core.urls)
+        num_urls = len(zap.core.urls())
         if num_urls == 0:
             logging.warning('No URLs found - is the target URL accessible? Local services may not be accessible from the Docker container')
         else:
@@ -389,7 +389,7 @@ def main(argv):
 
             if report_json:
                 # Save the report
-                write_report(base_dir + report_json, zap._request_other(zap.base_other + 'core/other/jsonreport/'))
+                write_report(base_dir + report_json, zap.core.jsonreport())
 
             if report_md:
                 # Save the report

--- a/build/docker/zap-full-scan.py
+++ b/build/docker/zap-full-scan.py
@@ -346,7 +346,7 @@ def main(argv):
         zap_wait_for_passive_scan(zap, timeout * 60)
 
         # Print out a count of the number of urls
-        num_urls = len(zap.core.urls)
+        num_urls = len(zap.core.urls())
         if num_urls == 0:
             logging.warning('No URLs found - is the target URL accessible? Local services may not be accessible from the Docker container')
         else:
@@ -432,7 +432,7 @@ def main(argv):
 
             if report_json:
                 # Save the report
-                write_report(base_dir + report_json, zap._request_other(zap.base_other + 'core/other/jsonreport/'))
+                write_report(base_dir + report_json, zap.core.jsonreport())
 
             if report_md:
                 # Save the report


### PR DESCRIPTION
Use core.jsonreport() and update calls to core.urls, no longer a
property in latest version.

Fix #4118 - zap-api-scan URL Error with zap2docker-weekly (2017-12-04)