### PR TITLE
Map old language codes when loading resources

### DIFF
--- a/src/org/zaproxy/zap/control/ExtensionFactory.java
+++ b/src/org/zaproxy/zap/control/ExtensionFactory.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.control;
 
 import java.io.File;
-import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -29,17 +28,16 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import java.util.TreeMap;
 import java.util.Vector;
+import java.util.function.Function;
 
 import javax.help.HelpBroker;
 import javax.help.HelpSet;
 import javax.help.HelpSetException;
-import javax.help.HelpUtilities;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.log4j.Logger;
@@ -50,6 +48,8 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
 import org.zaproxy.zap.extension.ext.ExtensionParam;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
+import org.zaproxy.zap.utils.LocaleUtils;
+import org.zaproxy.zap.utils.ZapResourceBundleControl;
 
 public class ExtensionFactory {
 
@@ -320,11 +320,7 @@ public class ExtensionFactory {
 
     private static ResourceBundle getPropertiesResourceBundle(String name, ClassLoader classLoader)
             throws MissingResourceException {
-        return ResourceBundle.getBundle(
-                name,
-                Constant.getLocale(),
-                classLoader,
-                ResourceBundle.Control.getControl(ResourceBundle.Control.FORMAT_PROPERTIES));
+        return ResourceBundle.getBundle(name, Constant.getLocale(), classLoader, new ZapResourceBundleControl());
     }
 
     /**
@@ -351,21 +347,23 @@ public class ExtensionFactory {
     }
 
     private static URL getExtensionHelpSetUrl(Extension extension) {
-        String extensionPackage = extension.getClass().getPackage().getName().replace('.', '/') + "/";
-        URL helpSetUrl = findResource(
-                extension.getClass().getClassLoader(),
-                extensionPackage + "resources/help",
-                "helpset",
-                ".hs",
-                Constant.getLocale());
+        String extensionPackage = extension.getClass().getPackage().getName();
+        String localeToken = "%LC%";
+        Function<String, URL> getResource = extension.getClass().getClassLoader()::getResource;
+        URL helpSetUrl = LocaleUtils.findResource(
+                extensionPackage + ".resources.help" + localeToken + "." + ExtensionHelp.HELP_SET_FILE_NAME,
+                ExtensionHelp.HELP_SET_FILE_EXTENSION,
+                localeToken,
+                Constant.getLocale(),
+                getResource);
         if (helpSetUrl == null) {
             // Search in old location
-            helpSetUrl = findResource(
-                    extension.getClass().getClassLoader(),
-                    extensionPackage + "resource/help",
-                    "helpset",
-                    ".hs",
-                    Constant.getLocale());
+            helpSetUrl = LocaleUtils.findResource(
+                    extensionPackage + ".resource.help" + localeToken + "." + ExtensionHelp.HELP_SET_FILE_NAME,
+                    ExtensionHelp.HELP_SET_FILE_EXTENSION,
+                    localeToken,
+                    Constant.getLocale(),
+                    getResource);
         }
         return helpSetUrl;
     }
@@ -432,93 +430,5 @@ public class ExtensionFactory {
                 }
             }
         }
-    }
-
-    /**
-     * Finds and returns the URL to a resource with the given class loader, or
-     * system class loader if {@code null}, for the given or default locales.
-     * <p>
-     * The resource pathname will be constructed using the parameters package
-     * name, file name, file extension and candidate locales. The candidate
-     * locales are created from the given locale using the method
-     * {@code HelpUtilities#getCandidates(Locale)}.
-     * </p>
-     * <p>
-     * The resource pathname is constructed as:
-     *
-     * <pre>
-     * &quot;package name&quot; + &quot;candidate locale&quot; + '/' + &quot;file name&quot; + &quot;candidate locale&quot; + &quot;file extension&quot;
-     * </pre>
-     *
-     * For example, with the following parameters:
-     * <ul>
-     * <li>package name - /org/zaproxy/zap/extension/example/resources/help</li>
-     * <li>file name - helpset</li>
-     * <li>file extension - .hs</li>
-     * <li>locale - es_ES</li>
-     * </ul>
-     * and default locale "en_GB", it would produce the following resource
-     * pathnames:
-     *
-     * <pre>
-     * /org/zaproxy/zap/extension/example/resources/help_es_ES/helpset_es_ES.hs
-     * /org/zaproxy/zap/extension/example/resources/help_es/helpset_es.hs
-     * /org/zaproxy/zap/extension/example/resources/help/helpset.hs
-     * /org/zaproxy/zap/extension/example/resources/help_en_GB/helpset_en_GB.hs
-     * /org/zaproxy/zap/extension/example/resources/help_en/helpset_en.hs
-     * </pre>
-     *
-     * The URL of the first existent resource is returned.
-     *
-     * @param cl the class loader that will be used to get the resource,
-     * {@code null} the system class loader is used.
-     * @param packageName the name of the package where the resource is
-     * @param fileName the file name of the resource
-     * @param fileExtension the file extension of the resource
-     * @param locale the target locale of the required resource
-     * @return An {@code URL} with the path to the resource or {@code null} if
-     * not found.
-     * @see HelpUtilities#getCandidates(Locale)
-     */
-    // Implementation based (read copied) from:
-    // javax.help.HelpUtilities#getLocalizedResource(ClassLoader cl, String front, String back, Locale locale, boolean tryRead)
-    // Changes:
-    // - Removed the "tryRead" flag since it's not needed (it's set to try to read always);
-    // - Replaced the use of StringBuffer with StringBuilder;
-    // - Renamed parameters "front" to "packageName" and "back" to "name";
-    // - Renamed variable "tail" to "candidateLocale";
-    // - Renamed variable "name" to "resource";
-    // - Added type parameter to "tails" enumeration (now "candidateLocales"), @SuppressWarnings annotation and removed the
-    // String cast;
-    // - Changed to use try-with-resource statement to manage the input stream.
-    // - Changed to also append the "candidateLocale" to the packageName followed by character '/';
-    private static URL findResource(ClassLoader cl, String packageName, String fileName, String fileExtension, Locale locale) {
-        URL url;
-
-        for (@SuppressWarnings("unchecked") Enumeration<String> candidateLocales = HelpUtilities.getCandidates(locale); candidateLocales.hasMoreElements();) {
-            String candidateLocale = candidateLocales.nextElement();
-            String resource = (new StringBuilder(packageName)).append(candidateLocale)
-                    .append('/')
-                    .append(fileName)
-                    .append(candidateLocale)
-                    .append(fileExtension)
-                    .toString();
-            if (cl == null) {
-                url = ClassLoader.getSystemResource(resource);
-            } else {
-                url = cl.getResource(resource);
-            }
-            if (url != null) {
-                // Try doing an actual read to be sure it exists
-                try (InputStream is = url.openConnection().getInputStream()) {
-                    if (is != null && is.read() != -1) {
-                        return url;
-                    }
-                } catch (Throwable t) {
-                    // ignore and continue looking
-                }
-            }
-        }
-        return null;
     }
 }

--- a/src/org/zaproxy/zap/extension/help/ExtensionHelp.java
+++ b/src/org/zaproxy/zap/extension/help/ExtensionHelp.java
@@ -49,6 +49,7 @@ import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.extension.AddOnInstallationStatusListener;
 import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.utils.LocaleUtils;
 import org.zaproxy.zap.view.ZapMenuItem;
 
 /**
@@ -66,7 +67,22 @@ public class ExtensionHelp extends ExtensionAdaptor {
 	 */
 	private static final String HELP_ID_PROPERTY = "HelpID";
 
-	private static final String HELP_SET_FILE_NAME = "helpset";
+	/**
+	 * The (default) file name of a HelpSet.
+	 * 
+	 * @see HelpSet
+	 * @since TODO add version
+	 */
+	public static final String HELP_SET_FILE_NAME = "helpset";
+
+	/**
+	 * The (default) file extension of a HelpSet.
+	 * 
+	 * @see HelpSet
+	 * @since TODO add version
+	 */
+	public static final String HELP_SET_FILE_EXTENSION = "hs";
+ 
 	/**
 	 * @deprecated (2.7.0) Use {@link #getHelpIcon()} instead.
 	 */
@@ -259,7 +275,11 @@ public class ExtensionHelp extends ExtensionAdaptor {
 	 * @see HelpSet
 	 */
 	private static URL findHelpSetUrl() {
-		return HelpSet.findHelpSet(ExtensionFactory.getAddOnLoader(), HELP_SET_FILE_NAME, Constant.getLocale());
+		return LocaleUtils.findResource(
+				HELP_SET_FILE_NAME,
+				HELP_SET_FILE_EXTENSION,
+				Constant.getLocale(),
+				r -> ExtensionFactory.getAddOnLoader().getResource(r));
 	}
 	
 	/**

--- a/src/org/zaproxy/zap/utils/I18N.java
+++ b/src/org/zaproxy/zap/utils/I18N.java
@@ -125,8 +125,7 @@ public class I18N {
 			return;
 		}
     	this.locale = locale;
-    	this.stdMessages = ResourceBundle.getBundle(Constant.MESSAGES_PREFIX, locale,
-                ResourceBundle.Control.getControl(ResourceBundle.Control.FORMAT_PROPERTIES));
+    	this.stdMessages = ResourceBundle.getBundle(Constant.MESSAGES_PREFIX, locale, new ZapResourceBundleControl());
     }
 
     

--- a/src/org/zaproxy/zap/utils/ZapResourceBundleControl.java
+++ b/src/org/zaproxy/zap/utils/ZapResourceBundleControl.java
@@ -1,0 +1,137 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2018 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.utils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
+
+/**
+ * A {@code ResourceBundle.Control} that reverts the language mappings done by the {@code Locale} class when
+ * {@link #toBundleName(String, Locale) creating bundle names}, so that the resources can have the newer ISO 639 language codes.
+ * <p>
+ * It does the following mappings:
+ * <ul>
+ * <li><code>in</code> to <code>id</code></li>
+ * <li><code>iw</code> to <code>he</code></li>
+ * <li><code>ji</code> to <code>yi</code></li>
+ * </ul>
+ *
+ * @since TODO add version
+ * @see Locale#Locale(String)
+ */
+public class ZapResourceBundleControl extends ResourceBundle.Control {
+
+    /**
+     * The language mappings, from old to new codes.
+     */
+    private static final Map<String, String> LANGUAGE_MAPPINGS = new HashMap<>(3);
+
+    static {
+        LANGUAGE_MAPPINGS.put("in", "id");
+        LANGUAGE_MAPPINGS.put("iw", "he");
+        LANGUAGE_MAPPINGS.put("ji", "yi");
+    }
+
+    /**
+     * The supported formats.
+     * 
+     * @see #getFormats(String)
+     */
+    private final List<String> formats;
+
+    private final Locale fallbackLocale;
+
+    /**
+     * Constructs a {@code ZapResourceBundleControl} with format {@link java.util.ResourceBundle.Control#FORMAT_PROPERTIES
+     * FORMAT_PROPERTIES} and {@link Locale#getDefault() default locale} as fallback locale.
+     * 
+     * @see #getFallbackLocale(String, Locale)
+     * @see #getFormats(String)
+     */
+    public ZapResourceBundleControl() {
+        this(Locale.getDefault());
+    }
+
+    /**
+     * Constructs a {@code ZapResourceBundleControl} with the given supported formats and {@link Locale#getDefault() default
+     * locale} as fallback locale.
+     *
+     * @param formats the supported formats.
+     * @see #getFallbackLocale(String, Locale)
+     * @see #getFormats(String)
+     */
+    public ZapResourceBundleControl(List<String> formats) {
+        this(formats, Locale.getDefault());
+    }
+
+    /**
+     * Constructs a {@code ZapResourceBundleControl} with the given fallback locale and with format
+     * {@link java.util.ResourceBundle.Control#FORMAT_PROPERTIES FORMAT_PROPERTIES} formats.
+     *
+     * @param fallbackLocale the fallback locale, might be {@code null}.
+     * @see #getFallbackLocale(String, Locale)
+     * @see #getFormats(String)
+     */
+    public ZapResourceBundleControl(Locale fallbackLocale) {
+        this(ResourceBundle.Control.FORMAT_PROPERTIES, fallbackLocale);
+    }
+
+    /**
+     * Constructs a {@code ZapResourceBundleControl} with the given supported formats and fallback locale.
+     *
+     * @param formats the supported formats.
+     * @param fallbackLocale the fallback locale, might be {@code null}.
+     * @see #getFallbackLocale(String, Locale)
+     * @see #getFormats(String)
+     */
+    public ZapResourceBundleControl(List<String> formats, Locale fallbackLocale) {
+        if (formats == null) {
+            throw new IllegalArgumentException("The parameter formats must not be null.");
+        }
+        this.formats = Collections.unmodifiableList(new ArrayList<>(formats));
+        this.fallbackLocale = fallbackLocale;
+    }
+
+    @Override
+    public String toBundleName(String baseName, Locale locale) {
+        String bundleName = super.toBundleName(baseName, locale);
+        String language = locale.getLanguage();
+        String mapping = LANGUAGE_MAPPINGS.get(language);
+        if (mapping != null) {
+            return bundleName.replace(baseName + "_" + language, baseName + "_" + mapping);
+        }
+        return bundleName;
+    }
+
+    @Override
+    public List<String> getFormats(String baseName) {
+        return formats;
+    }
+
+    @Override
+    public Locale getFallbackLocale(String baseName, Locale locale) {
+        return locale.equals(fallbackLocale) ? null : fallbackLocale;
+    }
+}

--- a/test/org/zaproxy/zap/utils/MessagesLocaleUnitTest.java
+++ b/test/org/zaproxy/zap/utils/MessagesLocaleUnitTest.java
@@ -1,0 +1,108 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2018 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.utils;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.apache.log4j.Logger;
+import org.apache.log4j.varia.NullAppender;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.parosproxy.paros.Constant;
+
+/**
+ * Unit test to verify that the {@code Messages.properties} files are loaded with expected {@code Locale}.
+ */
+public class MessagesLocaleUnitTest {
+
+    private static final Path DIRECTORY = Paths.get("src/" + Constant.LANG_DIR);
+    private static final String BASE_NAME = Constant.MESSAGES_PREFIX;
+    private static final String FILE_NAME = BASE_NAME + "_";
+    private static final String FILE_EXTENSION = ".properties";
+
+    @BeforeClass
+    public static void suppressLogging() {
+        Logger.getRootLogger().addAppender(new NullAppender());
+    }
+
+    @Test
+    public void shouldLoadAllMessagesFilesAvailable() throws Exception {
+        try (URLClassLoader classLoader = new URLClassLoader(new URL[] { DIRECTORY.toUri().toURL() })) {
+            List<String> brokenLocales = new ArrayList<>();
+            for (Path file : getMessagesFiles()) {
+                String fileName = file.getFileName().toString();
+                String[] localeParts = fileName.substring(FILE_NAME.length(), fileName.indexOf(FILE_EXTENSION)).split("_");
+
+                if (localeParts.length > 1) {
+                    Locale locale = new Locale(localeParts[0], localeParts[1]);
+                    ResourceBundle rb = ResourceBundle
+                            .getBundle(BASE_NAME, locale, classLoader, new ZapResourceBundleControl());
+                    if (!rb.getLocale().equals(locale)) {
+                        brokenLocales.add(buildMessage(fileName, locale, rb.getLocale()));
+                    }
+                } else {
+                    brokenLocales.add("File with unhandled locale: " + fileName);
+                }
+            }
+            assertThat(brokenLocales.toString(), brokenLocales, hasSize(0));
+        }
+    }
+
+    private static String buildMessage(String fileName, Locale expected, Locale actual) {
+        return fileName + " uses '" + ((actual == Locale.ROOT) ? "ROOT" : actual) + "' instead of '" + expected + "'";
+    }
+
+    private static List<Path> getMessagesFiles() {
+        final List<Path> files = new ArrayList<>();
+        try {
+            Files.walkFileTree(DIRECTORY, Collections.<FileVisitOption> emptySet(), 1, new SimpleFileVisitor<Path>() {
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    String fileName = file.getFileName().toString();
+                    if (fileName.startsWith(FILE_NAME) && fileName.endsWith(FILE_EXTENSION)) {
+                        files.add(file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            throw new RuntimeException("An error occurred while walking directory: " + DIRECTORY, e);
+        }
+        return files;
+    }
+}


### PR DESCRIPTION
Add a custom ResourceBundle.Control (ZapResourceBundleControl) that maps
old language codes to the new ones when creating the bundle names, to
pick the correct files.
Add helper methods to LocaleUtils that help find a localised resource.
Change ExtensionFactory, ExtensionHelp, VulnerabilitiesLoader, and I18N
to use ZapResourceBundleControl (either directly when getting a
ResourceBundle or indirectly using LocaleUtils), to load core and add-on
resources (e.g. help, vulnerabilities.xml, and Messages.properies) with
expected locale.
Add test (MessagesLocaleUnitTest) to verify that the custom Control can
correctly load all Messages.properties files.
Add tests to LocaleUtilsUnitTest to assert the expected resource names
are produced.

Fix #4408 - Reinstate locale mapping