### PR TITLE
Prefer dir node when recursing with spider API

### DIFF
--- a/src/org/zaproxy/zap/extension/spider/SpiderAPI.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderAPI.java
@@ -469,11 +469,7 @@ public class SpiderAPI extends ApiImplementor {
 				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_URL);
 			}
 
-			try {
-				node = SessionStructure.find(Model.getSingleton().getSession().getSessionId(), new URI(url, false), "GET", "");
-			} catch (Exception e) {
-				throw new ApiException(ApiException.Type.INTERNAL_ERROR);
-			}
+			node = getStartNode(startURI, recurse);
 		}
 		Target target;
 		if (useUrl) {
@@ -524,6 +520,32 @@ public class SpiderAPI extends ApiImplementor {
 		}
 		
 		return extension.startScan(target, user, objs.toArray(new Object[objs.size()]));
+	}
+
+	/**
+	 * Gets a node for the given URI and recurse value, for use as start/seed of the spider.
+	 * <p>
+	 * If {@code recurse} is {@code true} it returns a node that represents a directory (if present in the session) otherwise
+	 * the node represents a GET node of the URI. If neither of the nodes is found in the session it returns {@code null}.
+	 *
+	 * @param startURI the starting URI, must not be {@code null}.
+	 * @param recurse {@code true} if the spider should use existing URLs as seeds, {@code false} otherwise.
+	 * @return the start node, might be {@code null}.
+	 * @throws ApiException if an error occurred while obtaining the start node.
+	 */
+	private StructuralNode getStartNode(URI startURI, boolean recurse) throws ApiException {
+		StructuralNode startNode = null;
+		try {
+			if (recurse) {
+				startNode = SessionStructure.find(Model.getSingleton().getSession().getSessionId(), startURI, "", "");
+			}
+			if (startNode == null) {
+				startNode = SessionStructure.find(Model.getSingleton().getSession().getSessionId(), startURI, "GET", "");
+			}
+		} catch (Exception e) {
+			throw new ApiException(ApiException.Type.INTERNAL_ERROR, e);
+		}
+		return startNode;
 	}
 
 	@Override


### PR DESCRIPTION
Change SpiderAPI to try to get a directory node if recursing, to include
the child nodes as seeds.

Fix #4202 - API Spider call not taking ImportedUrls as input