### PR TITLE
Remove unneeded HTML tag from API proxy conf desc

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -128,7 +128,7 @@ api.home.links.online		= <li><a href="https://www.owasp.org/index.php/ZAP">ZAP H
 <li><a href="https://github.com/zaproxy/zaproxy/issues">Report an issue</a></li>
 api.home.proxypac			= <h2>Proxy Configuration</h2>\
 <p>To use ZAP effectively it is recommended that you configure your browser to proxy via ZAP.</p><p></p>\
-<p>You can do that manually or by configuring your browser to use the generated <a href="/OTHER/core/other/proxy.pac{0}">PAC file</a>.</p></html>
+<p>You can do that manually or by configuring your browser to use the generated <a href="/OTHER/core/other/proxy.pac{0}">PAC file</a>.</p>
 api.home.topmsg				= <h1>Welcome to the OWASP Zed Attack Proxy (ZAP)</h1>\
 <p>ZAP is an easy to use integrated penetration testing tool for finding vulnerabilities in web applications.</p><p></p>\
 <p>Please be aware that you should only attack applications that you have been specifically been given permission to test.</p>


### PR DESCRIPTION
Remove closing HTML tag from Proxy Configuration description in API home
page, it's not needed.