### PR TITLE
Remove unused resource message

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -277,7 +277,6 @@ ascan.policymgr.button.modify	= Modify
 ascan.policymgr.button.remove	= Remove
 ascan.policymgr.button.export	= Export
 ascan.policymgr.default.name	= Default Policy
-ascan.policymgr.lable.table		= THIS USED??
 ascan.policymgr.table.policy	= Policy Name
 ascan.policymgr.title			= Scan Policy Manager
 ascan.policymgr.warn.delete		= Are you sure you want to delete this policy?


### PR DESCRIPTION
Remove a resource message that's no longer in use (i.e. zaproxy and
zap-extensions' branches).