### PR TITLE
Expose getPluginPassiveScanners()

### DIFF
--- a/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -295,7 +295,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
         return scannerList;
     }
 
-    protected List<PluginPassiveScanner> getPluginPassiveScanners() {
+    public List<PluginPassiveScanner> getPluginPassiveScanners() {
         List<PluginPassiveScanner> pluginPassiveScanners = new ArrayList<>();
         for (PassiveScanner scanner : getPassiveScannerList().list()) {
             if ((scanner instanceof PluginPassiveScanner) && !(scanner instanceof RegexAutoTagScanner)) {


### PR DESCRIPTION
Per https://mozilla.logbot.info/websectools/20180302 change ExtensionPassiveScan.getPluginPassiveScanners() to be public so that the plugin details can be displayed by a standalone script similar to https://github.com/zaproxy/community-scripts/blob/master/standalone/Active%20scan%20rule%20list.js