### PR TITLE
Add tests for SpiderRedirectParser

### DIFF
--- a/src/org/zaproxy/zap/spider/parser/SpiderRedirectParser.java
+++ b/src/org/zaproxy/zap/spider/parser/SpiderRedirectParser.java
@@ -32,10 +32,6 @@ public class SpiderRedirectParser extends SpiderParser {
 	public boolean parseResource(HttpMessage message, Source source, int depth) {
 		log.debug("Parsing an HTTP redirection resource...");
 
-		if (message == null || message.getResponseHeader() == null) {
-			return false;
-		}
-
 		String location = message.getResponseHeader().getHeader(HttpHeader.LOCATION);
 		if (location != null && !location.isEmpty()) {
 			// Include the base url as well as some applications send relative URLs instead of

--- a/test/org/zaproxy/zap/spider/parser/SpiderParserTestUtils.java
+++ b/test/org/zaproxy/zap/spider/parser/SpiderParserTestUtils.java
@@ -63,6 +63,12 @@ public class SpiderParserTestUtils {
         return new TestSpiderParserListener();
     }
 
+    public static TestSpiderParserListener createAndAddTestSpiderParserListener(SpiderParser parser) {
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        parser.addSpiderParserListener(listener);
+        return listener;
+    }
+
     public static class TestSpiderParserListener implements SpiderParserListener {
 
         private final List<SpiderResource> resources;

--- a/test/org/zaproxy/zap/spider/parser/SpiderRedirectParserUnitTest.java
+++ b/test/org/zaproxy/zap/spider/parser/SpiderRedirectParserUnitTest.java
@@ -1,0 +1,199 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.spider.parser;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.apache.log4j.varia.NullAppender;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpStatusCode;
+
+/**
+ * Unit test for {@link SpiderRedirectParser}.
+ */
+public class SpiderRedirectParserUnitTest extends SpiderParserTestUtils {
+
+    private static final String ROOT_PATH = "/";
+    private static final int BASE_DEPTH = 0;
+
+    private static final List<Integer> NON_REDIRECTION_STATUS_CODES;
+    private static final List<Integer> REDIRECTION_STATUS_CODES;
+
+    static {
+        NON_REDIRECTION_STATUS_CODES = new ArrayList<>();
+        REDIRECTION_STATUS_CODES = new ArrayList<>();
+        Arrays.stream(HttpStatusCode.CODES).forEach(code -> {
+            if (HttpStatusCode.isRedirection(code)) {
+                REDIRECTION_STATUS_CODES.add(code);
+            } else {
+                NON_REDIRECTION_STATUS_CODES.add(code);
+            }
+        });
+    }
+
+    @BeforeClass
+    public static void suppressLogging() {
+        Logger.getRootLogger().addAppender(new NullAppender());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldFailToEvaluateAnUndefinedMessage() {
+        // Given
+        HttpMessage undefinedMessage = null;
+        SpiderRedirectParser redirectParser = new SpiderRedirectParser();
+        // When
+        redirectParser.canParseResource(undefinedMessage, ROOT_PATH, false);
+        // Then = NullPointerException
+    }
+
+    @Test
+    public void shouldNotParseNonRedirectionMessages() {
+        // Given
+        SpiderRedirectParser redirectParser = new SpiderRedirectParser();
+        for (int statusCode : NON_REDIRECTION_STATUS_CODES) {
+            HttpMessage msg = createMessageWithStatusCode(statusCode);
+            // When
+            boolean canParse = redirectParser.canParseResource(msg, ROOT_PATH, false);
+            // Then
+            assertThat(Integer.toString(statusCode), canParse, is(equalTo(false)));
+        }
+    }
+
+    @Test
+    public void shouldParseRedirectionMessages() {
+        // Given
+        SpiderRedirectParser redirectParser = new SpiderRedirectParser();
+        for (int statusCode : REDIRECTION_STATUS_CODES) {
+            HttpMessage msg = createMessageWithStatusCode(statusCode);
+            // When
+            boolean canParse = redirectParser.canParseResource(msg, ROOT_PATH, false);
+            // Then
+            assertThat(Integer.toString(statusCode), canParse, is(equalTo(true)));
+        }
+    }
+
+    @Test
+    public void shouldParseRedirectionMessageEvenIfAlreadyParsed() {
+        // Given
+        boolean alreadyParsed = true;
+        SpiderRedirectParser redirectParser = new SpiderRedirectParser();
+        HttpMessage msg = createMessageWithStatusCode(HttpStatusCode.FOUND);
+        // When
+        boolean canParse = redirectParser.canParseResource(msg, ROOT_PATH, alreadyParsed);
+        // Then
+        assertThat(canParse, is(equalTo(true)));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldFailToParseAnUndefinedMessage() {
+        // Given
+        HttpMessage undefinedMessage = null;
+        SpiderRedirectParser redirectParser = new SpiderRedirectParser();
+        // When
+        redirectParser.parseResource(undefinedMessage, null, BASE_DEPTH);
+        // Then = NullPointerException
+    }
+
+    @Test
+    public void shouldExtractUrlFromLocationHeader() {
+        // Given
+        String location = "http://example.com/redirection";
+        HttpMessage msg = createMessageWithLocationAndStatusCode(location, HttpStatusCode.FOUND);
+        SpiderRedirectParser redirectParser = new SpiderRedirectParser();
+        TestSpiderParserListener listener = createAndAddTestSpiderParserListener(redirectParser);
+        // When
+        boolean parsed = redirectParser.parseResource(msg, null, BASE_DEPTH);
+        // Then
+        assertThat(parsed, is(equalTo(true)));
+        assertThat(listener.getUrlsFound(), contains(location));
+    }
+
+    @Test
+    public void shouldExtractRelativeUrlFromLocationHeader() {
+        // Given
+        String location = "/rel/redirection";
+        HttpMessage msg = createMessageWithLocationAndStatusCode(location, HttpStatusCode.FOUND);
+        SpiderRedirectParser redirectParser = new SpiderRedirectParser();
+        TestSpiderParserListener listener = createAndAddTestSpiderParserListener(redirectParser);
+        // When
+        boolean parsed = redirectParser.parseResource(msg, null, BASE_DEPTH);
+        // Then
+        assertThat(parsed, is(equalTo(true)));
+        assertThat(listener.getUrlsFound(), contains("http://example.com" + location));
+    }
+
+    @Test
+    public void shouldNotExtractUrlIfLocationHeaderIsEmpty() {
+        // Given
+        String location = "";
+        HttpMessage msg = createMessageWithLocationAndStatusCode(location, HttpStatusCode.FOUND);
+        SpiderRedirectParser redirectParser = new SpiderRedirectParser();
+        TestSpiderParserListener listener = createAndAddTestSpiderParserListener(redirectParser);
+        // When
+        boolean parsed = redirectParser.parseResource(msg, null, 0);
+        // Then
+        assertThat(parsed, is(equalTo(true)));
+        assertThat(listener.getUrlsFound(), is(empty()));
+    }
+
+    @Test
+    public void shouldNotExtractUrlIfLocationHeaderIsNotPresent() {
+        // Given
+        HttpMessage msg = createMessageWithStatusCode(HttpStatusCode.FOUND);
+        SpiderRedirectParser redirectParser = new SpiderRedirectParser();
+        TestSpiderParserListener listener = createAndAddTestSpiderParserListener(redirectParser);
+        // When
+        boolean parsed = redirectParser.parseResource(msg, null, BASE_DEPTH);
+        // Then
+        assertThat(parsed, is(equalTo(true)));
+        assertThat(listener.getUrlsFound(), is(empty()));
+    }
+
+    private static HttpMessage createMessageWithStatusCode(int statusCode) {
+        HttpMessage msg = new HttpMessage();
+        try {
+            msg.setRequestHeader("GET / HTTP/1.1\r\nHost: example.com\r\n");
+            msg.setResponseHeader("HTTP/1.1 " + statusCode + " Reason\r\n");
+        } catch (HttpMalformedHeaderException e) {
+            throw new RuntimeException(e);
+        }
+        return msg;
+    }
+
+    private static HttpMessage createMessageWithLocationAndStatusCode(String location, int statusCode) {
+        HttpMessage msg = createMessageWithStatusCode(statusCode);
+        msg.getResponseHeader().addHeader(HttpHeader.LOCATION, location);
+        return msg;
+    }
+
+}


### PR DESCRIPTION
Add tests to assert the expected behaviour of SpiderRedirectParser and
change it to expect always a message when parsing.