### PR TITLE
Remove custom vectors' highlights when cleared

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
+++ b/src/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
@@ -162,6 +162,7 @@ public class CustomScanDialog extends StandardFieldsDialog {
 
         this.removeAllFields();
         this.injectionPointModel.clear();
+        getRequestField().getHighlighter().removeAllHighlights();
         this.headerLength = -1;
         this.urlPathStart = -1;
 


### PR DESCRIPTION
Change CustomScanDialog to remove the highlights when the custom vectors
are cleared.