### PR TITLE
Validate translated vulnerabilities files

### DIFF
--- a/src/org/zaproxy/zap/model/VulnerabilitiesLoader.java
+++ b/src/org/zaproxy/zap/model/VulnerabilitiesLoader.java
@@ -116,7 +116,7 @@ public class VulnerabilitiesLoader {
 		return resourceBuilder.toString();
 	}
 	
-	private List<Vulnerability> loadVulnerabilitiesFile(Path file) {
+	List<Vulnerability> loadVulnerabilitiesFile(Path file) {
 
 		ZapXmlConfiguration config;
         try {
@@ -169,7 +169,7 @@ public class VulnerabilitiesLoader {
 	 * @return the list of resources files contained in the {@code directory}
 	 * @see LocaleUtils#createResourceFilesPattern(String, String)
 	 */
-	private List<String> getListOfVulnerabilitiesFiles() {
+	List<String> getListOfVulnerabilitiesFiles() {
 		final Pattern filePattern = LocaleUtils.createResourceFilesPattern(fileName, fileExtension);
 		final List<String> fileNames = new ArrayList<>();
 		try {

--- a/test/org/zaproxy/zap/model/ValidateTranslatedVulnerabilitiesFilesUnitTest.java
+++ b/test/org/zaproxy/zap/model/ValidateTranslatedVulnerabilitiesFilesUnitTest.java
@@ -1,0 +1,85 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2018 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.model;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.log4j.Logger;
+import org.apache.log4j.varia.NullAppender;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Validates that the translated vulnerabilities files have expected content (e.g. same number of vulnerabilities as the source
+ * file).
+ */
+public class ValidateTranslatedVulnerabilitiesFilesUnitTest {
+
+    private static final Path DIRECTORY = Paths.get("src/lang");
+    private static final String FILE_NAME = "vulnerabilities";
+    private static final String FILE_EXTENSION = ".xml";
+    private static final String SOURCE_FILE = FILE_NAME + FILE_EXTENSION;
+
+    private VulnerabilitiesLoader loader = new VulnerabilitiesLoader(DIRECTORY, FILE_NAME, FILE_EXTENSION);
+
+    @BeforeClass
+    public static void suppressLogging() {
+        Logger.getRootLogger().addAppender(new NullAppender());
+    }
+
+    @Test
+    public void shouldThrownExceptionIfDirectoryIsNull() {
+        // Given
+        Map<String, Vulnerability> mainVulns = loadFile(SOURCE_FILE);
+        List<String> translations = loader.getListOfVulnerabilitiesFiles();
+        translations.remove(SOURCE_FILE);
+        // When
+        for (String file : translations) {
+            Map<String, Vulnerability> vulns = loadFile(file);
+            // Then
+            assertThat(file, vulns.values(), hasSize(mainVulns.size()));
+            mainVulns.forEach((k, v) -> {
+                Vulnerability vuln = vulns.get(k);
+                assertThat("Missing " + k + " in " + file, vuln, is(notNullValue()));
+                assertThat(
+                        "Wrong number of references in " + file + " for " + k,
+                        vuln.getReferences(),
+                        hasSize(v.getReferences().size()));
+            });
+        }
+    }
+
+    private Map<String, Vulnerability> loadFile(String fileName) {
+        Map<String, Vulnerability> map = new HashMap<>();
+        for (Vulnerability vulnerability : loader.loadVulnerabilitiesFile(DIRECTORY.resolve(fileName))) {
+            map.put(vulnerability.getId(), vulnerability);
+        }
+        return map;
+    }
+}


### PR DESCRIPTION
Add a test to check that the translated vulnerabilities files have the
same number of vulnerabilities as the source file (to catch issues where
the ID of the vulnerability was incorrectly translated, e.g. #4315).
Relax visibility of some methods in VulnerabilitiesLoader to ease the
tests.