### PR TITLE
Handle null value in ApiResponseElement

### DIFF
--- a/src/org/zaproxy/zap/extension/api/ApiResponseElement.java
+++ b/src/org/zaproxy/zap/extension/api/ApiResponseElement.java
@@ -18,6 +18,7 @@
 package org.zaproxy.zap.extension.api;
 
 import net.sf.json.JSON;
+import net.sf.json.JSONNull;
 import net.sf.json.JSONObject;
 
 import org.apache.commons.lang.StringEscapeUtils;
@@ -65,12 +66,9 @@ public class ApiResponseElement extends ApiResponse {
 
 	@Override
 	public JSON toJSON() {
-		if (value == null && apiResponse == null) {
-			return null;
-		}
 		JSONObject jo = new JSONObject();
 		if (apiResponse == null) {
-			jo.put(this.getName(), this.value);
+			jo.put(this.getName(), this.value == null ? JSONNull.getInstance() : this.value);
 		} else {
 			jo.put(this.getName(), apiResponse.toJSON());
 		}
@@ -80,7 +78,7 @@ public class ApiResponseElement extends ApiResponse {
 	@Override
 	public void toXML(Document doc, Element parent) {
 		if (apiResponse == null) {
-			parent.appendChild(doc.createTextNode(XMLStringUtil.escapeControlChrs(this.getValue())));
+			parent.appendChild(doc.createTextNode(getValue() != null ? XMLStringUtil.escapeControlChrs(this.getValue()) : ""));
 		} else {
 			apiResponse.toXML(doc, parent);
 		}

--- a/test/org/zaproxy/zap/extension/api/ApiResponseElementUnitTest.java
+++ b/test/org/zaproxy/zap/extension/api/ApiResponseElementUnitTest.java
@@ -1,0 +1,104 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.api;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Unit test for {@link ApiResponseElement}.
+ */
+public class ApiResponseElementUnitTest {
+
+    @Test
+    public void shouldReturnNullJsonObjectWithANullValue() throws ApiException {
+        // Given
+        String name = "response";
+        String value = null;
+        ApiResponseElement apiResponse = new ApiResponseElement(name, value);
+        // When
+        String jsonResponse = apiResponse.toJSON().toString();
+        // Then
+        assertThat(jsonResponse, is(equalTo("{\"" + name + "\":" + value + "}")));
+    }
+
+    @Test
+    public void shouldReturnStringJsonObjectWithNonNullValue() throws ApiException {
+        // Given
+        String name = "response";
+        String value = "value";
+        ApiResponseElement apiResponse = new ApiResponseElement(name, value);
+        // When
+        String jsonResponse = apiResponse.toJSON().toString();
+        // Then
+        assertThat(jsonResponse, is(equalTo("{\"" + name + "\":\"" + value + "\"}")));
+    }
+
+    @Test
+    public void shouldReturnEmptyXmlElementWithANullValue() throws ApiException {
+        // Given
+        String name = null;
+        String value = null;
+        ApiResponseElement apiResponse = new ApiResponseElement(name, value);
+        Document document = createDocument();
+        Element element = createElement(document, "response");
+        // When
+        apiResponse.toXML(document, element);
+        // Then
+        assertThat(element.getChildNodes().getLength(), is(equalTo(1)));
+        assertThat(element.getFirstChild().getNodeValue(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldReturnXmlElementWithTextNodeForNonNullValue() throws ApiException {
+        // Given
+        String name = null;
+        String value = "value";
+        ApiResponseElement apiResponse = new ApiResponseElement(name, value);
+        Document document = createDocument();
+        Element element = createElement(document, "response");
+        // When
+        apiResponse.toXML(document, element);
+        // Then
+        assertThat(element.getChildNodes().getLength(), is(equalTo(1)));
+        assertThat(element.getFirstChild().getNodeValue(), is(equalTo(value)));
+    }
+
+    private static Document createDocument() {
+        try {
+            return DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Element createElement(Document document, String elementName) {
+        Element element = document.createElement(elementName);
+        document.appendChild(element);
+        return element;
+    }
+}


### PR DESCRIPTION
Change ApiResponseElement to handle the null value when converting to
XML and JSON, otherwise it would lead to NullPointerException in API
when returning the response. For JSON convert to null value and for XML
to an empty element.
Add tests to assert the expected behaviour with null and non-null value.