### PR TITLE
Dont restrict callback urls to the specified addresses

### DIFF
--- a/src/org/zaproxy/zap/extension/api/API.java
+++ b/src/org/zaproxy/zap/extension/api/API.java
@@ -240,9 +240,6 @@ public class API {
 		
 		// Check for callbacks
 		if (url.contains(CALL_BACK_URL)) {
-			if (! isPermittedAddr(requestHeader)) {
-				return true;
-			}
 			logger.debug("handleApiRequest Callback: " + url);
 			for (Entry<String, ApiImplementor> callback : callBacks.entrySet()) {
 				if (url.startsWith(callback.getKey())) {
@@ -264,7 +261,8 @@ public class API {
 		if (shortcutImpl == null && callbackImpl == null && ! url.startsWith(API_URL) && ! url.startsWith(API_URL_S) && ! force) {
 			return false;
 		}
-		if (! isPermittedAddr(requestHeader)) {
+		if (callbackImpl == null && ! isPermittedAddr(requestHeader)) {
+			// Callback by their very nature are on the target domain
 			return true;
 		}
 		if (getOptionsParamApi().isSecureOnly() && ! requestHeader.isSecure()) {
@@ -533,7 +531,6 @@ public class API {
 					contentType = "text/html; charset=UTF-8";
 				}
 			}
-			logger.debug("handleApiRequest returning: " + response);
 			
 		} catch (Exception e) {
 			if (! getOptionsParamApi().isReportPermErrors()) {

--- a/test/org/zaproxy/zap/extension/api/APIUnitTest.java
+++ b/test/org/zaproxy/zap/extension/api/APIUnitTest.java
@@ -70,7 +70,7 @@ public class APIUnitTest {
     }
 
     @Test
-    public void shouldDenyAllAddressesIfNoneSet() throws Exception {
+    public void shouldAcceptCallbackIfNoAddressesSet() throws Exception {
         // Given
         API api = new API();
         api.setOptionsParamApi(createOptionsParamApi());
@@ -83,11 +83,11 @@ public class APIUnitTest {
                 createMockedHttpOutputStream());
         // Then
         assertThat(requestHandled, is(equalTo(true)));
-        assertThat(apiImplementor.wasUsed(), is(equalTo(false)));
+        assertThat(apiImplementor.wasUsed(), is(equalTo(true)));
     }
 
     @Test
-    public void shouldDenyAddressNotSet() throws Exception {
+    public void shouldAcceptCallbackEvenIfAddressNotSet() throws Exception {
         // Given
         API api = new API();
         OptionsParamApi apiOptions = createOptionsParamApi();
@@ -102,11 +102,11 @@ public class APIUnitTest {
                 createMockedHttpOutputStream());
         // Then
         assertThat(requestHandled, is(equalTo(true)));
-        assertThat(apiImplementor.wasUsed(), is(equalTo(false)));
+        assertThat(apiImplementor.wasUsed(), is(equalTo(true)));
     }
 
     @Test
-    public void shouldDenyHostnameNotSet() throws Exception {
+    public void shouldAcceptCallbackEvenIfHostnameNotSet() throws Exception {
         // Given
         API api = new API();
         OptionsParamApi apiOptions = createOptionsParamApi();
@@ -121,7 +121,7 @@ public class APIUnitTest {
                 createMockedHttpOutputStream());
         // Then
         assertThat(requestHandled, is(equalTo(true)));
-        assertThat(apiImplementor.wasUsed(), is(equalTo(false)));
+        assertThat(apiImplementor.wasUsed(), is(equalTo(true)));
     }
 
     @Test


### PR DESCRIPTION
Callback urls by their very nature are on the target domain and should be accessible from it.
Luckily all of the current add-ons have changed to use the ExtensionCallback.
Have also removed the debuging of the full API response - this is very noisy and is probably only needed when developing API calls, at which point it can be added back.