### PR TITLE
Allow to get the current parameter in IV scripts

### DIFF
--- a/src/scripts/templates/variant/Input Vector default template.js
+++ b/src/scripts/templates/variant/Input Vector default template.js
@@ -42,13 +42,14 @@ function parseParameters(helper, msg) {
 function setParameter(helper, msg, param, value, escaped) {
     size = helper.getParamNumber();
     query = "";
+    var pos = helper.getCurrentParam().getPosition();
 
     for (var i = 0; i < size; i++) {
         pname = helper.getParamName(i);
         pvalue = helper.getParamValue(i);
 
         if (paramStates[i] === B64STATE) { //Handle values that were originally base64
-            if (pname == param) {
+            if (i == pos) {
                 //Encode the injected value
                 pvalue = encodeURIComponent(helper.encodeBase64(value));
             } else {
@@ -56,7 +57,7 @@ function setParameter(helper, msg, param, value, escaped) {
                 pvalue = encodeURIComponent(helper.encodeBase64(pvalue));
             }
         } else { //Handle regular values
-            if (pname == param) {
+            if (i == pos) {
                 if (escaped == false) {
                     value = encodeURIComponent(value);
                 }


### PR DESCRIPTION
Change VariantCustom to allow Input Vector scripts to get the current
parameter being tested so that they can reliably know which parameter is
being tested (instead using custom names or the name being injected,
which might not be the same as the current parameter).
Change Input Vector default template.js to make use of the new method.