### PR TITLE
Update Webswing to 2.5 in Docker images

### DIFF
--- a/build/docker/Dockerfile-live
+++ b/build/docker/Dockerfile-live
@@ -64,9 +64,14 @@ RUN git clone --depth 1 https://github.com/zaproxy/zaproxy.git && \
 	cp -R /zap-src/zaproxy/build/zap/* /zap/ && \
 	rm -rf /zap-src/* && \
 	cd /zap/ && \
-	curl -s -L https://bitbucket.org/meszarv/webswing/downloads/webswing-2.3-distribution.zip > webswing.zip && \
+	# Setup Webswing
+	curl -s -L https://bitbucket.org/meszarv/webswing/downloads/webswing-2.5-distribution.zip > webswing.zip && \
 	unzip webswing.zip && \
 	rm webswing.zip && \
+	mv webswing-* webswing && \
+	# Remove Webswing demos
+	rm -R webswing/demo/ && \
+	# Accept ZAP license
 	touch AcceptedLicense
 
 ENV ZAP_PATH /zap/zap.sh
@@ -75,7 +80,7 @@ ENV ZAP_PORT 8080
 ENV HOME /home/zap/
 
 COPY zap* /zap/
-COPY webswing.config /zap/webswing-2.3/
+COPY webswing.config /zap/webswing/
 COPY policies /home/zap/.ZAP_D/policies/
 COPY scripts /home/zap/.ZAP_D/scripts/
 COPY .xinitrc /home/zap/
@@ -86,7 +91,7 @@ USER root
 RUN chown zap:zap /zap/zap-x.sh && \
 	chown zap:zap /zap/zap-baseline.py && \
 	chown zap:zap /zap/zap-webswing.sh && \
-	chown zap:zap /zap/webswing-2.3/webswing.config && \
+	chown zap:zap /zap/webswing/webswing.config && \
 	chown zap:zap -R /home/zap/.ZAP_D/ && \
 	chown zap:zap /home/zap/.xinitrc && \
 	chmod a+x /home/zap/.xinitrc && \

--- a/build/docker/Dockerfile-stable
+++ b/build/docker/Dockerfile-stable
@@ -43,9 +43,14 @@ RUN mkdir /home/zap/.vnc
 RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml | xmlstarlet sel -t -v //url |grep -i Linux | wget -nv --content-disposition -i - -O - | tar zxv && \
 	cp -R ZAP*/* . &&  \
 	rm -R ZAP* && \
-	curl -s -L https://bitbucket.org/meszarv/webswing/downloads/webswing-2.3-distribution.zip > webswing.zip && \
-	unzip *.zip && \
-	rm *.zip && \
+	# Setup Webswing
+	curl -s -L https://bitbucket.org/meszarv/webswing/downloads/webswing-2.5-distribution.zip > webswing.zip && \
+	unzip webswing.zip && \
+	rm webswing.zip && \
+	mv webswing-* webswing && \
+	# Remove Webswing demos
+	rm -R webswing/demo/ && \
+	# Accept ZAP license
 	touch AcceptedLicense
 
 
@@ -58,7 +63,7 @@ ENV ZAP_PORT 8080
 ENV HOME /home/zap/
 
 COPY zap* /zap/
-COPY webswing.config /zap/webswing-2.3/
+COPY webswing.config /zap/webswing/
 COPY policies /home/zap/.ZAP/policies/
 COPY .xinitrc /home/zap/
 
@@ -68,7 +73,7 @@ USER root
 RUN chown zap:zap /zap/zap-x.sh && \
 	chown zap:zap /zap/zap-baseline.py && \
 	chown zap:zap /zap/zap-webswing.sh && \
-	chown zap:zap /zap/webswing-2.3/webswing.config && \
+	chown zap:zap /zap/webswing/webswing.config && \
 	chown zap:zap -R /home/zap/.ZAP/ && \
 	chown zap:zap /home/zap/.xinitrc && \
 	chmod a+x /home/zap/.xinitrc

