### PR TITLE
Add shortcut key to Sites' Delete pop menu item

### DIFF
--- a/src/org/zaproxy/zap/extension/history/PopupMenuPurgeSites.java
+++ b/src/org/zaproxy/zap/extension/history/PopupMenuPurgeSites.java
@@ -40,6 +40,8 @@ public class PopupMenuPurgeSites extends PopupMenuItemSiteNodeContainer {
 
     public PopupMenuPurgeSites() {
         super(Constant.messages.getString("sites.purge.popup"), true);
+
+        setAccelerator(View.getSingleton().getDefaultDeleteKeyStroke());
     }
 
     @Override


### PR DESCRIPTION
Change PopupMenuPurgeSites to set the default shortcut key, to indicate
that the nodes can be deleted with a key.