### PR TITLE
Handle cookies without name in HtmlParameter

### DIFF
--- a/src/org/parosproxy/paros/network/HtmlParameter.java
+++ b/src/org/parosproxy/paros/network/HtmlParameter.java
@@ -37,26 +37,42 @@ public class HtmlParameter implements Comparable<HtmlParameter> {
 	private Type type;
 	private Set<String> flags;
 
+	/**
+	 * Constructs a {@code HtmlParameter} with the given type, name, and value.
+	 *
+	 * @param type the type.
+	 * @param name the name.
+	 * @param value the value.
+	 * @throws IllegalArgumentException if any of the parameters is {@code null}.
+	 */
 	public HtmlParameter(Type type, String name, String value) {
 		super();
-		this.name = name;
-		this.value = value;
-		this.type = type;
+		setName(name);
+		setValue(value);
+		setType(type);
 	}
 
+	/**
+	 * Constructs a {@code HtmlParameter}, with type {@link Type#cookie}, from the given cookie line.
+	 * <p>
+	 * The cookie line can be from a {@code Cookie} or {@code Set-Cookie} header.
+	 *
+	 * @param cookieLine the cookie line
+	 * @throws IllegalArgumentException if the given parameter is {@code null}.
+	 */
 	public HtmlParameter(String cookieLine) {
 		super();
-		String[] array = cookieLine.split(";");
-		if (array == null || array.length == 0) {
-			throw new IllegalArgumentException(cookieLine);
-		}
-		int eqOffset = array[0].indexOf("=");
-		if (eqOffset <= 0) {
-			throw new IllegalArgumentException(cookieLine);
-		}
+		validateNotNull(cookieLine, "cookieLine");
 		this.type = Type.cookie;
-		this.name = array[0].substring(0, eqOffset).trim();
-		this.value = array[0].substring(eqOffset + 1).trim();
+		String[] array = cookieLine.split(";");
+		int eqOffset = array[0].indexOf('=');
+		if (eqOffset == -1) {
+			this.name = "";
+			this.value = array[0].trim();
+		} else {
+			this.name = array[0].substring(0, eqOffset).trim();
+			this.value = array[0].substring(eqOffset + 1).trim();
+		}
 		if (array.length > 1) {
 			for (int i = 1; i < array.length; i++) {
 				this.addFlag(array[i].trim());
@@ -64,11 +80,24 @@ public class HtmlParameter implements Comparable<HtmlParameter> {
 		}
 	}
 
+	private static void validateNotNull(Object parameter, String parameterName) {
+		if (parameter == null) {
+			throw new IllegalArgumentException("Parameter " + parameterName + " must not be null");
+		}
+	}
+
 	public String getName() {
 		return name;
 	}
 
+	/**
+	 * Sets the name.
+	 *
+	 * @param name the new name.
+	 * @throws IllegalArgumentException if the given parameter is {@code null}.
+	 */
 	public void setName(String name) {
+		validateNotNull(name, "name");
 		this.name = name;
 	}
 
@@ -76,7 +105,14 @@ public class HtmlParameter implements Comparable<HtmlParameter> {
 		return value;
 	}
 
+	/**
+	 * Sets the value.
+	 *
+	 * @param value the new value.
+	 * @throws IllegalArgumentException if the given parameter is {@code null}.
+	 */
 	public void setValue(String value) {
+		validateNotNull(value, "value");
 		this.value = value;
 	}
 
@@ -84,7 +120,14 @@ public class HtmlParameter implements Comparable<HtmlParameter> {
 		return type;
 	}
 
+	/**
+	 * Sets the type.
+	 *
+	 * @param type the new type.
+	 * @throws IllegalArgumentException if the given parameter is {@code null}.
+	 */
 	public void setType(Type type) {
+		validateNotNull(type, "type");
 		this.type = type;
 	}
 

--- a/src/org/parosproxy/paros/network/HttpRequestHeader.java
+++ b/src/org/parosproxy/paros/network/HttpRequestHeader.java
@@ -45,6 +45,7 @@
 // ZAP: 2017/04/24 Added more HTTP methods
 // ZAP: 2017/10/19 Skip parsing of empty Cookie headers.
 // ZAP: 2017/11/22 Address a NPE in isImage().
+// ZAP: 2018/01/10 Tweak how cookie header is reconstructed from HtmlParameter(s).
 
 package org.parosproxy.paros.network;
 
@@ -701,13 +702,16 @@ public class HttpRequestHeader extends HttpHeader {
                 continue;
             }
 
-            sbData.append(parameter.getName());
-            sbData.append('=');
+            String cookieName = parameter.getName();
+            if (!cookieName.isEmpty()) {
+                sbData.append(cookieName);
+                sbData.append('=');
+            }
             sbData.append(parameter.getValue());
             sbData.append("; ");
         }
 
-        if (sbData.length() <= 3) {
+        if (sbData.length() <= 2) {
             setHeader(HttpHeader.COOKIE, null);
             return;
         }

--- a/test/org/parosproxy/paros/network/HtmlParameterUnitTest.java
+++ b/test/org/parosproxy/paros/network/HtmlParameterUnitTest.java
@@ -1,0 +1,166 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2018 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.network;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.zaproxy.zap.network.HttpBodyTestUtils;
+
+/**
+ * Unit test for {@link HtmlParameter}.
+ */
+public class HtmlParameterUnitTest extends HttpBodyTestUtils {
+
+    private static final HtmlParameter.Type NON_NULL_TYPE = HtmlParameter.Type.url;
+    private static final String NON_NULL_NAME = "name";
+    private static final String NON_NULL_VALUE = "value";
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToCreateHtmlParameterWithNullCookieLine() {
+        // Given / When
+        new HtmlParameter(null);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToCreateHtmlParameterWithNullType() {
+        // Given / When
+        new HtmlParameter(null, NON_NULL_NAME, NON_NULL_VALUE);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToCreateHtmlParameterWithNullName() {
+        // Given / When
+        new HtmlParameter(NON_NULL_TYPE, null, NON_NULL_VALUE);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToCreateHtmlParameterWithNullValue() {
+        // Given / When
+        new HtmlParameter(NON_NULL_TYPE, NON_NULL_NAME, null);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToSetNullType() {
+        // Given
+        HtmlParameter parameter = new HtmlParameter(NON_NULL_TYPE, NON_NULL_NAME, NON_NULL_VALUE);
+        // When
+        parameter.setType(null);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToSetNullName() {
+        // Given
+        HtmlParameter parameter = new HtmlParameter(NON_NULL_TYPE, NON_NULL_NAME, NON_NULL_VALUE);
+        // When
+        parameter.setName(null);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToSetNullValue() {
+        // Given
+        HtmlParameter parameter = new HtmlParameter(NON_NULL_TYPE, NON_NULL_NAME, NON_NULL_VALUE);
+        // When
+        parameter.setValue(null);
+        // Then = IllegalArgumentException
+    }
+
+    @Test
+    public void shouldCreateEmptyCookieWithEmptyCookieLine() {
+        // Given
+        String cookieLine = "";
+        // When
+        HtmlParameter parameter = new HtmlParameter(cookieLine);
+        // Then
+        assertThat(parameter.getType(), is(equalTo(HtmlParameter.Type.cookie)));
+        assertThat(parameter.getName(), is(equalTo("")));
+        assertThat(parameter.getValue(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldCreateCookieWithEmptyNameIfCookieLineHasJustValue() {
+        // Given
+        String cookieLine = "value";
+        // When
+        HtmlParameter parameter = new HtmlParameter(cookieLine);
+        // Then
+        assertThat(parameter.getType(), is(equalTo(HtmlParameter.Type.cookie)));
+        assertThat(parameter.getName(), is(equalTo("")));
+        assertThat(parameter.getValue(), is(equalTo("value")));
+    }
+
+    @Test
+    public void shouldCreateCookieWithEmptyValueIfCookieLineHasJustName() {
+        // Given
+        String cookieLine = "name=";
+        // When
+        HtmlParameter parameter = new HtmlParameter(cookieLine);
+        // Then
+        assertThat(parameter.getType(), is(equalTo(HtmlParameter.Type.cookie)));
+        assertThat(parameter.getName(), is(equalTo("name")));
+        assertThat(parameter.getValue(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldCreateEmptyCookieIfIfCookieLineHasEmptyNameAndValue() {
+        // Given
+        String cookieLine = "=";
+        // When
+        HtmlParameter parameter = new HtmlParameter(cookieLine);
+        // Then
+        assertThat(parameter.getType(), is(equalTo(HtmlParameter.Type.cookie)));
+        assertThat(parameter.getName(), is(equalTo("")));
+        assertThat(parameter.getValue(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldCreateCookieWithNameAndValueFromCookieLine() {
+        // Given
+        String cookieLine = "name=value";
+        // When
+        HtmlParameter parameter = new HtmlParameter(cookieLine);
+        // Then
+        assertThat(parameter.getType(), is(equalTo(HtmlParameter.Type.cookie)));
+        assertThat(parameter.getName(), is(equalTo("name")));
+        assertThat(parameter.getValue(), is(equalTo("value")));
+    }
+
+    @Test
+    public void shouldCreateCookieWithFlagsFromAttributesInCookieLine() {
+        // Given
+        String cookieLine = "name=value; attribute1; attribute2=value2";
+        // When
+        HtmlParameter parameter = new HtmlParameter(cookieLine);
+        // Then
+        assertThat(parameter.getType(), is(equalTo(HtmlParameter.Type.cookie)));
+        assertThat(parameter.getName(), is(equalTo("name")));
+        assertThat(parameter.getValue(), is(equalTo("value")));
+        assertThat(parameter.getFlags(), containsInAnyOrder("attribute1", "attribute2=value2"));
+    }
+}


### PR DESCRIPTION
Change HtmlParameter to handle the cookie without name/separator as a
cookie without name. Also, change to require non-null type, name, and
value, all required when comparing (compareTo).
Change HttpRequestHeader to not add the name (and separator) if there's
none.
Add tests to assert the expected behaviour.

Fix #4247 - ZAP should accept/parse cookies without name