### PR TITLE
Expand node of first context added

### DIFF
--- a/src/org/parosproxy/paros/view/AbstractParamContainerPanel.java
+++ b/src/org/parosproxy/paros/view/AbstractParamContainerPanel.java
@@ -25,6 +25,7 @@
 // ZAP: 2016/10/27 Explicitly show other panel when the selected panel is removed.
 // ZAP: 2017/06/23 Ensure panel with validation errors is visible.
 // ZAP: 2017/09/03 Cope with Java 9 change to TreeNode.children().
+// ZAP: 2018/01/08 Allow to expand the node of a param panel.
 
 package org.parosproxy.paros.view;
 
@@ -575,6 +576,19 @@ public class AbstractParamContainerPanel extends JSplitPane {
 
     public void expandRoot() {
         getTreeParam().expandPath(new TreePath(getRootNode()));
+    }
+
+    /**
+     * Expands the node of the param panel with the given name.
+     *
+     * @param panelName the name of the panel whose node should be expanded, should not be {@code null}.
+     * @since TODO add version
+     */
+    public void expandParamPanelNode(String panelName) {
+        DefaultMutableTreeNode node = getTreeNodeFromPanelName(panelName);
+        if (node != null) {
+            getTreeParam().expandPath(new TreePath(node.getPath()));
+        }
     }
 
     public void showDialog(boolean showRoot) {

--- a/src/org/parosproxy/paros/view/AbstractParamDialog.java
+++ b/src/org/parosproxy/paros/view/AbstractParamDialog.java
@@ -30,6 +30,7 @@
 // ZAP: 2014/02/21 Issue 1043: Custom active scan dialog
 // ZAP: 2014/12/10 Issue 1427: Standardize on [Cancel] [OK] button order
 // ZAP: 2016/11/17 Issue 2701 Added support for additional buttons to support Factory Reset
+// ZAP: 2018/01/08 Allow to expand the node of a param panel.
 
 package org.parosproxy.paros.view;
 
@@ -346,8 +347,24 @@ public class AbstractParamDialog extends AbstractDialog {
     	this.getJSplitPane().saveParam();
     }
 
+    /**
+     * Expands the root node.
+     *
+     * @see #expandParamPanelNode(String)
+     */
     protected void expandRoot() {
         this.getJSplitPane().expandRoot();
+    }
+
+    /**
+     * Expands the node of the param panel with the given name.
+     *
+     * @param panelName the name of the panel whose node should be expanded, should not be {@code null}.
+     * @since TODO add version
+     * @see #expandRoot()
+     */
+    protected void expandParamPanelNode(String panelName) {
+        getJSplitPane().expandParamPanelNode(panelName);
     }
 
     public int showDialog(boolean showRoot) {

--- a/src/org/parosproxy/paros/view/View.java
+++ b/src/org/parosproxy/paros/view/View.java
@@ -75,6 +75,7 @@
 // ZAP: 2017/09/02 Use KeyEvent instead of Event (deprecated in Java 9).
 // ZAP: 2017/10/20 Implement method to expose default delete keyboard shortcut (Issue 3626).
 // ZAP: 2017/10/31 Use ExtensionLoader.getExtension(Class).
+// ZAP: 2018/01/08 Expand first context added.
 
 package org.parosproxy.paros.view;
 
@@ -713,6 +714,7 @@ public class View implements ViewDelegate {
     }
 
     public void addContext(Context c) {
+        boolean expandContextNode = contextPanels.isEmpty();
         getSessionDialog().createUISharedContext(c);
 
         String contextsNodeName = Constant.messages.getString("context.list");
@@ -746,6 +748,10 @@ public class View implements ViewDelegate {
             addPanelForContext(c, cpf, contextPanelPath);
         }
         this.getSiteTreePanel().reloadContextTree();
+
+        if (expandContextNode) {
+            getSessionDialog().expandParamPanelNode(contextGenPanel.getName());
+        }
     }
 
     /**


### PR DESCRIPTION
Change View to expand the node of the first context added to the Session
Properties dialogue, to not require manually expanding the nodes to
configure it.
Change AbstractParamDialog and AbstractParamContainerPanel to allow
expand a node of a param panel.

Part of #387 - Context related changes