### PR TITLE
Issue 4215 - scanners.md update

### DIFF
--- a/src/doc/scanners.md
+++ b/src/doc/scanners.md
@@ -26,7 +26,7 @@ Scanners:
 
 10010   Cookie set without HttpOnly flag
 10011   Cookie set without secure flag
-10012   Password Autocomplete in browser
+10012   Password Autocomplete in browser [Deprecated]
 10013   Weak HTTP authentication over an unsecured connection [Deprecated]
 10014   Cross Site Request Forgery [Deprecated]
 10015   Incomplete or no cache-control and pragma HTTPHeader set


### PR DESCRIPTION
scanners.md - Updated entry 10012. Marked deprecated in relation to
retiring the password autocomplete passive scan rule.

See: https://github.com/zaproxy/zap-extensions/pull/1233

Fixes zaproxy/zaproxy#4215