### PR TITLE
Do not uninstall files in use by other add-ons

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnLoader.java
@@ -550,7 +550,7 @@ public class AddOnLoader extends URLClassLoader {
 			if (runnableAddOns.remove(ao) != null) {
 			    saveAddOnsRunState(runnableAddOns);
 			}
-			AddOnInstaller.uninstallAddOnFiles(ao, NULL_CALLBACK);
+			AddOnInstaller.uninstallAddOnFiles(ao, NULL_CALLBACK, runnableAddOns.keySet());
 			removeAddOnClassLoader(ao);
 			deleteAddOnFile(ao, upgrading);
 			ao.setInstallationStatus(AddOn.InstallationStatus.UNINSTALLATION_FAILED);
@@ -576,7 +576,7 @@ public class AddOnLoader extends URLClassLoader {
 		unloadDependentExtensions(ao);
 		softUninstallDependentAddOns(ao);
 
-		boolean uninstalledWithoutErrors = AddOnInstaller.uninstall(ao, callback);
+		boolean uninstalledWithoutErrors = AddOnInstaller.uninstall(ao, callback, runnableAddOns.keySet());
 
 		if (uninstalledWithoutErrors && ! this.aoc.removeAddOn(ao)) {
 			uninstalledWithoutErrors = false;


### PR DESCRIPTION
Change AddOnInstaller to check if the files are being in use by other
installed add-ons before uninstalling them.
Change AddOnLoader to use the new methods that take into account the
add-ons installed when uninstalling the files.

Fix #3399 - Do not uninstall files that are declared by other add-ons