### PR TITLE
Handle cancelled downloads

### DIFF
--- a/src/org/zaproxy/zap/extension/autoupdate/DownloadManager.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/DownloadManager.java
@@ -79,6 +79,8 @@ public class DownloadManager extends Thread {
 				        logger.debug("Download failed " + dl.getTargetFile().getAbsolutePath());
 				    } else if (dl.isValidated()) {
 						logger.debug("Download finished " + dl.getTargetFile().getAbsolutePath());
+					} else if (dl.isCancelled()) {
+						logger.debug("Download cancelled " + dl.getTargetFile().getAbsolutePath());
 					} else {
 						// Corrupt or corrupted file? Pretty bad anyway
 						logger.error("Validation failed " + dl.getTargetFile().getAbsolutePath());

--- a/src/org/zaproxy/zap/extension/autoupdate/Downloader.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/Downloader.java
@@ -140,6 +140,10 @@ public class Downloader extends Thread {
 		}
 	}
 
+	boolean isCancelled() {
+		return cancelDownload;
+	}
+
 	public void cancelDownload() {
 		this.cancelDownload = true;
 		if (complete && this.targetFile.exists()) {


### PR DESCRIPTION
Change DownloadManager to handle cancelled downloads, to not log that
the validation for those downloads failed (that's expected, there's no
file to validate).
Change Downloader to allow to query if the download was cancelled.