### PR TITLE
Allow to send a message body with all methods

### DIFF
--- a/src/org/zaproxy/zap/ZapGetMethod.java
+++ b/src/org/zaproxy/zap/ZapGetMethod.java
@@ -27,6 +27,7 @@ import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpConnection;
 import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.HttpState;
+import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -41,7 +42,7 @@ import org.zaproxy.zap.network.ZapHttpParser;
  * Malformed HTTP response header lines are ignored.
  * </p>
  */
-public class ZapGetMethod extends GetMethod {
+public class ZapGetMethod extends EntityEnclosingMethod {
     private static final Log LOG = LogFactory.getLog(ZapGetMethod.class);
     
     /**
@@ -56,6 +57,8 @@ public class ZapGetMethod extends GetMethod {
 	 */
 	private InputStream inputStream;
     
+	private boolean followRedirects = true;
+
 	/**
 	 * Constructor.
 	 */
@@ -70,6 +73,21 @@ public class ZapGetMethod extends GetMethod {
 	 */
 	public ZapGetMethod(String uri) {
 		super(uri);
+	}
+
+	@Override
+	public String getName() {
+		return "GET";
+	}
+
+	@Override
+	public void setFollowRedirects(boolean followRedirects) {
+		this.followRedirects = followRedirects;
+	}
+
+	@Override
+	public boolean getFollowRedirects() {
+		return followRedirects;
 	}
 
 	/**

--- a/src/org/zaproxy/zap/network/ZapOptionsMethod.java
+++ b/src/org/zaproxy/zap/network/ZapOptionsMethod.java
@@ -25,6 +25,7 @@ import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpConnection;
 import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.HttpState;
+import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
 import org.apache.commons.httpclient.methods.OptionsMethod;
 
 /**
@@ -32,7 +33,7 @@ import org.apache.commons.httpclient.methods.OptionsMethod;
  * 
  * @see OptionsMethod
  */
-public class ZapOptionsMethod extends OptionsMethod {
+public class ZapOptionsMethod extends EntityEnclosingMethod {
 
     public ZapOptionsMethod() {
         super();
@@ -40,6 +41,11 @@ public class ZapOptionsMethod extends OptionsMethod {
 
     public ZapOptionsMethod(String uri) {
         super(uri);
+    }
+
+    @Override
+    public String getName() {
+        return "OPTIONS";
     }
 
     /**

--- a/src/org/zaproxy/zap/network/ZapTraceMethod.java
+++ b/src/org/zaproxy/zap/network/ZapTraceMethod.java
@@ -25,6 +25,7 @@ import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpConnection;
 import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.HttpState;
+import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
 import org.apache.commons.httpclient.methods.TraceMethod;
 
 /**
@@ -32,10 +33,15 @@ import org.apache.commons.httpclient.methods.TraceMethod;
  * 
  * @see TraceMethod
  */
-public class ZapTraceMethod extends TraceMethod {
+public class ZapTraceMethod extends EntityEnclosingMethod {
 
     public ZapTraceMethod(String uri) {
         super(uri);
+    }
+
+    @Override
+    public String getName() {
+        return "TRACE";
     }
 
     /**


### PR DESCRIPTION
Change ZapGetMethod, ZapHeadMethod, ZapOptionsMethod, and ZapTraceMethod
to extend EntityEnclosingMethod so that they include a message body. All
other methods already allow to include a message body.