### PR TITLE
Allow to configure the irrelevant parameters for the Spider

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/OptionsSpiderPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/OptionsSpiderPanel.java
@@ -34,6 +34,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSlider;
+import javax.swing.ScrollPaneConstants;
 import javax.swing.SortOrder;
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
@@ -46,6 +47,7 @@ import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.view.AbstractParamPanel;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.ZapNumberSpinner;
+import org.zaproxy.zap.utils.ZapTextArea;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTablePanel;
 import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.PositiveValuesSlider;
@@ -83,6 +85,7 @@ public class OptionsSpiderPanel extends AbstractParamPanel {
     private JCheckBox chkAcceptCookies;
     private DomainsAlwaysInScopeMultipleOptionsPanel domainsAlwaysInScopePanel;
     private DomainsAlwaysInScopeTableModel domainsAlwaysInScopeTableModel;
+    private ZapTextArea irrelevantUrlParameters;
 
     private JComboBox<org.zaproxy.zap.spider.SpiderParam.HandleParametersOption> handleParameters =
             null;
@@ -189,6 +192,20 @@ public class OptionsSpiderPanel extends AbstractParamPanel {
             innerPanel.add(getChkParseGit(), gbc);
             innerPanel.add(getHandleODataSpecificParameters(), gbc);
 
+            ZapTextArea irrelevantUrlParameters = getIrrelevantUrlParameters();
+            JLabel label =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "spider.options.label.irrelevantUrlParameters"));
+            label.setLabelFor(irrelevantUrlParameters);
+            JScrollPane irrelevantUrlParametersScrollPane = new JScrollPane();
+            irrelevantUrlParametersScrollPane.setVerticalScrollBarPolicy(
+                    ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+            irrelevantUrlParametersScrollPane.setViewportView(irrelevantUrlParameters);
+
+            innerPanel.add(label, gbc);
+            innerPanel.add(irrelevantUrlParametersScrollPane, gbc);
+
             JScrollPane scrollPane = new JScrollPane(innerPanel);
             scrollPane.setBorder(BorderFactory.createEmptyBorder());
 
@@ -223,6 +240,8 @@ public class OptionsSpiderPanel extends AbstractParamPanel {
         getChkParseGit().setSelected(param.isParseGit());
         getComboHandleParameters().setSelectedItem(param.getHandleParameters());
         getHandleODataSpecificParameters().setSelected(param.isHandleODataParametersVisited());
+        getIrrelevantUrlParameters().setText(param.getIrrelevantUrlParametersAsString());
+        getIrrelevantUrlParameters().discardAllEdits();
     }
 
     @Override
@@ -252,6 +271,7 @@ public class OptionsSpiderPanel extends AbstractParamPanel {
                 (org.zaproxy.zap.spider.SpiderParam.HandleParametersOption)
                         getComboHandleParameters().getSelectedItem());
         param.setHandleODataParametersVisited(getHandleODataSpecificParameters().isSelected());
+        param.setIrrelevantUrlParameters(getIrrelevantUrlParameters().getText());
     }
 
     /**
@@ -486,6 +506,14 @@ public class OptionsSpiderPanel extends AbstractParamPanel {
             domainsAlwaysInScopeTableModel = new DomainsAlwaysInScopeTableModel();
         }
         return domainsAlwaysInScopeTableModel;
+    }
+
+    private ZapTextArea getIrrelevantUrlParameters() {
+        if (irrelevantUrlParameters == null) {
+            irrelevantUrlParameters = new ZapTextArea();
+            irrelevantUrlParameters.setLineWrap(true);
+        }
+        return irrelevantUrlParameters;
     }
 
     /** A renderer for properly displaying the name of the HandleParametersOptions in a ComboBox. */

