### PR TITLE
Parse -z arg as command line in Docker scripts

### DIFF
--- a/build/docker/zap-api-scan.py
+++ b/build/docker/zap-api-scan.py
@@ -280,9 +280,7 @@ def main(argv):
                 params.append('-addoninstall')
                 params.append('pscanrulesAlpha')
 
-            if zap_options:
-                for zap_opt in zap_options.split(" "):
-                    params.append(zap_opt)
+            add_zap_options(params, zap_options)
 
             start_zap(port, params)
 
@@ -301,9 +299,7 @@ def main(argv):
         if (zap_alpha):
             params.extend(['-addoninstall', 'pscanrulesAlpha'])
 
-        if zap_options:
-            for zap_opt in zap_options.split(" "):
-                params.append(zap_opt)
+        add_zap_options(params, zap_options)
 
         try:
             cid = start_docker_zap('owasp/zap2docker-weekly', port, params, mount_dir)

--- a/build/docker/zap-baseline.py
+++ b/build/docker/zap-baseline.py
@@ -259,9 +259,7 @@ def main(argv):
                 params.append('-addoninstall')
                 params.append('pscanrulesAlpha')
 
-            if zap_options:
-                for zap_opt in zap_options.split(" "):
-                    params.append(zap_opt)
+            add_zap_options(params, zap_options)
 
             start_zap(port, params)
 
@@ -282,9 +280,7 @@ def main(argv):
         if (zap_alpha):
             params.extend(['-addoninstall', 'pscanrulesAlpha'])
 
-        if zap_options:
-            for zap_opt in zap_options.split(" "):
-                params.append(zap_opt)
+        add_zap_options(params, zap_options)
 
         try:
             cid = start_docker_zap('owasp/zap2docker-weekly', port, params, mount_dir)

--- a/build/docker/zap-full-scan.py
+++ b/build/docker/zap-full-scan.py
@@ -263,9 +263,7 @@ def main(argv):
                 params.append('-addoninstall')
                 params.append('pscanrulesAlpha')
 
-            if zap_options:
-                for zap_opt in zap_options.split(" "):
-                    params.append(zap_opt)
+            add_zap_options(params, zap_options)
 
             start_zap(port, params)
 
@@ -287,9 +285,7 @@ def main(argv):
         if (zap_alpha):
             params.extend(['-addoninstall', 'pscanrulesAlpha'])
 
-        if zap_options:
-            for zap_opt in zap_options.split(" "):
-                params.append(zap_opt)
+        add_zap_options(params, zap_options)
 
         try:
             cid = start_docker_zap('owasp/zap2docker-weekly', port, params, mount_dir)

--- a/build/docker/zap_common.py
+++ b/build/docker/zap_common.py
@@ -23,6 +23,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import socket
 import subprocess
 import sys
@@ -165,6 +166,12 @@ def cp_to_docker(cid, file, dir):
 
 def running_in_docker():
     return os.path.exists('/.dockerenv')
+
+
+def add_zap_options(params, zap_options):
+    if zap_options:
+        for zap_opt in shlex.split(zap_options):
+            params.append(zap_opt)
 
 
 def start_zap(port, extra_zap_params):


### PR DESCRIPTION
Change Docker scripts to parse the -z argument as a command line, to
properly handle quotation and escaped characters, thus passing the
expected arguments to ZAP.

Fix #4332 - Struggling to Pass Authentication Header that contains space
(for API ZAP scan)