### PR TITLE
Tweak label in Exclude from Spider panel

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -2057,7 +2057,7 @@ session.scope.include.title        = Include in Scope
 session.select.session			   = Session:
 session.select.title			   = Open Session
 session.spider.exclude.title       = Exclude from Spider
-session.spider.label.ignore        = URLs which will be ignored by the spider 
+session.spider.label.ignore        = URLs which will be ignored by the spiders (standard and AJAX) 
 session.untitled                   = Untitled Session
 
 sessionmanagement.name = Session Management Extension


### PR DESCRIPTION
Change the label of Exclude from Spider panel to mention that it applies
to all spiders.

Related to zaproxy/zap-core-help#141 - Mention all spiders in Exclude
from Spider