### PR TITLE
Fail sooner if searching with invalid pattern

### DIFF
--- a/src/org/zaproxy/zap/extension/search/SearchThread.java
+++ b/src/org/zaproxy/zap/extension/search/SearchThread.java
@@ -38,6 +38,7 @@ public class SearchThread extends Thread {
 	private static final String THREAD_NAME = "ZAP-SearchThread";
 
 	private String filter;
+	private Pattern pattern;
 	private Type reqType;
 	private SearchListenner searchListenner;
 	private boolean stopSearch = false;
@@ -72,6 +73,7 @@ public class SearchThread extends Thread {
             boolean searchJustInScope, String baseUrl, int start, int count, boolean searchAllOccurrences, int maxOccurrences) {
 		super(THREAD_NAME);
 		this.filter = filter;
+		this.pattern = Pattern.compile(filter, Pattern.MULTILINE| Pattern.CASE_INSENSITIVE);
 		this.reqType = reqType;
 		this.customSearcherName = customSearcherName;
 		this.searchListenner = searchListenner;
@@ -102,7 +104,6 @@ public class SearchThread extends Thread {
 
 	private void search() {
 	    Session session = Model.getSingleton().getSession();
-        Pattern pattern = Pattern.compile(filter, Pattern.MULTILINE| Pattern.CASE_INSENSITIVE);
 		Matcher matcher = null;
 		
         try {


### PR DESCRIPTION
Change SearchThread to compile the pattern sooner (in the constructor)
to fail immediately if the provided filter/pattern is invalid, allowing
the caller to handle it (instead of failing later when already running
in the search thread).