### PR TITLE
Change variant cookie to behave like browsers do

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/VariantCookie.java
+++ b/src/org/parosproxy/paros/core/scanner/VariantCookie.java
@@ -62,11 +62,9 @@ public class VariantCookie implements Variant {
             String[] cookieArray = cookieLine.split("; ?");
             for (String cookie : cookieArray) {
                 String[] nameValuePair = cookie.split("=", 2);
-                String name = nameValuePair[0];
-                String value = null;
-                if (nameValuePair.length == 2) {
-                    value = getUnescapedValue(nameValuePair[1]);
-                }
+                boolean hasNameValuePair = nameValuePair.length == 2;
+                String name = hasNameValuePair ? nameValuePair[0] : null;
+                String value = getUnescapedValue(!hasNameValuePair ? nameValuePair[0] : nameValuePair[1]);
                 extractedParameters.add(new NameValuePair(NameValuePair.TYPE_COOKIE, name, value, extractedParameters.size()));
             }
         }
@@ -166,16 +164,16 @@ public class VariantCookie implements Variant {
                 }
             }
 
-            if (cookieString.length() != 0 && !(cookieName == null && cookieValue == null)) {
+            if (cookieString.length() != 0 && !((cookieName == null || cookieName.isEmpty()) && cookieValue == null)) {
                 cookieString.append("; ");
             }
 
-            if (cookieName != null) {
+            if (cookieName != null && !cookieName.isEmpty()) {
                 cookieString.append(cookieName);
+                cookieString.append('=');
             }
 
             if (cookieValue != null) {
-                cookieString.append('=');
                 cookieString.append(cookieValue);
             }
         }
@@ -186,11 +184,14 @@ public class VariantCookie implements Variant {
         }
 
         if (escapedValue == null) {
-            return name;
+            if (name == null || name.isEmpty()) {
+                return null;
+            }
+            return name + "=";
         }
 
         if (name == null) {
-            return "=" + escapedValue;
+            return escapedValue;
         }
 
         return name + "=" + escapedValue;

--- a/test/org/parosproxy/paros/core/scanner/VariantCookieUnitTest.java
+++ b/test/org/parosproxy/paros/core/scanner/VariantCookieUnitTest.java
@@ -135,7 +135,7 @@ public class VariantCookieUnitTest {
         assertThat(variantCookie.getParamList(), contains(
                 cookie("a", "", 0),
                 cookie("", "d", 1),
-                cookie("e", null, 2),
+                cookie(null, "e", 2),
                 cookie("g", "\"h", 3),
                 cookie("i", "j\"", 4)));
     }
@@ -154,8 +154,8 @@ public class VariantCookieUnitTest {
                 contains(
                         cookie("a", "", 0),
                         cookie("", "d", 1),
-                        cookie("e", null, 2),
-                        cookie("g", null, 3),
+                        cookie(null, "e", 2),
+                        cookie(null, "g", 3),
                         cookie("", "j", 4),
                         cookie("l", "", 5),
                         cookie("n", "\"", 6),
@@ -166,28 +166,33 @@ public class VariantCookieUnitTest {
     public void shouldDecodeValueFromExtractedParameters() {
         // Given
         VariantCookie variantCookie = new VariantCookie();
-        HttpMessage messageWithCookies = createMessageWithCookies("a=b; c=d; e=%26%27%28%29%2A", "=%27");
+        HttpMessage messageWithCookies = createMessageWithCookies("a=b; c=d; e=%26%27%28%29%2A", "=%27", "%26");
         // When
         variantCookie.setMessage(messageWithCookies);
         // Then
-        assertThat(variantCookie.getParamList().size(), is(equalTo(4)));
+        assertThat(variantCookie.getParamList().size(), is(equalTo(5)));
         assertThat(
                 variantCookie.getParamList(),
-                contains(cookie("a", "b", 0), cookie("c", "d", 1), cookie("e", "&'()*", 2), cookie("", "'", 3)));
+                contains(
+                        cookie("a", "b", 0),
+                        cookie("c", "d", 1),
+                        cookie("e", "&'()*", 2),
+                        cookie("", "'", 3),
+                        cookie(null, "&", 4)));
     }
 
     @Test
     public void shouldNotDecodeNameFromExtractedParameters() {
         // Given
         VariantCookie variantCookie = new VariantCookie();
-        HttpMessage messageWithCookies = createMessageWithCookies("%29=b; c=d; e=f", "%26");
+        HttpMessage messageWithCookies = createMessageWithCookies("%29=b; c=d; e=f", "%26=");
         // When
         variantCookie.setMessage(messageWithCookies);
         // Then
         assertThat(variantCookie.getParamList().size(), is(equalTo(4)));
         assertThat(
                 variantCookie.getParamList(),
-                contains(cookie("%29", "b", 0), cookie("c", "d", 1), cookie("e", "f", 2), cookie("%26", null, 3)));
+                contains(cookie("%29", "b", 0), cookie("c", "d", 1), cookie("e", "f", 2), cookie("%26", "", 3)));
     }
 
     @Test
@@ -224,10 +229,10 @@ public class VariantCookieUnitTest {
         HttpMessage message = createMessageWithCookies("a; =b; =d; e=;");
         variantCookie.setMessage(message);
         // When
-        String injectedCookie = variantCookie.setParameter(message, cookie("b", null, 1), "y", "z");
+        String injectedCookie = variantCookie.setParameter(message, cookie(null, "b", 1), "y", "z");
         // Then
         assertThat(injectedCookie, is(equalTo("y=z")));
-        assertThat(message, containsCookieHeader("a; y=z; =d; e="));
+        assertThat(message, containsCookieHeader("a; y=z; d; e="));
     }
 
     @Test
@@ -331,8 +336,8 @@ public class VariantCookieUnitTest {
         // When
         String injectedCookie = variantCookie.setParameter(message, cookie("e", "f", 2), null, "z");
         // Then
-        assertThat(injectedCookie, is(equalTo("=z")));
-        assertThat(message, containsCookieHeader("a=b; c=d; =z"));
+        assertThat(injectedCookie, is(equalTo("z")));
+        assertThat(message, containsCookieHeader("a=b; c=d; z"));
     }
 
     @Test
@@ -344,8 +349,8 @@ public class VariantCookieUnitTest {
         // When
         String injectedCookie = variantCookie.setParameter(message, cookie("c", "d", 1), "c", null);
         // Then
-        assertThat(injectedCookie, is(equalTo("c")));
-        assertThat(message, containsCookieHeader("a=b; c; e=f"));
+        assertThat(injectedCookie, is(equalTo("c=")));
+        assertThat(message, containsCookieHeader("a=b; c=; e=f"));
     }
 
     @Test


### PR DESCRIPTION
Change VariantCookie to handle the pairs without separator ("=") as a
cookie with empty name (and send just the value), to behave like the
browsers do (which should increase the likelihood of the cookie being
accepted by the target application).
Update tests to assert the new behaviour.