### PR TITLE
Do not include zero Content-Length in GET requests

### DIFF
--- a/src/org/zaproxy/zap/ZapGetMethod.java
+++ b/src/org/zaproxy/zap/ZapGetMethod.java
@@ -90,6 +90,15 @@ public class ZapGetMethod extends EntityEnclosingMethod {
 		return followRedirects;
 	}
 
+	@Override
+	protected void addContentLengthRequestHeader(HttpState state, HttpConnection conn) throws IOException, HttpException {
+		if (getRequestContentLength() == 0) {
+			// Don't add the header with 0 length, not everything accepts it.
+			return;
+		}
+		super.addContentLengthRequestHeader(state, conn);
+	}
+
 	/**
 	 * Allow response code 101, that is Switching Protocols.
 	 * 


### PR DESCRIPTION
Change ZapGetMethod to not add the Content-Length header with zero, it
might be rejected by some servers or WAFs.