--- a/build/docker/Dockerfile-weekly
+++ b/build/docker/Dockerfile-weekly
@@ -44,9 +44,14 @@ RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersio
 	rm *.zip && \
 	cp -R ZAP*/* . &&  \
 	rm -R ZAP* && \
-	curl -s -L https://bitbucket.org/meszarv/webswing/downloads/webswing-2.3-distribution.zip > webswing.zip && \
-	unzip *.zip && \
-	rm *.zip && \
+	# Setup Webswing
+	curl -s -L https://bitbucket.org/meszarv/webswing/downloads/webswing-2.5-distribution.zip > webswing.zip && \
+	unzip webswing.zip && \
+	rm webswing.zip && \
+	mv webswing-* webswing && \
+	# Remove Webswing demos
+	rm -R webswing/demo/ && \
+	# Accept ZAP license
 	touch AcceptedLicense
 
 
@@ -59,7 +64,7 @@ ENV ZAP_PORT 8080
 ENV HOME /home/zap/
 
 COPY zap* /zap/
-COPY webswing.config /zap/webswing-2.3/
+COPY webswing.config /zap/webswing/
 COPY policies /home/zap/.ZAP_D/policies/
 COPY .xinitrc /home/zap/
 
@@ -69,7 +74,7 @@ USER root
 RUN chown zap:zap /zap/zap-x.sh && \
 	chown zap:zap /zap/zap-baseline.py && \
 	chown zap:zap /zap/zap-webswing.sh && \
-	chown zap:zap /zap/webswing-2.3/webswing.config && \
+	chown zap:zap /zap/webswing/webswing.config && \
 	chown zap:zap -R /home/zap/.ZAP_D/ && \
 	chown zap:zap /home/zap/.xinitrc && \
 	chmod a+x /home/zap/.xinitrc

--- a/build/docker/webswing.config
+++ b/build/docker/webswing.config
@@ -1,24 +1,74 @@
 {
-  "applications" : [ {
-    "name" : "ZAP",
+  "/" : {
+    "path" : "/",
+    "security" : {
+      "module" : "EMBEDED",
+      "config" : {
+        "users" : []
+      },
+      "classPath" : [ ]
+    },
+    "icon" : null,
+    "webFolder" : null,
+    "langFolder" : "${webswing.rootDir}/lang",
+    "homeDir" : "${user.dir}",
+    "swingConfig" : null
+  },
+  "/zap" : {
+    "path" : "/zap",
+    "homeDir" : "/zap",
+    "webFolder" : "",
     "icon" : "icon.png",
-    "mainClass" : "org.zaproxy.zap.ZAP",
-    "classPathEntries" : [ "zap-*.jar", "lib/*.jar", "lang/" ],
-    "vmArgs" : "",
-    "args" : "-host 0.0.0.0 -port 8090",
-    "homeDir" : "/zap/",
-    "maxClients" : 1,
-    "antiAliasText" : true,
-    "swingSessionTimeout" : 300,
-    "authorization" : false,
-    "isolatedFs" : false,
-    "debug" : true,
-    "authentication" : false,
-    "directdraw" : false,
-    "allowDelete" : false,
-    "allowDownload" : false,
-    "allowUpload" : false,
-    "allowJsLink" : true
-  } ],
-  "applets" : []
+    "security" : {
+      "module" : "NONE",
+      "config" : null,
+      "classPath" : [ ],
+      "authorizationConfig" : {
+        "users" : [ ],
+        "roles" : [ ]
+      }
+    },
+    "swingConfig" : {
+      "allowUpload" : true,
+      "allowDownload" : true,
+      "isolatedFs" : false,
+      "autoLogout" : true,
+      "name" : "OWASP ZAP",
+      "theme" : "Murrine",
+      "directdraw" : false,
+      "javaFx" : true,
+      "debug" : false,
+      "userDir" : "",
+      "jreExecutable" : "${java.home}/bin/java",
+      "javaVersion" : "${java.version}",
+      "vmArgs" : null,
+      "launcherType" : "Desktop",
+      "launcherConfig" : {
+        "args" : "-host 0.0.0.0 -port 8090",
+        "mainClass" : "org.zaproxy.zap.ZAP"
+      },
+      "maxClients" : 1,
+      "sessionMode" : "CONTINUE_FOR_BROWSER",
+      "swingSessionTimeout" : -1,
+      "allowStealSession" : true,
+      "allowDelete" : true,
+      "allowAutoDownload" : true,
+      "uploadMaxSize" : 5,
+      "allowJsLink" : true,
+      "fontConfig" : { },
+      "classPathEntries" : [ "zap-*.jar" ],
+      "allowedCorsOrigins" : [ ],
+      "transferDir" : "${user}/upload",
+      "goodbyeUrl" : "",
+      "transparentFileSave" : true,
+      "clearTransferDir" : true,
+      "transparentFileOpen" : true,
+      "timeoutIfInactive" : false,
+      "monitorEdtEnabled" : false,
+      "allowLocalClipboard" : true,
+      "allowServerPrinting" : false
+    },
+    "enabled" : true,
+    "langFolder" : ""
+  }
 }

--- a/build/docker/zap-webswing.sh
+++ b/build/docker/zap-webswing.sh
@@ -6,8 +6,8 @@
 # the docker container running
 #
 # Set environment.
-export HOME=/zap/webswing-2.3/
-export OPTS="-h 0.0.0.0 -j $HOME/jetty.properties -u $HOME/user.properties -c $HOME/webswing.config"
+export HOME=/zap/webswing
+export OPTS="-h 0.0.0.0 -j $HOME/jetty.properties -c $HOME/webswing.config"
 export JAVA_OPTS="-Xmx128M"
 export LOG=$HOME/webswing.out
 export PID_PATH_NAME=$HOME/webswing.pid


### PR DESCRIPTION
Update Docker build files to download Webswing 2.5, remove its demos,
and use a directory without version for Webswing (less changes required
when updating).
Update Webswing configuration to 2.5, ZAP will now be started/available,
for example, under:
  `http://localhost:8080/zap/`
instead of:
  `http://localhost:8080/?anonym=true&app=ZAP`

ZAP will still be accessed with an anonymous account, no other account
will be available.
Update Webswing start up script, zap-webswing.sh, to use the new  dir
and to not pick the user.properties file, there's none to.

Fix #3553 - Update Webswing in Docker images