### PR TITLE
Remove unused command line argument

### DIFF
--- a/src/org/parosproxy/paros/CommandLine.java
+++ b/src/org/parosproxy/paros/CommandLine.java
@@ -39,6 +39,7 @@
 // ZAP: 2017/05/31 Handle null args and include a message in all exceptions.
 // ZAP: 2017/08/31 Use helper method I18N.getString(String, Object...).
 // ZAP: 2017/11/21 Validate that -cmd and -daemon are not set at the same time (they are mutually exclusive).
+// ZAP: 2017/12/26 Remove unused command line arg SP.
 
 package org.parosproxy.paros;
 
@@ -88,7 +89,6 @@ public class CommandLine {
     public static final String NOSTDOUT = "-nostdout";
 
     static final String NO_USER_AGENT = "-nouseragent";
-    static final String SP = "-sp";
 
     private boolean GUI = true;
     private boolean daemon = false;
@@ -291,10 +291,6 @@ public class CommandLine {
             Constant.setEyeCatcher("");
             result = true;
 
-        } else if (checkSwitch(args, SP, i)) {
-            Constant.setSP(true);
-            result = true;
-            
         } else if (checkSwitch(args, CMD, i)) {
             setDaemon(false);
             setGUI(false);

--- a/src/org/parosproxy/paros/Constant.java
+++ b/src/org/parosproxy/paros/Constant.java
@@ -69,6 +69,7 @@
 // ZAP: 2016/09/22 JavaDoc tweaks
 // ZAP: 2016/11/17 Issue 2701 Support Factory Reset
 // ZAP: 2017/05/04 Issue 3440: Log Exception when overwriting a config file
+// ZAP: 2017/12/26 Remove class methods no longer used.
 
 package org.parosproxy.paros;
 
@@ -221,7 +222,6 @@ public final class Constant {
     public static final String USER_AGENT = "";
 
     private static String staticEyeCatcher = "0W45pz4p";
-    private static boolean staticSP = false;
     
     private static final String USER_CONTEXTS_DIR = "contexts";
     private static final String USER_POLICIES_DIR = "policies";
@@ -306,15 +306,6 @@ public final class Constant {
     public static void setEyeCatcher(String eyeCatcher) {
         staticEyeCatcher = eyeCatcher;
     }
-    
-    public static void setSP(boolean isSP) {
-        staticSP = isSP;
-    }
-
-    public static boolean isSP() {
-        return staticSP;
-    }
-
 
     public Constant() {
     	initializeFilesAndDirectories();


### PR DESCRIPTION
Change CommandLine to remove unused command line argument -sp (related
to reverse proxy option), the argument/feature was not documented (since
Paros days) and it's no longer used.
Change Constant to remove related methods.