### PR TITLE
Enable help in Add/Edit Break Point dialogue

### DIFF
--- a/src/org/zaproxy/zap/extension/brk/impl/http/BreakAddEditDialog.java
+++ b/src/org/zaproxy/zap/extension/brk/impl/http/BreakAddEditDialog.java
@@ -156,4 +156,8 @@ public class BreakAddEditDialog extends StandardFieldsDialog {
 		dispose();
 	}
 	
+	@Override
+	public String getHelpIndex() {
+		return "ui.dialogs.addbreak";
+	}
 }


### PR DESCRIPTION
Change BreakAddEditDialog to declare the help index, to have the
corresponding help page accessible directly from the dialogue.