### PR TITLE
Correct case checks in HTTP related classes

### DIFF
--- a/src/org/parosproxy/paros/network/HttpRequestHeader.java
+++ b/src/org/parosproxy/paros/network/HttpRequestHeader.java
@@ -46,6 +46,7 @@
 // ZAP: 2017/10/19 Skip parsing of empty Cookie headers.
 // ZAP: 2017/11/22 Address a NPE in isImage().
 // ZAP: 2018/01/10 Tweak how cookie header is reconstructed from HtmlParameter(s).
+// ZAP: 2018/02/06 Make the upper case changes locale independent (Issue 4327).
 
 package org.parosproxy.paros.network;
 
@@ -56,6 +57,7 @@ import java.net.URLEncoder;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.TreeSet;
 import java.util.Vector;
 import java.util.regex.Matcher;
@@ -166,7 +168,7 @@ public class HttpRequestHeader extends HttpHeader {
 
     public HttpRequestHeader(String method, URI uri, String version,
     		ConnectionParam params) throws HttpMalformedHeaderException {
-        this(method + " " + uri.toString() + " " + version.toUpperCase() + CRLF + CRLF);
+        this(method + " " + uri.toString() + " " + version.toUpperCase(Locale.ROOT) + CRLF + CRLF);
         
         try {
             setHeader(HOST, uri.getHost() + (uri.getPort() > 0 ? ":" + Integer.toString(uri.getPort()) : ""));
@@ -253,7 +255,7 @@ public class HttpRequestHeader extends HttpHeader {
      * @param method the new method, must not be {@code null}.
      */
     public void setMethod(String method) {
-        mMethod = method.toUpperCase();
+        mMethod = method.toUpperCase(Locale.ROOT);
     }
 
     /**
@@ -347,7 +349,7 @@ public class HttpRequestHeader extends HttpHeader {
      */
     @Override
     public void setVersion(String version) {
-        mVersion = version.toUpperCase();
+        mVersion = version.toUpperCase(Locale.ROOT);
     }
 
     /**

--- a/src/org/parosproxy/paros/network/HttpResponseHeader.java
+++ b/src/org/parosproxy/paros/network/HttpResponseHeader.java
@@ -32,6 +32,7 @@
 // ZAP: 2016/06/17 Remove redundant initialisations of instance variables
 // ZAP: 2017/03/21 Add method to check if response type is json (isJson())
 // ZAP: 2017/11/10 Allow to set the status code and reason.
+// ZAP: 2018/02/06 Make the lower/upper case changes locale independent (Issue 4327).
 
 package org.parosproxy.paros.network;
 
@@ -40,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.TreeSet;
 import java.util.Vector;
 import java.util.regex.Matcher;
@@ -101,7 +103,7 @@ public class HttpResponseHeader extends HttpHeader {
 	
     @Override
 	public void setVersion(String version) {
-		mVersion = version.toUpperCase();
+		mVersion = version.toUpperCase(Locale.ROOT);
 	}
 
     /**
@@ -206,84 +208,37 @@ public class HttpResponseHeader extends HttpHeader {
 
 	@Override
 	public boolean isImage() {
-		String contentType = getHeader(CONTENT_TYPE.toUpperCase());
-
-		if (contentType != null) {
-			if (contentType.toLowerCase().indexOf(_CONTENT_TYPE_IMAGE) > -1) {
-				return true;
-			}
-		}
-		return false;
+		return hasContentType(_CONTENT_TYPE_IMAGE);
 	}
 
 	@Override
 	public boolean isText() {
-		String contentType = getHeader(CONTENT_TYPE.toUpperCase());
-
-		if (contentType != null) {
-			if (contentType.toLowerCase().indexOf(_CONTENT_TYPE_TEXT) > -1) {
-				return true;
-			} else if (contentType.toLowerCase().indexOf(_CONTENT_TYPE_HTML) > -1) {
-				return true;
-			} else if (contentType.toLowerCase().indexOf(_CONTENT_TYPE_JAVASCRIPT) > -1) {
-				return true;
-			} else if (contentType.toLowerCase().indexOf(_CONTENT_TYPE_JSON) > -1) {
-				return true;
-			} else if (contentType.toLowerCase().indexOf(_CONTENT_TYPE_XML) > -1) { 
-				return true; 
-			}
-
-		}
-		return false;
+		return hasContentType(
+				_CONTENT_TYPE_TEXT,
+				_CONTENT_TYPE_HTML,
+				_CONTENT_TYPE_JAVASCRIPT,
+				_CONTENT_TYPE_JSON,
+				_CONTENT_TYPE_XML);
 	}
 	
 	public boolean isHtml() {
-		String contentType = getHeader(CONTENT_TYPE.toUpperCase());
-
-		if (contentType != null) {
-			if (contentType.toLowerCase().indexOf(_CONTENT_TYPE_HTML) > -1) {
-				return true;
-			}
-		}
-		return false;
+		return hasContentType(_CONTENT_TYPE_HTML);
 		
 	}
 	
-	// ZAP: Added method
 	public boolean isXml() {
-		String contentType = getHeader(CONTENT_TYPE.toUpperCase());
-
-		if (contentType != null) {
-			if (contentType.toLowerCase().indexOf(_CONTENT_TYPE_XML) > -1) {
-				return true;
-			}
-		}
-		return false;
+		return hasContentType(_CONTENT_TYPE_XML);
 		
 	}
 	
 	public boolean isJson() {
-		String contentType = getHeader(CONTENT_TYPE.toUpperCase());
-
-		if (contentType != null) {
-			if (contentType.toLowerCase().indexOf(_CONTENT_TYPE_JSON) > -1) {
-				return true;
-			}
-		}
-		return false;
+		return hasContentType(_CONTENT_TYPE_JSON);
 		
 	}
 
 	
 	public boolean isJavaScript() {
-		String contentType = getHeader(CONTENT_TYPE.toUpperCase());
-
-		if (contentType != null) {
-			if (contentType.toLowerCase().indexOf(_CONTENT_TYPE_JAVASCRIPT) > -1) {
-				return true;
-			}
-		}
-		return false;
+		return hasContentType(_CONTENT_TYPE_JAVASCRIPT);
 	}
 
 	public static boolean isStatusLine(String data) {

--- a/src/org/parosproxy/paros/network/HttpSender.java
+++ b/src/org/parosproxy/paros/network/HttpSender.java
@@ -68,6 +68,7 @@
 // ZAP: 2017/11/20 Add initiator constant for Token Generator requests.
 // ZAP: 2017/11/27 Use custom CookieSpec (ZapCookieSpec).
 // ZAP: 2017/12/20 Apply socket connect timeout (Issue 4171).
+// ZAP: 2018/02/06 Make the lower case changes locale independent (Issue 4327).
 
 package org.parosproxy.paros.network;
 
@@ -76,6 +77,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.httpclient.DefaultHttpMethodRetryHandler;
@@ -348,7 +350,7 @@ public class HttpSender {
 		if (connectionHeader == null) {
 			return false;
 		}
-		return connectionHeader.getValue().toLowerCase().contains("upgrade");
+		return connectionHeader.getValue().toLowerCase(Locale.ROOT).contains("upgrade");
 	}
 
 	public void shutdown() {


### PR DESCRIPTION
Change HttpHeader, HttpRequestHeader, HttpResponseHeader, and HttpSender
to do upper/lower case conversions with a neutral locale.
Refactor (extract methods to HttpHeader) the checks for Content-Type and
normalisation of header name and value.

Part of #4327 - ZAP relies on default locale when it shouldn't