### PR TITLE
Reset user before sending a (manual) HTTP message

### DIFF
--- a/src/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
+++ b/src/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
@@ -88,6 +88,8 @@ public class HttpPanelSender implements MessageSender {
     @Override
     public void handleSendMessage(Message aMessage) throws IllegalArgumentException, IOException {
         final HttpMessage httpMessage = (HttpMessage) aMessage;
+        // Reset the user before sending (e.g. Forced User mode sets the user, if needed).
+        httpMessage.setRequestingUser(null);
         try {
             final ModeRedirectionValidator redirectionValidator = new ModeRedirectionValidator();
             boolean followRedirects = getButtonFollowRedirects().isSelected();


### PR DESCRIPTION
Change HttpPanelSender to reset the user of the message before sending
it to ensure it does not wrongly use a user previously set (if a user is
needed it is set again).

Fix #4291 - Manual Request Editor keeps using Forced User even if
disabled