### PR TITLE
Move ISO8601 Timestamp format out of properties

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -2310,9 +2310,7 @@ technologies.os = OS
 technologies.scm = SCM
 technologies.ws = WS
 
-timestamp.format.default = yyyy-MM-dd HH:mm:ss
 timestamp.format.datetime = yyyy-MM-dd HH:mm:ss
-timestamp.format.iso8601 = yyyy-MM-dd'T'HH:mm:ssZ
 timestamp.format.timeonly = HH:mm:ss
 # The following delimiter is used between timestamps and messages that are being stamped
 timestamp.format.delimiter = :

--- a/src/org/parosproxy/paros/extension/option/OptionsParamView.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsParamView.java
@@ -55,7 +55,7 @@ import org.zaproxy.zap.extension.httppanel.view.largeresponse.LargeResponseUtil;
 
 public class OptionsParamView extends AbstractParam {
 	
-	private static final String DEFAULT_TIME_STAMP_FORMAT =  Constant.messages.getString("timestamp.format.default");
+	private static final String DEFAULT_TIME_STAMP_FORMAT =  Constant.messages.getString("timestamp.format.datetime");
 	
 	public static final String BASE_VIEW_KEY = "view";
 

--- a/src/org/parosproxy/paros/extension/option/OptionsViewPanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsViewPanel.java
@@ -77,9 +77,11 @@ public class OptionsViewPanel extends AbstractParamPanel {
 	private static final long serialVersionUID = 1L;
 	
 	private static final String TIME_STAMP_FORMAT_COMBOBOX_TOOL_TIP = Constant.messages.getString("options.display.timestamp.format.combobox.tooltip");
+	// Translatable formats
 	private static final String TIME_STAMP_FORMAT_DATETIME =  Constant.messages.getString("timestamp.format.datetime");
-	private static final String TIME_STAMP_FORMAT_ISO8601 =  Constant.messages.getString("timestamp.format.iso8601");
 	private static final String TIME_STAMP_FORMAT_TIMEONLY =  Constant.messages.getString("timestamp.format.timeonly");
+	// ISO Standards compliant format
+	private static final String TIME_STAMP_FORMAT_ISO8601 = "yyyy-MM-dd'T'HH:mm:ssZ";
 	
 	private JPanel panelMisc = null;
 	private JScrollPane mainScrollPane;

--- a/src/org/zaproxy/zap/utils/TimeStampUtils.java
+++ b/src/org/zaproxy/zap/utils/TimeStampUtils.java
@@ -32,7 +32,7 @@ import org.parosproxy.paros.Constant;
 
 public final class TimeStampUtils {
      
-	private static final String DEFAULT_TIME_STAMP_FORMAT =  Constant.messages.getString("timestamp.format.default");
+	private static final String DEFAULT_TIME_STAMP_FORMAT =  Constant.messages.getString("timestamp.format.datetime");
 	private static final String TIME_STAMP_DELIMITER =  Constant.messages.getString("timestamp.format.delimiter");
 	private static final String SAFE_TIME_STAMP_FORMAT = "yyyy-MM-dd HH:mm:ss"; // Just in-case something goes wrong in translation
     


### PR DESCRIPTION
In follow-up to: https://github.com/zaproxy/zaproxy/pull/4441

Also simplify things by removing `timestamp.format.default` and simply using `timestamp.format.datetime` in those instances.
