### PR TITLE
Add OpenJDK 8 to Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ script: ant -buildfile build/build.xml test
 
 jdk:
   - oraclejdk8
+  - openjdk8
 
 env:
   global:


### PR DESCRIPTION
Change .travis.yml to also run the build with OpenJDK 8.

Part of #3470 - Move to using Java 8