### PR TITLE
Local ZapVersions.xml not correctly saved in all locales

### DIFF
--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -25,13 +25,13 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.StringReader;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -820,23 +820,12 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 
         // Save version file so we can report new addons next time
 		File f = new File(Constant.FOLDER_LOCAL_PLUGIN, VERSION_FILE_NAME);
-    	FileWriter out = null;
-	    try {
-	    	out = new FileWriter(f);
-	    	out.write(msg.getResponseBody().toString());
-		} catch (Exception e) {
-			logger.error(e.getMessage(), e);
-	    } finally {
-	    	try {
-				if (out != null) {
-					out.close();
-				}
-			} catch (IOException e) {
-				// Ignore
-			}
-		}
+        try{
+            Files.write(f.toPath(), msg.getResponseBody().getBytes());
+        }catch(IOException ioe){
+            logger.error(ioe.getMessage(), ioe);
+        }
 
-    	
     	return config;
     }
 


### PR DESCRIPTION
ZapXmlConfiguration uses UTF-8 encoding but ExtensionAutoUpdate overrides plugins config file with default encoding to the file system which causes the following exception on startup.

```
006 [ZAP-daemon] ERROR org.zaproxy.zap.extension.autoupdate.ExtensionAutoUpdate  - Unable to load the configuration
org.apache.commons.configuration.ConfigurationException: Unable to load the configuration
	at org.apache.commons.configuration.XMLConfiguration.load(XMLConfiguration.java:955)
	at org.apache.commons.configuration.XMLConfiguration.load(XMLConfiguration.java:908)
	at org.apache.commons.configuration.XMLConfiguration$XMLFileConfigurationDelegate.load(XMLConfiguration.java:1583)
	at org.apache.commons.configuration.AbstractFileConfiguration.load(AbstractFileConfiguration.java:324)
	at org.apache.commons.configuration.AbstractFileConfiguration.load(AbstractFileConfiguration.java:261)
	at org.apache.commons.configuration.AbstractFileConfiguration.load(AbstractFileConfiguration.java:238)
	at org.apache.commons.configuration.AbstractHierarchicalFileConfiguration.load(AbstractHierarchicalFileConfiguration.java:184)
	at org.zaproxy.zap.utils.ZapXmlConfiguration.<init>(ZapXmlConfiguration.java:88)
	at org.zaproxy.zap.extension.autoupdate.ExtensionAutoUpdate.getPreviousVersionInfo(ExtensionAutoUpdate.java:883)
	at org.zaproxy.zap.extension.autoupdate.ExtensionAutoUpdate.initialize(ExtensionAutoUpdate.java:170)
	at org.zaproxy.zap.extension.autoupdate.ExtensionAutoUpdate.<init>(ExtensionAutoUpdate.java:158)
	at org.zaproxy.zap.control.CoreFunctionality.createExtensions(CoreFunctionality.java:81)
	at org.zaproxy.zap.control.CoreFunctionality.getBuiltInExtensions(CoreFunctionality.java:60)
	at org.zaproxy.zap.control.ExtensionFactory.loadAllExtension(ExtensionFactory.java:107)
	at org.parosproxy.paros.control.Control.addExtension(Control.java:160)
	at org.parosproxy.paros.control.AbstractControl.loadExtension(AbstractControl.java:53)
	at org.parosproxy.paros.control.Control.init(Control.java:123)
	at org.parosproxy.paros.control.Control.initSingletonWithoutViewAndProxy(Control.java:309)
	at org.zaproxy.zap.HeadlessBootstrap.initControl(HeadlessBootstrap.java:58)
	at org.zaproxy.zap.DaemonBootstrap$1.run(DaemonBootstrap.java:77)
	at java.lang.Thread.run(Thread.java:748)
Caused by: com.sun.org.apache.xerces.internal.impl.io.MalformedByteSequenceException: Invalid byte 2 of 3-byte UTF-8 sequence.
	at com.sun.org.apache.xerces.internal.impl.io.UTF8Reader.invalidByte(UTF8Reader.java:701)
	at com.sun.org.apache.xerces.internal.impl.io.UTF8Reader.read(UTF8Reader.java:408)
	at com.sun.org.apache.xerces.internal.impl.XMLEntityScanner.load(XMLEntityScanner.java:1895)
	at com.sun.org.apache.xerces.internal.impl.XMLEntityScanner.skipChar(XMLEntityScanner.java:1551)
	at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl$FragmentContentDriver.next(XMLDocumentFragmentScannerImpl.java:2821)
	at com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:602)
	at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:505)
	at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:841)
	at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:770)
	at com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:141)
	at com.sun.org.apache.xerces.internal.parsers.DOMParser.parse(DOMParser.java:243)
	at com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderImpl.parse(DocumentBuilderImpl.java:339)
	at org.apache.commons.configuration.XMLConfiguration.load(XMLConfiguration.java:942)
	... 20 more
```