### PR TITLE
Fix enums' name upper/lower case checks

### DIFF
--- a/src/org/zaproxy/zap/extension/api/ApiException.java
+++ b/src/org/zaproxy/zap/extension/api/ApiException.java
@@ -18,6 +18,7 @@
 package org.zaproxy.zap.extension.api;
 
 import java.io.StringWriter;
+import java.util.Locale;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -105,7 +106,7 @@ public class ApiException extends Exception {
 	}
 
     public ApiException(Type type, String detail, Throwable cause) {
-        super(type.name().toLowerCase(), cause);
+        super(type.name().toLowerCase(Locale.ROOT), cause);
         this.type = type;
         this.detail = detail;
     }

--- a/src/org/zaproxy/zap/extension/api/WebUI.java
+++ b/src/org/zaproxy/zap/extension/api/WebUI.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.commons.httpclient.URI;
 import org.parosproxy.paros.Constant;
@@ -291,7 +292,7 @@ public class WebUI {
 						sb.append("\" value=\"");
 						if (this.isDevTestNonce && RequestType.other.equals(reqType)) {
 							sb.append(api.getOneTimeNonce("/" + 
-									reqType.name().toUpperCase() + "/" + 
+									reqType.name().toUpperCase(Locale.ROOT) + "/" + 
 									impl.getPrefix() + "/" + 
 									reqType.name() + "/" + 
 									element.getName() + "/"));

--- a/src/org/zaproxy/zap/extension/ascan/AllCategoryTableModel.java
+++ b/src/org/zaproxy/zap/extension/ascan/AllCategoryTableModel.java
@@ -25,9 +25,11 @@
 // ZAP: 2014/05/20 Issue 377: Unfulfilled dependencies hang the active scan
 // ZAP: 2016/07/25 Change constructor's parameter to PluginFactory
 // ZAP: 2017/06/05 Take into account the enabled state of the plugin when showing the AlertThreshold of the category.
+// ZAP: 2018/01/30 Do not rely on default locale for upper/lower case conversions (when locale is not important).
 package org.zaproxy.zap.extension.ascan;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import javax.swing.table.DefaultTableModel;
@@ -114,7 +116,7 @@ public class AllCategoryTableModel extends DefaultTableModel {
 
     private String strToI18n(String str) {
         // I18n's threshold and strength enums
-        return Constant.messages.getString("ascan.policy.level." + str.toLowerCase());
+        return Constant.messages.getString("ascan.policy.level." + str.toLowerCase(Locale.ROOT));
     }
 
     private String i18nToStr(String str) {

--- a/src/org/zaproxy/zap/extension/ascan/CategoryTableModel.java
+++ b/src/org/zaproxy/zap/extension/ascan/CategoryTableModel.java
@@ -27,12 +27,14 @@
 // ZAP: 2014/11/19 Issue 1412: Manage scan policies
 // ZAP: 2016/04/04 Use StatusUI in scanners' dialogues
 // ZAP: 2017/06/05 Return AlertThreshold.OFF if the plugin is disabled.
+// ZAP: 2018/01/30 Do not rely on default locale for upper/lower case conversions (when locale is not important).
 
 package org.zaproxy.zap.extension.ascan;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import javax.swing.table.DefaultTableModel;
@@ -194,7 +196,7 @@ public class CategoryTableModel extends DefaultTableModel {
 
     private String strToI18n (String str) {
     	// I18n's threshold and strength enums
-    	return Constant.messages.getString("ascan.policy.level." + str.toLowerCase());
+    	return Constant.messages.getString("ascan.policy.level." + str.toLowerCase(Locale.ROOT));
     }
 
     private String i18nToStr (String str) {

--- a/src/org/zaproxy/zap/extension/ascan/PolicyAllCategoryPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/PolicyAllCategoryPanel.java
@@ -24,6 +24,7 @@
 // ZAP: 2016/04/04 Use StatusUI in scanners' dialogues
 // ZAP: 2016/07/25 Use new AllCategoryTableModel's constructor
 // ZAP: 2017/06/22 Focus the component that contains validation errors.
+// ZAP: 2018/01/30 Do not rely on default locale for upper/lower case conversions (when locale is not important).
 package org.zaproxy.zap.extension.ascan;
 
 import java.awt.GridBagConstraints;
@@ -36,6 +37,7 @@ import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.EventListener;
 import java.util.List;
+import java.util.Locale;
 
 import javax.swing.DefaultCellEditor;
 import javax.swing.DefaultComboBoxModel;
@@ -380,16 +382,16 @@ public class PolicyAllCategoryPanel extends AbstractParamPanel {
 
     private void setThreshold(AlertThreshold threshold) {
         getComboThreshold().setSelectedItem(
-        		Constant.messages.getString("ascan.options.level." + threshold.name().toLowerCase()));
+        		Constant.messages.getString("ascan.options.level." + threshold.name().toLowerCase(Locale.ROOT)));
         getThresholdNotes().setText(
-        		Constant.messages.getString("ascan.options.level." + threshold.name().toLowerCase() + ".label"));
+        		Constant.messages.getString("ascan.options.level." + threshold.name().toLowerCase(Locale.ROOT) + ".label"));
     }
     
     private void setStrength(AttackStrength strength) {
         getComboStrength().setSelectedItem(
-        		Constant.messages.getString("ascan.options.strength." + strength.name().toLowerCase()));
+        		Constant.messages.getString("ascan.options.strength." + strength.name().toLowerCase(Locale.ROOT)));
         getStrengthNotes().setText(
-        		Constant.messages.getString("ascan.options.strength." + strength.name().toLowerCase() + ".label"));
+        		Constant.messages.getString("ascan.options.strength." + strength.name().toLowerCase(Locale.ROOT) + ".label"));
     }
     
     /**
@@ -418,7 +420,7 @@ public class PolicyAllCategoryPanel extends AbstractParamPanel {
             JComboBox<String> jcb1 = new JComboBox<>();
             jcb1.addItem("");	// Always show a blank one for where they are not all the same
             for (AlertThreshold level : AlertThreshold.values()) {
-                jcb1.addItem(Constant.messages.getString("ascan.policy.level." + level.name().toLowerCase()));
+                jcb1.addItem(Constant.messages.getString("ascan.policy.level." + level.name().toLowerCase(Locale.ROOT)));
             }
             
             tableTest.getColumnModel().getColumn(1).setCellEditor(new DefaultCellEditor(jcb1));
@@ -426,7 +428,7 @@ public class PolicyAllCategoryPanel extends AbstractParamPanel {
             JComboBox<String> jcb2 = new JComboBox<>();
             jcb2.addItem("");	// Always show a blank one for where they are not all the same
             for (AttackStrength level : AttackStrength.values()) {
-                jcb2.addItem(Constant.messages.getString("ascan.policy.level." + level.name().toLowerCase()));
+                jcb2.addItem(Constant.messages.getString("ascan.policy.level." + level.name().toLowerCase(Locale.ROOT)));
             }
             
             tableTest.getColumnModel().getColumn(2).setCellEditor(new DefaultCellEditor(jcb2));

--- a/src/org/zaproxy/zap/extension/ascan/PolicyCategoryPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/PolicyCategoryPanel.java
@@ -22,6 +22,7 @@
 // ZAP: 2013/11/28 Issue 923: Allow individual rule thresholds and strengths to be set via GUI
 // ZAP: 2014/11/19 Issue 1412: Manage scan policies
 // ZAP: 2017/01/09 Remove method no longer needed.
+// ZAP: 2018/01/30 Do not rely on default locale for upper/lower case conversions (when locale is not important).
 
 package org.zaproxy.zap.extension.ascan;
 
@@ -29,6 +30,7 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import javax.swing.DefaultCellEditor;
 import javax.swing.JComboBox;
@@ -104,13 +106,13 @@ public class PolicyCategoryPanel extends AbstractParamPanel {
 	        }
 	        JComboBox<String> jcb1 = new JComboBox<>();
             for (AlertThreshold level : AlertThreshold.values()) {
-                jcb1.addItem(Constant.messages.getString("ascan.policy.level." + level.name().toLowerCase()));
+                jcb1.addItem(Constant.messages.getString("ascan.policy.level." + level.name().toLowerCase(Locale.ROOT)));
             }
             tableTest.getColumnModel().getColumn(1).setCellEditor(new DefaultCellEditor(jcb1));
 
 	        JComboBox<String> jcb2 = new JComboBox<>();
             for (AttackStrength level : AttackStrength.values()) {
-                jcb2.addItem(Constant.messages.getString("ascan.policy.level." + level.name().toLowerCase()));
+                jcb2.addItem(Constant.messages.getString("ascan.policy.level." + level.name().toLowerCase(Locale.ROOT)));
             }
             tableTest.getColumnModel().getColumn(2).setCellEditor(new DefaultCellEditor(jcb2));
 

--- a/src/org/zaproxy/zap/extension/ascan/ScanProgressItem.java
+++ b/src/org/zaproxy/zap/extension/ascan/ScanProgressItem.java
@@ -20,6 +20,8 @@
 package org.zaproxy.zap.extension.ascan;
 
 import java.util.Date;
+import java.util.Locale;
+
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.HostProcess;
 import org.parosproxy.paros.core.scanner.Plugin;
@@ -67,7 +69,7 @@ public class ScanProgressItem {
      * @return
      */
     public String getAttackStrenghtLabel() {
-        return Constant.messages.getString("ascan.policy.level." + plugin.getAttackStrength().name().toLowerCase());
+        return Constant.messages.getString("ascan.policy.level." + plugin.getAttackStrength().name().toLowerCase(Locale.ROOT));
     }
 
     /**

--- a/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanPanel.java
+++ b/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanPanel.java
@@ -26,6 +26,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import javax.swing.DefaultCellEditor;
 import javax.swing.JButton;
@@ -175,7 +176,7 @@ public class PolicyPassiveScanPanel extends AbstractParamPanel {
             
             JComboBox<String> jcb1 = new JComboBox<>();
             for (AlertThreshold level : AlertThreshold.values()) {
-                jcb1.addItem(Constant.messages.getString("ascan.policy.level." + level.name().toLowerCase()));
+                jcb1.addItem(Constant.messages.getString("ascan.policy.level." + level.name().toLowerCase(Locale.ROOT)));
             }
             
             tableTest.getColumnModel().getColumn(1).setCellEditor(new DefaultCellEditor(jcb1));

--- a/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanTableModel.java
+++ b/src/org/zaproxy/zap/extension/pscan/PolicyPassiveScanTableModel.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.pscan;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import javax.swing.table.DefaultTableModel;
@@ -176,7 +177,7 @@ public class PolicyPassiveScanTableModel extends DefaultTableModel {
         
     private String strToI18n(String str) {
         // I18n's threshold and strength enums
-        return Constant.messages.getString("ascan.policy.level." + str.toLowerCase());
+        return Constant.messages.getString("ascan.policy.level." + str.toLowerCase(Locale.ROOT));
     }
 
     private String i18nToStr(String str) {


### PR DESCRIPTION
Change enums' name conversions to use a neutral Locale when converting
the names to upper/lower case to avoid issues with languages that have
different characters for lower/upper cases.

Part of #4327 - ZAP relies on default locale when it shouldn't