### PR TITLE
Include input elements with related form attribute

### DIFF
--- a/test/org/zaproxy/zap/spider/parser/SpiderHtmlFormParserUnitTest.java
+++ b/test/org/zaproxy/zap/spider/parser/SpiderHtmlFormParserUnitTest.java
@@ -1161,6 +1161,60 @@ public class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
                                 attribute("att2", "value2"))))));
     }
 
+    @Test
+    public void shouldParseGetFormAndIncludeRelatedInputsWithFormAttribute() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("GET", "FormAndInputsWithFormAttributes.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(3)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "http://example.org/?field1=Field1&field2=Field2&field3=Field3&field4=Field4&submit=Submit1",
+                        "http://example.org/?field1=Field1&field2=Field2&field3=Field3&field4=Field4&submit=Submit2",
+                        "http://example.org/?field1=Field1&field2=Field2&field3=Field3&field4=Field4&submit=Submit3"));
+    }
+
+    @Test
+    public void shouldParsePostFormAndIncludeRelatedInputsWithFormAttribute() {
+        // Given
+        SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage msg = createMessageWith("POST", "FormAndInputsWithFormAttributes.html");
+        Source source = createSource(msg);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(msg, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(3)));
+        assertThat(
+                listener.getResourcesFound(),
+                contains(
+                        postResource(
+                                msg,
+                                1,
+                                "http://example.org/",
+                                "field1=Field1&submit=Submit1&field2=Field2&field3=Field3&field4=Field4"),
+                        postResource(
+                                msg,
+                                1,
+                                "http://example.org/",
+                                "field1=Field1&submit=Submit2&field2=Field2&field3=Field3&field4=Field4"),
+                        postResource(
+                                msg,
+                                1,
+                                "http://example.org/",
+                                "field1=Field1&submit=Submit3&field2=Field2&field3=Field3&field4=Field4")));
+    }
+
     private static String formattedDate(String format, Date date) {
         return new SimpleDateFormat(format).format(date);
     }

--- a/test/resources/org/zaproxy/zap/spider/parser/htmlform/FormAndInputsWithFormAttributes.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/htmlform/FormAndInputsWithFormAttributes.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Form Attributes - Spider HTML Form Parser</title>
+</head>
+<body>
+
+<input form="form1" type="text" name="field1" value="Field1" />
+<input form="form1" type="submit" name="submit" value="Submit1" />
+
+<input form="" type="text" name="field1-EF" value="Field1 -empty-form" />
+
+<input form="missing-form" type="text" name="field1-MF" value="Field1 -missing-form" />
+
+<form id="form1" action="http://example.org/" method="%%METHOD%%">
+<input type="text" name="field2" value="Field2" />
+<input form="" type="text" name="field2-EF" value="Field2 -empty-form-inlined" />
+<input form="form1" type="text" name="field3" value="Field3" />
+<input type="submit" name="submit" value="Submit2" />
+<input form="missing-form" type="text" name="field2-MF" value="Field2 -missing-form-inlined" />
+</form>
+
+<input form="form1" type="text" name="field4" value="Field4" />
+<input form="form1" type="submit" name="submit" value="Submit3" />
+
+<input form="missing-form" type="submit" name="submit-MF" value="Submit -missing-form" />
+
+</body>
+</html>


### PR DESCRIPTION
Change SpiderHtmlFormParser to take into account the form attribute of
input elements when creating the form data, to submit all related input
elements.
Add tests to assert the expected behaviour.

Fix #4422 - Spider Scan does not understand HTML 5 form syntax