### PR TITLE
Skip Access Control responses for HTTP Sessions

### DIFF
--- a/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
@@ -652,7 +652,8 @@ public class ExtensionHttpSessions extends ExtensionAdaptor implements SessionCh
 		if (initiator == HttpSender.ACTIVE_SCANNER_INITIATOR || initiator == HttpSender.SPIDER_INITIATOR
 				|| initiator == HttpSender.AJAX_SPIDER_INITIATOR || initiator == HttpSender.FORCED_BROWSE_INITIATOR
 				|| initiator == HttpSender.CHECK_FOR_UPDATES_INITIATOR || initiator == HttpSender.FUZZER_INITIATOR
-				|| initiator == HttpSender.AUTHENTICATION_INITIATOR || initiator == HttpSender.TOKEN_GENERATOR_INITIATOR) {
+				|| initiator == HttpSender.AUTHENTICATION_INITIATOR || initiator == HttpSender.TOKEN_GENERATOR_INITIATOR
+				|| initiator == HttpSender.ACCESS_CONTROL_SCANNER_INITIATOR) {
 			// Not a session we care about
 			return;
 		}


### PR DESCRIPTION
Change class ExtensionHttpSessions to skip/ignore the responses from
Access Control, as with other automated responses they would end up
flood the HTTP Sessions tab with a lot of unnecessary sessions (e.g.
when testing with anonymous).