### PR TITLE
Address deprecation in driver/cert related classes

### DIFF
--- a/src/ch/csnc/extension/ui/DriverTableModel.java
+++ b/src/ch/csnc/extension/ui/DriverTableModel.java
@@ -28,15 +28,13 @@
 
 package ch.csnc.extension.ui;
 
-import java.util.Observable;
-import java.util.Observer;
 import java.util.Vector;
 
 import javax.swing.table.AbstractTableModel;
 
 import ch.csnc.extension.util.DriverConfiguration;
 
-public class DriverTableModel extends AbstractTableModel implements Observer {
+public class DriverTableModel extends AbstractTableModel {
 
 	private static final long serialVersionUID = -9114670362713975727L;
 
@@ -49,7 +47,7 @@ public class DriverTableModel extends AbstractTableModel implements Observer {
 
 	public DriverTableModel(DriverConfiguration driverConfig){
 		this.driverConfig = driverConfig;
-		driverConfig.addObserver(this);
+		this.driverConfig.addChangeListener(e -> fireTableDataChanged());
 
 		names = driverConfig.getNames();
 		paths = driverConfig.getPaths();
@@ -149,11 +147,6 @@ public class DriverTableModel extends AbstractTableModel implements Observer {
 		else {
 			throw new IllegalArgumentException("Invalid column number: " + columnNumber);
 		}
-	}
-
-	@Override
-	public void update(Observable arg0, Object arg1) {
-		fireTableDataChanged();
 	}
 
 }

--- a/src/ch/csnc/extension/util/DriverConfiguration.java
+++ b/src/ch/csnc/extension/util/DriverConfiguration.java
@@ -34,10 +34,12 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Observable;
 import java.util.Vector;
 
 import javax.swing.JOptionPane;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.EventListenerList;
 
 import org.apache.log4j.Logger;
 import org.jdom.Document;
@@ -46,7 +48,7 @@ import org.jdom.JDOMException;
 import org.jdom.input.SAXBuilder;
 import org.jdom.output.XMLOutputter;
 
-public class DriverConfiguration extends Observable {
+public class DriverConfiguration {
 	private File file = null;
 
 	private Vector<String> names;
@@ -55,6 +57,9 @@ public class DriverConfiguration extends Observable {
 	private Vector<Integer> slotListIndexes;
 
 	private final Logger logger = Logger.getLogger(this.getClass());
+
+	private EventListenerList eventListeners = new EventListenerList();
+	private ChangeEvent changeEvent;
 
 	public DriverConfiguration(File file) {
 		this.file = file;
@@ -160,8 +165,20 @@ public class DriverConfiguration extends Observable {
 					JOptionPane.ERROR_MESSAGE);
 			logger.error(e.getMessage(), e);
 		}
-		setChanged();
-		notifyObservers();
+		
+		fireStateChanged();
+	}
+
+	private void fireStateChanged() {
+		Object[] listeners = eventListeners.getListenerList();
+		for (int i = listeners.length - 2; i >= 0; i -= 2) {
+			if (listeners[i] == ChangeListener.class) {
+				if (changeEvent == null) {
+					changeEvent = new ChangeEvent(this);
+				}
+				((ChangeListener) listeners[i + 1]).stateChanged(changeEvent);
+			}
+		}
 	}
 
 	public Vector<String> getNames() {
@@ -196,4 +213,11 @@ public class DriverConfiguration extends Observable {
 		this.slotListIndexes = slotListIndexes;
 	}
 
+	public void addChangeListener(ChangeListener listener) {
+		eventListeners.add(ChangeListener.class, listener);
+	}
+
+	public void removeChangeListener(ChangeListener listener) {
+		eventListeners.remove(ChangeListener.class, listener);
+	}
 }

--- a/src/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
@@ -44,8 +44,6 @@ import java.net.URI;
 import java.security.KeyStoreException;
 import java.security.ProviderException;
 import java.security.cert.Certificate;
-import java.util.Observable;
-import java.util.Observer;
 
 import javax.swing.DefaultListModel;
 import javax.swing.JDialog;
@@ -74,7 +72,7 @@ import ch.csnc.extension.ui.CertificateView;
 import ch.csnc.extension.ui.DriversView;
 import ch.csnc.extension.util.DriverConfiguration;
 
-public class OptionsCertificatePanel extends AbstractParamPanel implements Observer{
+public class OptionsCertificatePanel extends AbstractParamPanel {
 
 	private static final long serialVersionUID = 4350957038174673492L;
 	
@@ -152,7 +150,7 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 
 		driverConfig = new DriverConfiguration(new File(Constant.getZapInstall(), "xml/drivers.xml"));
 		updateDriverComboBox();
-		driverConfig.addObserver(this);
+		driverConfig.addChangeListener(e -> updateDriverComboBox());
 
 		Certificate cert =contextManager.getDefaultCertificate();
 		if(cert!=null) {
@@ -1002,12 +1000,6 @@ public class OptionsCertificatePanel extends AbstractParamPanel implements Obser
 		certParam.setEnableCertificate(useClientCertificateCheckBox.isSelected());
 
 		certParam.setAllowUnsafeSslRenegotiation(enableUnsafeSSLRenegotiationCheckBox.isSelected());
-	}
-
-
-	@Override
-	public void update(Observable arg0, Object arg1) {
-		updateDriverComboBox();
 	}
 
 	@Override


### PR DESCRIPTION
Change DriverConfiguration to use ChangeListener to notify of state
changes, instead of extending the Observable class.
Change DriverTableModel and OptionsCertificatePanel to no longer
implement Observer interface, instead listen for changes.
The Observer interface and Observable class are deprecated in Java 9.

Part of #2602 - Java 9