### PR TITLE
Include all URLs when exporting

### DIFF
--- a/src/org/zaproxy/zap/extension/api/ContextAPI.java
+++ b/src/org/zaproxy/zap/extension/api/ContextAPI.java
@@ -30,7 +30,6 @@ import net.sf.json.JSONObject;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.SiteNode;
 import org.zaproxy.zap.authentication.AuthenticationMethod;
@@ -306,12 +305,7 @@ public class ContextAPI extends ApiImplementor {
 			resultList = new ApiResponseList(name);
 			Set<String> addedUrls = new HashSet<>();
 			for (SiteNode node : getContext(params).getNodesInContextFromSiteTree()) {
-				HistoryReference href = node.getHistoryReference();
-				if (HistoryReference.getTemporaryTypes().contains(href.getHistoryType())) {
-					continue;
-				}
-
-				String uri = href.getURI().toString();
+				String uri = node.getHistoryReference().getURI().toString();
 				if (!addedUrls.contains(uri)) {
 					resultList.addItem(new ApiResponseElement("url", uri));
 					addedUrls.add(uri);

--- a/src/org/zaproxy/zap/extension/history/PopupMenuExportContextURLs.java
+++ b/src/org/zaproxy/zap/extension/history/PopupMenuExportContextURLs.java
@@ -27,7 +27,6 @@ import java.util.TreeSet;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.Extension;
-import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.SiteMapPanel;
 import org.parosproxy.paros.view.View;
@@ -76,10 +75,7 @@ public class PopupMenuExportContextURLs extends PopupMenuExportURLs {
 		SortedSet<String> outputSet = new TreeSet<String>();
 
 		for (SiteNode node : ctx.getNodesInContextFromSiteTree()) {
-			HistoryReference nodeHR = node.getHistoryReference();
-			if (nodeHR != null && !HistoryReference.getTemporaryTypes().contains(nodeHR.getHistoryType())) {
-				outputSet.add(nodeHR.getURI().toString());
-			}
+			outputSet.add(node.getHistoryReference().getURI().toString());
 		}
 		return outputSet;
 	}

--- a/src/org/zaproxy/zap/extension/history/PopupMenuExportSelectedURLs.java
+++ b/src/org/zaproxy/zap/extension/history/PopupMenuExportSelectedURLs.java
@@ -32,7 +32,6 @@ import javax.swing.tree.TreePath;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.extension.Extension;
-import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.SiteNode;
 
 public class PopupMenuExportSelectedURLs extends PopupMenuExportURLs {
@@ -75,10 +74,7 @@ public class PopupMenuExportSelectedURLs extends PopupMenuExportURLs {
 				if (node.isRoot()) {
 					continue;
 				}
-				HistoryReference nodeHR = node.getHistoryReference();
-				if (nodeHR != null && !HistoryReference.getTemporaryTypes().contains(nodeHR.getHistoryType())) {
-					outputSet.add(nodeHR.getURI().toString());
-				}
+				outputSet.add(node.getHistoryReference().getURI().toString());
 			}
 		}
 		return outputSet;

--- a/src/org/zaproxy/zap/extension/history/PopupMenuExportURLs.java
+++ b/src/org/zaproxy/zap/extension/history/PopupMenuExportURLs.java
@@ -36,7 +36,6 @@ import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
-import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.SiteNode;
 import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
@@ -99,11 +98,7 @@ public class PopupMenuExportURLs extends ExtensionPopupMenuItem {
             if (node.isRoot()) {
                 continue;
             }
-            HistoryReference nodeHR = node.getHistoryReference();
-            if (nodeHR != null
-                    && !HistoryReference.getTemporaryTypes().contains(nodeHR.getHistoryType())) {
-                outputSet.add(nodeHR.getURI().toString());
-            }
+            outputSet.add(node.getHistoryReference().getURI().toString());
         }
         return outputSet;
     }


### PR DESCRIPTION
Change menus "Export URLs for Context", "Export All URLs to File", and
"Export Selected URLs to File" to include all URLs even if they are from
temporary messages. Also, change context API to also provide all URLs,
normalising the behaviour when exporting/obtaining the URLs (e.g. core
view "urls" was already returning all URLs).

Per review comments in #4380 - Add API view to get context's URLs