### PR TITLE
Ensure node selected param panel is visible

### DIFF
--- a/src/org/parosproxy/paros/view/AbstractParamContainerPanel.java
+++ b/src/org/parosproxy/paros/view/AbstractParamContainerPanel.java
@@ -26,6 +26,7 @@
 // ZAP: 2017/06/23 Ensure panel with validation errors is visible.
 // ZAP: 2017/09/03 Cope with Java 9 change to TreeNode.children().
 // ZAP: 2018/01/08 Allow to expand the node of a param panel.
+// ZAP: 2018/03/26 Ensure node of selected panel is visible.
 
 package org.parosproxy.paros.view;
 
@@ -35,6 +36,7 @@ import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -501,7 +503,9 @@ public class AbstractParamContainerPanel extends JSplitPane {
         nameLastSelectedPanel = name;
         currentShownPanel = panel; 
 
-        getTreeParam().setSelectionPath(new TreePath(getTreeNodeFromPanelName(name).getPath()));
+        TreePath nodePath = new TreePath(getTreeNodeFromPanelName(name).getPath());
+        getTreeParam().setSelectionPath(nodePath);
+        ensureNodeVisible(nodePath);
 
         getPanelHeadline();
         getTxtHeadline().setText(name);
@@ -512,6 +516,22 @@ public class AbstractParamContainerPanel extends JSplitPane {
         card.show(getPanelParam(), name);
         // ZAP: Notify the new panel that it is now shown
         panel.onShow();
+    }
+
+    /**
+     * Ensures the node of the panel is visible in the view port.
+     * <p>
+     * The node is assumed to be already {@link JTree#isVisible(TreePath) visible in the tree}.
+     * 
+     * @param nodePath the path to the node of the panel.
+     */
+    private void ensureNodeVisible(TreePath nodePath) {
+        Rectangle bounds = getTreeParam().getPathBounds(nodePath);
+        if (!getTreeParam().getVisibleRect().contains(bounds)) {
+            // Just do vertical scrolling.
+            bounds.x = 0;
+            getTreeParam().scrollRectToVisible(bounds);
+        }
     }
 
     /**


### PR DESCRIPTION
Change AbstractParamContainerPanel to ensure the node of the selected
panel is visible, specially useful in the Session Properties dialogue
when configuring contexts.