### PR TITLE
Allow to scan from Contexts tree

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/ActiveScanPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScanPanel.java
@@ -43,6 +43,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.model.ScanController;
 import org.zaproxy.zap.model.ScanListenner2;
+import org.zaproxy.zap.model.Target;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.TableExportButton;
 import org.zaproxy.zap.view.ScanPanel2;
@@ -134,12 +135,7 @@ public class ActiveScanPanel extends ScanPanel2<ActiveScan, ScanController<Activ
 		if (scanButton == null) {
 			scanButton = new JButton(Constant.messages.getString("ascan.toolbar.button.new"));
 			scanButton.setIcon(DisplayUtils.getScaledIcon(new ImageIcon(ActiveScanPanel.class.getResource("/resource/icon/16/093.png"))));
-			scanButton.addActionListener(new ActionListener () {
-				@Override
-				public void actionPerformed(ActionEvent e) {
-					extension.showCustomScanDialog(null);
-				}
-			});
+			scanButton.addActionListener(e -> extension.showCustomScanDialog((Target) null));
 		}
 		return scanButton;
 	}

--- a/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -95,6 +95,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
 
     private ZapMenuItem menuItemPolicy = null;
     private ZapMenuItem menuItemCustomScan = null;
+    private PopupMenuActiveScanCustomWithContext popupMenuActiveScanCustomWithContext;
     private OptionsScannerPanel optionsScannerPanel = null;
     private OptionsVariantPanel optionsVariantPanel = null;
     private ActiveScanPanel activeScanPanel = null;
@@ -148,6 +149,8 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
         if (getView() != null) {
             extensionHook.getHookMenu().addAnalyseMenuItem(getMenuItemPolicy());
             extensionHook.getHookMenu().addToolsMenuItem(getMenuItemCustomScan());
+
+            extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuActiveScanCustomWithContext());
 
             extensionHook.getHookView().addStatusPanel(getActiveScanPanel());
             extensionHook.getHookView().addOptionPanel(getOptionsScannerPanel());
@@ -354,16 +357,17 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
                     KeyStroke.getKeyStroke(KeyEvent.VK_A, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK, false));
             menuItemCustomScan.setEnabled(Control.getSingleton().getMode() != Mode.safe);
 
-            menuItemCustomScan.addActionListener(new java.awt.event.ActionListener() {
-                @Override
-                public void actionPerformed(java.awt.event.ActionEvent e) {
-                	showCustomScanDialog(null);
-                }
-            });
-
+            menuItemCustomScan.addActionListener(e -> showCustomScanDialog((Target) null));
         }
         
         return menuItemCustomScan;
+    }
+
+    private PopupMenuActiveScanCustomWithContext getPopupMenuActiveScanCustomWithContext() {
+        if (popupMenuActiveScanCustomWithContext == null) {
+            popupMenuActiveScanCustomWithContext = new PopupMenuActiveScanCustomWithContext(this);
+        }
+        return popupMenuActiveScanCustomWithContext;
     }
 
     @Override
@@ -566,6 +570,16 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
     }
 
 	public void showCustomScanDialog(SiteNode node) {
+		showCustomScanDialog(node != null ? new Target(node) : null);
+	}
+
+	/**
+	 * Shows the active scan dialogue with the given target, if not already visible.
+	 *
+	 * @param target the target, might be {@code null}.
+	 * @since TODO add version.
+	 */
+	public void showCustomScanDialog(Target target) {
 		if (customScanDialog == null) {
 			// Work out the tabs 
 			String[] tabs = CustomScanDialog.STD_TAB_LABELS;
@@ -589,8 +603,8 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
 			customScanDialog.toFront();
 			return;
 		}
-		if (node != null) {
-			customScanDialog.init(new Target(node));
+		if (target != null) {
+			customScanDialog.init(target);
 		} else {
 			// Keep the previously selected target
 			customScanDialog.init(null);

--- a/src/org/zaproxy/zap/extension/ascan/PopupMenuActiveScanCustomWithContext.java
+++ b/src/org/zaproxy/zap/extension/ascan/PopupMenuActiveScanCustomWithContext.java
@@ -1,0 +1,49 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2018 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascan;
+
+import javax.swing.ImageIcon;
+
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.extension.stdmenus.PopupContextTreeMenu;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.model.Target;
+
+/**
+ * A {@code PopupContextTreeMenu} that allows to show the Active Scan dialogue for a selected {@link Context}.
+ * 
+ * @see ExtensionActiveScan#showCustomScanDialog(Target)
+ */
+public class PopupMenuActiveScanCustomWithContext extends PopupContextTreeMenu {
+
+    private static final long serialVersionUID = 1L;
+
+    public PopupMenuActiveScanCustomWithContext(ExtensionActiveScan extension) {
+        super();
+
+        this.setText(extension.getMessages().getString("ascan.custom.popup"));
+        this.setIcon(new ImageIcon(PopupMenuActiveScanCustomWithContext.class.getResource("/resource/icon/16/093.png")));
+
+        this.addActionListener(e -> {
+            Context context = Model.getSingleton().getSession().getContext(getContextId());
+            extension.showCustomScanDialog(new Target(context));
+        });
+    }
+}

--- a/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
+++ b/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
@@ -87,6 +87,8 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
 
 	private PopupMenuItemSpiderDialog popupMenuItemSpiderDialog;
 
+	private PopupMenuItemSpiderDialogWithContext popupMenuItemSpiderDialogWithContext;
+
 	/** The options spider panel. */
 	private OptionsSpiderPanel optionsSpiderPanel = null;
 
@@ -158,6 +160,7 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
 			extensionHook.getHookView().addStatusPanel(getSpiderPanel());
 			extensionHook.getHookView().addOptionPanel(getOptionsSpiderPanel());
 			extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuItemSpiderDialog());
+			extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuItemSpiderDialogWithContext());
 			ExtensionHelp.enableHelpKey(getSpiderPanel(), "ui.tabs.spider");
 		}
 
