### PR TITLE
Normalise Source instantiations

### DIFF
--- a/src/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRF.java
+++ b/src/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRF.java
@@ -241,8 +241,7 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
 	}
 	
 	public String getTokenValue(HttpMessage tokenMsg, String tokenName) {
-		String response = tokenMsg.getResponseHeader().toString() + tokenMsg.getResponseBody().toString();
-		Source source = new Source(response);
+		Source source = new Source(tokenMsg.getResponseBody().toString());
 		List<Element> formElements = source.getAllElements(HTMLElementName.FORM);
 		
 		if (formElements != null && formElements.size() > 0) {
@@ -342,9 +341,7 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
 				HistoryReference hRef = historyReferenceFactory.createHistoryReference(i);
 				if (filter.matches(hRef)) {
 					HttpMessage msg = hRef.getHttpMessage();
-					String response = msg.getResponseHeader().toString() + 
-						msg.getResponseBody().toString();
-					Source src = new Source(response);
+					Source src = new Source(msg.getResponseBody().toString());
 
 					if (msg.isResponseFromTargetHost()) {
 					    antiCsrfDetectScanner.scanHttpResponseReceive(msg, hRef.getHistoryId(), src);

--- a/src/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
+++ b/src/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
@@ -139,8 +139,7 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
 					try {
 						// Parse the record
 						HttpMessage msg = href.getHttpMessage();
-						String response = msg.getResponseHeader().toString() + msg.getResponseBody().toString();
-						Source src = new Source(response);
+						Source src = new Source(msg.getResponseBody().toString());
 						
 						for (PassiveScanner scanner : scannerList.list()) {
 							try {

--- a/src/org/zaproxy/zap/httputils/HtmlContextAnalyser.java
+++ b/src/org/zaproxy/zap/httputils/HtmlContextAnalyser.java
@@ -88,7 +88,7 @@ public class HtmlContextAnalyser {
 
 	public HtmlContextAnalyser (HttpMessage msg) {
 		this.msg = msg;
-		this.htmlPage = msg.getResponseHeader().toString() + msg.getResponseBody().toString();
+		this.htmlPage = msg.getResponseBody().toString();
 		src = new Source(htmlPage);
 		src.fullSequentialParse();
 	}


### PR DESCRIPTION
Change ExtensionAntiCSRF, PassiveScanThread, and HtmlContextAnalyser to
only use the response body when instantiating the Source, the header is
not necessary, the body is already using the expected charset (as
specified in the header or determined from inspecting the body).
Other classes (spider parsers and corresponding tests) were already
using just the body.

Per talks in IRC channel (related to #2577).