### PR TITLE
Address deadlock with add-on class loaders

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnClassLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnClassLoader.java
@@ -35,6 +35,10 @@ import java.util.List;
  */
 public class AddOnClassLoader extends URLClassLoader {
 
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
+
     private final ParentClassLoader parent;
     private final List<AddOnClassLoader> childClassLoaders;
     private List<AddOnClassLoader> dependencies;

--- a/src/org/zaproxy/zap/control/AddOnLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnLoader.java
@@ -94,6 +94,10 @@ public class AddOnLoader extends URLClassLoader {
 	
     private static final Logger logger = Logger.getLogger(AddOnLoader.class);
 
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
+
     private Lock installationLock = new ReentrantLock();
     private AddOnCollection aoc = null;
     private List<File> jars = new ArrayList<>();


### PR DESCRIPTION
Change AddOnLoader and AddOnClassLoader to declare them as parallel
capable to ensure all the locks are shared by both class loaders
(through `getClassLoadingLock(String)`), otherwise they could use
themselves (`this`) as the lock for some of the methods (while others
used the shared locks).
Both class loaders extend from URLClassLoader which is parallel capable.

Fix #4119 - Ajax Spider deadlock