### PR TITLE
Disable unsupported extensions

### DIFF
--- a/src/org/zaproxy/zap/control/ExtensionFactory.java
+++ b/src/org/zaproxy/zap/control/ExtensionFactory.java
@@ -165,8 +165,10 @@ public class ExtensionFactory {
             intitializeHelpSet(extension);
         } else if (!extension.supportsDb(Model.getSingleton().getDb().getType())) {
             log.debug("Not loading extension " + extension.getName() + ": doesnt support " + Model.getSingleton().getDb().getType());
+            extension.setEnabled(false);
         } else if (extension.supportsLowMemory() || ! Constant.isLowMemoryOptionSet()) {
             log.debug("Not loading extension " + extension.getName() + ": doesnt support low memory option");
+            extension.setEnabled(false);
         }
     }
 


### PR DESCRIPTION
Change ExtensionFactory to disable the extensions that are not supported
by current options (e.g. experimental DB or low memory), otherwise the
extensions would be handled as if they were enabled/loaded while they
aren't (leading to exceptions when starting, uninstalling or querying
its state).