### PR TITLE
Tweak bundled READMEs

### DIFF
--- a/src/doc/README
+++ b/src/doc/README
@@ -26,7 +26,7 @@ There are 3 options on Windows:
 
 Linux
 
-On Linux theres just a 'zap.sh' script in the installation directory, although
+On Linux there's just a 'zap.sh' script in the installation directory, although
 you can create a desktop icon manually as well.
 
 Mac OS
@@ -64,5 +64,4 @@ https://github.com/zaproxy/zap-api-java/releases
 It is also available on Maven Central:
  - GroupId: 'org.zaproxy'
  - ArtifactId: 'zap-clientapi'
- - Version: '1.0.0'
 

--- a/src/doc/README.weekly
+++ b/src/doc/README.weekly
@@ -25,8 +25,6 @@ If you have not used ZAP before it might be better to start with the latest
 'full' release.
 
 Weekly releases do not include an installer.
-You will need to download and install Java 1.7 (minimum) in order to run 
-weekly ZAP releases.
 
 How to start ZAP
 ----------------
@@ -66,4 +64,4 @@ https://github.com/zaproxy/zap-api-java/releases
 It is also available on Maven Central:
  - GroupId: 'org.zaproxy'
  - ArtifactId: 'zap-clientapi'
- - Version: '1.0.0'
+


### PR DESCRIPTION
Fix typo in README.
Remove mention of the minimum Java version in README.weekly, that's now
the same as the main release.
In both remove the ZAP API client version, to not require keeping it
up-to-date.