### PR TITLE
Use default msg types in Python pscan workaround

### DIFF
--- a/src/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
+++ b/src/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
@@ -114,7 +114,7 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
 					logger.debug("Script [Name=" + wrapper.getName() + ", Engine=" + wrapper.getEngineName()
 									+ "]  does not implement the optional method appliesToHistoryType: ", e);
 				}
-				return true;
+				return super.appliesToHistoryType(currentHistoryType);
 			}
 			throw e;
 		}


### PR DESCRIPTION
Change ScriptsPassiveScanner to check default types when applying the
workaround for Python scripts that do not implement the function
appliesToHistoryType.

Fix #4279 - Python Passive Rules scan all message types by default