### PR TITLE
Tweak API response cache directives

### DIFF
--- a/src/org/zaproxy/zap/extension/api/API.java
+++ b/src/org/zaproxy/zap/extension/api/API.java
@@ -927,7 +927,7 @@ public class API {
         sb.append("HTTP/1.1 ").append(responseStatus).append("\r\n");
         if (! canCache) {
         	sb.append("Pragma: no-cache\r\n");
-        	sb.append("Cache-Control: no-cache\r\n");
+        	sb.append("Cache-Control: no-cache, no-store, must-revalidate\r\n");
         }
         sb.append("Content-Security-Policy: default-src 'none'; script-src 'self'; connect-src 'self'; child-src 'self'; img-src 'self' data:; font-src 'self' data:; style-src 'self'\r\n");
         sb.append("Referrer-Policy: no-referrer\r\n");


### PR DESCRIPTION
Change API to add the Cache-Control directives must-revalidate and
no-store to try ensure that the clients don't reuse previous responses
and get always the latest content.