### PR TITLE
Remove filter extension from core functionality

### DIFF
--- a/src/org/parosproxy/paros/extension/filter/AllFilterPanel.java
+++ b/src/org/parosproxy/paros/extension/filter/AllFilterPanel.java
@@ -27,6 +27,7 @@
 // ZAP: 2015/02/16 Issue 1528: Support user defined font size
 // ZAP: 2016/04/05 Issue 2458: Fix xlint warning messages 
 // ZAP: 2017/01/09 Remove method no longer needed.
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 
 package org.parosproxy.paros.extension.filter;
 
@@ -46,6 +47,10 @@ import org.parosproxy.paros.view.AbstractParamPanel;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.LayoutHelper;
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public class AllFilterPanel extends AbstractParamPanel {
 
 	private static final long serialVersionUID = 1L;

--- a/src/org/parosproxy/paros/extension/filter/AllFilterTableEditor.java
+++ b/src/org/parosproxy/paros/extension/filter/AllFilterTableEditor.java
@@ -22,6 +22,7 @@
 // removed unnecessary cast.
 // ZAP: 2012/07/09 Update row in UI after editing its properties.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 package org.parosproxy.paros.extension.filter;
 
 import java.awt.Component;
@@ -31,6 +32,10 @@ import javax.swing.JButton;
 import javax.swing.JTable;
 import javax.swing.table.TableCellEditor;
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 class AllFilterTableEditor extends AbstractCellEditor implements TableCellEditor {
 	private static final long serialVersionUID = 1L;
     

--- a/src/org/parosproxy/paros/extension/filter/AllFilterTableModel.java
+++ b/src/org/parosproxy/paros/extension/filter/AllFilterTableModel.java
@@ -26,6 +26,7 @@
 // method setValueAt(Object, int , int).
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 
 package org.parosproxy.paros.extension.filter;
 
@@ -36,6 +37,10 @@ import javax.swing.table.DefaultTableModel;
 
 import org.parosproxy.paros.Constant;
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public class AllFilterTableModel extends DefaultTableModel {
 	private static final long serialVersionUID = 1L;
 	

--- a/src/org/parosproxy/paros/extension/filter/AllFilterTableRenderer.java
+++ b/src/org/parosproxy/paros/extension/filter/AllFilterTableRenderer.java
@@ -20,6 +20,7 @@
  */
 // ZAP: 2012/04/25 Added @Override annotation to all appropriate methods.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 package org.parosproxy.paros.extension.filter;
 
 import java.awt.Component;
@@ -30,6 +31,10 @@ import javax.swing.JLabel;
 import javax.swing.JTable;
 import javax.swing.table.TableCellRenderer;
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 class AllFilterTableRenderer extends JComponent implements TableCellRenderer {
 	private static final long serialVersionUID = 1L;
 	

--- a/src/org/parosproxy/paros/extension/filter/ExtensionFilter.java
+++ b/src/org/parosproxy/paros/extension/filter/ExtensionFilter.java
@@ -38,6 +38,7 @@
 // ZAP: 2015/03/16 Issue 1525: Further database independence changes
 // ZAP: 2016/06/28 Do not start the timer thread if no filter is enabled
 // ZAP: 2017/04/07 Added getUIName()
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 
 package org.parosproxy.paros.extension.filter;
 
@@ -54,6 +55,10 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.view.ZapMenuItem;
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public class ExtensionFilter extends ExtensionAdaptor implements ProxyListener {
 
 	private static final Logger log = Logger.getLogger(ExtensionFilter.class);
@@ -70,6 +75,11 @@ public class ExtensionFilter extends ExtensionAdaptor implements ProxyListener {
         this.setOrder(8);
     }
     
+    @Override
+    public boolean isDepreciated() {
+        return true;
+    }
+
     @Override
     public String getUIName() {
     	return Constant.messages.getString("filter.name");

--- a/src/org/parosproxy/paros/extension/filter/Filter.java
+++ b/src/org/parosproxy/paros/extension/filter/Filter.java
@@ -21,12 +21,17 @@
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
 // ZAP: 2013/05/02 Removed redundant public modifiers from interface method declarations
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 package org.parosproxy.paros.extension.filter;
 
 import org.parosproxy.paros.extension.ViewDelegate;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public interface Filter {
 
     /**

--- a/src/org/parosproxy/paros/extension/filter/FilterAbstractReplace.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterAbstractReplace.java
@@ -24,6 +24,7 @@
 // to ease extensibility and moved code from getFilterReplaceDialog() there.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
 // ZAP: 2013/05/02 Re-arranged all modifiers into Java coding standard order
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 package org.parosproxy.paros.extension.filter;
 
 import java.util.regex.Pattern;
@@ -31,6 +32,10 @@ import java.util.regex.Pattern;
 import javax.swing.JOptionPane;
 
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public abstract class FilterAbstractReplace extends FilterAdaptor {
     
     private FilterReplaceDialog filterReplaceDialog = null;

--- a/src/org/parosproxy/paros/extension/filter/FilterAdaptor.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterAdaptor.java
@@ -22,6 +22,7 @@
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
 // ZAP: 2013/05/02 Re-arranged all modifiers into Java coding standard order
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 package org.parosproxy.paros.extension.filter;
 
 import org.parosproxy.paros.extension.ViewDelegate;
@@ -29,6 +30,10 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public abstract class FilterAdaptor implements Filter {
 
     private boolean enabled = false;

--- a/src/org/parosproxy/paros/extension/filter/FilterChangeUserAgent.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterChangeUserAgent.java
@@ -23,6 +23,7 @@
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
 // ZAP: 2016/0405 Issue 2458: Fix xlint warning messages 
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 
 package org.parosproxy.paros.extension.filter;
 
@@ -33,6 +34,10 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public class FilterChangeUserAgent extends FilterAdaptor {
     static final String[] userAgentName = {
             "Firefox 1.0.1 Windows XP",

--- a/src/org/parosproxy/paros/extension/filter/FilterChangeUserAgentDialog.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterChangeUserAgentDialog.java
@@ -22,6 +22,7 @@
 // ZAP: 2012/04/25 Added @Override annotation to all appropriate methods.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
 // ZAP: 2016/04/05 Issue 2458: Fix xlint warning messages 
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 
 package org.parosproxy.paros.extension.filter;
 
@@ -41,6 +42,10 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractDialog;
 import org.parosproxy.paros.model.Model;
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public class FilterChangeUserAgentDialog extends AbstractDialog {
 
 	private static final long serialVersionUID = 1L;

--- a/src/org/parosproxy/paros/extension/filter/FilterDetectMalciousContent.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterDetectMalciousContent.java
@@ -26,6 +26,7 @@
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
 // ZAP: 2013/05/02 Re-arranged all modifiers into Java coding standard order
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 
 package org.parosproxy.paros.extension.filter;
 
@@ -37,6 +38,10 @@ import org.parosproxy.paros.network.HttpMessage;
 
 
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public class FilterDetectMalciousContent extends FilterAdaptor {
 
     @Override

--- a/src/org/parosproxy/paros/extension/filter/FilterDetectSetCookie.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterDetectSetCookie.java
@@ -25,6 +25,7 @@
 // ZAP: 2012/07/29 Removed incorrect (and unused) init method 
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 
 package org.parosproxy.paros.extension.filter;
 
@@ -41,6 +42,10 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
 
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public class FilterDetectSetCookie extends FilterAdaptor {
 
     private static final String CRLF = "\r\n";

--- a/src/org/parosproxy/paros/extension/filter/FilterDialog.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterDialog.java
@@ -22,6 +22,7 @@
 // ZAP: 2012/04/25 Added argument type to generic type.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
 // ZAP: 2016/04/05 Issue 2458: Fix xlint warning messages 
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 
 package org.parosproxy.paros.extension.filter;
 
@@ -35,6 +36,10 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.view.AbstractParamDialog;
 
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public class FilterDialog extends AbstractParamDialog {
 
 	private static final long serialVersionUID = 1L;

--- a/src/org/parosproxy/paros/extension/filter/FilterFactory.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterFactory.java
@@ -22,6 +22,7 @@
 // unnecessary cast and changed to use the method Integer.valueOf.
 // ZAP: 2012/11/20 Issue 419: Restructure jar loading code
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 
 package org.parosproxy.paros.extension.filter;
 
@@ -34,6 +35,10 @@ import org.apache.log4j.Logger;
 import org.zaproxy.zap.control.ExtensionFactory;
 
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public class FilterFactory {
 
     private static Logger log = Logger.getLogger(FilterFactory.class);

--- a/src/org/parosproxy/paros/extension/filter/FilterIfModifiedSince.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterIfModifiedSince.java
@@ -21,6 +21,7 @@
 // ZAP: 2012/04/25 Added @Override annotation to all appropriate methods.
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 package org.parosproxy.paros.extension.filter;
 
 import org.parosproxy.paros.Constant;
@@ -28,6 +29,10 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public class FilterIfModifiedSince extends FilterAdaptor {
 
     @Override

--- a/src/org/parosproxy/paros/extension/filter/FilterLogCookie.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterLogCookie.java
@@ -25,6 +25,7 @@
 // as introduced with version 3.1 of HttpClient
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 
 package org.parosproxy.paros.extension.filter;
 
@@ -36,6 +37,10 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public class FilterLogCookie extends FilterAdaptor {
 
     private static final String DELIM = "\t";

--- a/src/org/parosproxy/paros/extension/filter/FilterLogGetQuery.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterLogGetQuery.java
@@ -26,6 +26,7 @@
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
 // ZAP: 2016/06/07 Use ZAP's home filter directory
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 
 package org.parosproxy.paros.extension.filter;
 
@@ -47,6 +48,10 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public class FilterLogGetQuery extends FilterAdaptor {
 
     private static final String LOG_FILE = Paths.get(Constant.FOLDER_FILTER, "get.xls").toString();

--- a/src/org/parosproxy/paros/extension/filter/FilterLogPostQuery.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterLogPostQuery.java
@@ -25,6 +25,7 @@
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
 // ZAP: 2016/06/07 Use Constant.FOLDER_FILTER
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 
 package org.parosproxy.paros.extension.filter;
 
@@ -38,6 +39,10 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public class FilterLogPostQuery extends FilterLogGetQuery {
 
     private static final String LOG_FILE = Paths.get(Constant.FOLDER_FILTER, "post.xls").toString();

--- a/src/org/parosproxy/paros/extension/filter/FilterLogRequestResponse.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterLogRequestResponse.java
@@ -25,6 +25,7 @@
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
 // ZAP: 2016/06/07 Use ZAP's home filter directory
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 
 package org.parosproxy.paros.extension.filter;
 
@@ -39,6 +40,10 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
 
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public class FilterLogRequestResponse extends FilterAdaptor {
 
     private static final String logFile = Paths.get(Constant.FOLDER_FILTER, "message.txt").toString();

--- a/src/org/parosproxy/paros/extension/filter/FilterReplaceDialog.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterReplaceDialog.java
@@ -25,6 +25,7 @@
 // private to protected. Use i18n strings for labels and warnings.
 // ZAP: 2012/07/09 Added 10 more pixels to the dialog's height.
 // Changed visibility of getJPanel1().
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 package org.parosproxy.paros.extension.filter;
 
 import java.awt.Dimension;
@@ -45,6 +46,10 @@ import org.parosproxy.paros.extension.ViewDelegate;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.utils.ZapTextField;
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public class FilterReplaceDialog extends AbstractDialog {
 
 

--- a/src/org/parosproxy/paros/extension/filter/FilterReplaceRequestBody.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterReplaceRequestBody.java
@@ -22,6 +22,7 @@
 // ZAP: 2012/04/25 Added @Override annotation to all appropriate methods.
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 
 package org.parosproxy.paros.extension.filter;
 
@@ -31,6 +32,10 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
 
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public class FilterReplaceRequestBody extends FilterAbstractReplace {
 
     @Override

--- a/src/org/parosproxy/paros/extension/filter/FilterReplaceRequestHeader.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterReplaceRequestHeader.java
@@ -22,6 +22,7 @@
 // ZAP: 2012/04/25 Added @Override annotation to all appropriate methods.
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 
 package org.parosproxy.paros.extension.filter;
 
@@ -32,6 +33,10 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public class FilterReplaceRequestHeader extends FilterAbstractReplace {
 
     @Override

--- a/src/org/parosproxy/paros/extension/filter/FilterReplaceResponseBody.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterReplaceResponseBody.java
@@ -22,6 +22,7 @@
 // ZAP: 2012/04/25 Added @Override annotation to all appropriate methods.
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 
 package org.parosproxy.paros.extension.filter;
 
@@ -32,6 +33,10 @@ import org.parosproxy.paros.network.HttpMessage;
 
 
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public class FilterReplaceResponseBody extends FilterAbstractReplace {
 
 	

--- a/src/org/parosproxy/paros/extension/filter/FilterReplaceResponseHeader.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterReplaceResponseHeader.java
@@ -22,6 +22,7 @@
 // ZAP: 2012/04/25 Added @Override annotation to all appropriate methods.
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
+// ZAP: 2017/12/28 Add deprecated annotation and JavaDoc tag.
 
 package org.parosproxy.paros.extension.filter;
 
@@ -32,6 +33,10 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
 
+/**
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
+ */
+@Deprecated
 public class FilterReplaceResponseHeader extends FilterAbstractReplace {
 
     @Override

--- a/src/org/parosproxy/paros/extension/filter/FilterZapRequestId.java
+++ b/src/org/parosproxy/paros/extension/filter/FilterZapRequestId.java
@@ -35,7 +35,9 @@ import org.parosproxy.paros.network.HttpRequestHeader;
  * See <a href="https://github.com/zaproxy/zaproxy/issues/68">Issue 68</a>
  * 
  * @author MaWoKi
+ * @deprecated (TODO add version) Filters were superseded by scripts and Replacer add-on.
  */
+@Deprecated
 public class FilterZapRequestId extends FilterAdaptor {
 
 	private static final AtomicLong requestCounter = new AtomicLong(1);

--- a/src/org/zaproxy/zap/control/CoreFunctionality.java
+++ b/src/org/zaproxy/zap/control/CoreFunctionality.java
@@ -66,7 +66,6 @@ public final class CoreFunctionality {
 		if (builtInExtensions == null) {
 			ArrayList<Extension> extensions = new ArrayList<>();
 			extensions.add(new org.parosproxy.paros.extension.edit.ExtensionEdit());
-			extensions.add(new org.parosproxy.paros.extension.filter.ExtensionFilter());
 			extensions.add(new org.parosproxy.paros.extension.history.ExtensionHistory());
 			extensions.add(new org.parosproxy.paros.extension.manualrequest.ExtensionManualRequestEditor());
 			extensions.add(new org.parosproxy.paros.extension.option.ExtensionOption());


### PR DESCRIPTION
Change CoreFunctionality to not add the ExtensionFilter, superseded by
scripts and Replacer add-on. The filter functionality is deprecated (UI
message) since version 2.4.0.
Add deprecated annotation and JavaDoc tag to filter related classes, for
ExtensionFilter also override the deprecated method. The remove of the
code and related resources should be done in a following release, once
all known add-ons are no longer using it.