### PR TITLE
Address exception in Scan Progress dialogue

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/HostProcess.java
+++ b/src/org/parosproxy/paros/core/scanner/HostProcess.java
@@ -80,6 +80,7 @@
 // ZAP: 2017/10/05 Replace usage of Class.newInstance (deprecated in Java 9).
 // ZAP: 2017/11/29 Skip plugins if there's nothing to scan.
 // ZAP: 2017/12/29 Provide means to validate the redirections.
+// ZAP: 2018/01/01 Update initialisation of PluginStats.
 
 package org.parosproxy.paros.core.scanner;
 
@@ -290,7 +291,7 @@ public class HostProcess implements Runnable {
             pluginFactory.reset();
             synchronized (mapPluginStats) {
                 for (Plugin plugin : pluginFactory.getPending()) {
-                    mapPluginStats.put(plugin.getId(), new PluginStats());
+                    mapPluginStats.put(plugin.getId(), new PluginStats(plugin.getName()));
                 }
             }
 

--- a/src/org/parosproxy/paros/core/scanner/PluginStats.java
+++ b/src/org/parosproxy/paros/core/scanner/PluginStats.java
@@ -27,6 +27,7 @@ package org.parosproxy.paros.core.scanner;
  */
 public class PluginStats {
 
+    private final String pluginName;
     private long startTime;
     private int messageCount;
     private int alertCount;
@@ -37,9 +38,21 @@ public class PluginStats {
     /**
      * Constructs a {@code PluginStats}.
      * 
+     * @param pluginName the name of the plugin.
      * @see #start()
      */
-    PluginStats() {
+    PluginStats(String pluginName) {
+        this.pluginName = pluginName == null ? "" : pluginName;
+    }
+
+    /**
+     * Gets the name of the plugin.
+     *
+     * @return the name of the plugin, never {@code null}.
+     * @since TODO add version
+     */
+    public String getPluginName() {
+        return pluginName;
     }
 
     /**

--- a/src/org/zaproxy/zap/extension/ascan/ScanProgressItem.java
+++ b/src/org/zaproxy/zap/extension/ascan/ScanProgressItem.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.HostProcess;
 import org.parosproxy.paros.core.scanner.Plugin;
+import org.parosproxy.paros.core.scanner.PluginStats;
 
 /**
  * Class for Visual Plugin Progress management
@@ -38,6 +39,7 @@ public class ScanProgressItem {
     private Plugin plugin;
     private int status;
     private ScanProgressActionIcon progressAction;
+    private final PluginStats pluginStats;
 
     /**
      *
@@ -47,6 +49,7 @@ public class ScanProgressItem {
     public ScanProgressItem(HostProcess hProcess, Plugin plugin, int status) {
         this.hProcess = hProcess;
         this.plugin = plugin;
+        this.pluginStats = hProcess.getPluginStats(plugin.getId());
         this.status = status;
         this.progressAction = new ScanProgressActionIcon(this);
     }
@@ -56,7 +59,7 @@ public class ScanProgressItem {
      * @return
      */
     public String getNameLabel() {
-        return plugin.getName();
+        return pluginStats.getPluginName();
     }
 
     /**
@@ -157,7 +160,7 @@ public class ScanProgressItem {
      * @see #getSkippedReason()
      */
     public boolean isSkipped() {
-        return hProcess.isSkipped(plugin);
+        return pluginStats.isSkipped();
     }
 
     /**
@@ -168,7 +171,7 @@ public class ScanProgressItem {
      * @see #isSkipped()
      */
     public String getSkippedReason() {
-        return hProcess.getSkippedReason(plugin);
+        return pluginStats.getSkippedReason();
     }
 
     public void skip() {
@@ -186,7 +189,7 @@ public class ScanProgressItem {
     }
 
 	public int getReqCount() {
-		return hProcess.getPluginRequestCount(plugin.getId());
+		return pluginStats.getMessageCount();
 	}
 
 	/**
@@ -195,7 +198,7 @@ public class ScanProgressItem {
 	 * @return the alert count.
 	 */
 	int getAlertCount() {
-		return hProcess.getPluginStats(plugin.getId()).getAlertCount();
+		return pluginStats.getAlertCount();
 	}
 
 	@Override


### PR DESCRIPTION
Fix MissingResourceException(s) in Scan Progress dialogue after
uninstalling an add-on with scanners used in a previous active scan.

Change PluginStats to cache the name of the scanner.
Change ScanProgressItem to use the name from PluginStats (instead of
Plugin, the latter might no longer be available). Also, change to use
PluginStats were possible instead of going through the HostProcess.
Change HostProcess to initialise the the PluginStats with the name of
the Plugin.