### PR TITLE
Do not submit unused parameters in API Web UI

### DIFF
--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -204,7 +204,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 	private static final String PARAM_FILE_PATH = "filePath";
 
 	/* Update the version whenever the script is changed (once per release) */
-	protected static final int API_SCRIPT_VERSION = 1;
+	protected static final int API_SCRIPT_VERSION = 2;
 	private static final String API_SCRIPT = 
 			"function submitScript() {\n" +
 			"  var button=document.getElementById('button');\n" +
@@ -221,9 +221,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 			"  var url = '/' + format + '/' + component + '/' + type + '/' + name + '/'\n" +
 			"  var form=document.getElementById('zapform');\n" +
 			"  form.action = url;\n" +
-			"  if (form.elements[\"formMethod\"]) {\n" +
-			"    form.method = form.elements[\"formMethod\"].value;\n" +
-			"  }\n" +
+			"  form.method = document.getElementById('formMethod').value;\n" +
 			"  form.submit();\n" +
 			"}\n" +
 			"document.addEventListener('DOMContentLoaded', function () {\n" +

--- a/src/org/zaproxy/zap/extension/api/WebUI.java
+++ b/src/org/zaproxy/zap/extension/api/WebUI.java
@@ -258,7 +258,7 @@ public class WebUI {
 					sb.append("<tr><td>");
 					sb.append(Constant.messages.getString("api.html.format"));
 					sb.append("</td><td>\n");
-					sb.append("<select id=\"zapapiformat\" name=\"zapapiformat\">\n");
+					sb.append("<select id=\"zapapiformat\">\n");
 					sb.append("<option value=\"JSON\">JSON</option>\n");
 					if (getOptionsParamApi().isEnableJSONP()) {
 						sb.append("<option value=\"JSONP\">JSONP</option>\n");
@@ -310,7 +310,7 @@ public class WebUI {
 					sb.append(Constant.messages.getString("api.html.formMethod"));
 					sb.append("</td>");
 					sb.append("<td>");
-					sb.append("<select name=\"formMethod\">\n");
+					sb.append("<select id=\"formMethod\">\n");
 					sb.append("<option value=\"GET\" selected>GET</option>\n");
 					sb.append("<option value=\"POST\">POST</option>\n");
 					sb.append("</select>\n");


### PR DESCRIPTION
Change the CoreAPI and WebUI to not submit the fields "zapapiformat" and
"formMethod", those are not necessary for the API. (Avoids polluting the
API requests, which end up being used as is in API clients.)