### PR TITLE
Add message to status code check in CFU requests

### DIFF
--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -805,7 +805,9 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
         		Model.getSingleton().getOptionsParam().getConnectionParam());
         getHttpSender().sendAndReceive(msg,true);
         if (msg.getResponseHeader().getStatusCode() != HttpStatusCode.OK) {
-            throw new IOException();
+            throw new IOException(
+                    "Expected '200 OK' but got '" + msg.getResponseHeader().getStatusCode() + " "
+                            + msg.getResponseHeader().getReasonPhrase() + "'");
         }
         if (! msg.getRequestHeader().isSecure()) {
         	// Only access the cfu page over https


### PR DESCRIPTION
Change ExtensionAutoUpdate to include a message in the exception thrown
by the status code check.

---
From OWASP ZAP User Group: https://groups.google.com/d/topic/zaproxy-users/-pDDJ2bOAFg/discussion