### PR TITLE
Expand parameters double-quoted in zap-x.sh

### DIFF
--- a/build/docker/zap-x.sh
+++ b/build/docker/zap-x.sh
@@ -4,4 +4,4 @@ if [ ! -f /tmp/.X1-lock ]
 then
   Xvfb :1 -screen 0 1024x768x16 -ac &
 fi
-/zap/zap.sh $@
+/zap/zap.sh "$@"


### PR DESCRIPTION
Change zap-x.sh script to expand the parameters double-quoted to pass
the parameters as is to ZAP.

Fix #4332 - Struggling to Pass Authentication Header that contains space
(for API ZAP scan)