### PR TITLE
Be more defensive when instantiating add-on class

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnLoaderUtils.java
+++ b/src/org/zaproxy/zap/control/AddOnLoaderUtils.java
@@ -111,7 +111,7 @@ final class AddOnLoaderUtils {
             Constructor<T> c = (Constructor<T>) cls.getConstructor();
             T instance = c.newInstance();
             return instance;
-        } catch (Exception e) {
+        } catch (ExceptionInInitializerError | Exception e) {
             LOGGER.error("Failed to initialise: " + classname, e);
         }
         return null;


### PR DESCRIPTION
Change AddOnLoaderUtils to also catch ExceptionInInitializerError when
instantiating the add-on class, to prevent it from propagating and
breaking other ZAP extensions/functionalities.

Related to zaproxy/zap-extensions#1326.