### PR TITLE
Allow to specify ResourceBundle in API generators

### DIFF
--- a/src/org/zaproxy/zap/extension/api/AbstractAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/AbstractAPIGenerator.java
@@ -62,13 +62,27 @@ abstract class AbstractAPIGenerator {
      * @param optional {@code true} if the API client files are optional, {@code false} otherwise
      */
     protected AbstractAPIGenerator(String directory, boolean optional) {
+        this(directory, optional, null);
+    }
+
+    /**
+     * Constructs an {@code AbstractAPIGenerator} with the given directory, optional state, and {@code ResourceBundle}.
+     *
+     * @param directory the directory where the API client files should be generated
+     * @param optional {@code true} if the API client files are optional, {@code false} otherwise
+     * @param resourceBundle the {@code ResourceBundle} used for doc of the generated classes.
+     * @since TODO add version
+     */
+    protected AbstractAPIGenerator(String directory, boolean optional, ResourceBundle resourceBundle) {
         this.directory = Paths.get(directory);
         this.optional = optional;
 
-        messages = ResourceBundle.getBundle(
-                "lang." + Constant.MESSAGES_PREFIX,
-                Locale.ENGLISH,
-                ResourceBundle.Control.getControl(ResourceBundle.Control.FORMAT_PROPERTIES));
+        messages = resourceBundle != null
+                ? resourceBundle
+                : ResourceBundle.getBundle(
+                        "lang." + Constant.MESSAGES_PREFIX,
+                        Locale.ENGLISH,
+                        ResourceBundle.Control.getControl(ResourceBundle.Control.FORMAT_PROPERTIES));
     }
 
     /**

--- a/src/org/zaproxy/zap/extension/api/DotNetAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/DotNetAPIGenerator.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.ResourceBundle;
 
 public class DotNetAPIGenerator extends AbstractAPIGenerator {
 	
@@ -77,6 +78,10 @@ public class DotNetAPIGenerator extends AbstractAPIGenerator {
 
     public DotNetAPIGenerator(String path, boolean optional) {
     	super(path, optional);
+    }
+
+    public DotNetAPIGenerator(String path, boolean optional, ResourceBundle resourceBundle) {
+        super(path, optional, resourceBundle);
     }
 
     /**

--- a/src/org/zaproxy/zap/extension/api/GoAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/GoAPIGenerator.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.ResourceBundle;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -51,6 +52,10 @@ public class GoAPIGenerator extends AbstractAPIGenerator {
 
 	public GoAPIGenerator(String path, boolean optional) {
 		super(path, optional);
+	}
+
+	public GoAPIGenerator(String path, boolean optional, ResourceBundle resourceBundle) {
+		super(path, optional, resourceBundle);
 	}
 
 	/**

--- a/src/org/zaproxy/zap/extension/api/JavaAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/JavaAPIGenerator.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.ResourceBundle;
 
 public class JavaAPIGenerator extends AbstractAPIGenerator {
 
@@ -80,6 +81,10 @@ public class JavaAPIGenerator extends AbstractAPIGenerator {
 
     public JavaAPIGenerator(String path, boolean optional) {
     	super(path, optional);
+    }
+
+    public JavaAPIGenerator(String path, boolean optional, ResourceBundle resourceBundle) {
+        super(path, optional, resourceBundle);
     }
 
     /**

--- a/src/org/zaproxy/zap/extension/api/NodeJSAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/NodeJSAPIGenerator.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.ResourceBundle;
 
 public class NodeJSAPIGenerator extends AbstractAPIGenerator {
     
@@ -69,6 +70,10 @@ public class NodeJSAPIGenerator extends AbstractAPIGenerator {
 
     public NodeJSAPIGenerator(String path, boolean optional) {
     	super(path, optional);
+    }
+
+    public NodeJSAPIGenerator(String path, boolean optional, ResourceBundle resourceBundle) {
+        super(path, optional, resourceBundle);
     }
 
     /**

--- a/src/org/zaproxy/zap/extension/api/PhpAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/PhpAPIGenerator.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.ResourceBundle;
 
 public class PhpAPIGenerator extends AbstractAPIGenerator {
 
@@ -71,6 +72,10 @@ public class PhpAPIGenerator extends AbstractAPIGenerator {
 
     public PhpAPIGenerator(String path, boolean optional) {
     	super(path, optional);
+    }
+
+    public PhpAPIGenerator(String path, boolean optional, ResourceBundle resourceBundle) {
+        super(path, optional, resourceBundle);
     }
 
     /**

--- a/src/org/zaproxy/zap/extension/api/PythonAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/PythonAPIGenerator.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.ResourceBundle;
 
 public class PythonAPIGenerator extends AbstractAPIGenerator {
 
@@ -76,6 +77,10 @@ public class PythonAPIGenerator extends AbstractAPIGenerator {
 
     public PythonAPIGenerator(String path, boolean optional) {
     	super(path, optional);
+    }
+
+    public PythonAPIGenerator(String path, boolean optional, ResourceBundle resourceBundle) {
+        super(path, optional, resourceBundle);
     }
 
     /**

--- a/src/org/zaproxy/zap/extension/api/WikiAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/WikiAPIGenerator.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.ResourceBundle;
 
 import org.parosproxy.paros.Constant;
 
@@ -44,6 +45,10 @@ public class WikiAPIGenerator extends AbstractAPIGenerator {
 
     public WikiAPIGenerator(String path, boolean optional) {
     	super(path, optional);
+    }
+
+    public WikiAPIGenerator(String path, boolean optional, ResourceBundle resourceBundle) {
+        super(path, optional, resourceBundle);
     }
 
 	private void generateWikiIndex() throws IOException {


### PR DESCRIPTION
Change AbstractAPIGenerator and actual generators, to allow to specify
a ResourceBundle, so that the add-ons can use their own more easily.