### PR TITLE
Display Memory Info on JVM Options Panel

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1411,6 +1411,9 @@ jvm.options.title				= JVM
 jvm.options.error.writing		= Failed to save JVM Options in property file {0}:\n {1}
 jvm.options.label.jvmoptions	= JVM Options:
 jvm.options.warning.restart		= Changes to the JVM Options will only be applied when the program is restarted.
+jvm.options.memory.size = Size: {0}
+jvm.options.memory.used = Used: {0}
+jvm.options.memory.max = Max: {0}
 
 keyboard.api.cheatsheet.header		= <head><title>OWASP ZAP Keyboard shortcuts</title></head><body><H1>OWASP ZAP Keyboard shortcuts</H1>\
 <table border="0"><tr><th>Action</th><th></th><th>Modifiers</th><th>Key</th></tr>

--- a/src/org/parosproxy/paros/extension/option/OptionsJvmPanel.java
+++ b/src/org/parosproxy/paros/extension/option/OptionsJvmPanel.java
@@ -29,12 +29,16 @@ import java.util.List;
 
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JSeparator;
+import javax.swing.SwingConstants;
 
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.view.AbstractParamPanel;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.utils.ZapLabel;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.LayoutHelper;
+import org.zaproxy.zap.view.renderer.SizeBytesStringValue;
 
 /**
  * The JVM options panel.
@@ -55,11 +59,16 @@ public class OptionsJvmPanel extends AbstractParamPanel {
      */
     private static final String NAME = Constant.messages.getString("jvm.options.title");
     
+    private static final SizeBytesStringValue sbsv = new SizeBytesStringValue(false);
     
 	/**
 	 * The text field for the JVM options.
 	 */
 	private ZapTextField jvmOptionsField = null; 
+	
+	private ZapLabel sizeMemoryLabel = null;
+	private ZapLabel usedMemoryLabel = null;
+	private ZapLabel maxMemoryLabel = null;
 	
     public OptionsJvmPanel() {
         super();
@@ -69,17 +78,25 @@ public class OptionsJvmPanel extends AbstractParamPanel {
         JPanel panel = new JPanel();
 		panel.setLayout(new GridBagLayout());
 		
+		int row=0;
 		JLabel jvmOptionsLabel = new JLabel(Constant.messages.getString("jvm.options.label.jvmoptions"));
 		jvmOptionsLabel.setLabelFor(getJvmOptionsField());
 		
 		panel.add(jvmOptionsLabel, 
-				LayoutHelper.getGBC(0, 0, 1, 2.0));
+				LayoutHelper.getGBC(0, row, 1, 2.0));
 		panel.add(getJvmOptionsField(), 
-				LayoutHelper.getGBC(1, 0, 1, 8.0));
+				LayoutHelper.getGBC(1, row, 1, 8.0));
 
 		panel.add(new JLabel(Constant.messages.getString("jvm.options.warning.restart")), 
-				LayoutHelper.getGBC(0, 1, 2, 1.0));
+				LayoutHelper.getGBC(0, ++row, 2, 1.0));
 
+		panel.add(new JSeparator(SwingConstants.HORIZONTAL), 
+				LayoutHelper.getGBC(0, ++row, 2, 0.0D, 0.0D));
+
+		panel.add(getSizeMemoryLabel(), LayoutHelper.getGBC(0, ++row, 2, 1.0));
+		panel.add(getUsedMemoryLabel(), LayoutHelper.getGBC(0, ++row, 2, 1.0));
+		panel.add(getMaxMemoryLabel(), LayoutHelper.getGBC(0, ++row, 2, 1.0));
+		
 		panel.add(new JLabel(), 
 				LayoutHelper.getGBC(0, 10, 1, 0.5D, 1.0D));	// Spacer
 		
@@ -93,8 +110,38 @@ public class OptionsJvmPanel extends AbstractParamPanel {
 		return jvmOptionsField;
 	}
 	
+	private ZapLabel getSizeMemoryLabel() {
+		if (sizeMemoryLabel == null) {
+			sizeMemoryLabel = new ZapLabel();
+		}
+		return sizeMemoryLabel;
+	}
+	
+	private ZapLabel getUsedMemoryLabel() {
+		if (usedMemoryLabel == null) {
+			usedMemoryLabel = new ZapLabel();
+		}
+		return usedMemoryLabel;
+	}
+	
+	private ZapLabel getMaxMemoryLabel() {
+		if (maxMemoryLabel == null) {
+			maxMemoryLabel = new ZapLabel();
+		}
+		return maxMemoryLabel;
+	}
+	
+	private void updateMemoryLabel(ZapLabel labelToUpdate, String key, long value) {
+		labelToUpdate.setText(Constant.messages.getString(key, sbsv.getString(value)));
+	}
+	
     @Override
     public void initParam(Object obj) {
+    	long size = Runtime.getRuntime().totalMemory();
+    	// initParam happens before display of the panel so the values are appropriately set when viewed
+		updateMemoryLabel(getSizeMemoryLabel(), "jvm.options.memory.size", size);
+		updateMemoryLabel(getUsedMemoryLabel(), "jvm.options.memory.used", size - Runtime.getRuntime().freeMemory());
+		updateMemoryLabel(getMaxMemoryLabel(), "jvm.options.memory.max", Runtime.getRuntime().maxMemory());
 		try {
 			/* JVM properties are unusual in that they are held
 			 * in a separate file from the other options.

--- a/src/org/zaproxy/zap/view/renderer/SizeBytesStringValue.java
+++ b/src/org/zaproxy/zap/view/renderer/SizeBytesStringValue.java
@@ -57,6 +57,10 @@ public class SizeBytesStringValue implements StringValue {
     
     public SizeBytesStringValue() {
     }
+    
+    public SizeBytesStringValue(boolean shouldUseJustBytesUnit) {
+        setUseJustBytesUnit(shouldUseJustBytesUnit);
+    }
 
     /**
      * Tells whether or not the conversion to {@code String} should use just bytes, that is, it should not use bigger units


### PR DESCRIPTION
OptionsJvmPanel > Updated with necessary ZapLabels and getters to display the headings and human readable (eg: MiB/GiB) values. Values (labels) are updated by calling update methods in the overridden initParam function.
SizeBytesStringValue > Added supplemental constructor that accepts a boolean for the useJustBytesUnit flag. (Thus providing a means of creating and simultaneously setting the flag, vs. using 2 steps in
calling code.)
Messages.properties > Updated with the necessary supporting keys and
messages.

Fixes zaproxy/zaproxy#3485