### PR TITLE
Fix internal error when adding script with the API

### DIFF
--- a/src/org/zaproxy/zap/extension/script/ScriptAPI.java
+++ b/src/org/zaproxy/zap/extension/script/ScriptAPI.java
@@ -222,6 +222,9 @@ public class ScriptAPI extends ApiImplementor {
 			if (!file.exists()) {
 				throw new ApiException(ApiException.Type.DOES_NOT_EXIST, file.getAbsolutePath());
 			}
+			if (extension.getScript(params.getString(ACTION_PARAM_SCRIPT_NAME)) != null) {
+				throw new ApiException(ApiException.Type.ALREADY_EXISTS, ACTION_PARAM_SCRIPT_NAME);
+			}
 			
 			ScriptWrapper script = new ScriptWrapper(
 					params.getString(ACTION_PARAM_SCRIPT_NAME),


### PR DESCRIPTION
Change ScriptAPI to validate if a script with the same name already
exists when adding a new script (and thus prevent an internal error
because of unhandled exception).

Exception stack trace from 2.7.0:
```
171474 [ZAP-ProxyThread-4] ERROR org.zaproxy.zap.extension.api.API  - Exception while handling API request:
java.security.InvalidParameterException: A script with the same name already exists: ScriptName
	at org.zaproxy.zap.extension.script.ScriptTreeModel.addScript(ScriptTreeModel.java:127)
	at org.zaproxy.zap.extension.script.ExtensionScript.addScript(ExtensionScript.java:559)
	at org.zaproxy.zap.extension.script.ScriptAPI.handleApiAction(ScriptAPI.java:181)
	at org.zaproxy.zap.extension.api.API.handleApiRequest(API.java:431)
	at org.parosproxy.paros.core.proxy.ProxyThread.processHttp(ProxyThread.java:456)
	at org.parosproxy.paros.core.proxy.ProxyThread.run(ProxyThread.java:317)
	at java.base/java.lang.Thread.run(Thread.java:844)
```