### PR TITLE
Allow to create ScriptEngineWrapper with a factory

### DIFF
--- a/src/org/zaproxy/zap/extension/script/DefaultEngineWrapper.java
+++ b/src/org/zaproxy/zap/extension/script/DefaultEngineWrapper.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
 import javax.swing.ImageIcon;
 
 import org.apache.log4j.Logger;
@@ -37,8 +38,26 @@ public class DefaultEngineWrapper extends ScriptEngineWrapper {
 
     private static Logger logger = Logger.getLogger(DefaultEngineWrapper.class);
 
+	/**
+	 * Constructs a {@code DefaultEngineWrapper} with the given engine (to obtain a factory).
+	 *
+	 * @param engine an engine to obtain the corresponding {@code ScriptEngineFactory}.
+	 * @deprecated (TODO add version) Use {@link #DefaultEngineWrapper(ScriptEngineFactory)} instead.
+	 */
+	@Deprecated
 	public DefaultEngineWrapper(ScriptEngine engine) {
 		super(engine);
+	}
+
+	/**
+	 * Constructs a {@code DefaultEngineWrapper} with the given engine factory.
+	 *
+	 * @param factory the factory to create {@code ScriptEngine}s and obtain engine data (for example, engine name, language).
+	 * @since TODO add version
+	 * @see #getEngine()
+	 */
+	public DefaultEngineWrapper(ScriptEngineFactory factory) {
+		super(factory);
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/src/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -150,7 +150,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
         
         ScriptEngine se = mgr.getEngineByName("ECMAScript");
         if (se != null) {
-        	this.registerScriptEngineWrapper(new JavascriptEngineWrapper(se));
+        	this.registerScriptEngineWrapper(new JavascriptEngineWrapper(se.getFactory()));
         } else {
         	logger.error("No Javascript/ECMAScript engine found");
         }
@@ -426,7 +426,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 			}
 		}
 		if (engine != null) {
-			DefaultEngineWrapper dew = new DefaultEngineWrapper(engine);
+			DefaultEngineWrapper dew = new DefaultEngineWrapper(engine.getFactory());
 			this.registerScriptEngineWrapper(dew);
 			return dew;
 		}

--- a/src/org/zaproxy/zap/extension/script/JavascriptEngineWrapper.java
+++ b/src/org/zaproxy/zap/extension/script/JavascriptEngineWrapper.java
@@ -21,6 +21,7 @@
 package org.zaproxy.zap.extension.script;
 
 import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
 import javax.swing.ImageIcon;
 
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
@@ -37,8 +38,26 @@ public class JavascriptEngineWrapper extends DefaultEngineWrapper {
 	 */
 	private static ImageIcon icon;
 
+	/**
+	 * Constructs a {@code JavascriptEngineWrapper} with the given engine (to obtain a factory).
+	 *
+	 * @param engine an engine to obtain the corresponding {@code ScriptEngineFactory}.
+	 * @deprecated (TODO add version) Use {@link #JavascriptEngineWrapper(ScriptEngineFactory)} instead.
+	 */
+	@Deprecated
 	public JavascriptEngineWrapper(ScriptEngine engine) {
 		super(engine);
+	}
+
+	/**
+	 * Constructs a {@code JavascriptEngineWrapper} with the given engine factory.
+	 *
+	 * @param factory the factory to create {@code ScriptEngine}s and obtain engine data (for example, engine name, language).
+	 * @since TODO add version
+	 * @see #getEngine()
+	 */
+	public JavascriptEngineWrapper(ScriptEngineFactory factory) {
+		super(factory);
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/script/ScriptEngineWrapper.java
+++ b/src/org/zaproxy/zap/extension/script/ScriptEngineWrapper.java
@@ -30,8 +30,26 @@ public abstract class ScriptEngineWrapper {
 
 	private final ScriptEngineFactory factory;
 	
+	/**
+	 * Constructs a {@code ScriptEngineWrapper} with the given engine (to obtain a factory).
+	 *
+	 * @param engine an engine to obtain the corresponding {@code ScriptEngineFactory}.
+	 * @deprecated (TODO add version) Use {@link #ScriptEngineWrapper(ScriptEngineFactory)} instead.
+	 */
+	@Deprecated
 	public ScriptEngineWrapper(ScriptEngine engine) {
-		this.factory = engine.getFactory();
+		this(engine.getFactory());
+	}
+
+	/**
+	 * Constructs a {@code ScriptEngineWrapper} with the given engine factory.
+	 *
+	 * @param factory the factory to create {@code ScriptEngine}s and obtain engine data (for example, engine name, language).
+	 * @since TODO add version
+	 * @see #getEngine()
+	 */
+	public ScriptEngineWrapper(ScriptEngineFactory factory) {
+		this.factory = factory;
 	}
 	
 	public String getLanguageName() {


### PR DESCRIPTION
Add constructors to ScriptEngineWrapper and DefaultEngineWrapper that
have ScriptEngineFactory as parameter, these classes just need a factory
not an engine. Also, deprecated the ScriptEngine constructors.