--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderDialog.java
@@ -68,6 +68,8 @@ public class SpiderDialog extends StandardFieldsDialog {
     private static final String FIELD_PARSE_SVN = "spider.custom.label.parseSvn";
     private static final String FIELD_PARSE_GIT = "spider.custom.label.parseGit";
     private static final String FIELD_HANDLE_ODATA = "spider.custom.label.handleOdata";
+    private static final String FIELD_IRRELEVANT_URL_PARAMETERS =
+            "spider.custom.label.irrelevantUrlParameters";
 
     private static Logger logger = LogManager.getLogger(SpiderDialog.class);
 
@@ -146,6 +148,10 @@ public class SpiderDialog extends StandardFieldsDialog {
         this.addCheckBoxField(1, FIELD_PARSE_GIT, getSpiderParam().isParseGit());
         this.addCheckBoxField(
                 1, FIELD_HANDLE_ODATA, getSpiderParam().isHandleODataParametersVisited());
+        this.addMultilineField(
+                1,
+                FIELD_IRRELEVANT_URL_PARAMETERS,
+                getSpiderParam().getIrrelevantUrlParametersAsString());
         this.addPadding(1);
 
         if (!getBoolValue(FIELD_PROCESS_FORMS)) {
@@ -339,6 +345,8 @@ public class SpiderDialog extends StandardFieldsDialog {
             spiderParam.setParseGit(this.getBoolValue(FIELD_PARSE_GIT));
             spiderParam.setHandleODataParametersVisited(this.getBoolValue(FIELD_HANDLE_ODATA));
             spiderParam.setThreadCount(extension.getSpiderParam().getThreadCount());
+            spiderParam.setIrrelevantUrlParameters(
+                    this.getStringValue(FIELD_IRRELEVANT_URL_PARAMETERS));
 
             contextSpecificObjects.add(spiderParam);
         }

--- a/zap/src/main/java/org/zaproxy/zap/spider/SpiderController.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/SpiderController.java
@@ -124,11 +124,11 @@ public class SpiderController implements org.zaproxy.zap.spider.parser.SpiderPar
         }
 
         // Redirect requests parser
-        parser = new org.zaproxy.zap.spider.parser.SpiderRedirectParser();
+        parser = new org.zaproxy.zap.spider.parser.SpiderRedirectParser(spider.getSpiderParam());
         parsers.add(parser);
 
         // HTTP Header parser
-        parser = new org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser();
+        parser = new org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser(spider.getSpiderParam());
         parsers.add(parser);
 
         // Simple HTML parser
@@ -143,11 +143,11 @@ public class SpiderController implements org.zaproxy.zap.spider.parser.SpiderPar
         Config.CurrentCompatibilityMode.setFormFieldNameCaseInsensitive(false);
 
         // Prepare the parsers for OData ATOM files
-        parser = new org.zaproxy.zap.spider.parser.SpiderODataAtomParser();
+        parser = new org.zaproxy.zap.spider.parser.SpiderODataAtomParser(spider.getSpiderParam());
         this.parsers.add(parser);
 
         // Prepare the parsers for simple non-HTML files
-        parser = new org.zaproxy.zap.spider.parser.SpiderTextParser();
+        parser = new org.zaproxy.zap.spider.parser.SpiderTextParser(spider.getSpiderParam());
         this.parsers.add(parser);
 
         this.parsersUnmodifiableView = Collections.unmodifiableList(parsers);
@@ -270,7 +270,8 @@ public class SpiderController implements org.zaproxy.zap.spider.parser.SpiderPar
                 URLCanonicalizer.buildCleanedParametersURIRepresentation(
                         uri,
                         spider.getSpiderParam().getHandleParameters(),
-                        spider.getSpiderParam().isHandleODataParametersVisited());
+                        spider.getSpiderParam().isHandleODataParametersVisited(),
+                        spider.getSpiderParam()::isIrrelevantUrlParameter);
         identifierBuilder.append(resourceFound.getMethod());
         identifierBuilder.append(" ");
         identifierBuilder.append(visitedURI);
@@ -401,6 +402,7 @@ public class SpiderController implements org.zaproxy.zap.spider.parser.SpiderPar
 
     public void addSpiderParser(org.zaproxy.zap.spider.parser.SpiderParser parser) {
         log.debug("Loading custom Spider Parser: " + parser.getClass().getSimpleName());
+        parser.setSpiderParam(spider.getSpiderParam());
         this.parsers.addFirst(parser);
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/spider/SpiderParam.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/SpiderParam.java
@@ -20,9 +20,13 @@
 package org.zaproxy.zap.spider;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.commons.configuration.ConversionException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.commons.httpclient.URI;
@@ -30,7 +34,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.common.AbstractParam;
+import org.parosproxy.paros.control.Control;
 import org.zaproxy.zap.extension.api.ZapApiIgnore;
+import org.zaproxy.zap.extension.httpsessions.ExtensionHttpSessions;
 
 /**
  * The SpiderParam wraps all the parameters that are given to the spider.
@@ -123,6 +129,11 @@ public class SpiderParam extends AbstractParam {
      * @see #maxParseSizeBytes
      */
     private static final int DEFAULT_MAX_PARSE_SIZE_BYTES = 2621440; // 2.5 MiB
+
+    /** Configuration key to write/read the {@link #irrelevantUrlParameters} property. */
+    private static final String SPIDER_IRRELEVANT_URL_PARAMETERS = "spider.irrelevantUrlParameters";
+
+    private static ExtensionHttpSessions extensionHttpSessions;
 
     /**
      * This option is used to define how the parameters are used when checking if an URI was already
@@ -238,12 +249,24 @@ public class SpiderParam extends AbstractParam {
      */
     private int maxParseSizeBytes = DEFAULT_MAX_PARSE_SIZE_BYTES;
 
+    /**
+     * Parameter names which are ignored in the {@link URLCanonicalizer}.
+     *
+     * @see #SPIDER_IRRELEVANT_URL_PARAMETERS
+     */
+    private Set<String> irrelevantUrlParameters = Collections.emptySet();
+
     /** Instantiates a new spider param. */
     public SpiderParam() {}
 
     @Override
     protected void parse() {
         updateOptions();
+
+        extensionHttpSessions =
+                Control.getSingleton()
+                        .getExtensionLoader()
+                        .getExtension(ExtensionHttpSessions.class);
 
         this.threadCount = getInt(SPIDER_THREAD, 2);
 
@@ -303,6 +326,9 @@ public class SpiderParam extends AbstractParam {
         this.acceptCookies = getBoolean(SPIDER_ACCEPT_COOKIES, true);
 
         this.maxParseSizeBytes = getInt(SPIDER_MAX_PARSE_SIZE_BYTES, DEFAULT_MAX_PARSE_SIZE_BYTES);
+
+        this.irrelevantUrlParameters =
+                getStringSet(SPIDER_IRRELEVANT_URL_PARAMETERS, this.irrelevantUrlParameters);
     }
 
     private void updateOptions() {
@@ -971,5 +997,54 @@ public class SpiderParam extends AbstractParam {
      */
     public int getMaxParseSizeBytes() {
         return maxParseSizeBytes;
+    }
+
+    public Set<String> getIrrelevantUrlParameters() {
+        return irrelevantUrlParameters;
+    }
+
+    public void setIrrelevantUrlParameters(Set<String> irrelevantUrlParameters) {
+        this.irrelevantUrlParameters = irrelevantUrlParameters;
+        getConfig().setProperty(SPIDER_IRRELEVANT_URL_PARAMETERS, irrelevantUrlParameters);
+    }
+
+    public String getIrrelevantUrlParametersAsString() {
+        return this.getIrrelevantUrlParameters().stream().collect(Collectors.joining(", "));
+    }
+
+    public void setIrrelevantUrlParameters(String irrelevantUrlParameters) {
+        this.setIrrelevantUrlParameters(
+                (Set<String>)
+                        Arrays.stream(irrelevantUrlParameters.split(","))
+                                .map(String::trim)
+                                .filter(str -> !str.isEmpty())
+                                .collect(Collectors.toCollection(LinkedHashSet::new)));
+    }
+
+    public boolean isIrrelevantUrlParameter(String name) {
+        return getIrrelevantUrlParameters().contains(name)
+                || name.startsWith("utm_")
+                || isSessionToken(name);
+    }
+
+    private static boolean isSessionToken(String paramName) {
+        if (extensionHttpSessions == null) {
+            return false;
+        }
+        return extensionHttpSessions.isDefaultSessionToken(paramName);
+    }
+
+    private Set<String> getStringSet(String key, Set<String> defaultSet) {
+        try {
+            List<Object> parsedList = getConfig().getList(key, Collections.emptyList());
+            return parsedList.isEmpty()
+                    ? defaultSet
+                    : parsedList.stream()
+                            .map(Object::toString)
+                            .collect(Collectors.toCollection(LinkedHashSet::new));
+        } catch (ConversionException e) {
+            logConversionException(key, e);
+        }
+        return defaultSet;
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderGitParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderGitParser.java
@@ -37,9 +37,6 @@ import org.parosproxy.paros.network.HttpMessage;
 @Deprecated
 public class SpiderGitParser extends SpiderParser {
 
-    /** The Spider parameters. */
-    private org.zaproxy.zap.spider.SpiderParam params;
-
     /** a pattern to match the file name of the Git index file */
     private static final Pattern gitIndexFilenamePattern = Pattern.compile("/.git/index$");
 
@@ -52,10 +49,10 @@ public class SpiderGitParser extends SpiderParser {
      * Instantiates a new spider Git Index parser.
      *
      * @param params the params
+     * @throws NullPointerException if {@code params} is null.
      */
     public SpiderGitParser(org.zaproxy.zap.spider.SpiderParam params) {
-        super();
-        this.params = params;
+        super(params);
     }
 
     @SuppressWarnings("unused")
@@ -64,7 +61,7 @@ public class SpiderGitParser extends SpiderParser {
 
         // parse the Git index file, based on publicly available (but incomplete) documentation of
         // the file format, and some reverse-engineering.
-        if (message == null || !params.isParseGit()) {
+        if (message == null || !getSpiderParam().isParseGit()) {
             return false;
         }
         getLogger().debug("Parsing a Git resource...");

--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderHtmlParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderHtmlParser.java
@@ -84,21 +84,14 @@ public class SpiderHtmlParser extends SpiderParser {
 
     private boolean baseTagSet;
 
-    /** The params. */
-    private org.zaproxy.zap.spider.SpiderParam params;
-
     /**
      * Instantiates a new spider html parser.
      *
      * @param params the params
-     * @throws IllegalArgumentException if {@code params} is null.
+     * @throws NullPointerException if {@code params} is null.
      */
     public SpiderHtmlParser(org.zaproxy.zap.spider.SpiderParam params) {
-        super();
-        if (params == null) {
-            throw new IllegalArgumentException("Parameter params must not be null.");
-        }
-        this.params = params;
+        super(params);
     }
 
     /** @throws NullPointerException if {@code message} is null. */
@@ -121,7 +114,7 @@ public class SpiderHtmlParser extends SpiderParser {
             }
             String href = base.getAttributeValue("href");
             if (href != null && !href.isEmpty()) {
-                baseURL = org.zaproxy.zap.spider.URLCanonicalizer.getCanonicalURL(href, baseURL);
+                baseURL = getCanonicalURL(href, baseURL);
                 baseTagSet = true;
             }
         }
@@ -130,7 +123,7 @@ public class SpiderHtmlParser extends SpiderParser {
         parseSource(message, source, depth, baseURL);
 
         // Parse the comments
-        if (params.isParseComments()) {
+        if (getSpiderParam().isParseComments()) {
             List<StartTag> comments = source.getAllStartTags(StartTagType.COMMENT);
             for (StartTag comment : comments) {
                 Source s = new Source(comment.getTagContent());

--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderHttpHeaderParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderHttpHeaderParser.java
@@ -33,6 +33,10 @@ import org.parosproxy.paros.network.HttpMessage;
 @Deprecated
 public class SpiderHttpHeaderParser extends SpiderParser {
 
+    public SpiderHttpHeaderParser(org.zaproxy.zap.spider.SpiderParam params) {
+        super(params);
+    }
+
     @Override
     public boolean parseResource(HttpMessage message, Source source, int depth) {
         String baseURL = message.getRequestHeader().getURI().toString();

--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderODataAtomParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderODataAtomParser.java
@@ -43,6 +43,14 @@ public class SpiderODataAtomParser extends SpiderParser {
     private static final Pattern patternBase =
             Pattern.compile("base=\"(http(s?)://[^\\x00-\\x1f\"'\\s<>#]+)\"");
 
+    public SpiderODataAtomParser() {
+        this(null);
+    }
+
+    public SpiderODataAtomParser(org.zaproxy.zap.spider.SpiderParam param) {
+        super(param);
+    }
+
     @Override
     public boolean parseResource(HttpMessage message, Source source, int depth) {
         getLogger().debug("Parsing an OData Atom resource.");

--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderParser.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.spider.parser;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import net.htmlparser.jericho.Source;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,6 +51,23 @@ public abstract class SpiderParser {
             org.apache.log4j.Logger.getLogger(SpiderParser.class);
 
     private final Logger logger = LogManager.getLogger(getClass());
+
+    private org.zaproxy.zap.spider.SpiderParam spiderParam;
+
+    public SpiderParser() {}
+
+    public SpiderParser(org.zaproxy.zap.spider.SpiderParam spiderParam) {
+        this.spiderParam =
+                Objects.requireNonNull(spiderParam, "Parameter spiderParam must not be null.");
+    }
+
+    public void setSpiderParam(org.zaproxy.zap.spider.SpiderParam spiderParam) {
+        this.spiderParam = spiderParam;
+    }
+
+    protected org.zaproxy.zap.spider.SpiderParam getSpiderParam() {
+        return spiderParam;
+    }
 
     /**
      * Gets the logger.
@@ -142,7 +160,7 @@ public abstract class SpiderParser {
      */
     protected void processURL(HttpMessage message, int depth, String localURL, String baseURL) {
         // Build the absolute canonical URL
-        String fullURL = org.zaproxy.zap.spider.URLCanonicalizer.getCanonicalURL(localURL, baseURL);
+        String fullURL = getCanonicalURL(localURL, baseURL);
         if (fullURL == null) {
             return;
         }
@@ -154,6 +172,11 @@ public abstract class SpiderParser {
                         .setDepth(depth + 1)
                         .setUri(fullURL)
                         .build());
+    }
+
+    protected String getCanonicalURL(String localURL, String baseURL) {
+        return org.zaproxy.zap.spider.URLCanonicalizer.getCanonicalURL(
+                localURL, baseURL, spiderParam::isIrrelevantUrlParameter);
     }
 
     /**

--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderRedirectParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderRedirectParser.java
@@ -32,6 +32,14 @@ import org.parosproxy.paros.network.HttpStatusCode;
 @Deprecated
 public class SpiderRedirectParser extends SpiderParser {
 
+    public SpiderRedirectParser() {
+        this(null);
+    }
+
+    public SpiderRedirectParser(org.zaproxy.zap.spider.SpiderParam param) {
+        super(param);
+    }
+
     @Override
     public boolean parseResource(HttpMessage message, Source source, int depth) {
         getLogger().debug("Parsing an HTTP redirection resource...");

--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderRobotstxtParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderRobotstxtParser.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.spider.parser;
 
-import java.util.Objects;
 import java.util.StringTokenizer;
 import net.htmlparser.jericho.Source;
 import org.parosproxy.paros.network.HttpMessage;
@@ -41,9 +40,6 @@ public class SpiderRobotstxtParser extends SpiderParser {
     private static final int PATTERNS_DISALLOW_LENGTH = 9;
     private static final int PATTERNS_ALLOW_LENGTH = 6;
 
-    /** The params. */
-    private org.zaproxy.zap.spider.SpiderParam params;
-
     /**
      * Instantiates a new spider robotstxt parser.
      *
@@ -51,14 +47,13 @@ public class SpiderRobotstxtParser extends SpiderParser {
      * @throws NullPointerException if {@code params} is null.
      */
     public SpiderRobotstxtParser(org.zaproxy.zap.spider.SpiderParam params) {
-        super();
-        this.params = Objects.requireNonNull(params, "Parameter params must not be null.");
+        super(params);
     }
 
     /** @throws NullPointerException if {@code message} is null. */
     @Override
     public boolean parseResource(HttpMessage message, Source source, int depth) {
-        if (!params.isParseRobotsTxt()) {
+        if (!getSpiderParam().isParseRobotsTxt()) {
             return false;
         }
         getLogger().debug("Parsing a robots.txt resource...");

--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderSVNEntriesParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderSVNEntriesParser.java
@@ -69,9 +69,6 @@ public class SpiderSVNEntriesParser extends SpiderParser {
     private static final Pattern svnRepoLocationPattern =
             Pattern.compile("^(http://|https://)", Pattern.CASE_INSENSITIVE);
 
-    /** The Spider parameters. */
-    private org.zaproxy.zap.spider.SpiderParam params;
-
     /** used to parse the XML based .svn/entries file format */
     private static DocumentBuilder dBuilder;
 
@@ -92,13 +89,12 @@ public class SpiderSVNEntriesParser extends SpiderParser {
      * @param params the params
      */
     public SpiderSVNEntriesParser(org.zaproxy.zap.spider.SpiderParam params) {
-        super();
-        this.params = params;
+        super(params);
     }
 
     @Override
     public boolean parseResource(HttpMessage message, Source source, int depth) {
-        if (message == null || !params.isParseSVNEntries()) {
+        if (message == null || !getSpiderParam().isParseSVNEntries()) {
             return false;
         }
         getLogger().debug("Parsing an SVN resource...");

--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderSitemapXMLParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderSitemapXMLParser.java
@@ -56,9 +56,6 @@ public class SpiderSitemapXMLParser extends SpiderParser {
             Pattern.compile(
                     "^<\\?xml\\s+version\\s*=\\s*\"[0-9.]+\"\\s+encoding\\s*=\\s*\"[^\"]+\"\\s*\\?>");
 
-    /** The Spider parameters. */
-    private org.zaproxy.zap.spider.SpiderParam params;
-
     /** used to parse the XML based file format */
     private static DocumentBuilder dBuilder;
 
@@ -80,14 +77,10 @@ public class SpiderSitemapXMLParser extends SpiderParser {
      * Instantiates a new sitemap.xml parser.
      *
      * @param params the params
-     * @throws IllegalArgumentException if {@code params} is null.
+     * @throws NullPointerException if {@code params} is null.
      */
     public SpiderSitemapXMLParser(org.zaproxy.zap.spider.SpiderParam params) {
-        super();
-        if (params == null) {
-            throw new IllegalArgumentException("Parameter params must not be null.");
-        }
-        this.params = params;
+        super(params);
     }
 
     @Override
@@ -96,7 +89,7 @@ public class SpiderSitemapXMLParser extends SpiderParser {
         if (getLogger().isDebugEnabled()) getLogger().debug("Parsing a sitemap.xml resource...");
 
         if (message == null
-                || !params.isParseSitemapXml()
+                || !getSpiderParam().isParseSitemapXml()
                 || !message.getResponseHeader().isXml()
                 || HttpStatusCode.isClientError(message.getResponseHeader().getStatusCode())
                 || HttpStatusCode.isServerError(message.getResponseHeader().getStatusCode())) {

--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderTextParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderTextParser.java
@@ -39,6 +39,14 @@ public class SpiderTextParser extends SpiderParser {
             Pattern.compile(
                     "\\W(http(s?)://[^\\x00-\\x1f\"'\\s<>#()\\[\\]{}]+)", Pattern.CASE_INSENSITIVE);
 
+    public SpiderTextParser() {
+        this(null);
+    }
+
+    public SpiderTextParser(org.zaproxy.zap.spider.SpiderParam params) {
+        super(params);
+    }
+
     @Override
     public boolean parseResource(HttpMessage message, Source source, int depth) {
         getLogger().debug("Parsing a non-HTML text resource.");

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -2971,6 +2971,7 @@ spider.custom.label.sitemap			= Parse 'sitemap.xml':
 spider.custom.label.parseSvn		= Parse SVN Metadata:
 spider.custom.label.parseGit		= Parse Git Metadata:
 spider.custom.label.handleOdata		= Handle OData Parameters:
+spider.custom.label.irrelevantUrlParameters = Irrelevant URL Parameters:
 
 spider.custom.label.processForms	= Process Forms:
 spider.custom.label.recurse = Recurse:
@@ -3027,6 +3028,7 @@ spider.options.label.handleparameters				= Query parameters handling for checkin
 spider.options.value.handleparameters.useAll 		= Consider both parameter's name and value
 spider.options.value.handleparameters.ignoreValue 	= Consider only parameter's name
 spider.options.value.handleparameters.ignoreAll 	= Ignore parameters completely
+spider.options.label.irrelevantUrlParameters = Irrelevant URL parameters
 
 spider.options.title            = Spider
 spider.panel.emptyView	        = You need to visit the website via a browser first and select a URL/folder/node in the 'Sites' panel displayed.

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlFormParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlFormParserUnitTest.java
@@ -63,7 +63,7 @@ class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
         org.zaproxy.zap.spider.SpiderParam undefinedSpiderOptions = null;
         // When / Then
         assertThrows(
-                IllegalArgumentException.class,
+                NullPointerException.class,
                 () ->
                         new org.zaproxy.zap.spider.parser.SpiderHtmlFormParser(
                                 undefinedSpiderOptions, new DefaultValueGenerator()));

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlParserUnitTest.java
@@ -50,7 +50,7 @@ class SpiderHtmlParserUnitTest extends SpiderParserTestUtils {
         org.zaproxy.zap.spider.SpiderParam undefinedSpiderOptions = null;
         // When / Then
         assertThrows(
-                IllegalArgumentException.class, () -> new SpiderHtmlParser(undefinedSpiderOptions));
+                NullPointerException.class, () -> new SpiderHtmlParser(undefinedSpiderOptions));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHttpHeaderParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHttpHeaderParserUnitTest.java
@@ -25,7 +25,9 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -40,11 +42,18 @@ class SpiderHttpHeaderParserUnitTest extends SpiderParserTestUtils {
     private static final String ROOT_PATH = "/";
     private static final int BASE_DEPTH = 0;
 
+    private org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser headerParser;
+
+    @BeforeEach
+    void setup() {
+        org.zaproxy.zap.spider.SpiderParam spiderOptions =
+                mock(org.zaproxy.zap.spider.SpiderParam.class);
+        headerParser = new org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser(spiderOptions);
+    }
+
     @Test
     void shouldParseAnyMessage() {
         // Given
-        org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser headerParser =
-                new org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser();
         HttpMessage msg = createMessage();
         // When
         boolean canParse = headerParser.canParseResource(msg, ROOT_PATH, false);
@@ -56,8 +65,6 @@ class SpiderHttpHeaderParserUnitTest extends SpiderParserTestUtils {
     void shouldParseAnyMessageEvenIfAlreadyParsed() {
         // Given
         boolean alreadyParsed = true;
-        org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser headerParser =
-                new org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser();
         HttpMessage msg = createMessage();
         // When
         boolean canParse = headerParser.canParseResource(msg, ROOT_PATH, alreadyParsed);
@@ -69,8 +76,6 @@ class SpiderHttpHeaderParserUnitTest extends SpiderParserTestUtils {
     void shouldFailToParseAnUndefinedMessage() {
         // Given
         HttpMessage undefinedMessage = null;
-        org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser headerParser =
-                new org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser();
         // When / Then
         assertThrows(
                 NullPointerException.class,
@@ -81,8 +86,6 @@ class SpiderHttpHeaderParserUnitTest extends SpiderParserTestUtils {
     void shouldNotExtractUrlIfNoUrlHeadersPresent() {
         // Given
         HttpMessage msg = createMessage();
-        org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser headerParser =
-                new org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser();
         TestSpiderParserListener listener = createAndAddTestSpiderParserListener(headerParser);
         // When
         boolean parsed = headerParser.parseResource(msg, null, BASE_DEPTH);
@@ -97,8 +100,6 @@ class SpiderHttpHeaderParserUnitTest extends SpiderParserTestUtils {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().addHeader(header, "");
-        org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser headerParser =
-                new org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser();
         TestSpiderParserListener listener = createAndAddTestSpiderParserListener(headerParser);
         // When
         boolean parsed = headerParser.parseResource(msg, null, 0);
@@ -113,8 +114,6 @@ class SpiderHttpHeaderParserUnitTest extends SpiderParserTestUtils {
         String value = "http://example.com/contentlocation";
         HttpMessage msg = createMessage();
         msg.getResponseHeader().addHeader(HttpHeader.CONTENT_LOCATION, value);
-        org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser headerParser =
-                new org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser();
         TestSpiderParserListener listener = createAndAddTestSpiderParserListener(headerParser);
         // When
         boolean parsed = headerParser.parseResource(msg, null, BASE_DEPTH);
@@ -129,8 +128,6 @@ class SpiderHttpHeaderParserUnitTest extends SpiderParserTestUtils {
         String url = "/rel/redirection";
         HttpMessage msg = createMessage();
         msg.getResponseHeader().addHeader(HttpHeader.CONTENT_LOCATION, url);
-        org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser headerParser =
-                new org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser();
         TestSpiderParserListener listener = createAndAddTestSpiderParserListener(headerParser);
         // When
         boolean parsed = headerParser.parseResource(msg, null, BASE_DEPTH);
@@ -149,8 +146,6 @@ class SpiderHttpHeaderParserUnitTest extends SpiderParserTestUtils {
                 .addHeader(
                         HttpHeader.LINK,
                         "<" + url1 + ">; param1=value1; param2=\"value2\";<" + url2 + ">");
-        org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser headerParser =
-                new org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser();
         TestSpiderParserListener listener = createAndAddTestSpiderParserListener(headerParser);
         // When
         boolean parsed = headerParser.parseResource(msg, null, BASE_DEPTH);
@@ -171,8 +166,6 @@ class SpiderHttpHeaderParserUnitTest extends SpiderParserTestUtils {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().addHeader(HttpHeader.LINK, value);
-        org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser headerParser =
-                new org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser();
         TestSpiderParserListener listener = createAndAddTestSpiderParserListener(headerParser);
         // When
         boolean parsed = headerParser.parseResource(msg, null, BASE_DEPTH);
@@ -187,8 +180,6 @@ class SpiderHttpHeaderParserUnitTest extends SpiderParserTestUtils {
         String url = "http://example.com/refresh";
         HttpMessage msg = createMessage();
         msg.getResponseHeader().addHeader(HttpHeader.REFRESH, "999; url=" + url);
-        org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser headerParser =
-                new org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser();
         TestSpiderParserListener listener = createAndAddTestSpiderParserListener(headerParser);
         // When
         boolean parsed = headerParser.parseResource(msg, null, BASE_DEPTH);
@@ -203,8 +194,6 @@ class SpiderHttpHeaderParserUnitTest extends SpiderParserTestUtils {
         String url = "/rel/refresh";
         HttpMessage msg = createMessage();
         msg.getResponseHeader().addHeader(HttpHeader.REFRESH, "999; url=" + url);
-        org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser headerParser =
-                new org.zaproxy.zap.spider.parser.SpiderHttpHeaderParser();
         TestSpiderParserListener listener = createAndAddTestSpiderParserListener(headerParser);
         // When
         boolean parsed = headerParser.parseResource(msg, null, BASE_DEPTH);

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderParserUnitTest.java
@@ -154,6 +154,10 @@ class SpiderParserUnitTest extends SpiderParserTestUtils {
 
     private static class TestSpiderParser extends SpiderParser {
 
+        TestSpiderParser() {
+            super(mock(org.zaproxy.zap.spider.SpiderParam.class));
+        }
+
         @Override
         public boolean parseResource(HttpMessage message, Source source, int depth) {
             return true;

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderRedirectParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderRedirectParserUnitTest.java
@@ -25,10 +25,12 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
@@ -59,11 +61,19 @@ class SpiderRedirectParserUnitTest extends SpiderParserTestUtils {
                         });
     }
 
+    private SpiderRedirectParser redirectParser;
+
+    @BeforeEach
+    void setup() {
+        org.zaproxy.zap.spider.SpiderParam spiderOptions =
+                mock(org.zaproxy.zap.spider.SpiderParam.class);
+        redirectParser = new SpiderRedirectParser(spiderOptions);
+    }
+
     @Test
     void shouldFailToEvaluateAnUndefinedMessage() {
         // Given
         HttpMessage undefinedMessage = null;
-        SpiderRedirectParser redirectParser = new SpiderRedirectParser();
         // When / Then
         assertThrows(
                 NullPointerException.class,
@@ -73,7 +83,6 @@ class SpiderRedirectParserUnitTest extends SpiderParserTestUtils {
     @Test
     void shouldNotParseNonRedirectionMessages() {
         // Given
-        SpiderRedirectParser redirectParser = new SpiderRedirectParser();
         for (int statusCode : NON_REDIRECTION_STATUS_CODES) {
             HttpMessage msg = createMessageWithStatusCode(statusCode);
             // When
@@ -86,7 +95,6 @@ class SpiderRedirectParserUnitTest extends SpiderParserTestUtils {
     @Test
     void shouldParseRedirectionMessages() {
         // Given
-        SpiderRedirectParser redirectParser = new SpiderRedirectParser();
         for (int statusCode : REDIRECTION_STATUS_CODES) {
             HttpMessage msg = createMessageWithStatusCode(statusCode);
             // When
@@ -100,7 +108,6 @@ class SpiderRedirectParserUnitTest extends SpiderParserTestUtils {
     void shouldParseRedirectionMessageEvenIfAlreadyParsed() {
         // Given
         boolean alreadyParsed = true;
-        SpiderRedirectParser redirectParser = new SpiderRedirectParser();
         HttpMessage msg = createMessageWithStatusCode(HttpStatusCode.FOUND);
         // When
         boolean canParse = redirectParser.canParseResource(msg, ROOT_PATH, alreadyParsed);
@@ -112,7 +119,6 @@ class SpiderRedirectParserUnitTest extends SpiderParserTestUtils {
     void shouldFailToParseAnUndefinedMessage() {
         // Given
         HttpMessage undefinedMessage = null;
-        SpiderRedirectParser redirectParser = new SpiderRedirectParser();
         // When / Then
         assertThrows(
                 NullPointerException.class,
@@ -124,7 +130,6 @@ class SpiderRedirectParserUnitTest extends SpiderParserTestUtils {
         // Given
         String location = "http://example.com/redirection";
         HttpMessage msg = createMessageWithLocationAndStatusCode(location, HttpStatusCode.FOUND);
-        SpiderRedirectParser redirectParser = new SpiderRedirectParser();
         TestSpiderParserListener listener = createAndAddTestSpiderParserListener(redirectParser);
         // When
         boolean parsed = redirectParser.parseResource(msg, null, BASE_DEPTH);
@@ -138,7 +143,6 @@ class SpiderRedirectParserUnitTest extends SpiderParserTestUtils {
         // Given
         String location = "/rel/redirection";
         HttpMessage msg = createMessageWithLocationAndStatusCode(location, HttpStatusCode.FOUND);
-        SpiderRedirectParser redirectParser = new SpiderRedirectParser();
         TestSpiderParserListener listener = createAndAddTestSpiderParserListener(redirectParser);
         // When
         boolean parsed = redirectParser.parseResource(msg, null, BASE_DEPTH);
@@ -152,7 +156,6 @@ class SpiderRedirectParserUnitTest extends SpiderParserTestUtils {
         // Given
         String location = "";
         HttpMessage msg = createMessageWithLocationAndStatusCode(location, HttpStatusCode.FOUND);
-        SpiderRedirectParser redirectParser = new SpiderRedirectParser();
         TestSpiderParserListener listener = createAndAddTestSpiderParserListener(redirectParser);
         // When
         boolean parsed = redirectParser.parseResource(msg, null, 0);
@@ -165,7 +168,6 @@ class SpiderRedirectParserUnitTest extends SpiderParserTestUtils {
     void shouldNotExtractUrlIfLocationHeaderIsNotPresent() {
         // Given
         HttpMessage msg = createMessageWithStatusCode(HttpStatusCode.FOUND);
-        SpiderRedirectParser redirectParser = new SpiderRedirectParser();
         TestSpiderParserListener listener = createAndAddTestSpiderParserListener(redirectParser);
         // When
         boolean parsed = redirectParser.parseResource(msg, null, BASE_DEPTH);

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderSitemapXMLParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderSitemapXMLParserUnitTest.java
@@ -46,7 +46,7 @@ class SpiderSitemapXMLParserUnitTest extends SpiderParserTestUtils {
         org.zaproxy.zap.spider.SpiderParam undefinedSpiderOptions = null;
         // When / Then
         assertThrows(
-                IllegalArgumentException.class,
+                NullPointerException.class,
                 () ->
                         new org.zaproxy.zap.spider.parser.SpiderSitemapXMLParser(
                                 undefinedSpiderOptions));

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderTextParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderTextParserUnitTest.java
@@ -25,8 +25,10 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
 import net.htmlparser.jericho.Source;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 
@@ -38,12 +40,19 @@ class SpiderTextParserUnitTest extends SpiderParserTestUtils {
     private static final String ROOT_PATH = "/";
     private static final int BASE_DEPTH = 0;
 
+    private SpiderTextParser spiderParser;
+
+    @BeforeEach
+    void setup() {
+        org.zaproxy.zap.spider.SpiderParam undefinedSpiderOptions =
+                mock(org.zaproxy.zap.spider.SpiderParam.class);
+        spiderParser = new org.zaproxy.zap.spider.parser.SpiderTextParser(undefinedSpiderOptions);
+    }
+
     @Test
     void shouldFailToEvaluateAnUndefinedMessage() {
         // Given
         HttpMessage undefinedMessage = null;
-        org.zaproxy.zap.spider.parser.SpiderTextParser spiderParser =
-                new org.zaproxy.zap.spider.parser.SpiderTextParser();
         // When / Then
         assertThrows(
                 NullPointerException.class,
@@ -53,8 +62,6 @@ class SpiderTextParserUnitTest extends SpiderParserTestUtils {
     @Test
     void shouldNotParseMessageIfAlreadyParsed() {
         // Given
-        org.zaproxy.zap.spider.parser.SpiderTextParser spiderParser =
-                new org.zaproxy.zap.spider.parser.SpiderTextParser();
         boolean parsed = true;
         // When
         boolean canParse = spiderParser.canParseResource(new HttpMessage(), ROOT_PATH, parsed);
@@ -66,7 +73,6 @@ class SpiderTextParserUnitTest extends SpiderParserTestUtils {
     void shouldNotParseNonTextResponse() {
         // Given
         HttpMessage message = createMessageWith("application/xyz", EMPTY_BODY);
-        SpiderTextParser spiderParser = new SpiderTextParser();
         boolean parsed = false;
         // When
         boolean canParse = spiderParser.canParseResource(message, ROOT_PATH, parsed);
@@ -78,7 +84,6 @@ class SpiderTextParserUnitTest extends SpiderParserTestUtils {
     void shouldNotParseTextHtmlResponse() {
         // Given
         HttpMessage message = createMessageWith("text/html", EMPTY_BODY);
-        SpiderTextParser spiderParser = new SpiderTextParser();
         boolean parsed = false;
         // When
         boolean canParse = spiderParser.canParseResource(message, ROOT_PATH, parsed);
@@ -89,7 +94,6 @@ class SpiderTextParserUnitTest extends SpiderParserTestUtils {
     @Test
     void shouldParseTextResponse() {
         // Given
-        SpiderTextParser spiderParser = new SpiderTextParser();
         HttpMessage messageHtmlResponse = createMessageWith(EMPTY_BODY);
         boolean parsed = false;
         // When
@@ -101,7 +105,6 @@ class SpiderTextParserUnitTest extends SpiderParserTestUtils {
     @Test
     void shouldParseTextResponseEvenIfProvidedPathIsNull() {
         // Given
-        SpiderTextParser spiderParser = new SpiderTextParser();
         HttpMessage messageHtmlResponse = createMessageWith(EMPTY_BODY);
         boolean parsed = false;
         // When
@@ -113,7 +116,6 @@ class SpiderTextParserUnitTest extends SpiderParserTestUtils {
     @Test
     void shouldNotParseTextResponseIfAlreadyParsed() {
         // Given
-        SpiderTextParser spiderParser = new SpiderTextParser();
         HttpMessage messageHtmlResponse = createMessageWith(EMPTY_BODY);
         boolean parsed = true;
         // When
@@ -126,7 +128,6 @@ class SpiderTextParserUnitTest extends SpiderParserTestUtils {
     void shouldFailToParseAnUndefinedMessage() {
         // Given
         HttpMessage undefinedMessage = null;
-        SpiderTextParser spiderParser = new SpiderTextParser();
         Source source = createSource(createMessageWith(EMPTY_BODY));
         // When / Then
         assertThrows(
@@ -137,8 +138,6 @@ class SpiderTextParserUnitTest extends SpiderParserTestUtils {
     @Test
     void shouldNeverConsiderCompletelyParsed() {
         // Given
-        org.zaproxy.zap.spider.parser.SpiderTextParser spiderParser =
-                new org.zaproxy.zap.spider.parser.SpiderTextParser();
         HttpMessage message = createMessageWith("Non Empty Body...");
         Source source = createSource(message);
         // When
@@ -150,8 +149,6 @@ class SpiderTextParserUnitTest extends SpiderParserTestUtils {
     @Test
     void shouldNotFindUrlsIfThereIsNone() {
         // Given
-        org.zaproxy.zap.spider.parser.SpiderTextParser spiderParser =
-                new org.zaproxy.zap.spider.parser.SpiderTextParser();
         TestSpiderParserListener listener = createTestSpiderParserListener();
         spiderParser.addSpiderParserListener(listener);
         HttpMessage message =
@@ -173,8 +170,6 @@ class SpiderTextParserUnitTest extends SpiderParserTestUtils {
     @Test
     void shouldFindUrlsInCommentsWithoutElements() {
         // Given
-        org.zaproxy.zap.spider.parser.SpiderTextParser spiderParser =
-                new org.zaproxy.zap.spider.parser.SpiderTextParser();
         TestSpiderParserListener listener = createTestSpiderParserListener();
         spiderParser.addSpiderParserListener(listener);
         HttpMessage messageHtmlResponse =


### PR DESCRIPTION
Fix #4388.

* Added irrelevantParameters property to `SpiderParam`.
* Tweaked URLCanonicalizer to take into account irrelevant parameters. 
* Made changes on UI side to allow custom configuration for irrelevant parameters.

Spider options screenshot:
![selection_001](https://user-images.githubusercontent.com/11192279/36228387-c9231896-11dc-11e8-8c3e-3988cdf28384.png)

Spider dialog screenshot:
![selection_002](https://user-images.githubusercontent.com/11192279/36228445-e0bbabb2-11dc-11e8-8040-2b00c4d1c3cf.png)

Please, review:
@thc202
