### PR TITLE
Do not change case when ignoring case in equals

### DIFF
--- a/src/org/parosproxy/paros/Constant.java
+++ b/src/org/parosproxy/paros/Constant.java
@@ -75,6 +75,7 @@
 // ZAP: 2018/01/04 Clear SNI Terminator options when updating from older ZAP versions.
 // ZAP: 2018/01/05 Prevent use of install dir as home dir.
 // ZAP: 2018/02/14 Remove unnecessary boxing / unboxing
+// ZAP: 2018/03/16 Use equalsIgnoreCase (Issue 4327).
 
 package org.parosproxy.paros;
 
@@ -1155,7 +1156,7 @@ public final class Constant {
 		    		if (osLikeValue != null) { 
 			    		String [] oSLikes = osLikeValue.split(" ");
 			    		for (String osLike: oSLikes) {
-			    			if (osLike.toLowerCase().equals("kali")) {    				
+			    			if (osLike.equalsIgnoreCase("kali")) {
 			    				onKali = Boolean.TRUE;
 			    				break;
 			    			}

--- a/src/org/zaproxy/zap/extension/api/DotNetAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/DotNetAPIGenerator.java
@@ -157,9 +157,9 @@ public class DotNetAPIGenerator extends AbstractAPIGenerator {
 				} else {
 					out.write(", ");
 				}
-				if (param.toLowerCase().equals("boolean")) {
+				if (param.equalsIgnoreCase("boolean")) {
 					out.write("bool boolean");
-				} else if (param.toLowerCase().equals("integer")) {
+				} else if (param.equalsIgnoreCase("integer")) {
 					out.write("int i");
 				} else {
 					out.write("string ");
@@ -174,9 +174,9 @@ public class DotNetAPIGenerator extends AbstractAPIGenerator {
 				} else {
 					out.write(", ");
 				}
-				if (param.toLowerCase().equals("boolean")) {
+				if (param.equalsIgnoreCase("boolean")) {
 					out.write("bool boolean");
-				} else if (param.toLowerCase().equals("integer")) {
+				} else if (param.equalsIgnoreCase("integer")) {
 					out.write("int i");
 				} else {
 					out.write("string ");
@@ -195,9 +195,9 @@ public class DotNetAPIGenerator extends AbstractAPIGenerator {
 			if (element.getMandatoryParamNames() != null) {
 				for (String param : element.getMandatoryParamNames()) {
 					out.write("\t\t\tparameters.Add(\"" + param + "\", ");
-					if (param.toLowerCase().equals("boolean")) {
+					if (param.equalsIgnoreCase("boolean")) {
 						out.write("Convert.ToString(boolean)");
-					} else if (param.toLowerCase().equals("integer")) {
+					} else if (param.equalsIgnoreCase("integer")) {
 						out.write("Convert.ToString(i)");
 					} else {
 						out.write(createParameterName(param.toLowerCase()));
@@ -208,9 +208,9 @@ public class DotNetAPIGenerator extends AbstractAPIGenerator {
 			if (element.getOptionalParamNames() != null) {
 				for (String param : element.getOptionalParamNames()) {
 					out.write("\t\t\tparameters.Add(\"" + param + "\", ");
-					if (param.toLowerCase().equals("boolean")) {
+					if (param.equalsIgnoreCase("boolean")) {
 						out.write("Convert.ToString(boolean)");
-					} else if (param.toLowerCase().equals("integer")) {
+					} else if (param.equalsIgnoreCase("integer")) {
 						out.write("Convert.ToString(i)");
 					} else {
 						out.write(createParameterName(param.toLowerCase()));

--- a/src/org/zaproxy/zap/extension/api/GoAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/GoAPIGenerator.java
@@ -198,13 +198,13 @@ public class GoAPIGenerator extends AbstractAPIGenerator {
 		if (elements != null && elements.size() > 0) {
 			ArrayList<String> args = new ArrayList<String>();
 			for (String param : elements) {
-				if (param.toLowerCase().equals("boolean")) {
+				if (param.equalsIgnoreCase("boolean")) {
 					args.add("boolean bool");
-				} else if (param.toLowerCase().equals("integer")) {
+				} else if (param.equalsIgnoreCase("integer")) {
 					args.add("i int");
-				} else if (param.toLowerCase().equals("string")) {
+				} else if (param.equalsIgnoreCase("string")) {
 					args.add("str string");
-				} else if (param.toLowerCase().equals("type")) {
+				} else if (param.equalsIgnoreCase("type")) {
 					args.add("t string");
 				} else {
 					args.add(param.toLowerCase() + " string");
@@ -219,15 +219,15 @@ public class GoAPIGenerator extends AbstractAPIGenerator {
 		if (elements != null && elements.size() > 0) {
 			for (String param : elements) {
 				out.write("\n\t\t\"" + param + "\": ");
-				if (param.toLowerCase().equals("boolean")) {
+				if (param.equalsIgnoreCase("boolean")) {
 					addImports = true;
 					out.write("strconv.FormatBool(boolean)");
-				} else if (param.toLowerCase().equals("integer")) {
+				} else if (param.equalsIgnoreCase("integer")) {
 					addImports = true;
 					out.write("strconv.Itoa(i)");
-				} else if (param.toLowerCase().equals("string")) {
+				} else if (param.equalsIgnoreCase("string")) {
 					out.write("str");
-				} else if (param.toLowerCase().equals("type")) {
+				} else if (param.equalsIgnoreCase("type")) {
 					out.write("t");
 				} else {
 					out.write(param.toLowerCase());

--- a/src/org/zaproxy/zap/extension/api/JavaAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/JavaAPIGenerator.java
@@ -149,9 +149,9 @@ public class JavaAPIGenerator extends AbstractAPIGenerator {
 				} else {
 					out.write(", ");
 				}
-				if (param.toLowerCase().equals("boolean")) {
+				if (param.equalsIgnoreCase("boolean")) {
 					out.write("boolean bool");
-				} else if (param.toLowerCase().equals("integer")) {
+				} else if (param.equalsIgnoreCase("integer")) {
 					out.write("int i");
 				} else {
 					out.write("String ");
@@ -166,9 +166,9 @@ public class JavaAPIGenerator extends AbstractAPIGenerator {
 				} else {
 					out.write(", ");
 				}
-				if (param.toLowerCase().equals("boolean")) {
+				if (param.equalsIgnoreCase("boolean")) {
 					out.write("boolean bool");
-				} else if (param.toLowerCase().equals("integer")) {
+				} else if (param.equalsIgnoreCase("integer")) {
 					out.write("int i");
 				} else {
 					out.write("String ");
@@ -184,9 +184,9 @@ public class JavaAPIGenerator extends AbstractAPIGenerator {
 			if (element.getMandatoryParamNames() != null) {
 				for (String param : element.getMandatoryParamNames()) {
 					out.write("\t\tmap.put(\"" + param + "\", ");
-					if (param.toLowerCase().equals("boolean")) {
+					if (param.equalsIgnoreCase("boolean")) {
 						out.write("Boolean.toString(bool)");
-					} else if (param.toLowerCase().equals("integer")) {
+					} else if (param.equalsIgnoreCase("integer")) {
 						out.write("Integer.toString(i)");
 					} else {
 						out.write(param.toLowerCase());
@@ -200,9 +200,9 @@ public class JavaAPIGenerator extends AbstractAPIGenerator {
 					out.write(param.toLowerCase());
 					out.write(" != null) {\n");
 					out.write("\t\t\tmap.put(\"" + param + "\", ");
-					if (param.toLowerCase().equals("boolean")) {
+					if (param.equalsIgnoreCase("boolean")) {
 						out.write("Boolean.toString(bool)");
-					} else if (param.toLowerCase().equals("integer")) {
+					} else if (param.equalsIgnoreCase("integer")) {
 						out.write("Integer.toString(i)");
 					} else {
 						out.write(param.toLowerCase());

--- a/src/org/zaproxy/zap/extension/brk/BreakAPI.java
+++ b/src/org/zaproxy/zap/extension/brk/BreakAPI.java
@@ -127,7 +127,7 @@ public class BreakAPI extends ApiImplementor {
 			}
 			
 		} else if (ACTION_BREAK_ON_ID.equals(name)) {
-			extension.setBreakOnId(params.getString(PARAM_KEY), params.getString(PARAM_STATE).toLowerCase().equals("on"));
+			extension.setBreakOnId(params.getString(PARAM_KEY), params.getString(PARAM_STATE).equalsIgnoreCase("on"));
 
 		} else if (ACTION_CONTINUE.equals(name)) {
 			extension.getBreakpointManagementInterface().cont();

--- a/src/org/zaproxy/zap/utils/HttpUserAgent.java
+++ b/src/org/zaproxy/zap/utils/HttpUserAgent.java
@@ -51,7 +51,7 @@ public final class HttpUserAgent {
 					browserVersion = line.substring(2, line.length()-1);
 					continue;
 				}
-				if (line.toLowerCase().equals(userAgent)) {
+				if (line.equalsIgnoreCase(userAgent)) {
 					return browserVersion;
 				}
 			}


### PR DESCRIPTION
Replace usage of `toLowerCase().equals` (none using `toUpperCase`) to
`equalsIgnoreCase`, making the checks (correctly) locale independent.

Part of #4327 - ZAP relies on default locale when it shouldn't