### PR TITLE
Plugin ID Reservations (HttpsInfo)

### DIFF
--- a/src/doc/scanners.md
+++ b/src/doc/scanners.md
@@ -96,8 +96,9 @@ Scanners:
 
 10200   Beast (via HTTPS Info Extension)
 10201   Crime (via HTTPS Info Extension)
-
 10202   Absence of Anti-CSRF Tokens
+10203   Freak (via HTTPS Info Extension)
+10204   Robot (via HTTPS Info Extension)
 
 20000   Cold Fusion default file [Deprecated]
 20001   Lotus Domino default files [Deprecated]


### PR DESCRIPTION
Reserve two IDs for the HttpsInfo extension, to cover Freak and Robot alerts.