### PR TITLE
Do not return empty XML API response on error

### DIFF
--- a/src/org/zaproxy/zap/extension/api/API.java
+++ b/src/org/zaproxy/zap/extension/api/API.java
@@ -648,9 +648,10 @@ public class API {
 	 *
 	 * @param endpointName the name of the API endpoint, must not be {@code null}.
 	 * @param response the API response, must not be {@code null}.
-	 * @return the XML representation of the given response, or an empty string if an error occurred while converting.
+	 * @return the XML representation of the given response.
+	 * @throws ApiException if an error occurred while converting the response.
 	 */
-	static String responseToXml(String endpointName, ApiResponse response) {
+	static String responseToXml(String endpointName, ApiResponse response) throws ApiException {
 		try {
 			DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
 			DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
@@ -672,8 +673,8 @@ public class API {
 
 		} catch (Exception e) {
 			logger.error("Failed to convert API response to XML: " + e.getMessage(), e);
+			throw new ApiException(ApiException.Type.INTERNAL_ERROR, e);
 		}
-		return "";
 	}
 
 	public static JSONObject getParams (String params) throws ApiException {

--- a/test/org/zaproxy/zap/extension/api/APIUnitTest.java
+++ b/test/org/zaproxy/zap/extension/api/APIUnitTest.java
@@ -340,52 +340,48 @@ public class APIUnitTest {
         assertThat(baseUrl, is(equalTo("https://127.0.0.1:8080/JSON/test/view/test/")));
     }
 
-    @Test
-    public void shouldGetEmptyXmlFromResponseWithNullEndpointName() {
+    @Test(expected = ApiException.class)
+    public void shouldFailToGetXmlFromResponseWithNullEndpointName() throws ApiException {
         // Given
         String endpointName = null;
         ApiResponse response = ApiResponseTest.INSTANCE;
         // When
-        String xmlResponse = API.responseToXml(endpointName, response);
-        // Then
-        assertThat(xmlResponse, is(equalTo("")));
+        API.responseToXml(endpointName, response);
+        // Then = ApiException
     }
 
-    @Test
-    public void shouldGetEmptyXmlFromResponseWithEmptyEndpointName() {
+    @Test(expected = ApiException.class)
+    public void shouldFailToGetXmlFromResponseWithEmptyEndpointName() throws ApiException {
         // Given
         String endpointName = "";
         ApiResponse response = ApiResponseTest.INSTANCE;
         // When
-        String xmlResponse = API.responseToXml(endpointName, response);
-        // Then
-        assertThat(xmlResponse, is(equalTo("")));
+        API.responseToXml(endpointName, response);
+        // Then = ApiException
     }
 
-    @Test
-    public void shouldGetEmptyXmlFromResponseWithNonXmlValidEndpointName() {
+    @Test(expected = ApiException.class)
+    public void shouldFailToGetXmlFromResponseWithInvalidXmlEndpointName() throws ApiException {
         // Given
         String endpointName = "<";
         ApiResponse response = ApiResponseTest.INSTANCE;
         // When
-        String xmlResponse = API.responseToXml(endpointName, response);
-        // Then
-        assertThat(xmlResponse, is(equalTo("")));
+        API.responseToXml(endpointName, response);
+        // Then = ApiException
     }
 
-    @Test
-    public void shouldGetEmptyXmlFromNullResponse() {
+    @Test(expected = ApiException.class)
+    public void shouldFailToGetXmlFromNullResponse() throws ApiException {
         // Given
         String endpointName = "Name";
         ApiResponse response = null;
         // When
-        String xmlResponse = API.responseToXml(endpointName, response);
-        // Then
-        assertThat(xmlResponse, is(equalTo("")));
+        API.responseToXml(endpointName, response);
+        // Then = ApiException
     }
 
     @Test
-    public void shouldGetXmlFromResponse() {
+    public void shouldGetXmlFromResponse() throws ApiException {
         // Given
         String endpointName = "Name";
         ApiResponse response = ApiResponseTest.INSTANCE;


### PR DESCRIPTION
Change API to throw an exception if an error occurred while converting
the response to XML (instead of returning an empty string) to return a
proper (internal error) XML response to clients.
Update tests to match the new behaviour.