### PR TITLE
Remove unnecessary resource message

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -2392,7 +2392,6 @@ view.options.label.scaleImages				= Scale Images:
 view.options.label.showTabNames             = Show Tab Names
 view.options.label.showMainToolbar          = Show Main Toolbar
 view.options.label.wmuihandler              = Let Window Manager handle ZAP window
-view.options.misc.title                     = Miscellaneous
 view.options.title                          = Display
 view.table.autoscroll.label = Auto-Scroll
 view.table.autoscroll.tooltip = Auto-scrolls when new entries are added to the table, if the scroll bar is at the bottom.

--- a/src/org/parosproxy/paros/extension/option/OptionsViewPanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsViewPanel.java
@@ -28,10 +28,11 @@
 // ZAP: 2016/04/04 Do not require a restart to show/hide the tool bar
 // ZAP: 2016/04/06 Fix layouts' issues
 // ZAP: 2017/01/09 Remove method no longer needed.
+// ZAP: 2018/03/01 Remove the name from a panel and use BorderLayout.
 
 package org.parosproxy.paros.extension.option;
 
-import java.awt.CardLayout;
+import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Font;
@@ -123,9 +124,9 @@ public class OptionsViewPanel extends AbstractParamPanel {
 	 * This method initializes this
 	 */
 	private void initialize() {
-        this.setLayout(new CardLayout());
+        this.setLayout(new BorderLayout());
         this.setName(Constant.messages.getString("view.options.title"));
-        this.add(getPanelMisc(), getPanelMisc().getName());
+        this.add(getPanelMisc());
 
 	}
 	
@@ -142,7 +143,6 @@ public class OptionsViewPanel extends AbstractParamPanel {
 		    if (Model.getSingleton().getOptionsParam().getViewParam().getWmUiHandlingOption() == 0) {
 		    	panelMisc.setSize(114, 132);
 		    }
-			panelMisc.setName(Constant.messages.getString("view.options.misc.title"));
 
 			displayLabel = new JLabel(Constant.messages.getString("view.options.label.display"));
 			brkPanelViewLabel = new JLabel(Constant.messages.getString("view.options.label.brkPanelView"));

--- a/src/org/zaproxy/zap/extension/option/OptionsLocalePanel.java
+++ b/src/org/zaproxy/zap/extension/option/OptionsLocalePanel.java
@@ -19,7 +19,7 @@
  */
 package org.zaproxy.zap.extension.option;
 
-import java.awt.CardLayout;
+import java.awt.BorderLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
@@ -51,9 +51,9 @@ public class OptionsLocalePanel extends AbstractParamPanel {
 	 * This method initializes this
 	 */
     private void initialize() {
-        this.setLayout(new CardLayout());
+        this.setLayout(new BorderLayout());
         this.setName(Constant.messages.getString("view.options.title"));
-        this.add(getPanelMisc(), getPanelMisc().getName());
+        this.add(getPanelMisc());
 
 	}
 	/**
@@ -67,7 +67,6 @@ public class OptionsLocalePanel extends AbstractParamPanel {
 
 			panelMisc.setLayout(new GridBagLayout());
 			panelMisc.setSize(114, 132);
-			panelMisc.setName(Constant.messages.getString("view.options.misc.title"));
 
 			GridBagConstraints gbc0 = new GridBagConstraints();
 			GridBagConstraints gbc1_0 = new GridBagConstraints();


### PR DESCRIPTION
Remove a resource message that was not being shown in the UI (it was
only used internally in a UI panel). Also, tweak the panels that were
using it to not require a name.