### PR TITLE
Ignore CFUs in HTTP Sender docker scripts

### DIFF
--- a/build/docker/scripts/scripts/httpsender/Alert_on_HTTP_Response_Code_Errors.js
+++ b/build/docker/scripts/scripts/httpsender/Alert_on_HTTP_Response_Code_Errors.js
@@ -9,6 +9,11 @@ function sendingRequest(msg, initiator, helper) {
 }
 
 function responseReceived(msg, initiator, helper) {
+	if (initiator == 7) { // CHECK_FOR_UPDATES_INITIATOR
+		// Not of interest.
+		return
+	}
+
 	var extensionAlert = org.parosproxy.paros.control.Control.getSingleton().getExtensionLoader().getExtension(
 		org.zaproxy.zap.extension.alert.ExtensionAlert.NAME)
 	if (extensionAlert != null) {
@@ -52,9 +57,6 @@ function responseReceived(msg, initiator, helper) {
 						break
 					case 6:	// MANUAL_REQUEST_INITIATOR
 						type = 15 // User 
-						break
-					case 7:	// CHECK_FOR_UPDATES_INITIATOR
-						type = 1 // Proxied 
 						break
 					case 8:	// BEAN_SHELL_INITIATOR
 						type = 15 // User 

--- a/build/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
+++ b/build/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
@@ -22,6 +22,11 @@ function sendingRequest(msg, initiator, helper) {
 }
 
 function responseReceived(msg, initiator, helper) {
+	if (initiator == 7) { // CHECK_FOR_UPDATES_INITIATOR
+		// Not of interest.
+		return
+	}
+
 	if (extensionAlert != null) {
 		var ctype = msg.getResponseHeader().getHeader("Content-Type")
 		if (ctype != null) {
@@ -62,9 +67,6 @@ function responseReceived(msg, initiator, helper) {
 							break
 						case 6:	// MANUAL_REQUEST_INITIATOR
 							type = 15 // User 
-							break
-						case 7:	// CHECK_FOR_UPDATES_INITIATOR
-							type = 1 // Proxied 
 							break
 						case 8:	// BEAN_SHELL_INITIATOR
 							type = 15 // User 


### PR DESCRIPTION
Change the HTTP Sender docker scripts to ignore CFU requests.

Fix #4187 - API scanning script is scanning ZAP urls