### PR TITLE
Allow to check if several techs are enabled

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/src/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -57,6 +57,7 @@
 // ZAP: 2017/10/31 Use ExtensionLoader.getExtension(Class).
 // ZAP: 2017/11/14 Notify completion in a finally block.
 // ZAP: 2017/12/29 Rely on HostProcess to validate the redirections.
+// ZAP: 2018/02/02 Add helper method to check if any of several techs is in scope.
 
 package org.parosproxy.paros.core.scanner;
 
@@ -900,9 +901,31 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
         this.delayInMs = delayInMs;
     }
 
+    /**
+     * @see #isAnyInScope(Tech...)
+     */
     @Override
     public boolean inScope(Tech tech) {
         return this.techSet.includes(tech);
+    }
+
+    /**
+     * Tells whether or not any of the given technologies is enabled for the scan.
+     * <p>
+     * Helper method to check if any of the related technologies is enabled before performing a test/scan. For example:
+     * <pre> {@code
+     * if (isAnyInScope(Tech.Linux, Tech.MacOS)) {
+     *     // Perform nix test...
+     * }}</pre>
+     * 
+     * @param techs the technologies that will be checked.
+     * @return {@code true} if any of the technologies is enabled for the scan, {@code false} otherwise.
+     * @since TODO add version
+     * @see #inScope(Tech)
+     * @see #targets(TechSet)
+     */
+    protected boolean isAnyInScope(Tech... techs) {
+        return this.techSet.includesAny(techs);
     }
 
     @Override

--- a/src/org/parosproxy/paros/core/scanner/Plugin.java
+++ b/src/org/parosproxy/paros/core/scanner/Plugin.java
@@ -296,7 +296,7 @@ public interface Plugin extends Runnable {
     /**
      * Tells whether or not the given technology is enabled for the scan.
      * <p>
-     * Helper method to check if a technology is enabled before performing the scan.
+     * Helper method to check if a technology is enabled before performing a test/scan.
      *
      * @param tech the technology that will be checked
      * @return {@code true} if the technology is enabled for the scan, {@code false} otherwise

--- a/src/org/zaproxy/zap/model/TechSet.java
+++ b/src/org/zaproxy/zap/model/TechSet.java
@@ -75,6 +75,26 @@ public class TechSet {
 			return this.includes(tech.getParent());
 		}
 	}
+
+	/**
+	 * Tells whether or not any of the given technologies is included.
+	 * 
+	 * @param techs the technologies that will be checked.
+	 * @return {@code true} if any of the technologies is included, {@code false} otherwise.
+	 * @since TODO add version
+	 * @see #includes(Tech)
+	 */
+	public boolean includesAny(Tech... techs) {
+		if (techs == null || techs.length == 0) {
+			return false;
+		}
+		for (Tech tech : techs) {
+			if (includes(tech)) {
+				return true;
+			}
+		}
+		return false;
+	}
 	
 	public TreeSet<Tech> getIncludeTech() {
 		TreeSet<Tech> copy = new TreeSet<>();


### PR DESCRIPTION
Change AbstractPlugin to allow to check if any of several techs are
enabled for the scan, to make it more straightforward when checking
several techs for the same test/scan.
Change TechSet to allow to check if any of several techs are included.
Tweak JavaDoc in Plugin.inScope to also mention tests.