### PR TITLE
Include parameter names when compiling

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -98,6 +98,7 @@
 			<compilerarg value="-Xlint:all"/>
 			<compilerarg value="-Xlint:-options"/> <!-- Otherwise fails with Java 8 -->
 			<compilerarg value="-Werror"/>
+			<compilerarg value="-parameters"/>
 			<classpath>
 				<fileset dir="${dist.lib.dir}">
 					<include name="**/*.jar" />


### PR DESCRIPTION
Change build.xml file to include the parameter names to show more useful
names (instead of arg0, arg1...) in Script Console auto complete.

Related to zaproxy/zap-extensions#1247.

(This change slightly increases the size of the zap.jar, ~2%, 162KiB.)