### PR TITLE
Remove unused locale resource messages

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -2355,13 +2355,6 @@ view.href.table.cell.alert.risk.label.low    = Low
 view.href.table.cell.alert.risk.label.info   = Informational
 view.href.table.cell.alert.risk.label.undefined = Undefined
 
-# Locales specified in the config file array: view.locales
-view.locale.de_DE                           = Deutsch
-view.locale.en_GB                           = English
-view.locale.es_ES                           = Espa\u00F1gol
-view.locale.fr_FR                           = Fran\u00E7ais
-view.locale.pl_PL                           = Polski
-view.locale.pt_BR                           = Portugu\u00EAs
 view.options.label.advancedview             = Activate advanced view
 view.options.label.askonexit                = Ask for confirmation to save data on exit
 view.options.label.brkPanelView             = Show break buttons:


### PR DESCRIPTION
The resource messages with language names are no longer in use (the name
is "now" (1.3?) obtained from the Locale instance).