### PR TITLE
Do not throw MissingResourceException in I18N

### DIFF
--- a/src/org/parosproxy/paros/view/View.java
+++ b/src/org/parosproxy/paros/view/View.java
@@ -76,6 +76,7 @@
 // ZAP: 2017/10/20 Implement method to expose default delete keyboard shortcut (Issue 3626).
 // ZAP: 2017/10/31 Use ExtensionLoader.getExtension(Class).
 // ZAP: 2018/01/08 Expand first context added.
+// ZAP: 2018/03/30 Check if resource message exists (for changes in I18N).
 
 package org.parosproxy.paros.view;
 
@@ -90,7 +91,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.MissingResourceException;
 import java.util.Vector;
 
 import javax.swing.ImageIcon;
@@ -277,19 +277,12 @@ public class View implements ViewDelegate {
         
         String statusString;
         for(Status status : AddOn.Status.values()) {     	
-        	//Try/catch in case AddOn.Status gets out of sync with cfu.status i18n entries
-        	try {
-        		statusString = Constant.messages.getString("cfu.status." + status.toString());
-        	} catch (MissingResourceException mre) {
+        	// Handle the case AddOn.Status gets out of sync with cfu.status i18n entries
+        	String i18nKey = "cfu.status." + status.toString();
+        	if (Constant.messages.containsKey(i18nKey)) {
+        		statusString = Constant.messages.getString(i18nKey);
+        	} else {
         		statusString = status.toString();
-        		
-        		String errString="Caught " + mre.getClass().getName() + " " + mre.getMessage() + 
-						" when looking for i18n string: cfu.status." + statusString;
-        		if (Constant.isDevBuild()) {
-        			logger.error(errString);
-        		} else {
-        			logger.warn(errString);
-        		}
         	}
         	statusMap.put(status, new StatusUI(status, statusString));
         }

--- a/src/org/zaproxy/zap/extension/api/WebUI.java
+++ b/src/org/zaproxy/zap/extension/api/WebUI.java
@@ -155,10 +155,9 @@ public class WebUI {
 				// This is the default, but it can be overriden by the getDescriptionTag method if required
 				descTag = component + ".api." + type + "." + element.getName();
 			}
-			try {
+			if (Constant.messages.containsKey(descTag)) {
 				sb.append(Constant.messages.getString(descTag));
-			} catch (Exception e) {
-				// Might not be set, so ignore failures
+			} else {
 				// Uncomment to see what tags are missing via the UI
 				// sb.append(descTag);
 			}
@@ -246,10 +245,8 @@ public class WebUI {
 					// This is the default, but it can be overriden by the getDescriptionTag method if required
 					descTag = component + ".api." + reqType.name() + "." + name;
 				}
-				try {
+				if (Constant.messages.containsKey(descTag)) {
 					sb.append(Constant.messages.getString(descTag));
-				} catch (Exception e) {
-					// Might not be set, so ignore failures
 				}
 				
 				sb.append("\n<form id=\"zapform\" name=\"zapform\" action=\"override\">");


### PR DESCRIPTION
Change I18N to not throw a MissingResourceException if the message does
not exist when obtaining it using getString(String), to avoid failing
hard when the message does not exist, while the cases are rare they
happen and it's preferable to show something than nothing at all. Also,
the method getString(String, Object...) was already catching the
exception (and returning the key itself). Now both methods will log an
error indicating that the key is missing and return the key itself.
Change View and WebUI to no longer rely on the exception, instead check
(explicitly) if the message exists.