### PR TITLE
Add BreakAPI through the ExtensionHook

### DIFF
--- a/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
+++ b/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
@@ -51,7 +51,6 @@ import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.brk.impl.http.HttpBreakpointManagementDaemonImpl;
 import org.zaproxy.zap.extension.brk.impl.http.HttpBreakpointMessage;
 import org.zaproxy.zap.extension.brk.impl.http.HttpBreakpointMessage.Location;
@@ -140,7 +139,7 @@ public class ExtensionBreak extends ExtensionAdaptor implements SessionChangedLi
         extensionHook.addSessionListener(this);
         extensionHook.addOptionsChangedListener(this);
 
-        API.getInstance().registerApiImplementor(api);
+        extensionHook.addApiImplementor(api);
 	    
 	    if (getView() != null) {
 	        breakPanel = new BreakPanel(this, getOptionsParam());


### PR DESCRIPTION
Change ExtensionBreak to add the API with the ExtensionHook, best
practice as it does not require to manually unload it (if/when moved to
an add-on).

Related to #2785 - Allow to hook ApiImplementor