### PR TITLE
Fix Issue 1161 - Manual Request SessionTracking Button Sync

### DIFF
--- a/src/org/parosproxy/paros/extension/manualrequest/ExtensionManualRequestEditor.java
+++ b/src/org/parosproxy/paros/extension/manualrequest/ExtensionManualRequestEditor.java
@@ -41,6 +41,7 @@
 // ZAP: 2016/06/20 Removed unnecessary/unused constructor
 // ZAP: 2017/04/07 Added getUIName()
 // ZAP: 2017/06/06 Clear dialogues in EDT.
+// ZAP: 2018/02/23 Issue 1161: Fix Session Tracking button sync
 
 package org.parosproxy.paros.extension.manualrequest;
 
@@ -65,6 +66,7 @@ import org.zaproxy.zap.extension.httppanel.Message;
 public class ExtensionManualRequestEditor extends ExtensionAdaptor implements SessionChangedListener {
 	
 	private Map<Class<? extends Message>, ManualRequestEditorDialog> dialogues = new HashMap<>();
+	private ManualHttpRequestEditorDialog httpSendEditorDialog;
 	
 	/**
 	 * Name of this extension.
@@ -87,7 +89,7 @@ public class ExtensionManualRequestEditor extends ExtensionAdaptor implements Se
         super.initView(view);
 
         // add default manual request editor
-        ManualRequestEditorDialog httpSendEditorDialog = new ManualHttpRequestEditorDialog(true, "manual", "ui.dialogs.manreq");
+        httpSendEditorDialog = new ManualHttpRequestEditorDialog(true, "manual", "ui.dialogs.manreq");
         httpSendEditorDialog.setTitle(Constant.messages.getString("manReq.dialog.title"));
         
         addManualSendEditor(httpSendEditorDialog);
@@ -139,6 +141,7 @@ public class ExtensionManualRequestEditor extends ExtensionAdaptor implements Se
 			}
 			
 			extensionHook.addSessionListener(this);
+			extensionHook.addOptionsChangedListener(httpSendEditorDialog);
 		}
 	}
 

--- a/src/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
+++ b/src/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
@@ -18,6 +18,7 @@
 package org.parosproxy.paros.extension.manualrequest.http.impl;
 
 import java.awt.EventQueue;
+import java.awt.event.ItemEvent;
 import java.io.IOException;
 import java.net.Socket;
 import java.net.UnknownHostException;
@@ -202,10 +203,6 @@ public class HttpPanelSender implements MessageSender {
             delegate.shutdown();
             delegate = null;
         }
-
-        final boolean isSessionTrackingEnabled = Model.getSingleton()
-                .getOptionsParam().getConnectionParam().isHttpStateEnabled();
-        getButtonUseTrackingSessionState().setEnabled(isSessionTrackingEnabled);
     }
 
     private HttpSender getDelegate() {
@@ -239,6 +236,7 @@ public class HttpPanelSender implements MessageSender {
                     .getResource("/resource/icon/fugue/cookie.png"))); // Cookie
             useTrackingSessionState.setToolTipText(Constant.messages
                     .getString("manReq.checkBox.useSession"));
+            useTrackingSessionState.addItemListener(e -> setUseTrackingSessionState(e.getStateChange() == ItemEvent.SELECTED));
         }
         return useTrackingSessionState;
     }
@@ -310,5 +308,16 @@ public class HttpPanelSender implements MessageSender {
         public URI getInvalidRedirection() {
             return invalidRedirection;
         }
+    }
+    
+    private void setUseTrackingSessionState(boolean shouldUseTrackingSessionState) {
+        if (delegate != null) {
+            delegate.setUseGlobalState(shouldUseTrackingSessionState);
+        }
+    }
+    
+    public void setButtonTrackingSessionStateEnabled(boolean enabled) {
+        getButtonUseTrackingSessionState().setEnabled(enabled);
+        getButtonUseTrackingSessionState().setSelected(enabled);
     }
 }

--- a/src/org/parosproxy/paros/extension/manualrequest/http/impl/ManualHttpRequestEditorDialog.java
+++ b/src/org/parosproxy/paros/extension/manualrequest/http/impl/ManualHttpRequestEditorDialog.java
@@ -52,9 +52,10 @@ import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.extension.OptionsChangedListener;
 import org.parosproxy.paros.extension.manualrequest.ManualRequestEditorDialog;
-import org.parosproxy.paros.extension.manualrequest.MessageSender;
 import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
@@ -68,7 +69,7 @@ import org.zaproxy.zap.extension.httppanel.Message;
 import org.zaproxy.zap.view.ZapMenuItem;
 
 
-public class ManualHttpRequestEditorDialog extends ManualRequestEditorDialog {
+public class ManualHttpRequestEditorDialog extends ManualRequestEditorDialog implements OptionsChangedListener {
 
 	private static final long serialVersionUID = -5830450800029295419L;
     private static final Logger logger = Logger.getLogger(ManualHttpRequestEditorDialog.class);
@@ -146,7 +147,7 @@ public class ManualHttpRequestEditorDialog extends ManualRequestEditorDialog {
 	}
 
 	@Override
-	protected MessageSender getMessageSender() {
+	protected HttpPanelSender getMessageSender() {
 		return sender;
 	}
 	
@@ -566,10 +567,15 @@ public class ManualHttpRequestEditorDialog extends ManualRequestEditorDialog {
 	}
 	
 	public void addPersistentConnectionListener(PersistentConnectionListener listener) {
-		((HttpPanelSender) getMessageSender()).addPersistentConnectionListener(listener);
+		getMessageSender().addPersistentConnectionListener(listener);
 	}
 
 	public void removePersistentConnectionListener(PersistentConnectionListener listener) {
-		((HttpPanelSender) getMessageSender()).removePersistentConnectionListener(listener);
+		getMessageSender().removePersistentConnectionListener(listener);
+	}
+	
+	@Override
+	public void optionsChanged(OptionsParam optionsParam) {
+		getMessageSender().setButtonTrackingSessionStateEnabled(optionsParam.getConnectionParam().isHttpStateEnabled());
 	}
 }

--- a/src/org/parosproxy/paros/network/HttpSender.java
+++ b/src/org/parosproxy/paros/network/HttpSender.java
@@ -70,6 +70,8 @@
 // ZAP: 2017/12/20 Apply socket connect timeout (Issue 4171).
 // ZAP: 2018/02/06 Make the lower case changes locale independent (Issue 4327).
 // ZAP: 2018/02/19 Added WEB_SOCKET_INITIATOR.
+// ZAP: 2018/02/23 Issue 1161: Allow to override the global session tracking setting
+//                 Fix Session Tracking button sync
 
 package org.parosproxy.paros.network;
 
@@ -213,11 +215,8 @@ public class HttpSender {
 		client.getParams().setParameter(HttpMethodDirector.PARAM_DEFAULT_USER_AGENT_CONNECT_REQUESTS, defaultUserAgent);
 		clientViaProxy.getParams().setParameter(HttpMethodDirector.PARAM_DEFAULT_USER_AGENT_CONNECT_REQUESTS, defaultUserAgent);
 
-		if (useGlobalState) {
-			checkState();
-		} else {
-			setClientsCookiePolicy(CookiePolicy.BROWSER_COMPATIBILITY);
-		}
+		setUseGlobalState(useGlobalState);
+
 	}
 
 	private void setClientsCookiePolicy(String policy) {
@@ -236,6 +235,16 @@ public class HttpSender {
 			setClientsCookiePolicy(CookiePolicy.BROWSER_COMPATIBILITY);
 		} else {
 			setClientsCookiePolicy(CookiePolicy.IGNORE_COOKIES);
+		}
+	}
+
+	public void setUseGlobalState(boolean enableGlobalState) {
+		if (enableGlobalState) {
+			checkState();
+		} else {
+			client.setState(new HttpState());
+			clientViaProxy.setState(new HttpState());
+			setClientsCookiePolicy(CookiePolicy.BROWSER_COMPATIBILITY);
 		}
 	}
 


### PR DESCRIPTION
Add overridden windowActivated method when initializing. Calls `getMessageSender().cleanup()` so that the state of the Session Tracking button is properly set to be the same as the current global config option setting.

Fixes zaproxy/zaproxy#1161