### PR TITLE
Refactor redirection validation in active scans

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/HostProcess.java
+++ b/src/org/parosproxy/paros/core/scanner/HostProcess.java
@@ -79,6 +79,7 @@
 // ZAP: 2017/09/27 Allow to skip scanners by ID and don't allow to skip scanners already finished/skipped.
 // ZAP: 2017/10/05 Replace usage of Class.newInstance (deprecated in Java 9).
 // ZAP: 2017/11/29 Skip plugins if there's nothing to scan.
+// ZAP: 2017/12/29 Provide means to validate the redirections.
 
 package org.parosproxy.paros.core.scanner;
 
@@ -108,6 +109,8 @@ import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.model.SessionStructure;
 import org.zaproxy.zap.model.StructuralNode;
 import org.zaproxy.zap.model.TechSet;
+import org.zaproxy.zap.network.HttpRedirectionValidator;
+import org.zaproxy.zap.network.HttpRequestConfig;
 import org.zaproxy.zap.users.User;
 
 public class HostProcess implements Runnable {
@@ -168,6 +171,27 @@ public class HostProcess implements Runnable {
      * @see #messageIdToHostScan
      */
     private List<Integer> messagesIdsToAppScan;
+
+    /**
+     * The HTTP request configuration, uses a {@link HttpRedirectionValidator} that ensures the followed redirections are in
+     * scan's scope.
+     * <p>
+     * Lazily initialised.
+     * 
+     * @see #getRedirectRequestConfig()
+     * @see #redirectionValidator
+     */
+    private HttpRequestConfig redirectRequestConfig;
+
+    /**
+     * The redirection validator that ensures the followed redirections are in scan's scope.
+     * <p>
+     * Lazily initialised.
+     * 
+     * @see #getRedirectionValidator()
+     * @see #redirectRequestConfig
+     */
+    private HttpRedirectionValidator redirectionValidator;
     
     /**
      * Constructs a {@code HostProcess}, with no rules' configurations.
@@ -753,6 +777,42 @@ public class HostProcess implements Runnable {
         }
         
         return analyser;
+    }
+
+    /**
+     * Gets the HTTP request configuration that ensures the followed redirections are in scan's scope.
+     *
+     * @return the HTTP request configuration, never {@code null}.
+     * @since TODO add version
+     * @see #getRedirectionValidator()
+     */
+    HttpRequestConfig getRedirectRequestConfig() {
+        if (redirectRequestConfig == null) {
+            redirectRequestConfig = HttpRequestConfig.builder().setRedirectionValidator(getRedirectionValidator()).build();
+        }
+        return redirectRequestConfig;
+    }
+
+    /**
+     * Gets the redirection validator that ensures the followed redirections are in scan's scope.
+     *
+     * @return the redirection validator, never {@code null}.
+     * @since TODO add version
+     * @see #getRedirectRequestConfig()
+     */
+    HttpRedirectionValidator getRedirectionValidator() {
+        if (redirectionValidator == null) {
+            redirectionValidator = redirection -> {
+                if (!nodeInScope(redirection.getEscapedURI())) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Skipping redirection out of scan's scope: " + redirection);
+                    }
+                    return false;
+                }
+                return true;
+            };
+        }
+        return redirectionValidator;
     }
 
     public boolean handleAntiCsrfTokens() {

--- a/src/org/zaproxy/zap/network/DefaultHttpRedirectionValidator.java
+++ b/src/org/zaproxy/zap/network/DefaultHttpRedirectionValidator.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.network;
 
 import org.apache.commons.httpclient.URI;
-import org.parosproxy.paros.network.HttpMessage;
 
 /**
  * Default implementation of {@link HttpRedirectionValidator}, all redirections are considered valid and notifications of new
@@ -45,13 +44,5 @@ public class DefaultHttpRedirectionValidator implements HttpRedirectionValidator
     @Override
     public boolean isValid(URI redirection) {
         return true;
-    }
-
-    /**
-     * Does nothing.
-     */
-    @Override
-    public void notifyMessageReceived(HttpMessage message) {
-        // Nothing to do.
     }
 }

--- a/src/org/zaproxy/zap/network/HttpRedirectionValidator.java
+++ b/src/org/zaproxy/zap/network/HttpRedirectionValidator.java
@@ -30,6 +30,7 @@ import org.parosproxy.paros.network.HttpMessage;
  * 
  * @since 2.6.0
  */
+@FunctionalInterface
 public interface HttpRedirectionValidator {
 
     /**
@@ -45,5 +46,6 @@ public interface HttpRedirectionValidator {
      *
      * @param message the HTTP message that was received, never {@code null}.
      */
-    void notifyMessageReceived(HttpMessage message);
+    default void notifyMessageReceived(HttpMessage message) {
+    }
 }


### PR DESCRIPTION
Change AbtractPlugin and Analyser to use HostProcess to validate the
redirections, to reduce code duplication.
Change HostProcess to provide a HttpRedirectionValidator and a
HttpRequestConfig for validation of redirects.
Change HttpRedirectionValidator to have notifyMessageReceived as a
default method, the method is provided for convenience and not all
implementation require it, allowing the interface to be functional.
Change DefaultHttpRedirectionValidator to not implement the now default
method.