### PR TITLE
Do not use main config file for add-ons' state

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnLoader.java
@@ -49,7 +49,9 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
 
+import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.FileConfiguration;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -62,6 +64,7 @@ import org.zaproxy.zap.Version;
 import org.zaproxy.zap.control.AddOn.AddOnRunRequirements;
 import org.zaproxy.zap.control.AddOn.ExtensionRunRequirements;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 /**
  * This class is heavily based on the original Paros class org.parosproxy.paros.common.DynamicLoader
@@ -122,9 +125,26 @@ public class AddOnLoader extends URLClassLoader {
      */
     private Map<String, AddOnClassLoader> addOnLoaders = new HashMap<>();
 
+    /**
+     * File where the data of runnable state and blocked add-ons is saved.
+     */
+    private ZapXmlConfiguration addOnsStateConfig;
+
     public AddOnLoader(File[] dirs) {
         super(new URL[0], AddOnLoader.class.getClassLoader());
         
+        addOnsStateConfig = new ZapXmlConfiguration();
+        addOnsStateConfig.setRootElementName("addonsstate");
+        File configFile = new File(Constant.getZapHome(), "add-ons-state.xml");
+        addOnsStateConfig.setFile(configFile);
+        if (!migrateOldAddOnsState(addOnsStateConfig) && configFile.exists()) {
+            try {
+                addOnsStateConfig.load();
+            } catch (ConfigurationException e) {
+                logger.warn("Failed to read add-ons' state file:", e);
+            }
+        }
+
         this.loadBlockList();
 
         this.aoc = new AddOnCollection(dirs);
@@ -169,7 +189,7 @@ public class AddOnLoader extends URLClassLoader {
     private void loadAllAddOns() {
         runnableAddOns = new HashMap<>();
         idsAddOnsWithRunningIssuesSinceLastRun = new ArrayList<>();
-        Map<AddOn, AddOnRunState> oldRunnableAddOns = loadAddOnsRunState(aoc);
+        Map<AddOn, AddOnRunState> oldRunnableAddOns = loadAddOnsRunState(addOnsStateConfig, aoc);
         List<AddOn> runAddons = new ArrayList<>();
         Set<AddOn> updatedAddOns = new HashSet<>();
         for (Iterator<AddOn> iterator = aoc.getAddOns().iterator(); iterator.hasNext();) {
@@ -657,11 +677,11 @@ public class AddOnLoader extends URLClassLoader {
     }
 
 	private void loadBlockList() {
-	    blockList = loadList(ADDONS_BLOCK_LIST);
+		blockList = loadList(addOnsStateConfig, ADDONS_BLOCK_LIST);
 	}
 	
 	private void saveBlockList() {
-		saveList(ADDONS_BLOCK_LIST, this.blockList);
+		saveList(addOnsStateConfig, ADDONS_BLOCK_LIST, this.blockList);
 	}
 
     private <T> List<ClassNameWrapper> getClassNames (String packageName, Class<T> classType) {
@@ -1010,9 +1030,9 @@ public class AddOnLoader extends URLClassLoader {
     	
     }
 
-    private static List<String> loadList(String key) {
+    private static List<String> loadList(Configuration config, String key) {
         List<String> data = new ArrayList<>();
-        String blockStr = Model.getSingleton().getOptionsParam().getConfig().getString(key, null);
+        String blockStr = config.getString(key, null);
         if (blockStr != null && blockStr.length() > 0) {
             for (String str : blockStr.split(",")) {
                 data.add(str);
@@ -1021,7 +1041,7 @@ public class AddOnLoader extends URLClassLoader {
         return data;
     }
 
-    private static void saveList(String key, List<String> list) {
+    private static void saveList(FileConfiguration config, String key, List<String> list) {
         StringBuilder sb = new StringBuilder();
 
         for (String id: list) {
@@ -1031,18 +1051,16 @@ public class AddOnLoader extends URLClassLoader {
             sb.append(id);
         }
 
-        Model.getSingleton().getOptionsParam().getConfig().setProperty(key, sb.toString());
+        config.setProperty(key, sb.toString());
         try {
-            Model.getSingleton().getOptionsParam().getConfig().save();
+            config.save();
         } catch (ConfigurationException e) {
             logger.error("Failed to save list [" + key + "]: " + sb.toString(), e);
         }
     }
 
-    private static Map<AddOn, AddOnRunState> loadAddOnsRunState(AddOnCollection addOnCollection) {
-        List<HierarchicalConfiguration> savedAddOns = ((HierarchicalConfiguration) Model.getSingleton()
-                .getOptionsParam()
-                .getConfig()).configurationsAt(ADDONS_RUNNABLE_KEY);
+    private static Map<AddOn, AddOnRunState> loadAddOnsRunState(HierarchicalConfiguration config, AddOnCollection addOnCollection) {
+        List<HierarchicalConfiguration> savedAddOns = config.configurationsAt(ADDONS_RUNNABLE_KEY);
 
         Map<AddOn, AddOnRunState> runnableAddOns = new HashMap<>();
         for (HierarchicalConfiguration savedAddOn : savedAddOns) {
@@ -1107,33 +1125,69 @@ public class AddOnLoader extends URLClassLoader {
         return null;
     }
 
-    private static void saveAddOnsRunState(Map<AddOn, List<String>> runnableAddOns) {
-        HierarchicalConfiguration config = (HierarchicalConfiguration) Model.getSingleton().getOptionsParam().getConfig();
-        config.clearTree(ADDONS_RUNNABLE_BASE_KEY);
+    private void saveAddOnsRunState(Map<AddOn, List<String>> runnableAddOns) {
+        addOnsStateConfig.clearTree(ADDONS_RUNNABLE_BASE_KEY);
 
         int i = 0;
         for (Map.Entry<AddOn, List<String>> runnableAddOnEntry : runnableAddOns.entrySet()) {
             String elementBaseKey = ADDONS_RUNNABLE_KEY + "(" + i + ").";
             AddOn addOn = runnableAddOnEntry.getKey();
 
-            config.setProperty(elementBaseKey + ADDON_RUNNABLE_ID_KEY, addOn.getId());
-            config.setProperty(elementBaseKey + ADDON_RUNNABLE_FULL_VERSION_KEY, addOn.getVersion());
+            addOnsStateConfig.setProperty(elementBaseKey + ADDON_RUNNABLE_ID_KEY, addOn.getId());
+            addOnsStateConfig.setProperty(elementBaseKey + ADDON_RUNNABLE_FULL_VERSION_KEY, addOn.getVersion());
             // For older ZAP versions, which can't read the semantic version, just an integer.
-            config.setProperty(elementBaseKey + ADDON_RUNNABLE_VERSION_KEY, addOn.getVersion().getMajorVersion());
+            addOnsStateConfig.setProperty(elementBaseKey + ADDON_RUNNABLE_VERSION_KEY, addOn.getVersion().getMajorVersion());
 
             String extensionBaseKey = elementBaseKey + ADDON_RUNNABLE_ALL_EXTENSIONS_KEY;
             for (String extension : runnableAddOnEntry.getValue()) {
-                config.addProperty(extensionBaseKey, extension);
+                addOnsStateConfig.addProperty(extensionBaseKey, extension);
             }
 
             i++;
         }
 
         try {
-            Model.getSingleton().getOptionsParam().getConfig().save();
+            addOnsStateConfig.save();
         } catch (ConfigurationException e) {
             logger.error("Failed to save state of runnable add-ons:", e);
         }
+    }
+
+    private static boolean migrateOldAddOnsState(ZapXmlConfiguration newConfig) {
+        boolean dataMigrated = false;
+        HierarchicalConfiguration oldConfig = (HierarchicalConfiguration) Model.getSingleton().getOptionsParam().getConfig();
+
+        if (oldConfig.containsKey(ADDONS_BLOCK_LIST)) {
+            List<String> blockList = loadList(oldConfig, ADDONS_BLOCK_LIST);
+            oldConfig.clearProperty(ADDONS_BLOCK_LIST);
+            saveList(newConfig, ADDONS_BLOCK_LIST, blockList);
+            dataMigrated = true;
+        }
+
+        List<HierarchicalConfiguration> oldAddOnsState = oldConfig.configurationsAt(ADDONS_RUNNABLE_KEY);
+        if (!oldAddOnsState.isEmpty()) {
+            int i = 0;
+            for (HierarchicalConfiguration savedAddOn : oldAddOnsState) {
+                String elementBaseKey = ADDONS_RUNNABLE_KEY + "(" + i + ").";
+                newConfig.setProperty(elementBaseKey + ADDON_RUNNABLE_ID_KEY, savedAddOn.getString(ADDON_RUNNABLE_ID_KEY, ""));
+                String version = savedAddOn.getString(ADDON_RUNNABLE_FULL_VERSION_KEY, "");
+                if (version.isEmpty()) {
+                    newConfig.setProperty(
+                            elementBaseKey + ADDON_RUNNABLE_VERSION_KEY,
+                            savedAddOn.getString(ADDON_RUNNABLE_VERSION_KEY, ""));
+                } else {
+                    newConfig.setProperty(elementBaseKey + ADDON_RUNNABLE_FULL_VERSION_KEY, version);
+                }
+
+                String extensionBaseKey = elementBaseKey + ADDON_RUNNABLE_ALL_EXTENSIONS_KEY;
+                for (String extension : savedAddOn.getStringArray(ADDON_RUNNABLE_ALL_EXTENSIONS_KEY)) {
+                    newConfig.addProperty(extensionBaseKey, extension);
+                }
+            }
+            oldConfig.clearTree(ADDONS_RUNNABLE_KEY);
+            dataMigrated = true;
+        }
+        return dataMigrated;
     }
 
     /**


### PR DESCRIPTION
Change AddOnLoader to use other file to persist the runnable state and
the blocked add-ons, as this type of data should not be tied to main
configuration/options file. The old data is migrated to new file when
starting ZAP.