### PR TITLE
Avoid create array when composing resource message

### DIFF
--- a/src/org/zaproxy/zap/extension/autoupdate/DownloadManager.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/DownloadManager.java
@@ -85,7 +85,7 @@ public class DownloadManager extends Thread {
 						dl.cancelDownload();
 						if (View.isInitialised()) {
 							View.getSingleton().showWarningDialog(
-									Constant.messages.getString("cfu.warn.badhash", new Object[] {dl.getTargetFile().getName()}));
+									Constant.messages.getString("cfu.warn.badhash", dl.getTargetFile().getName()));
 						}
 					}
 					finishedDownloads.add(dl);

--- a/src/org/zaproxy/zap/model/Target.java
+++ b/src/org/zaproxy/zap/model/Target.java
@@ -154,7 +154,7 @@ public class Target {
     public String getDisplayName() {
     	if (this.getStartNode() == null) {
     		if (context != null) {
-    			return Constant.messages.getString("context.prefixName", new Object[] {context.getName()});
+    			return Constant.messages.getString("context.prefixName", context.getName());
     		} else if (this.inScopeOnly) {
     			return Constant.messages.getString("target.allInScope");
     		} else {


### PR DESCRIPTION
Change Target and DownloadManager to not create an array when composing
the resource message, it's not necessary.