### PR TITLE
Correct case checks in HttpClient classes

### DIFF
--- a/src/org/apache/commons/httpclient/HttpMethodDirector.java
+++ b/src/org/apache/commons/httpclient/HttpMethodDirector.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -70,6 +71,7 @@ import org.apache.commons.logging.LogFactory;
  *  - Added constant PARAM_REMOVE_USER_DEFINED_AUTH_HEADERS;
  *  - Added the public modifier to the class.
  *  - Establish a tunnel if the request has a connection upgrade.
+ *  - Use neutral Locale when converting to lower case.
  */
 /**
  * Handles the process of executing a method including authentication, redirection and retries.
@@ -535,7 +537,7 @@ public class HttpMethodDirector {
         if (connectionHeader == null) {
             return false;
         }
-        return connectionHeader.getValue().toLowerCase().contains("upgrade");
+        return connectionHeader.getValue().toLowerCase(Locale.ROOT).contains("upgrade");
     }
 
     /**

--- a/src/org/apache/commons/httpclient/URI.java
+++ b/src/org/apache/commons/httpclient/URI.java
@@ -54,6 +54,7 @@ import org.apache.commons.httpclient.util.EncodingUtil;
  *  - Add missing override and deprecated annotations;
  *  - Fix unchecked/rawtypes warnings (required by lint checks).
  *  - Allow to use underscores in hostnames.
+ *  - Use neutral Locale when converting to lower case.
  */
 /**
  * The interface for the URI(Uniform Resource Identifiers) version of RFC 2396.
@@ -280,7 +281,7 @@ public class URI implements Cloneable, Comparable<Object>, Serializable {
         if (scheme == null) {
            throw new URIException(URIException.PARSING, "scheme required");
         }
-        char[] s = scheme.toLowerCase().toCharArray();
+        char[] s = scheme.toLowerCase(Locale.ROOT).toCharArray();
         if (validate(s, URI.scheme)) {
             _scheme = s; // is_absoluteURI
         } else {
@@ -1964,7 +1965,7 @@ public class URI implements Cloneable, Comparable<Object>, Serializable {
          * </pre></blockquote><p>
          */
         if (at > 0 && at < length && tmp.charAt(at) == ':') {
-            char[] target = tmp.substring(0, at).toLowerCase().toCharArray();
+            char[] target = tmp.substring(0, at).toLowerCase(Locale.ROOT).toCharArray();
             if (validate(target, scheme)) {
                 _scheme = target;
             } else {


### PR DESCRIPTION
Change HttpMethodDirector and URI to do lower case conversions with a
neutral locale.

Part of #4327 - ZAP relies on default locale when it shouldn't