### PR TITLE
Use FileNameExtensionFilter where possible

### DIFF
--- a/src/ch/csnc/extension/ui/DriversView.java
+++ b/src/ch/csnc/extension/ui/DriversView.java
@@ -40,7 +40,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.LayoutStyle;
 import javax.swing.SwingConstants;
-import javax.swing.filechooser.FileFilter;
+import javax.swing.filechooser.FileNameExtensionFilter;
 
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.Model;
@@ -318,19 +318,8 @@ public class DriversView extends AbstractFrame {
 
 	private void browseButtonActionPerformed(ActionEvent evt) {
 		final JFileChooser fc = new JFileChooser();
-		fc.setFileFilter(new FileFilter() {
-			@Override
-			public String getDescription() {
-				return "DLL/dylib";
-			}
-
-			//FIXME: Support so and dynlib files as well
-
-			@Override
-			public boolean accept(java.io.File f) {
-				return f.isDirectory() || f.getName().toLowerCase().endsWith(".dll") || f.getName().toLowerCase().endsWith(".dylib");
-			}
-		});
+		// TODO Support so and dynlib files as well
+		fc.setFileFilter(new FileNameExtensionFilter("DLL/dylib", "dll", "dylib"));
 
 		final int state = fc.showOpenDialog(null);
 

--- a/src/org/parosproxy/paros/extension/history/PopupMenuExportMessage.java
+++ b/src/org/parosproxy/paros/extension/history/PopupMenuExportMessage.java
@@ -29,6 +29,7 @@
 // ZAP: 2014/03/23 Changed to a JMenuItem.
 // ZAP: 2016/04/05 Issue 2458: Fix xlint warning messages 
 // ZAP: 2016/07/25 Remove String constructor (unused/unnecessary)
+// ZAP: 2018/03/29 Use FileNameExtensionFilter.
 
 package org.parosproxy.paros.extension.history;
 
@@ -37,11 +38,12 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.Writer;
 import java.util.List;
+import java.util.Locale;
 
 import javax.swing.JFileChooser;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
-import javax.swing.filechooser.FileFilter;
+import javax.swing.filechooser.FileNameExtensionFilter;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -160,21 +162,7 @@ public class PopupMenuExportMessage extends JMenuItem {
     private File getOutputFile() {
 
 	    JFileChooser chooser = new JFileChooser(extension.getModel().getOptionsParam().getUserDirectory());
-	    chooser.setFileFilter(new FileFilter() {
-	           @Override
-	           public boolean accept(File file) {
-	                if (file.isDirectory()) {
-	                    return true;
-	                } else if (file.isFile() && file.getName().endsWith(".txt")) {
-	                    return true;
-	                }
-	                return false;
-	            }
-	           @Override
-	           public String getDescription() {
-	               return Constant.messages.getString("file.format.ascii");
-	           }
-	    });
+	    chooser.setFileFilter(new FileNameExtensionFilter(Constant.messages.getString("file.format.ascii"), "txt"));
 		File file = null;
 	    int rc = chooser.showSaveDialog(extension.getView().getMainFrame());
 	    if(rc == JFileChooser.APPROVE_OPTION) {
@@ -184,7 +172,7 @@ public class PopupMenuExportMessage extends JMenuItem {
     		}
             extension.getModel().getOptionsParam().setUserDirectory(chooser.getCurrentDirectory());
     		String fileName = file.getAbsolutePath();
-    		if (!fileName.endsWith(".txt")) {
+    		if (!fileName.toLowerCase(Locale.ROOT).endsWith(".txt")) {
     		    fileName += ".txt";
     		    file = new File(fileName);
     		}

--- a/src/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
@@ -34,6 +34,7 @@
 // ZAP: 2017/12/12 Use first alias by default (Issue 3879).
 // ZAP: 2017/12/13 Do not allow to edit the name/key of active cert.
 // ZAP: 2018/02/14 Remove unnecessary boxing / unboxing
+// ZAP: 2018/03/29 Use FileNameExtensionFilter.
 
 package org.parosproxy.paros.extension.option;
 
@@ -55,7 +56,7 @@ import javax.swing.JPanel;
 import javax.swing.JPasswordField;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
-import javax.swing.filechooser.FileFilter;
+import javax.swing.filechooser.FileNameExtensionFilter;
 
 import org.apache.log4j.Logger;
 import org.jdesktop.swingx.JXHyperlink;
@@ -813,20 +814,11 @@ public class OptionsCertificatePanel extends AbstractParamPanel {
 
 	private void browseButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_browseButtonActionPerformed
 		JFileChooser fc = new JFileChooser();
-		fc.setFileFilter( new FileFilter()
-		{
-			@Override
-			public String getDescription()
-			{
-				return Constant.messages.getString("options.cert.label.client.cert") + " (*.p12, *.pfx)";
-			}
-			@Override
-			public boolean accept(File f) {
-				return f.isDirectory() ||
-				f.getName().toLowerCase().endsWith( ".p12" ) || 
-				f.getName().toLowerCase().endsWith( ".pfx" );
-			}
-		} );
+		fc.setFileFilter(
+				new FileNameExtensionFilter(
+						Constant.messages.getString("options.cert.label.client.cert") + " (*.p12, *.pfx)",
+						"p12",
+						"pfx"));
 
 		int state = fc.showOpenDialog( null );
 

--- a/src/org/zaproxy/zap/extension/ascan/PolicyManagerDialog.java
+++ b/src/org/zaproxy/zap/extension/ascan/PolicyManagerDialog.java
@@ -36,7 +36,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JTable;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
-import javax.swing.filechooser.FileFilter;
+import javax.swing.filechooser.FileNameExtensionFilter;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.log4j.Logger;
@@ -166,22 +166,7 @@ public class PolicyManagerDialog extends StandardFieldsDialog {
                 public void actionPerformed(ActionEvent e) {
                     // Default to ZAP home dir - we dont want to import/export to the policy dir
                     JFileChooser chooser = new JFileChooser(Constant.getZapHome());
-                    chooser.setFileFilter(new FileFilter() {
-                        @Override
-                        public boolean accept(File file) {
-                            if (file.isDirectory()) {
-                                return true;
-                            } else if (file.isFile() && file.getName().endsWith(".policy")) {
-                                return true;
-                            }
-                            return false;
-                        }
-
-                        @Override
-                        public String getDescription() {
-                            return Constant.messages.getString("file.format.zap.policy");
-                        }
-                    });
+                    chooser.setFileFilter(new FileNameExtensionFilter(Constant.messages.getString("file.format.zap.policy"), "policy"));
                     File file = null;
                     int rc = chooser.showOpenDialog(View.getSingleton().getMainFrame());
                     if (rc == JFileChooser.APPROVE_OPTION) {
@@ -216,22 +201,8 @@ public class PolicyManagerDialog extends StandardFieldsDialog {
                         File file = new File(Constant.getZapHome(), name + PolicyManager.POLICY_EXTENSION);
                         chooser.setSelectedFile(file);
 
-                        chooser.setFileFilter(new FileFilter() {
-                            @Override
-                            public boolean accept(File file) {
-                                if (file.isDirectory()) {
-                                    return true;
-                                } else if (file.isFile() && file.getName().endsWith(".policy")) {
-                                    return true;
-                                }
-                                return false;
-                            }
-
-                            @Override
-                            public String getDescription() {
-                                return Constant.messages.getString("file.format.zap.policy");
-                            }
-                        });
+                        chooser.setFileFilter(
+                                new FileNameExtensionFilter(Constant.messages.getString("file.format.zap.policy"), "policy"));
                         int rc = chooser.showSaveDialog(View.getSingleton().getMainFrame());
                         if (rc == JFileChooser.APPROVE_OPTION) {
                             file = chooser.getSelectedFile();

--- a/src/org/zaproxy/zap/extension/compare/ExtensionCompare.java
+++ b/src/org/zaproxy/zap/extension/compare/ExtensionCompare.java
@@ -32,6 +32,7 @@ import java.util.TreeSet;
 import javax.swing.JFileChooser;
 import javax.swing.JMenuItem;
 import javax.swing.filechooser.FileFilter;
+import javax.swing.filechooser.FileNameExtensionFilter;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.log4j.Logger;
@@ -313,25 +314,7 @@ public class ExtensionCompare extends ExtensionAdaptor implements SessionChanged
     private File getOutputFile() {
 
 	    JFileChooser chooser = new JFileChooser(getModel().getOptionsParam().getUserDirectory());
-	    chooser.setFileFilter(new FileFilter() {
-	           @Override
-	           public boolean accept(File file) {
-	                if (file.isDirectory()) {
-	                    return true;
-	                } else if (file.isFile() && 
-	                		file.getName().toLowerCase().endsWith(".htm")) {
-	                    return true;
-	                } else if (file.isFile() && 
-	                		file.getName().toLowerCase().endsWith(".html")) {
-	                    return true;
-	                }
-	                return false;
-	            }
-	           @Override
-	           public String getDescription() {
-	               return Constant.messages.getString("file.format.html");
-	           }
-	    });
+	    chooser.setFileFilter(new FileNameExtensionFilter(Constant.messages.getString("file.format.html"), "htm", "html"));
 	    
 		File file = null;
 	    int rc = chooser.showSaveDialog(getView().getMainFrame());

--- a/src/org/zaproxy/zap/extension/dynssl/DynamicSSLPanel.java
+++ b/src/org/zaproxy/zap/extension/dynssl/DynamicSSLPanel.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
+import java.util.Locale;
 
 import javax.swing.GroupLayout;
 import javax.swing.GroupLayout.Alignment;
@@ -286,8 +287,8 @@ public class DynamicSSLPanel extends AbstractParamPanel {
 			}
 			@Override
 			public boolean accept(File f) {
-				return f.getName().toLowerCase().endsWith(CONFIGURATION_FILENAME) ||
-						f.getName().toLowerCase().endsWith("pem") || f.isDirectory();
+				String lcFileName = f.getName().toLowerCase(Locale.ROOT);
+				return lcFileName.endsWith(CONFIGURATION_FILENAME) || lcFileName.endsWith("pem") || f.isDirectory();
 			}
 		});
 		final int result = fc.showOpenDialog(this);

--- a/src/org/zaproxy/zap/extension/lang/OptionsLangPanel.java
+++ b/src/org/zaproxy/zap/extension/lang/OptionsLangPanel.java
@@ -34,7 +34,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
-import javax.swing.filechooser.FileFilter;
+import javax.swing.filechooser.FileNameExtensionFilter;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
 
@@ -213,17 +213,8 @@ public class OptionsLangPanel extends AbstractParamPanel {
 	
 	private void browseButtonActionPerformed(ActionEvent evt) {
 		final JFileChooser fc = new JFileChooser();
-		fc.setFileFilter(new FileFilter() {
-			@Override
-			public String getDescription() {
-				return Constant.messages.getString("options.lang.file.chooser.description");
-			}
-
-			@Override
-			public boolean accept(java.io.File f) {
-				return f.isDirectory() || f.getName().toLowerCase().endsWith(".zaplang");
-			}
-		});
+		fc.setFileFilter(
+				new FileNameExtensionFilter(Constant.messages.getString("options.lang.file.chooser.description"), "zaplang"));
 
 		final int state = fc.showOpenDialog(null);
 

--- a/src/org/zaproxy/zap/utils/FilenameExtensionFilter.java
+++ b/src/org/zaproxy/zap/utils/FilenameExtensionFilter.java
@@ -1,22 +1,53 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2010 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.zaproxy.zap.utils;
 
 import java.io.File;
 import java.io.FilenameFilter;
+import java.util.Locale;
 
+/**
+ * A {@link FilenameFilter} that allows to filter by an extension.
+ * 
+ * @since 1.2.0
+ */
 public class FilenameExtensionFilter implements FilenameFilter {
 
 	String ext;
 	boolean ignoreCase = false;
 	
+	/**
+	 * Constructs a {@code FilenameExtensionFilter} with the given extension and if the case should be ignored.
+	 *
+	 * @param ext the extension that the files must have.
+	 * @param ignoreCase if the case should be ignored.
+	 */
 	public FilenameExtensionFilter (String ext, boolean ignoreCase) {
-		this.ext = ext;
 		this.ignoreCase = ignoreCase;
+		this.ext = ignoreCase ? ext.toLowerCase(Locale.ROOT) : ext;
 	}
 	
 	@Override
 	public boolean accept(File dir, String name) {
 		if (ignoreCase) {
-			return name.toLowerCase().endsWith(ext.toLowerCase());
+			return name.toLowerCase(Locale.ROOT).endsWith(ext);
 		}
 		return name.endsWith(ext);
 	}


### PR DESCRIPTION
Change to use FileNameExtensionFilter instead of custom FileFilter where
just the file extension of the file was being checked. For the other
cases correct lower case comparisons to use a neutral locale.
Tweak FilenameExtensionFilter to only do lower case conversion of the
extension once, add JavaDoc, and license header.

Related to #4327 - ZAP relies on default locale when it shouldn't