### PR TITLE
Remove resource message no longer needed

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1451,8 +1451,6 @@ manReq.checkBox.followRedirect = Follow redirect
 manReq.checkBox.useSession     = Use current tracking session
 manReq.dialog.title            = Manual Request Editor
 manReq.pullDown.method         = Method
-# TODO remove manReq.resend.popup once websockets addon is no longer using it
-manReq.resend.popup            = Manual Request Editor
 manReq.tab.request             = Request
 manReq.tab.response            = Response
 manReq.display.tabs            = Separate tabs for Request and Response


### PR DESCRIPTION
The resource message "manReq.resend.popup" is no longer needed, the
add-on that was using it was already changed and released (twice).

Related to #3820 and zaproxy/zap-extensions#998.