### PR TITLE
Ignore non-dependents when installing an add-on

### DIFF
--- a/src/org/zaproxy/zap/extension/autoupdate/AddOnDependencyChecker.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/AddOnDependencyChecker.java
@@ -410,13 +410,19 @@ class AddOnDependencyChecker {
             }
         }
 
+        Set<AddOn> changedAddOns = new HashSet<>();
+        changedAddOns.addAll(selectedAddOns);
+        changedAddOns.addAll(installs);
+        changedAddOns.addAll(newVersions);
+
         Set<AddOn> expectedInstalledAddOns = new HashSet<>(remainingInstalledAddOns);
-        expectedInstalledAddOns.addAll(selectedAddOns);
-        expectedInstalledAddOns.addAll(installs);
-        expectedInstalledAddOns.addAll(newVersions);
+        expectedInstalledAddOns.addAll(changedAddOns);
+
+        changedAddOns.addAll(oldVersions);
 
         for (AddOn addOn : remainingInstalledAddOns) {
-            if (addOn.calculateRunRequirements(expectedInstalledAddOns).hasDependencyIssue()) {
+            if (addOn.dependsOn(changedAddOns)
+                    && addOn.calculateRunRequirements(expectedInstalledAddOns).hasDependencyIssue()) {
                 uninstalls.add(addOn);
             }
         }


### PR DESCRIPTION
Change AddOnDependencyChecker to ignore add-ons with running issues
(e.g. missing dependencies) if those don't depend on the add-on(s) being
installed, avoiding the need to (un)install/update unrelated add-ons.