### PR TITLE
Issue 3879 - Auto Set Active Imported Certificate

### DIFF
--- a/src/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
@@ -31,6 +31,7 @@
 // ZAP: 2017/08/16 Tidy up usage of CertificateView.
 // ZAP: 2017/08/16 Show error message if failed to activate the certificate.
 // ZAP: 2017/08/17 Reduce code duplication when showing cert/keystore errors
+// ZAP: 2017/12/12 Use first alias by default (Issue 3879).
 
 package org.parosproxy.paros.extension.option;
 
@@ -637,7 +638,7 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 			retry = true;
 
 			certificatejTabbedPane.setSelectedIndex(0);
-			selectFirstAliasOfKeyStore(ksIndex);
+			activateFirstOnlyAliasOfKeyStore(ksIndex);
 
 			driverComboBox.setSelectedIndex(-1);
 			pkcs11PasswordField.setText("");
@@ -709,7 +710,7 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 
 	}//GEN-LAST:event_addPkcs11ButtonActionPerformed
 
-	private void selectFirstAliasOfKeyStore(int ksIndex) {
+	private void activateFirstOnlyAliasOfKeyStore(int ksIndex) {
 		if (ksIndex < 0 || ksIndex >= keyStoreList.getModel().getSize()) {
 			return;
 		}
@@ -717,7 +718,16 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 		keyStoreList.setSelectedIndex(ksIndex);
 		if (aliasTable.getRowCount() != 0) {
 			aliasTable.setRowSelectionInterval(0, 0);
+
+			if (aliasTable.getRowCount() == 1 && !isCertActive()) {
+				setActiveAction();
+			}
 		}
+	}
+
+	private boolean isCertActive() {
+		String currentKey = contextManager.getDefaultKey();
+		return currentKey != null && !currentKey.isEmpty();
 	}
 
 	private void showErrorMessageSunPkcs11ProviderNotAvailable() {
@@ -793,7 +803,7 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 
 
 		certificatejTabbedPane.setSelectedIndex(0);
-		selectFirstAliasOfKeyStore(ksIndex);
+		activateFirstOnlyAliasOfKeyStore(ksIndex);
 
 		fileTextField.setText("");
 		pkcs12PasswordField.setText("");
@@ -849,6 +859,10 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 	}
 	
 	private void setActiveButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_setActiveButtonActionPerformed
+		setActiveAction();
+	}//GEN-LAST:event_setActiveButtonActionPerformed
+	
+	private void setActiveAction() {
 		int ks = keyStoreList.getSelectedIndex();
 		int alias = aliasTable.getSelectedRow();
 		if (ks > -1 && alias>-1) {
@@ -887,10 +901,7 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 			}
 			certificateTextField.setText(contextManager.getDefaultKey());
 		}
-
-
-
-	}//GEN-LAST:event_setActiveButtonActionPerformed
+	}
 
 	public String getPassword() {
 		JPasswordField askPasswordField = new JPasswordField();


### PR DESCRIPTION
Automatically activate the first client cert imported.

Fixes zaproxy/zaproxy#3879