### PR TITLE
Cope with empty auth credentials while decoding

### DIFF
--- a/src/org/zaproxy/zap/authentication/UsernamePasswordAuthenticationCredentials.java
+++ b/src/org/zaproxy/zap/authentication/UsernamePasswordAuthenticationCredentials.java
@@ -107,6 +107,12 @@ class UsernamePasswordAuthenticationCredentials implements AuthenticationCredent
 		}
 
 		String[] pieces = encodedCredentials.split(FIELD_SEPARATOR);
+		if (pieces.length == 0) {
+			this.username = "";
+			this.password = "";
+			return;
+		}
+
 		this.username = new String(Base64.decodeBase64(pieces[0]));
 		if (pieces.length > 1)
 			this.password = new String(Base64.decodeBase64(pieces[1]));

--- a/test/org/zaproxy/zap/authentication/UsernamePasswordAuthenticationCredentialsUnitTest.java
+++ b/test/org/zaproxy/zap/authentication/UsernamePasswordAuthenticationCredentialsUnitTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 import org.zaproxy.zap.extension.api.ApiResponse;
 
@@ -121,6 +122,18 @@ public class UsernamePasswordAuthenticationCredentialsUnitTest {
                     encodedUsernamePassword,
                     is("bXlVc2Vy~bXlQYXNz~"));
         }
+    }
+
+    @Test
+    public void shouldDecodeEmptyUsernameAndPassword() {
+        // Given
+        String encodedCredentials = "~~";
+        UsernamePasswordAuthenticationCredentials authCredentials = new UsernamePasswordAuthenticationCredentials();
+        // When
+        authCredentials.decode(encodedCredentials);
+        // Then
+        assertThat(authCredentials.getUsername(), is(equalTo("")));
+        assertThat(authCredentials.getPassword(), is(equalTo("")));
     }
 
     @Test


### PR DESCRIPTION
Change UsernamePasswordAuthenticationCredentials to properly decode
empty username/password, preventing an ArrayIndexOutOfBoundsException.
Add a test to assert the expected behaviour.