### PR TITLE
Update extensions that support experimental DB

### DIFF
--- a/src/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRF.java
+++ b/src/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRF.java
@@ -86,6 +86,11 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
 	}
 
     @Override
+    public boolean supportsDb(String type) {
+        return true;
+    }
+
+    @Override
     public void init() {
         antiCsrfDetectScanner = new AntiCsrfDetectScanner(this);
     }

--- a/src/org/zaproxy/zap/extension/authentication/ExtensionAuthentication.java
+++ b/src/org/zaproxy/zap/extension/authentication/ExtensionAuthentication.java
@@ -92,6 +92,11 @@ public class ExtensionAuthentication extends ExtensionAdaptor implements Context
 	}
 
 	@Override
+	public boolean supportsDb(String type) {
+		return true;
+	}
+
+	@Override
 	public String getUIName() {
 		return Constant.messages.getString("authentication.name");
 	}

--- a/src/org/zaproxy/zap/extension/authorization/ExtensionAuthorization.java
+++ b/src/org/zaproxy/zap/extension/authorization/ExtensionAuthorization.java
@@ -72,6 +72,11 @@ public class ExtensionAuthorization extends ExtensionAdaptor implements ContextP
 	}
 
 	@Override
+	public boolean supportsDb(String type) {
+		return true;
+	}
+
+	@Override
 	public String getUIName() {
 		return Constant.messages.getString("autorization.name");
 	}

--- a/src/org/zaproxy/zap/extension/callback/ExtensionCallback.java
+++ b/src/org/zaproxy/zap/extension/callback/ExtensionCallback.java
@@ -63,6 +63,11 @@ public class ExtensionCallback extends ExtensionAdaptor implements
     }
 
     @Override
+    public boolean supportsDb(String type) {
+        return true;
+    }
+
+    @Override
     public String getUIName() {
     	return Constant.messages.getString("callback.name");
     }

--- a/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
@@ -125,6 +125,11 @@ public class ExtensionHttpSessions extends ExtensionAdaptor implements SessionCh
 	}
 
 	@Override
+	public boolean supportsDb(String type) {
+		return true;
+	}
+
+	@Override
 	public String getUIName() {
 		return Constant.messages.getString("httpsessions.name");
 	}

--- a/src/org/zaproxy/zap/extension/params/ExtensionParams.java
+++ b/src/org/zaproxy/zap/extension/params/ExtensionParams.java
@@ -82,6 +82,11 @@ public class ExtensionParams extends ExtensionAdaptor
         super(NAME);
         this.setOrder(58);
 	}
+
+    @Override
+    public boolean supportsDb(String type) {
+        return true;
+    }
 	
     @Override
     public String getUIName() {

--- a/src/org/zaproxy/zap/extension/proxies/ExtensionProxies.java
+++ b/src/org/zaproxy/zap/extension/proxies/ExtensionProxies.java
@@ -68,6 +68,11 @@ public class ExtensionProxies extends ExtensionAdaptor implements OptionsChanged
     }
 
     @Override
+    public boolean supportsDb(String type) {
+        return true;
+    }
+
+    @Override
     public String getUIName() {
         return Constant.messages.getString("proxies.name");
     }

--- a/src/org/zaproxy/zap/extension/sessions/ExtensionSessionManagement.java
+++ b/src/org/zaproxy/zap/extension/sessions/ExtensionSessionManagement.java
@@ -81,6 +81,11 @@ public class ExtensionSessionManagement extends ExtensionAdaptor implements Cont
 	}
 
 	@Override
+	public boolean supportsDb(String type) {
+		return true;
+	}
+
+	@Override
 	public String getUIName() {
 		return Constant.messages.getString("sessionmanagement.name");
 	}


### PR DESCRIPTION
Change extensions that support the experimental DB option to declare
that they support it.

Fix #4196 - Supported core extensions not available when using
experimental DB option