### PR TITLE
Keep panel of selected context selected

### DIFF
--- a/src/org/parosproxy/paros/view/AbstractParamContainerPanel.java
+++ b/src/org/parosproxy/paros/view/AbstractParamContainerPanel.java
@@ -27,6 +27,7 @@
 // ZAP: 2017/09/03 Cope with Java 9 change to TreeNode.children().
 // ZAP: 2018/01/08 Allow to expand the node of a param panel.
 // ZAP: 2018/03/26 Ensure node of selected panel is visible.
+// ZAP: 2018/04/12 Allow to check if a param panel is selected.
 
 package org.parosproxy.paros.view;
 
@@ -609,6 +610,43 @@ public class AbstractParamContainerPanel extends JSplitPane {
         if (node != null) {
             getTreeParam().expandPath(new TreePath(node.getPath()));
         }
+    }
+
+    /**
+     * Tells whether or not the given param panel is selected.
+     *
+     * @param panelName the name of the panel to check if it is selected, should not be {@code null}.
+     * @return {@code true} if the panel is selected, {@code false} otherwise.
+     * @since TODO add version
+     * @see #isParamPanelOrChildSelected(String)
+     */
+    public boolean isParamPanelSelected(String panelName) {
+        DefaultMutableTreeNode node = getTreeNodeFromPanelName(panelName);
+        if (node != null) {
+            return getTreeParam().isPathSelected(new TreePath(node.getPath()));
+        }
+        return false;
+    }
+
+    /**
+     * Tells whether or not the given param panel, or one of its child panels, is selected.
+     *
+     * @param panelName the name of the panel to check, should not be {@code null}.
+     * @return {@code true} if the panel or one of its child panels is selected, {@code false} otherwise.
+     * @since TODO add version
+     * @see #isParamPanelSelected(String)
+     */
+    public boolean isParamPanelOrChildSelected(String panelName) {
+        DefaultMutableTreeNode node = getTreeNodeFromPanelName(panelName);
+        if (node != null) {
+            TreePath panelPath = new TreePath(node.getPath());
+            if (getTreeParam().isPathSelected(panelPath)) {
+                return true;
+            }
+            TreePath selectedPath = getTreeParam().getSelectionPath();
+            return selectedPath != null && panelPath.equals(selectedPath.getParentPath());
+        }
+        return false;
     }
 
     public void showDialog(boolean showRoot) {

--- a/src/org/parosproxy/paros/view/AbstractParamDialog.java
+++ b/src/org/parosproxy/paros/view/AbstractParamDialog.java
@@ -31,6 +31,7 @@
 // ZAP: 2014/12/10 Issue 1427: Standardize on [Cancel] [OK] button order
 // ZAP: 2016/11/17 Issue 2701 Added support for additional buttons to support Factory Reset
 // ZAP: 2018/01/08 Allow to expand the node of a param panel.
+// ZAP: 2018/04/12 Allow to check if a param panel is selected.
 
 package org.parosproxy.paros.view;
 
@@ -365,6 +366,30 @@ public class AbstractParamDialog extends AbstractDialog {
      */
     protected void expandParamPanelNode(String panelName) {
         getJSplitPane().expandParamPanelNode(panelName);
+    }
+
+    /**
+     * Tells whether or not the given param panel is selected.
+     *
+     * @param panelName the name of the panel to check if it is selected, should not be {@code null}.
+     * @return {@code true} if the panel is selected, {@code false} otherwise.
+     * @since TODO add version
+     * @see #isParamPanelOrChildSelected(String)
+     */
+    protected boolean isParamPanelSelected(String panelName) {
+        return getJSplitPane().isParamPanelSelected(panelName);
+    }
+
+    /**
+     * Tells whether or not the given param panel, or one of its child panels, is selected.
+     *
+     * @param panelName the name of the panel to check, should not be {@code null}.
+     * @return {@code true} if the panel or one of its child panels is selected, {@code false} otherwise.
+     * @since TODO add version
+     * @see #isParamPanelSelected(String)
+     */
+    protected boolean isParamPanelOrChildSelected(String panelName) {
+        return getJSplitPane().isParamPanelOrChildSelected(panelName);
     }
 
     public int showDialog(boolean showRoot) {

--- a/src/org/parosproxy/paros/view/SiteMapPanel.java
+++ b/src/org/parosproxy/paros/view/SiteMapPanel.java
@@ -45,6 +45,7 @@
 // ZAP: 2017/11/29 Delete site nodes with keyboard shortcut.
 // ZAP: 2017/12/22 Select context on row click.
 // ZAP: 2018/03/26 Expand node of selected context.
+// ZAP: 2018/04/12 Keep panel of selected context selected.
 
 package org.parosproxy.paros.view;
 
@@ -491,6 +492,9 @@ public class SiteMapPanel extends AbstractPanel {
 					    	Target target = (Target)node.getUserObject();
 					    	String panelName = ContextGeneralPanel.getPanelName(target.getContext());
 					    	getView().getSessionDialog().expandParamPanelNode(panelName);
+					    	if (getView().getSessionDialog().isParamPanelOrChildSelected(panelName)) {
+					    		panelName = null;
+					    	}
 					    	getView().showSessionDialog(Model.getSingleton().getSession(), panelName);
 					    }
 				    }


### PR DESCRIPTION
Change SiteMapPanel to not change the selected panel (to main context
panel) if the panel belongs to the selected context, it's more likely
that the user wants to keep using the previously selected panel than go
to main panel every time the context is double clicked.
Change AbstractParamContainerPanel and AbstractParamDialog to allow to
check if a panel or its child panels is selected, to support the above
use case.