### PR TITLE
Fix typos in JavaDoc

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/HostProcess.java
+++ b/src/org/parosproxy/paros/core/scanner/HostProcess.java
@@ -1096,7 +1096,7 @@ public class HostProcess implements Runnable {
 	}
 	
 	/**
-	 * Gets the request count of the plugin with the give ID.
+	 * Gets the request count of the plugin with the given ID.
 	 *
 	 * @param pluginId the ID of the plugin
 	 * @return the request count

--- a/src/org/parosproxy/paros/network/HttpSender.java
+++ b/src/org/parosproxy/paros/network/HttpSender.java
@@ -919,7 +919,7 @@ public class HttpSender {
     }
 
     /**
-     * Follows redirections using the response of the given {@code message}. The {@code validator} in the give request
+     * Follows redirections using the response of the given {@code message}. The {@code validator} in the given request
      * configuration will be called for each redirection received. After the call to this method the given {@code message} will
      * have the contents of the last response received (possibly the response of a redirection).
      * <p>

--- a/src/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/src/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -194,7 +194,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 	}
 
 	/**
-	 * Creates an {@code ImageIcon} with the give resource path, if in view mode.
+	 * Creates an {@code ImageIcon} with the given resource path, if in view mode.
 	 *
 	 * @param resourcePath the resource path of the icon, must not be {@code null}.
 	 * @return the icon, or {@code null} if not in view mode.

--- a/src/org/zaproxy/zap/extension/script/ScriptVars.java
+++ b/src/org/zaproxy/zap/extension/script/ScriptVars.java
@@ -251,7 +251,7 @@ public final class ScriptVars {
 	}
 
 	/**
-	 * Gets a variable from the script with the give name.
+	 * Gets a variable from the script with the given name.
 	 * 
 	 * @param scriptName the name of the script.
 	 * @param key the key of the variable.

--- a/src/org/zaproxy/zap/view/table/DefaultHistoryReferencesTableModel.java
+++ b/src/org/zaproxy/zap/view/table/DefaultHistoryReferencesTableModel.java
@@ -258,10 +258,10 @@ public class DefaultHistoryReferencesTableModel extends AbstractHistoryReference
     }
     
     /**
-     * Returns the history reference with the give ID. If the history reference is not found {@code null} is returned.
+     * Returns the history reference with the given ID. If the history reference is not found {@code null} is returned.
      * 
      * @param historyReferenceId the ID of the history reference that will be searched
-     * @return the history refernce, or {@code null} if not found
+     * @return the history reference, or {@code null} if not found
      */
     public HistoryReference getHistoryReference(int historyReferenceId) {
         DefaultHistoryReferencesTableEntry entry = getEntryWithHistoryId(historyReferenceId);


### PR DESCRIPTION
Fix typos in JavaDoc, add missing N to "given" (and correct spelling
in other word).

Per review comments in #4225.