### PR TITLE
Test ApiResponse conversions

### DIFF
--- a/src/org/zaproxy/zap/extension/api/API.java
+++ b/src/org/zaproxy/zap/extension/api/API.java
@@ -435,9 +435,9 @@ public class API {
 									break;
 						case JSONP: response = this.getJsonpWrapper(res.toJSON().toString()); 
 									break;
-						case XML:	response = this.responseToXml(name, res);
+						case XML:	response = responseToXml(name, res);
 									break;
-						case HTML:	response = this.responseToHtml(name, res);
+						case HTML:	response = responseToHtml(res);
 									break;
 						default:
 									break;
@@ -471,9 +471,9 @@ public class API {
 									break;
 						case JSONP: response = this.getJsonpWrapper(res.toJSON().toString()); 
 									break;
-						case XML:	response = this.responseToXml(name, res);
+						case XML:	response = responseToXml(name, res);
 									break;
-						case HTML:	response = this.responseToHtml(name, res);
+						case HTML:	response = responseToHtml(res);
 									break;
 						default:
 									break;
@@ -622,25 +622,43 @@ public class API {
 		return strBuilder.toString();
 	}
 	
-	private String responseToHtml(String name, ApiResponse res) {
+	/**
+	 * Gets the HTML representation of the given API {@code response}.
+	 * <p>
+	 * An empty HTML head with the HTML body containing the API response (as given by {@link ApiResponse#toHTML(StringBuilder)}.
+	 *
+	 * @param response the API response, must not be {@code null}.
+	 * @return the HTML representation of the given response.
+	 */
+	static String responseToHtml(ApiResponse response) {
 		StringBuilder sb = new StringBuilder();
 		sb.append("<head>\n");
 		sb.append("</head>\n");
 		sb.append("<body>\n");
-		res.toHTML(sb);
+		response.toHTML(sb);
 		sb.append("</body>\n");
 		return sb.toString();
 	}
 
-	private String responseToXml(String name, ApiResponse res) {
+	/**
+	 * Gets the XML representation of the given API {@code response}.
+	 * <p>
+	 * An XML element named with name of the endpoint and with child elements as given by
+	 * {@link ApiResponse#toXML(Document, Element)}.
+	 *
+	 * @param endpointName the name of the API endpoint, must not be {@code null}.
+	 * @param response the API response, must not be {@code null}.
+	 * @return the XML representation of the given response, or an empty string if an error occurred while converting.
+	 */
+	static String responseToXml(String endpointName, ApiResponse response) {
 		try {
 			DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
 			DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
 	
 			Document doc = docBuilder.newDocument();
-			Element rootElement = doc.createElement(name);
+			Element rootElement = doc.createElement(endpointName);
 			doc.appendChild(rootElement);
-			res.toXML(doc, rootElement);
+			response.toXML(doc, rootElement);
 			
 			TransformerFactory transformerFactory = TransformerFactory.newInstance();
 			Transformer transformer = transformerFactory.newTransformer();
@@ -653,7 +671,7 @@ public class API {
 			return sw.toString();
 
 		} catch (Exception e) {
-			logger.error(e.getMessage(), e);
+			logger.error("Failed to convert API response to XML: " + e.getMessage(), e);
 		}
 		return "";
 	}

--- a/test/org/zaproxy/zap/extension/api/APIUnitTest.java
+++ b/test/org/zaproxy/zap/extension/api/APIUnitTest.java
@@ -43,9 +43,12 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpOutputStream;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.view.View;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.zaproxy.zap.network.DomainMatcher;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
+import net.sf.json.JSON;
 import net.sf.json.JSONObject;
 
 /**
@@ -335,6 +338,100 @@ public class APIUnitTest {
         String baseUrl = api.getBaseURL(API.Format.JSON, "test", API.RequestType.view, "test", proxying);
         // Then
         assertThat(baseUrl, is(equalTo("https://127.0.0.1:8080/JSON/test/view/test/")));
+    }
+
+    @Test
+    public void shouldGetEmptyXmlFromResponseWithNullEndpointName() {
+        // Given
+        String endpointName = null;
+        ApiResponse response = ApiResponseTest.INSTANCE;
+        // When
+        String xmlResponse = API.responseToXml(endpointName, response);
+        // Then
+        assertThat(xmlResponse, is(equalTo("")));
+    }
+
+    @Test
+    public void shouldGetEmptyXmlFromResponseWithEmptyEndpointName() {
+        // Given
+        String endpointName = "";
+        ApiResponse response = ApiResponseTest.INSTANCE;
+        // When
+        String xmlResponse = API.responseToXml(endpointName, response);
+        // Then
+        assertThat(xmlResponse, is(equalTo("")));
+    }
+
+    @Test
+    public void shouldGetEmptyXmlFromResponseWithNonXmlValidEndpointName() {
+        // Given
+        String endpointName = "<";
+        ApiResponse response = ApiResponseTest.INSTANCE;
+        // When
+        String xmlResponse = API.responseToXml(endpointName, response);
+        // Then
+        assertThat(xmlResponse, is(equalTo("")));
+    }
+
+    @Test
+    public void shouldGetEmptyXmlFromNullResponse() {
+        // Given
+        String endpointName = "Name";
+        ApiResponse response = null;
+        // When
+        String xmlResponse = API.responseToXml(endpointName, response);
+        // Then
+        assertThat(xmlResponse, is(equalTo("")));
+    }
+
+    @Test
+    public void shouldGetXmlFromResponse() {
+        // Given
+        String endpointName = "Name";
+        ApiResponse response = ApiResponseTest.INSTANCE;
+        // When
+        String xmlResponse = API.responseToXml(endpointName, response);
+        // Then
+        assertThat(xmlResponse, is(equalTo("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><Name>XML</Name>")));
+    }
+
+    @Test
+    public void shouldGetHtmlFromResponse() {
+        // Given
+        ApiResponse response = ApiResponseTest.INSTANCE;
+        // When
+        String htmlResponse = API.responseToHtml(response);
+        // Then
+        assertThat(htmlResponse, is(equalTo("<head>\n</head>\n<body>\nHTML</body>\n")));
+    }
+
+    private static class ApiResponseTest extends ApiResponse {
+
+        private static final ApiResponseTest INSTANCE = new ApiResponseTest("");
+
+        public ApiResponseTest(String name) {
+            super(name);
+        }
+
+        @Override
+        public JSON toJSON() {
+            return null;
+        }
+
+        @Override
+        public void toXML(Document doc, Element rootElement) {
+            rootElement.appendChild(doc.createTextNode("XML"));
+        }
+
+        @Override
+        public void toHTML(StringBuilder sb) {
+            sb.append("HTML");
+        }
+
+        @Override
+        public String toString(int indent) {
+            return null;
+        }
     }
 
     private static void assertApiNonceMatch(API api, String baseUrl) {


### PR DESCRIPTION
Add tests to assert the expected conversion from ApiResponse to XML/HTML
response. Also, add JavaDoc, remove unused parameter and tweak exception
message.