### PR TITLE
Remove AbstractPanel from internal list, always

### DIFF
--- a/src/org/zaproxy/zap/view/TabbedPanel2.java
+++ b/src/org/zaproxy/zap/view/TabbedPanel2.java
@@ -371,6 +371,22 @@ public class TabbedPanel2 extends TabbedPanel {
 
 	public void removeTab(AbstractPanel panel) {
 		this.remove(panel);
+	}
+
+	@Override
+	public void removeTabAt(int index) {
+		if (index < 0 || index >= getTabCount()) {
+			throw new IndexOutOfBoundsException("Index: " + index + ", Tab count: " + getTabCount());
+		}
+
+		Component component = getComponentAt(index);
+		super.removeTabAt(index);
+
+		if (!(component instanceof AbstractPanel)) {
+			return;
+		}
+
+		AbstractPanel panel = (AbstractPanel) component;
 		this.fullTabList.remove(panel);
 		if (this.removedTabList.remove(panel)) {
 			handleHiddenTabListTab();


### PR DESCRIPTION
Change `TabbedPanel2` to override `removeTabAt(int)` and remove the
`AbstractPanel` from the internal list in this method (instead of in
`removeTab(AbstractPanel)`) to ensure the panels are removed always,
thus avoid leaking them. The method `removeTabAt(int)` ends up being
called by `removeTab(AbstractPanel))`, `remove(Component)`, and
`remove(int)`.