### PR TITLE
Allow to snapshot with a name through the API

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -974,6 +974,7 @@ core.api.action.saveSession = Saves the session with the name supplied, optional
 core.api.action.sendRequest = Sends the HTTP request, optionally following redirections. Returns the request sent and response received and followed redirections, if any. The Mode is enforced when sending the request (and following redirections), custom manual requests are not allowed in 'Safe' mode nor in 'Protected' mode if out of scope.
 core.api.action.setMode = Sets the mode, which may be one of [safe, protect, standard, attack]
 core.api.action.setOptionDnsTtlSuccessfulQueries = Sets the TTL (in seconds) of successful DNS queries (applies after ZAP restart).
+core.api.action.snapshotSession = Snapshots the session, optionally with the given name, and overwriting existing files. If no name is specified the name of the current session with a timestamp appended is used. If a relative path is specified it will be resolved against the "session" directory in ZAP "home" dir.
 core.api.action.shutdown = Shuts down ZAP
 core.api.action.addProxyChainExcludedDomain = Adds a domain to be excluded from the outgoing proxy, using the specified value. Optionally sets if the new entry is enabled (default, true) and whether or not the new value is specified as a regex (default, false).
 core.api.action.modifyProxyChainExcludedDomain = Modifies a domain excluded from the outgoing proxy. Allows to modify the value, if enabled or if a regex. The domain is selected with its index, which can be obtained with the view proxyChainExcludedDomains.


### PR DESCRIPTION
Change CoreAPI to allow to specify a name for session snapshot, also, if
it should overwrite existing files.
Add a description to the action in Messages.properties file.

Fix #4365 - Allow to specify a name for session snapshot through the API