### PR TITLE
Stop spider scans when mode changed to Safe

### DIFF
--- a/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
+++ b/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
@@ -336,6 +336,10 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
 
 	@Override
 	public void sessionModeChanged(Mode mode) {
+		if (Mode.safe.equals(mode)) {
+			this.scanController.stopAllScans();
+		}
+
 		if (View.isInitialised()) {
 			this.getSpiderPanel().sessionModeChanged(mode);
 			getMenuItemCustomScan().setEnabled( ! Mode.safe.equals(mode));


### PR DESCRIPTION
Change ExtensionSpider to also stop the scans when the mode is changed
to Safe, like done with active scans (the Spider panel was already being
disabled but the scans were kept running).