@@ -175,6 +178,13 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
 			popupMenuItemSpiderDialog = new PopupMenuItemSpiderDialog(this);
 		}
 		return popupMenuItemSpiderDialog;
+	}
+
+	private PopupMenuItemSpiderDialogWithContext getPopupMenuItemSpiderDialogWithContext() {
+		if (popupMenuItemSpiderDialogWithContext == null) {
+			popupMenuItemSpiderDialogWithContext = new PopupMenuItemSpiderDialogWithContext(this);
+		}
+		return popupMenuItemSpiderDialogWithContext;
 	}
 
 	@Override
@@ -806,19 +816,23 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
                     KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK, false));
             menuItemCustomScan.setEnabled(Control.getSingleton().getMode() != Mode.safe);
 
-            menuItemCustomScan.addActionListener(new java.awt.event.ActionListener() {
-                @Override
-                public void actionPerformed(java.awt.event.ActionEvent e) {
-                	showSpiderDialog(null);
-                }
-            });
-
+            menuItemCustomScan.addActionListener(e -> showSpiderDialog((Target) null));
         }
         
         return menuItemCustomScan;
     }
 
 	public void showSpiderDialog(SiteNode node) {
+		showSpiderDialog(node != null ? new Target(node) : null);
+	}
+
+	/**
+	 * Shows the spider dialogue with the given target, if not already visible.
+	 *
+	 * @param target the target, might be {@code null}.
+	 * @since TODO add version.
+	 */
+	public void showSpiderDialog(Target target) {
 		if (spiderDialog == null) {
 			spiderDialog = new SpiderDialog(this, View.getSingleton().getMainFrame(), new Dimension(700, 430));
 		}
@@ -827,8 +841,8 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
 			spiderDialog.toFront();
 			return;
 		}
-		if (node != null) {
-			spiderDialog.init(new Target(node));
+		if (target != null) {
+			spiderDialog.init(target);
 		} else {
 			// Keep the previous target
 			spiderDialog.init(null);

--- a/src/org/zaproxy/zap/extension/spider/PopupMenuItemSpiderDialogWithContext.java
+++ b/src/org/zaproxy/zap/extension/spider/PopupMenuItemSpiderDialogWithContext.java
@@ -1,0 +1,47 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2018 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.spider;
+
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.extension.stdmenus.PopupContextTreeMenu;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.model.Target;
+
+/**
+ * A {@code PopupContextTreeMenu} that allows to show the Spider dialogue for a selected {@link Context}.
+ * 
+ * @see ExtensionSpider#showSpiderDialog(Target)
+ */
+public class PopupMenuItemSpiderDialogWithContext extends PopupContextTreeMenu {
+
+    private static final long serialVersionUID = 1L;
+
+    public PopupMenuItemSpiderDialogWithContext(ExtensionSpider extension) {
+        super();
+
+        this.setText(extension.getMessages().getString("spider.custom.popup"));
+        this.setIcon(extension.getIcon());
+
+        this.addActionListener(e -> {
+            Context context = Model.getSingleton().getSession().getContext(getContextId());
+            extension.showSpiderDialog(new Target(context));
+        });
+    }
+}


### PR DESCRIPTION
Add two pop up menus that allow to show the dialogues Spider and Active
Scan with the context selected in the Contexts tree.