### PR TITLE
Expose global and script variables

### DIFF
--- a/src/org/zaproxy/zap/extension/script/ScriptVars.java
+++ b/src/org/zaproxy/zap/extension/script/ScriptVars.java
@@ -19,105 +19,259 @@
  */
 package org.zaproxy.zap.extension.script;
 
-import java.security.InvalidParameterException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import javax.script.ScriptContext;
 
-public class ScriptVars {
+/**
+ * Manages global and script variables.
+ * <p>
+ * The global variables are meant to be accessible by all scripts and the script variables are meant to be accessible by just a
+ * given script (identified by its name).
+ * <p>
+ * <strong>Note:</strong> While it's possible to a script to access the variables of another script that usage is discouraged.
+ * <p>
+ * The keys and values of the variables have restrictions on its character length:
+ * <ul>
+ * <li>Key: {@value #MAX_KEY_SIZE};</li>
+ * <li>Value: {@value #MAX_VALUE_SIZE};</li>
+ * </ul>
+ * <p>
+ * There's a maximum number of global/script variables:
+ * <ul>
+ * <li>Global: {@value #MAX_GLOBAL_VARS};</li>
+ * <li>Script: {@value #MAX_SCRIPT_VARS};</li>
+ * </ul>
+ * 
+ * @since 2.4.0
+ */
+public final class ScriptVars {
 	
-	private static int MAX_KEY_SIZE = 30;
-	private static int MAX_VALUE_SIZE = 1024*1024;
-	private static int MAX_SCRIPT_VARS = 20;
-	private static int MAX_GLOBAL_VARS = 50;
+	// Relaxed accessibility for tests.
+	static final int MAX_KEY_SIZE = 30;
+	static final int MAX_VALUE_SIZE = 1024*1024;
+	static final int MAX_SCRIPT_VARS = 20;
+	static final int MAX_GLOBAL_VARS = 50;
 
-	private static Map<String, String> globalVars = new HashMap<String, String>();
-	private static Map<String, Map<String, String>> scriptVars = new HashMap<String, Map<String, String>>();
+	private static Map<String, String> globalVars = Collections.synchronizedMap(new HashMap<String, String>());
+	private static Map<String, Map<String, String>> scriptVars = Collections.synchronizedMap(new HashMap<String, Map<String, String>>());
+	
+	private ScriptVars() {
+	}
 	
 	/**
-	 * Set a global variable which will be accessible by all scripts
-	 * @param key
-	 * @param value
+	 * Sets or removes a global variable.
+	 * <p>
+	 * The variable is removed when the {@code value} is {@code null}.
+	 * 
+	 * @param key the key of the variable.
+	 * @param value the value of the variable.
+	 * @throws IllegalArgumentException if one of the following conditions is met:
+	 *             <ul>
+	 *             <li>The {@code key} is {@code null} or its length is higher than the maximum allowed
+	 *             ({@value #MAX_KEY_SIZE});</li>
+	 *             <li>The {@code value}'s length is higher than the maximum allowed ({@value #MAX_VALUE_SIZE});</li>
+	 *             <li>The number of global variables is higher than the maximum allowed ({@value #MAX_GLOBAL_VARS});</li>
+	 *             </ul>
 	 */
 	public static void setGlobalVar(String key, String value) {
-		if (key == null || key.length() > MAX_KEY_SIZE) {
-			throw new InvalidParameterException("Invalid key - must be non null and have a length less than " + MAX_KEY_SIZE);
-		}
+		validateKey(key);
 
 		if (value == null) {
 			globalVars.remove(key);
 		} else {
-			if (value.length() > MAX_VALUE_SIZE) {
-				throw new InvalidParameterException("Invalid value - must have a length less than " + MAX_VALUE_SIZE);
-			}
+			validateValueLength(value);
 			if (globalVars.size() > MAX_GLOBAL_VARS) {
-				throw new InvalidParameterException("Maximum number of global variables reached: " + MAX_GLOBAL_VARS);
+				throw new IllegalArgumentException("Maximum number of global variables reached: " + MAX_GLOBAL_VARS);
 			}
 			globalVars.put(key, value);
 		}
 	}
+
+	/**
+	 * Validates the given key.
+	 *
+	 * @param key the key to validate.
+	 * @throws IllegalArgumentException if the {@code key} is {@code null} or its length is higher than the maximum allowed
+	 *             ({@value #MAX_KEY_SIZE}).
+	 */
+	private static void validateKey(String key) {
+		if (key == null || key.length() > MAX_KEY_SIZE) {
+			throw new IllegalArgumentException("Invalid key - must be non null and have a length less than " + MAX_KEY_SIZE);
+		}
+	}
+
+	/**
+	 * Validates the length of the given value.
+	 *
+	 * @param value the value to validate, must not be {@code null}.
+	 * @throws IllegalArgumentException if the length is higher than the maximum allowed ({@value #MAX_VALUE_SIZE}).
+	 */
+	private static void validateValueLength(String value) {
+		if (value.length() > MAX_VALUE_SIZE) {
+			throw new IllegalArgumentException("Invalid value - must have a length less than " + MAX_VALUE_SIZE);
+		}
+	}
 	
 	/**
-	 * Get a global variable which is be accessible to all scripts
-	 * @param key
+	 * Gets a global variable.
+	 * 
+	 * @param key the key of the variable.
+	 * @return the value of the variable, might be {@code null} if no value was previously set.
 	 */
 	public static String getGlobalVar(String key) {
 		return globalVars.get(key);
 	}
 
 	/**
-	 * Set a variable that is only accessible to this script.
-	 * This method is only usable from scripting languages that provide access to the ScriptContext (like JavaScript)
-	 * @param context
-	 * @param key
-	 * @param value
+	 * Gets an unmodifiable map, variable key to value, containing the global variables.
+	 * <p>
+	 * Iterations should be done in a synchronised block using the returned map.
+	 * 
+	 * @return an unmodifiable map containing the global variables, never {@code null}.
+	 * @since TODO add version
+	 */
+	public static Map<String, String> getGlobalVars() {
+		return Collections.unmodifiableMap(globalVars);
+	}
+	
+	/**
+	 * Sets or removes a script variable.
+	 * <p>
+	 * The variable is removed when the {@code value} is {@code null}.
+	 * 
+	 * @param context the context of the script.
+	 * @param key the key of the variable.
+	 * @param value the value of the variable.
+	 * @throws IllegalArgumentException if one of the following conditions is met:
+	 *             <ul>
+	 *             <li>The {@code context} is {@code null} or it does not contain the name of the script;</li>
+	 *             <li>The {@code key} is {@code null} or its length is higher than the maximum allowed
+	 *             ({@value #MAX_KEY_SIZE});</li>
+	 *             <li>The {@code value}'s length is higher than the maximum allowed ({@value #MAX_VALUE_SIZE});</li>
+	 *             <li>The number of script variables is higher than the maximum allowed ({@value #MAX_SCRIPT_VARS});</li>
+	 *             </ul>
 	 */
 	public static void setScriptVar(ScriptContext context, String key, String value) {
+		setScriptVarImpl(getScriptName(context), key, value);
+	}
+
+	/**
+	 * Gets the script name from the given context.
+	 *
+	 * @param context the context of the script.
+	 * @return the name of the script, never {@code null}.
+	 * @throws IllegalArgumentException if the {@code context} is {@code null} or it does not contain the name of the script.
+	 */
+	private static String getScriptName(ScriptContext context) {
 		if (context == null) {
-			throw new InvalidParameterException("Invalid context - must be non null");
+			throw new IllegalArgumentException("Invalid context - must be non null");
 		}
-		if (key == null || key.length() > MAX_KEY_SIZE) {
-			throw new InvalidParameterException("Invalid key - must be non null and have a length less than " + MAX_KEY_SIZE);
-		}
-		String scriptName = (String)context.getAttribute(ExtensionScript.SCRIPT_NAME_ATT);
+		Object scriptName = context.getAttribute(ExtensionScript.SCRIPT_NAME_ATT);
 		if (scriptName == null) {
-			throw new InvalidParameterException("Failed to find script name");
+			throw new IllegalArgumentException("Failed to find script name in the script context.");
 		}
-		Map<String, String> scVars = scriptVars.get(scriptName);
-		if (scVars == null) {
-			scVars = new HashMap<String, String>();
-			scriptVars.put(scriptName, scVars);
+		if (!(scriptName instanceof String)) {
+			throw new IllegalArgumentException("The script name is not a String: " + scriptName.getClass().getCanonicalName());
 		}
+		return (String) scriptName;
+	}
+	
+	/**
+	 * Sets or removes a script variable.
+	 * <p>
+	 * The variable is removed when the {@code value} is {@code null}.
+	 *
+	 * @param scriptName the name of the script.
+	 * @param key the key of the variable.
+	 * @param value the value of the variable.
+	 * @throws IllegalArgumentException if one of the following conditions is met:
+	 *             <ul>
+	 *             <li>The {@code scriptName} is {@code null};</li>
+	 *             <li>The {@code key} is {@code null} or its length is higher than the maximum allowed
+	 *             ({@value #MAX_KEY_SIZE});</li>
+	 *             <li>The {@code value}'s length is higher than the maximum allowed ({@value #MAX_VALUE_SIZE});</li>
+	 *             <li>The number of script variables is higher than the maximum allowed ({@value #MAX_SCRIPT_VARS});</li>
+	 *             </ul>
+	 * @since TODO add version
+	 */
+	public static void setScriptVar(String scriptName, String key, String value) {
+		validateScriptName(scriptName);
+		setScriptVarImpl(scriptName, key, value);
+	}
+	
+	/**
+	 * Internal method that sets a variable without validating the script name.
+	 *
+	 * @param scriptName the name of the script.
+	 * @param key the key of the variable.
+	 * @param value the value of the variable.
+	 */
+	private static void setScriptVarImpl(String scriptName, String key, String value) {	
+		validateKey(key);
+		
+		Map<String, String> scVars = scriptVars
+				.computeIfAbsent(scriptName, k -> Collections.synchronizedMap(new HashMap<String, String>()));
 		
 		if (value == null) {
 			scVars.remove(key);
 		} else {
-			if (value.length() > MAX_VALUE_SIZE) {
-				throw new InvalidParameterException("Invalid value - must have a length less than " + MAX_VALUE_SIZE);
-			}
+			validateValueLength(value);
 			if (scVars.size() > MAX_SCRIPT_VARS) {
-				throw new InvalidParameterException("Maximum number of script variables reached: " + MAX_SCRIPT_VARS);
+				throw new IllegalArgumentException("Maximum number of script variables reached: " + MAX_SCRIPT_VARS);
 			}
 			scVars.put(key, value);
 		}
 	}
+
+	/**
+	 * Validates the given script name.
+	 *
+	 * @param scriptName the name to validate.
+	 * @throws IllegalArgumentException if the name is {@code null}.
+	 */
+	private static void validateScriptName(String scriptName) {
+		if (scriptName == null) {
+			throw new IllegalArgumentException("The script name must not be null.");
+		}
+	}
 	
 	/**
-	 * Get a variable that is only accessible from this script.
-	 * This method is only usable from scripting languages that provide access to the ScriptContext (like JavaScript)
-	 * @param context
-	 * @param key
-	 * @return
+	 * Gets a script variable.
+	 * 
+	 * @param context the context of the script.
+	 * @param key the key of the variable.
+	 * @return the value of the variable, might be {@code null} if no value was previously set.
+	 * @throws IllegalArgumentException if the {@code context} is {@code null} or it does not contain the name of the script.
 	 */
 	public static String getScriptVar(ScriptContext context, String key) {
-		if (context == null) {
-			throw new InvalidParameterException("Invalid context - must be non null");
-		}
-		String scriptName = (String)context.getAttribute(ExtensionScript.SCRIPT_NAME_ATT);
-		if (scriptName == null) {
-			throw new InvalidParameterException("Failed to find script name");
-		}
+		return getScriptVarImpl(getScriptName(context), key);
+	}
+
+	/**
+	 * Gets a variable from the script with the give name.
+	 * 
+	 * @param scriptName the name of the script.
+	 * @param key the key of the variable.
+	 * @return the value of the variable, might be {@code null} if no value was previously set.
+	 * @throws IllegalArgumentException if the {@code scriptName} is {@code null}.
+	 * @since TODO add version
+	 */
+	public static String getScriptVar(String scriptName, String key) {
+		validateScriptName(scriptName);
+		return getScriptVarImpl(scriptName, key);
+	}
+	
+	/**
+	 * Internal method that gets a variable without validating the script name.
+	 *
+	 * @param scriptName the name of the script.
+	 * @param key the key of the variable.
+	 * @return the value of the variable, might be {@code null} if no value was previously set.
+	 */
+	private static String getScriptVarImpl(String scriptName, String key) {
 		Map<String, String> scVars = scriptVars.get(scriptName);
 		if (scVars == null) {
 			// No vars have been associated with this script
@@ -127,6 +281,24 @@ public class ScriptVars {
 		return scVars.get(key);
 	}
 
+	/**
+	 * Gets an unmodifiable map, variable key to value, containing the variables of the script with the given name.
+	 * <p>
+	 * Iterations should be done in a synchronised block using the returned map.
+	 * 
+	 * @param scriptName the name of the script.
+	 * @return an unmodifiable map containing the script variables, never {@code null}.
+	 * @since TODO add version
+	 */
+	public static Map<String, String> getScriptVars(String scriptName) {
+		return Collections.unmodifiableMap(scriptVars.getOrDefault(scriptName, Collections.emptyMap()));
+	}
+
+	/**
+	 * Clears all variables, global and script.
+	 * 
+	 * @since 2.5.0
+	 */
 	static void clear() {
 		globalVars.clear();
 		scriptVars.clear();

--- a/test/org/zaproxy/zap/extension/script/ScriptVarsUnitTest.java
+++ b/test/org/zaproxy/zap/extension/script/ScriptVarsUnitTest.java
@@ -1,0 +1,374 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.script;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.util.Map;
+
+import javax.script.ScriptContext;
+import javax.script.SimpleScriptContext;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link ScriptVars}.
+ */
+public class ScriptVarsUnitTest {
+
+    @Before
+    public void setUp() {
+        ScriptVars.clear();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldNotAllowToModifyReturnedGlobalVariables() {
+        // Given
+        Map<String, String> vars = ScriptVars.getGlobalVars();
+        // When
+        vars.put(createKey(), createValue());
+        // Then = UnsupportedOperationException
+    }
+
+    @Test
+    public void shouldSetGlobalVariable() {
+        // Given
+        String key = createKey();
+        String value = createValue();
+        // When
+        ScriptVars.setGlobalVar(key, value);
+        // Then
+        assertThat(ScriptVars.getGlobalVars(), hasEntry(key, value));
+        assertThat(ScriptVars.getGlobalVar(key), is(equalTo(value)));
+    }
+
+    @Test
+    public void shouldClearGlobalVariableWithNullValue() {
+        // Given
+        String key = createKey();
+        String value = createValue();
+        ScriptVars.setGlobalVar(key, value);
+        // When
+        ScriptVars.setGlobalVar(key, null);
+        // Then
+        assertThat(ScriptVars.getGlobalVars(), not(hasEntry(key, value)));
+        assertThat(ScriptVars.getGlobalVar(key), is(nullValue()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotSetGlobalVariableWithNullKey() {
+        // Given
+        String key = null;
+        // When
+        ScriptVars.setGlobalVar(key, createValue());
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotSetGlobalVariableIfMoreThanAllowed() {
+        // Given
+        for (int i = 0; i <= ScriptVars.MAX_GLOBAL_VARS; i++) {
+            ScriptVars.setGlobalVar(createKey(), createValue());
+        }
+        // When
+        ScriptVars.setGlobalVar(createKey(), createValue());
+        // Then = IllegalArgumentException
+    }
+
+    @Test
+    public void shouldHaveNoScriptVariablesByDefault() {
+        // Given
+        String scriptName = "ScriptName";
+        // When
+        Map<String, String> vars = ScriptVars.getScriptVars(scriptName);
+        // Then
+        assertThat(vars, is(notNullValue()));
+        assertThat(vars.size(), is(equalTo(0)));
+    }
+
+    @Test
+    public void shouldReturnNullForNoScriptVariableSet() {
+        // Given
+        String scriptName = "ScriptName";
+        String key = createKey();
+        // When
+        String value = ScriptVars.getScriptVar(scriptName, key);
+        // Then
+        assertThat(value, is(nullValue()));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldNotAllowToModifyReturnedScriptVariables() {
+        // Given
+        String scriptName = "ScriptName";
+        Map<String, String> vars = ScriptVars.getScriptVars(scriptName);
+        // When
+        vars.put(createKey(), createValue());
+        // Then = UnsupportedOperationException
+    }
+
+    @Test
+    public void shouldSetScriptVariableUsingScriptContext() {
+        // Given
+        String key = createKey();
+        String value = createValue();
+        String scriptName = "ScriptName";
+        ScriptContext scriptContext = createScriptContextWithName(scriptName);
+        // When
+        ScriptVars.setScriptVar(scriptContext, key, value);
+        // Then
+        assertThat(ScriptVars.getScriptVars(scriptName), hasEntry(key, value));
+        assertThat(ScriptVars.getScriptVar(scriptContext, key), is(equalTo(value)));
+    }
+
+    @Test
+    public void shouldClearScriptVariableWithNullValueUsingScriptContext() {
+        // Given
+        String key = createKey();
+        String value = createValue();
+        String scriptName = "ScriptName";
+        ScriptContext scriptContext = createScriptContextWithName(scriptName);
+        ScriptVars.setScriptVar(scriptContext, key, value);
+        // When
+        ScriptVars.setScriptVar(scriptContext, key, null);
+        // Then
+        assertThat(ScriptVars.getScriptVars(scriptName), not(hasEntry(key, value)));
+        assertThat(ScriptVars.getScriptVar(scriptContext, key), is(nullValue()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotSetScriptVariableUsingNullScriptContext() {
+        // Given
+        ScriptContext scriptContext = null;
+        // When
+        ScriptVars.setScriptVar(scriptContext, createKey(), createValue());
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotSetScriptVariableUsingNullScriptNameInScriptContext() {
+        // Given
+        ScriptContext scriptContext = createScriptContextWithName(null);
+        // When
+        ScriptVars.setScriptVar(scriptContext, createKey(), createValue());
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotSetScriptVariableUsingNonStringScriptNameInScriptContext() {
+        // Given
+        ScriptContext scriptContext = createScriptContextWithName(10);
+        // When
+        ScriptVars.setScriptVar(scriptContext, createKey(), createValue());
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotSetScriptVariableWithNullKeyUsingScriptContext() {
+        // Given
+        ScriptContext scriptContext = createScriptContextWithName("ScriptName");
+        // When
+        ScriptVars.setScriptVar(scriptContext, null, createValue());
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotSetScriptVariableWithInvalidKeyLengthUsingScriptContext() {
+        // Given
+        ScriptContext scriptContext = createScriptContextWithName("ScriptName");
+        // When
+        ScriptVars.setScriptVar(scriptContext, createKeyWithInvalidLength(), createValue());
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotSetScriptVariableWithInvalidValueLengthUsingScriptContext() {
+        // Given
+        ScriptContext scriptContext = createScriptContextWithName("ScriptName");
+        // When
+        ScriptVars.setScriptVar(scriptContext, createKey(), createValueWithInvalidLength());
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotSetScriptVariableIfMoreThanAllowedUsingScriptContext() {
+        // Given
+        ScriptContext scriptContext = createScriptContextWithName("ScriptName");
+        for (int i = 0; i <= ScriptVars.MAX_SCRIPT_VARS; i++) {
+            ScriptVars.setScriptVar(scriptContext, createKey(), createValue());
+        }
+        // When
+        ScriptVars.setScriptVar(scriptContext, createKey(), createValue());
+        // Then = IllegalArgumentException
+    }
+
+    @Test
+    public void shouldNotReturnScriptVariablesFromOtherScriptsUsingScriptContext() {
+        // Given
+        ScriptContext scriptContext1 = createScriptContextWithName("ScriptName1");
+        ScriptContext scriptContext2 = createScriptContextWithName("ScriptName2");
+        String key = createKey();
+        // When
+        ScriptVars.setScriptVar(scriptContext1, key, createValue());
+        // Then
+        assertThat(ScriptVars.getScriptVar(scriptContext2, key), is(nullValue()));
+    }
+
+    @Test
+    public void shouldSetScriptVariableUsingScriptName() {
+        // Given
+        String key = createKey();
+        String value = createValue();
+        String scriptName = "ScriptName";
+        // When
+        ScriptVars.setScriptVar(scriptName, key, value);
+        // Then
+        assertThat(ScriptVars.getScriptVars(scriptName), hasEntry(key, value));
+        assertThat(ScriptVars.getScriptVar(scriptName, key), is(equalTo(value)));
+    }
+
+    @Test
+    public void shouldClearScriptVariableWithNullValueUsingScriptName() {
+        // Given
+        String key = createKey();
+        String value = createValue();
+        String scriptName = "ScriptName";
+        ScriptVars.setScriptVar(scriptName, key, value);
+        // When
+        ScriptVars.setScriptVar(scriptName, key, null);
+        // Then
+        assertThat(ScriptVars.getScriptVars(scriptName), not(hasEntry(key, value)));
+        assertThat(ScriptVars.getScriptVar(scriptName, key), is(nullValue()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotSetScriptVariableUsingNullScriptName() {
+        // Given
+        String scriptName = null;
+        // When
+        ScriptVars.setScriptVar(scriptName, createKey(), createValue());
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldNotAllowToModifyReturnedScriptVariablesSet() {
+        // Given
+        String scriptName = "ScriptName";
+        ScriptVars.setScriptVar(scriptName, createKey(), createValue());
+        Map<String, String> vars = ScriptVars.getScriptVars(scriptName);
+        // When
+        vars.put(createKey(), createValue());
+        // Then = UnsupportedOperationException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotSetScriptVariableWithNullKeyUsingScriptName() {
+        // Given
+        String key = null;
+        // When
+        ScriptVars.setScriptVar("ScriptName", key, createValue());
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotSetScriptVariableWithInvalidKeyLengthUsingScriptName() {
+        // Given
+        String key = createKeyWithInvalidLength();
+        // When
+        ScriptVars.setScriptVar("ScriptName", key, createValue());
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotSetScriptVariableWithInvalidValueLengthUsingScriptName() {
+        // Given
+        String value = createValueWithInvalidLength();
+        // When
+        ScriptVars.setScriptVar("ScriptName", createKey(), value);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotSetScriptVariableIfMoreThanAllowedUsingScriptName() {
+        // Given
+        String scriptName = "ScriptName";
+        for (int i = 0; i <= ScriptVars.MAX_SCRIPT_VARS; i++) {
+            ScriptVars.setScriptVar(scriptName, createKey(), createValue());
+        }
+        // When
+        ScriptVars.setScriptVar(scriptName, createKey(), createValue());
+        // Then = IllegalArgumentException
+    }
+
+    @Test
+    public void shouldNotReturnScriptVariablesFromOtherScriptsUsingScriptName() {
+        // Given
+        String scriptName1 = "ScriptName1";
+        String scriptName2 = "ScriptName2";
+        String key = createKey();
+        // When
+        ScriptVars.setScriptVar(scriptName1, key, createValue());
+        // Then
+        assertThat(ScriptVars.getScriptVar(scriptName2, key), is(nullValue()));
+    }
+
+    @Test
+    public void shouldClearGlobalAndScriptVariables() {
+        // Given
+        String scriptName = "ScriptName";
+        ScriptVars.setScriptVar(scriptName, createKey(), createValue());
+        ScriptVars.setGlobalVar(createKey(), createValue());
+        // When
+        ScriptVars.clear();
+        // Then
+        assertThat(ScriptVars.getGlobalVars().size(), is(equalTo(0)));
+        assertThat(ScriptVars.getScriptVars(scriptName).size(), is(equalTo(0)));
+    }
+
+    private static String createKey() {
+        return "Key-" + Math.random();
+    }
+
+    private static String createValue() {
+        return "Value-" + Math.random();
+    }
+
+    private static String createKeyWithInvalidLength() {
+        return StringUtils.repeat("A", ScriptVars.MAX_KEY_SIZE + 1);
+    }
+
+    private static String createValueWithInvalidLength() {
+        return StringUtils.repeat("A", ScriptVars.MAX_VALUE_SIZE + 1);
+    }
+
+    private static ScriptContext createScriptContextWithName(Object scriptName) {
+        ScriptContext context = new SimpleScriptContext();
+        context.setAttribute(ExtensionScript.SCRIPT_NAME_ATT, scriptName, ScriptContext.ENGINE_SCOPE);
+        return context;
+    }
+}


### PR DESCRIPTION
Change ScriptVars to:
 - Expose the global and script variables (e.g. to manage the variables
 with UI/API);
 - Allow to set script variables using the script name (e.g. to set or
 clear them through the UI/API, without the need of a ScriptContext);
 - Throw IllegalArgumentException instead of InvalidParameterException;
 - Extract methods to remove code duplication when validating the keys
 and values;
 - Synchronise global and script maps;
 - Add more JavaDoc.

Add tests to assert the expected behaviour.