### PR TITLE
AlertsViewPanel Yet Another Tweak

### DIFF
--- a/src/org/zaproxy/zap/extension/alert/AlertAddDialog.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertAddDialog.java
@@ -27,7 +27,6 @@ import java.awt.HeadlessException;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -81,7 +80,6 @@ public class AlertAddDialog extends AbstractDialog {
      */
     private HttpMessage httpMessage;
 	
-	private JScrollPane jScrollPane = null;
 	private AlertViewPanel alertViewPanel = null;
 	
     /**
@@ -170,7 +168,7 @@ public class AlertAddDialog extends AbstractDialog {
 			gridBagConstraints15.ipadx = 0;
 			gridBagConstraints15.ipady = 10;
 
-			jPanel.add(getJScrollPane(), gridBagConstraints15);
+			jPanel.add(getAlertViewPanel(), gridBagConstraints15);
 			jPanel.add(jLabel2, gridBagConstraints13);
 			jPanel.add(getBtnCancel(), gridBagConstraints2);
 			jPanel.add(getBtnOk(), gridBagConstraints3);
@@ -261,21 +259,6 @@ public class AlertAddDialog extends AbstractDialog {
 		}
 		// Change the title as we're editing an existing alert
         this.setTitle(Constant.messages.getString("alert.edit.title"));
-	}
-	
-	/**
-	 * This method initializes jScrollPane	
-	 * 	
-	 * @return javax.swing.JScrollPane	
-	 */    
-	private JScrollPane getJScrollPane() {
-		if (jScrollPane == null) {
-			jScrollPane = new JScrollPane();
-			jScrollPane.setHorizontalScrollBarPolicy(javax.swing.JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-			jScrollPane.setVerticalScrollBarPolicy(javax.swing.JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
-			jScrollPane.setViewportView(getAlertViewPanel());
-		}
-		return jScrollPane;
 	}
 
 	public HistoryReference getHistoryRef() {

--- a/src/org/zaproxy/zap/extension/alert/AlertViewPanel.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertViewPanel.java
@@ -46,6 +46,8 @@ import javax.swing.ScrollPaneConstants;
 import javax.swing.border.TitledBorder;
 
 import org.apache.log4j.Logger;
+import org.jdesktop.swingx.JXPanel;
+import org.jdesktop.swingx.ScrollableSizeHint;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -77,7 +79,7 @@ public class AlertViewPanel extends AbstractPanel {
 	private JScrollPane defaultPane = null;
 	private JScrollPane alertPane = null;
 	private ZapTextArea defaultOutput = null;
-	private JPanel alertDisplay = null;
+	private JXPanel alertDisplay = null;
 	private CardLayout cardLayout = null;
 	
 	private ZapLabel alertUrl = null;
@@ -188,8 +190,9 @@ public class AlertViewPanel extends AbstractPanel {
 	
 	private JPanel getAlertDisplay() {
 		if (alertDisplay == null) {
-			alertDisplay = new JPanel();
+			alertDisplay = new JXPanel();
 			alertDisplay.setLayout(new GridBagLayout());
+			alertDisplay.setScrollableHeightHint(ScrollableSizeHint.NONE);
 			alertDisplay.setName("alertDisplay");
 			
 			// Create the labels
@@ -276,7 +279,6 @@ public class AlertViewPanel extends AbstractPanel {
 			alertUrl.setLineWrap(true);
 			
 			alertDescription = createZapTextArea();
-			alertDescription.setLineWrap(true);
 			JScrollPane descSp = createJScrollPane(Constant.messages.getString("alert.label.desc"));
 			descSp.setViewportView(alertDescription);
 			alertDescription.addKeyListener(new KeyAdapter() {
@@ -290,7 +292,6 @@ public class AlertViewPanel extends AbstractPanel {
 			});
 
 			alertOtherInfo = createZapTextArea();
-			alertOtherInfo.setLineWrap(true);
 			JScrollPane otherSp = createJScrollPane(Constant.messages.getString("alert.label.other"));
 			otherSp.setViewportView(alertOtherInfo);
 			alertOtherInfo.addKeyListener(new KeyAdapter() {
@@ -304,7 +305,6 @@ public class AlertViewPanel extends AbstractPanel {
 			});
 
 			alertSolution = createZapTextArea();
-			alertSolution.setLineWrap(true);
 			JScrollPane solutionSp = createJScrollPane(Constant.messages.getString("alert.label.solution"));
 			solutionSp.setViewportView(alertSolution);
 			alertSolution.addKeyListener(new KeyAdapter() {
@@ -318,7 +318,6 @@ public class AlertViewPanel extends AbstractPanel {
 			});
 
 			alertReference = createZapTextArea();
-			alertReference.setLineWrap(true);
 			JScrollPane referenceSp = createJScrollPane(Constant.messages.getString("alert.label.ref"));
 			referenceSp.setViewportView(alertReference);
 			alertReference.addKeyListener(new KeyAdapter() {


### PR DESCRIPTION
In follow-up to: https://github.com/zaproxy/zaproxy/pull/4201

There is one very minor issue in that the text of the combo boxes in the alert add/edit view don't word wrap, but you have to make the dialog awfully small for that to be an issue.

Also address https://github.com/zaproxy/zaproxy/pull/4201/files/b3ece927b73af8c9952be68172e873207f58b7d0#r169200840