### PR TITLE
Fix Issue 4391 - Include MultipartFormPost Params on Params Tab

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1808,6 +1808,7 @@ params.type.cookie			= Cookie
 params.type.form			= FORM
 params.type.url				= URL
 params.type.header          = Header
+params.type.multipart = Multipart
 
 paste.desc        = Provides a right click option to paste text from the clipboard
 paste.paste.popup = Paste

--- a/src/org/parosproxy/paros/network/HtmlParameter.java
+++ b/src/org/parosproxy/paros/network/HtmlParameter.java
@@ -25,7 +25,7 @@ import java.util.Set;
 
 public class HtmlParameter implements Comparable<HtmlParameter> {
 	public enum Type {
-		cookie, form, url, header
+		cookie, form, url, header, multipart
 	};
 
 	public enum Flags {

--- a/src/org/zaproxy/zap/extension/params/ExtensionParams.java
+++ b/src/org/zaproxy/zap/extension/params/ExtensionParams.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Pattern;
 
 import javax.swing.tree.TreeNode;
 
@@ -38,6 +39,8 @@ import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.control.Control.Mode;
+import org.parosproxy.paros.core.scanner.NameValuePair;
+import org.parosproxy.paros.core.scanner.VariantMultipartFormParameters;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.db.RecordParam;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
@@ -305,6 +308,16 @@ public class ExtensionParams extends ExtensionAdaptor
 			persist(sps.addParam(site, param, msg));
 		}
 		
+		VariantMultipartFormParameters params2 = new VariantMultipartFormParameters();
+		params2.setMessage(msg);
+		for (NameValuePair nvp : params2.getParamList()) {
+			if (nvp.getType() == NameValuePair.TYPE_MULTIPART_DATA_PARAM
+					|| nvp.getType() == NameValuePair.TYPE_MULTIPART_DATA_FILE_NAME) {
+				persist(sps.addParam(site, new HtmlParameter(HtmlParameter.Type.multipart, nvp.getName(), nvp.getValue()),
+						msg));
+			}
+		}
+		
 		return true;
 	}
 	
@@ -406,14 +419,17 @@ public class ExtensionParams extends ExtensionAdaptor
 
 			if (extSearch != null) {
 				if (HtmlParameter.Type.url.equals(item.getType())) {
-					extSearch.search("[?&]" + item.getName() + "=.*", ExtensionSearch.Type.URL, true, false);
+					extSearch.search("[?&]" + Pattern.quote(item.getName()) + "=.*", ExtensionSearch.Type.URL, true, false);
 				} else if (HtmlParameter.Type.cookie.equals(item.getType())) {
-						extSearch.search(/*".*" + */item.getName() + "=.*", ExtensionSearch.Type.Header, true, false);
+						extSearch.search(Pattern.quote(item.getName()) + "=.*", ExtensionSearch.Type.Header, true, false);
 				} else if (HtmlParameter.Type.header.equals(item.getType())) {
-					extSearch.search(item.getName() + ":.*", ExtensionSearch.Type.Header, true, false);
+					extSearch.search(Pattern.quote(item.getName()) + ":.*", ExtensionSearch.Type.Header, true, false);
+				} else if (HtmlParameter.Type.multipart.equals(item.getType())) {
+					extSearch.search("(?i)\\s*content-disposition\\s*:.*\\s+name\\s*\\=?\\s*\\\"?"
+							+ Pattern.quote(item.getName()), ExtensionSearch.Type.Request, true, false);
 				} else {
 					// FORM
-					extSearch.search(/*".*" + */item.getName() + "=.*", ExtensionSearch.Type.Request, true, false);
+					extSearch.search(Pattern.quote(item.getName()) + "=.*", ExtensionSearch.Type.Request, true, false);
 				}
 			}
 		}

--- a/src/org/zaproxy/zap/extension/params/SiteParameters.java
+++ b/src/org/zaproxy/zap/extension/params/SiteParameters.java
@@ -40,6 +40,7 @@ public class SiteParameters {
 	private Map<String, HtmlParameterStats> urlParams = new HashMap<>();
 	private Map<String, HtmlParameterStats> formParams = new HashMap<>();
 	private Map<String, HtmlParameterStats> headerParams = new HashMap<>();
+	private Map<String, HtmlParameterStats> multipartParams = new HashMap<>();
 
 	public SiteParameters(ExtensionParams extension, String site) {
 		this.extension = extension;
@@ -63,7 +64,7 @@ public class SiteParameters {
 	 * @since 2.5.0
 	 */
 	public boolean hasParams() {
-		return !cookieParams.isEmpty() || !urlParams.isEmpty() || !formParams.isEmpty() || !headerParams.isEmpty();
+		return !cookieParams.isEmpty() || !urlParams.isEmpty() || !formParams.isEmpty() || !headerParams.isEmpty() || !multipartParams.isEmpty();
 	}
 
 	public HtmlParameterStats getParam(HtmlParameter.Type type, String name) {
@@ -76,6 +77,8 @@ public class SiteParameters {
 			return formParams.get(name);
 		case header:
 			return headerParams.get(name);
+		case multipart:
+			return multipartParams.get(name);
 		}
 		return null;
 	}
@@ -95,6 +98,9 @@ public class SiteParameters {
 		case header:
 			params.addAll(this.headerParams.values());
 			break;
+		case multipart:
+			params.addAll(this.multipartParams.values());
+			break;
 		}
 		return params;
 	}
@@ -105,6 +111,7 @@ public class SiteParameters {
 		params.addAll(this.urlParams.values());
 		params.addAll(this.formParams.values());
 		params.addAll(this.headerParams.values());
+		params.addAll(this.multipartParams.values());
 		return params;
 	}
 
@@ -124,6 +131,9 @@ public class SiteParameters {
 			break;
 		case header:
 			params = headerParams;
+			break;
+		case multipart:
+			params = multipartParams;
 			break;
 		}
 
@@ -185,6 +195,9 @@ public class SiteParameters {
 			break;
 		case header:
 			params = headerParams;
+			break;
+		case multipart:
+			params = multipartParams;
 			break;
 		}
 		// These should all be new


### PR DESCRIPTION
Update the Params Extension to include multipart/form-data parameters. The "value" for file parameters is the filename. Leverage `Pattern.quote()` for existing search functionality. Remove inline block comments.

Fixes zaproxy/zaproxy#4391