### PR TITLE
Normalise state of Technology tab in ascan dialog

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
+++ b/src/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
@@ -73,6 +73,7 @@ import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.StructuralNode;
 import org.zaproxy.zap.model.StructuralSiteNode;
 import org.zaproxy.zap.model.Target;
+import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.users.User;
 import org.zaproxy.zap.utils.ZapTextArea;
 import org.zaproxy.zap.view.LayoutHelper;
@@ -122,6 +123,7 @@ public class CustomScanDialog extends StandardFieldsDialog {
     private final JLabel customPanelStatus = new JLabel();
     private JCheckBox disableNonCustomVectors = null;
     private TechnologyTreePanel techTree;
+    private TechSet techTreeState;
     private String scanPolicyName;
     private ScanPolicy scanPolicy = null;
     private OptionsVariantPanel variantPanel = null;
@@ -231,6 +233,8 @@ public class CustomScanDialog extends StandardFieldsDialog {
 
         // Technology panel
         this.setCustomTabPanel(3, getTechPanel());
+
+        setTechSet(techTreeState);
 
         // Policy panel
         policyPanel.resetAndSetPolicy(scanPolicy.getName());
@@ -405,11 +409,16 @@ public class CustomScanDialog extends StandardFieldsDialog {
     private void setTech() {
         Context context = this.getSelectedContext();
 
-        if (context != null) {
-            techTree.setTechSet(context.getTechSet());
+        setTechSet(context != null ? context.getTechSet() : null);
+    }
+
+    private void setTechSet(TechSet techSet) {
+        if (techSet != null) {
+            techTree.setTechSet(techSet);
         } else {
             techTree.reset();
         }
+        techTreeState = techSet;
     }
 
     private ZapTextArea getRequestField() {
@@ -690,6 +699,7 @@ public class CustomScanDialog extends StandardFieldsDialog {
 
     private void reset(boolean refreshUi) {
         scannerParam = (ScannerParam) extension.getScannerParam().clone();
+        techTreeState = null;
 
         if (refreshUi) {
             init(target);
@@ -725,6 +735,8 @@ public class CustomScanDialog extends StandardFieldsDialog {
     @Override
     public void save() {
         List<Object> contextSpecificObjects = new ArrayList<Object>();
+
+        techTreeState = getTechTree().getTechSet();
 
         if (!this.getBoolValue(FIELD_ADVANCED)) {
             contextSpecificObjects.add(scanPolicy);
@@ -781,7 +793,7 @@ public class CustomScanDialog extends StandardFieldsDialog {
 
 
             contextSpecificObjects.add(scannerParam);
-            contextSpecificObjects.add(getTechTree().getTechSet());
+            contextSpecificObjects.add(techTreeState);
             
             if (this.customPanels != null) {
             	for (CustomScanPanel customPanel : this.customPanels) {


### PR DESCRIPTION
Change CustomScanDialog to have the Technology tab behave like Input
Vectors tab, if the dialogue is cancelled the changes done in the tab
are reverted to a previous state, only if the scan is started are the
changes kept in place.

Part of #3538 - Active Scan Advanced Options Tab Consistency