### PR TITLE
Update list of parameters to ignore

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -405,6 +405,11 @@ variant.param.type.postdata = PostData
 variant.param.type.path = URLPath
 variant.param.type.header = Header
 variant.param.type.cookie = Cookie
+variant.param.type.json = JSON
+variant.param.type.multipart.contenttype = Content-Type (Multipart Form-Data)
+variant.param.type.multipart.dataparam =  Parameter (non-file) (Multipart Form-Data)
+variant.param.type.multipart.filename = File Name (Multipart Form-Data)
+variant.param.type.multipart.fileparam = File Content (Multipart Form-Data)
 
 variant.options.excludedparam.label.tokens = <html><body><p>Parameters shown here will be ignored by the Scanner, if both the wildcarded URL and the specified location match.</p></body></html>
 variant.options.excludedparam.table.header.url = URL

--- a/src/org/parosproxy/paros/core/scanner/NameValuePair.java
+++ b/src/org/parosproxy/paros/core/scanner/NameValuePair.java
@@ -28,7 +28,7 @@ package org.parosproxy.paros.core.scanner;
 
 public class NameValuePair {
 
-    // ZAP: Parameter type constants
+    // NOTE: After adding a new type update ScannerParamFilter.
     public static final int TYPE_URL_PATH = ScannerParam.TARGET_URLPATH;
     public static final int TYPE_QUERY_STRING = ScannerParam.TARGET_QUERYSTRING;
     public static final int TYPE_COOKIE = ScannerParam.TARGET_COOKIE;

--- a/src/org/parosproxy/paros/core/scanner/ScannerParamFilter.java
+++ b/src/org/parosproxy/paros/core/scanner/ScannerParamFilter.java
@@ -21,7 +21,7 @@ package org.parosproxy.paros.core.scanner;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -44,7 +44,7 @@ public class ScannerParamFilter implements Cloneable {
     private Pattern paramNamePattern;
     private Pattern urlPattern;
     
-    private static final Map<Integer, String> typeMap = new HashMap<>();
+    private static final Map<Integer, String> typeMap = new LinkedHashMap<>();
     static {
         typeMap.put(NameValuePair.TYPE_UNDEFINED, Constant.messages.getString("variant.param.type.all"));
         typeMap.put(NameValuePair.TYPE_QUERY_STRING, Constant.messages.getString("variant.param.type.query"));
@@ -52,6 +52,11 @@ public class ScannerParamFilter implements Cloneable {
         typeMap.put(NameValuePair.TYPE_URL_PATH, Constant.messages.getString("variant.param.type.path"));
         typeMap.put(NameValuePair.TYPE_HEADER, Constant.messages.getString("variant.param.type.header"));
         typeMap.put(NameValuePair.TYPE_COOKIE, Constant.messages.getString("variant.param.type.cookie"));
+        typeMap.put(NameValuePair.TYPE_JSON, Constant.messages.getString("variant.param.type.json"));
+        typeMap.put(NameValuePair.TYPE_MULTIPART_DATA_PARAM, Constant.messages.getString("variant.param.type.multipart.dataparam"));
+        typeMap.put(NameValuePair.TYPE_MULTIPART_DATA_FILE_NAME, Constant.messages.getString("variant.param.type.multipart.filename"));
+        typeMap.put(NameValuePair.TYPE_MULTIPART_DATA_FILE_PARAM, Constant.messages.getString("variant.param.type.multipart.fileparam"));
+        typeMap.put(NameValuePair.TYPE_MULTIPART_DATA_FILE_CONTENTTYPE, Constant.messages.getString("variant.param.type.multipart.contenttype"));
     }
     
 


### PR DESCRIPTION
Change ScannerParamFilter to include the latest types of NameValuePair,
also, change the map to LinkedHashMap to preserve the order in which the
types are added.
Add comment to NameValuePair to mention that ScannerParamFilter should
be updated when new types are added.

Related to #4208 and #4415.