### PR TITLE
Update HTTP Sender docker scripts to Java 8

### DIFF
--- a/build/docker/scripts/scripts/httpsender/Alert_on_HTTP_Response_Code_Errors.js
+++ b/build/docker/scripts/scripts/httpsender/Alert_on_HTTP_Response_Code_Errors.js
@@ -2,10 +2,6 @@
 // By default it will raise 'Info' level alerts for Client Errors (4xx) (apart from 404s) and 'Low' Level alerts for Server Errors (5xx)
 // But it can be easily changed.
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 pluginid = 100000	// https://github.com/zaproxy/zaproxy/blob/develop/src/doc/scanners.md
 
 function sendingRequest(msg, initiator, helper) {

--- a/build/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
+++ b/build/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
@@ -2,10 +2,6 @@
 // By default it will raise 'Low' level alerts for content types that are not expected to be returned by APIs.
 // But it can be easily changed.
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 var pluginid = 100001	// https://github.com/zaproxy/zaproxy/blob/develop/src/doc/scanners.md
 
 var extensionAlert = org.parosproxy.paros.control.Control.getSingleton().getExtensionLoader().getExtension(


### PR DESCRIPTION
Update the HTTP Sender (JavaScript) scripts to Nashorn (remove println
workaround).

Part of #3470 - Move to using Java 8