### PR TITLE
Allow direct access to add-ons' optional classes

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnClassLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnClassLoader.java
@@ -216,6 +216,15 @@ public class AddOnClassLoader extends URLClassLoader {
         childClassLoaders.remove(child);
     }
 
+    /**
+     * Gets the child class loaders.
+     *
+     * @return an unmodifiable list with the child class loaders.
+     */
+    List<AddOnClassLoader> getChildClassLoaders() {
+        return Collections.unmodifiableList(childClassLoaders);
+    }
+
     @Override
     public void close() throws IOException {
         for (AddOnClassLoader childClassLoader : childClassLoaders) {

--- a/src/org/zaproxy/zap/control/AddOnLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnLoader.java
@@ -329,6 +329,13 @@ public class AddOnLoader extends URLClassLoader {
         		} catch (ClassNotFoundException e) {
         			// Continue for now
         		}
+                for (AddOnClassLoader childLoader : loader.getChildClassLoaders()) {
+                    try {
+                        return childLoader.loadClass(name);
+                    } catch (ClassNotFoundException e) {
+                        // Continue for now
+                    }
+                }
             }
             throw new ClassNotFoundException(name);
         }


### PR DESCRIPTION
Change AddOnLoader to also (try to) load optional classes of an add-on,
mainly for typed scripts which might require the class to be defined.

Per comments in zaproxy/zap-extensions#1493 - Added Groovy Script Templates