### PR TITLE
Add JavaDoc to script interfaces

### DIFF
--- a/src/org/zaproxy/zap/extension/script/HttpSenderScript.java
+++ b/src/org/zaproxy/zap/extension/script/HttpSenderScript.java
@@ -23,9 +23,39 @@ import javax.script.ScriptException;
 
 import org.parosproxy.paros.network.HttpMessage;
 
+/**
+ * A script that is executed for each {@link HttpMessage HTTP message} sent by/through ZAP.
+ * <p>
+ * The IDs of the initiators are defined in the {@link org.parosproxy.paros.network.HttpSender HttpSender} class (for example,
+ * {@link org.parosproxy.paros.network.HttpSender#SPIDER_INITIATOR SPIDER_INITIATOR}).
+ * <p>
+ * <strong>Note:</strong> In the presence of more than one script or, internally, a
+ * {@link org.zaproxy.zap.network.HttpSenderListener HttpSenderListener} there are <i>no</i> guarantees that the (final)
+ * request/response is exactly the same as the one crafted by this script, as the following scripts/listeners may modify it.
+ *
+ * @since 2.4.1
+ */
 public interface HttpSenderScript {
 
+    /**
+     * Called before sending the request to the server.
+     * <p>
+     * Only the request should be modified.
+     *
+     * @param msg the HTTP message (request) being sent.
+     * @param initiator the ID of the initiator of the HTTP message being sent.
+     * @param helper the helper class that allows to send other HTTP messages.
+     * @throws ScriptException if an error occurred while executing the script.
+     */
     void sendingRequest(HttpMessage msg, int initiator, HttpSenderScriptHelper helper) throws ScriptException;
 
-    void responseReceived(HttpMessage msg, int initiator, HttpSenderScriptHelper helperr) throws ScriptException;
+    /**
+     * Called after receiving the response from the server (if any).
+     *
+     * @param msg the HTTP message (response) received.
+     * @param initiator the ID of the initiator of the HTTP message sent.
+     * @param helper the helper class that allows to send other HTTP messages.
+     * @throws ScriptException if an error occurred while executing the script.
+     */
+    void responseReceived(HttpMessage msg, int initiator, HttpSenderScriptHelper helper) throws ScriptException;
 }

--- a/src/org/zaproxy/zap/extension/script/ProxyScript.java
+++ b/src/org/zaproxy/zap/extension/script/ProxyScript.java
@@ -24,9 +24,44 @@ import javax.script.ScriptException;
 
 import org.parosproxy.paros.network.HttpMessage;
 
+/**
+ * A script that will be executed when a proxied request is ready to be forwarded to the server and when the response is ready
+ * to be forwarded to the client.
+ * <p>
+ * <strong>Note:</strong> In the presence of more than one script or listener (for example,
+ * {@link org.parosproxy.paros.core.proxy.ProxyListener ProxyListener} and {@link org.zaproxy.zap.network.HttpSenderListener
+ * HttpSenderListener}) there are <i>no</i> guarantees that the (final) request/response is exactly the same as the one crafted
+ * by this script, or, that the request/response is actually going to be forwarded, as the following scripts/listeners may
+ * modify it or drop it.
+ *
+ * @since 2.2.0
+ */
 public interface ProxyScript {
 
+	/**
+	 * Called when a request is received from the client.
+	 * <p>
+	 * Both the request and response of the HTTP message may be modified. If a response is set the request is <i>not</i>
+	 * forwarded to the server, thus preventing the request and overriding the response. If the return value is {@code true} the
+	 * request <i>may be</i> forwarded and the following scripts/listeners will be called, if the value is {@code false} the
+	 * request is dropped and no more scripts/listeners will be called.
+	 *
+	 * @param msg the HTTP message (request) being proxied/sent.
+	 * @return {@code true} if the request should be forwarded to the server, {@code false} otherwise.
+	 * @throws ScriptException if an error occurred while executing the script.
+	 */
 	boolean proxyRequest (HttpMessage msg) throws ScriptException;
 
+	/**
+	 * Called after receiving the response from a proxied request.
+	 * <p>
+	 * If the return value is {@code true} the response <i>may be</i> forwarded and the following scripts/listeners will be
+	 * called, if the value is {@code false} the response <i>will not</i> be forwarded and no more scripts/listeners will be
+	 * called.
+	 *
+	 * @param msg the HTTP message (response) received (or overridden by a script/listener).
+	 * @return {@code true} if the response should be forwarded to the client, {@code false} otherwise.
+	 * @throws ScriptException if an error occurred while executing the script.
+	 */
 	boolean proxyResponse (HttpMessage msg) throws ScriptException;
 }

--- a/src/org/zaproxy/zap/extension/script/TargetedScript.java
+++ b/src/org/zaproxy/zap/extension/script/TargetedScript.java
@@ -24,8 +24,19 @@ import javax.script.ScriptException;
 
 import org.parosproxy.paros.network.HttpMessage;
 
+/**
+ * A script that is executed on demand by the user for selected {@link HttpMessage HTTP message}(s).
+ *
+ * @since 2.2.0
+ */
 public interface TargetedScript {
 
+	/**
+	 * Called for each HTTP message selected by the user.
+	 * 
+	 * @param msg the HTTP message selected, never {@code null}.
+	 * @throws ScriptException if an error occurred while executing the script.
+	 */
 	void invokeWith(HttpMessage msg) throws ScriptException;
 
 }


### PR DESCRIPTION
Add JavaDoc to HttpSenderScript, ProxyScript, and TargetedScript.
Fix typo in a parameter name in HttpSenderScript.