### PR TITLE
Log as error when failed to import the context

### DIFF
--- a/src/org/parosproxy/paros/control/MenuFileControl.java
+++ b/src/org/parosproxy/paros/control/MenuFileControl.java
@@ -570,7 +570,7 @@ public class MenuFileControl implements SessionListener {
 				}
 				View.getSingleton().showWarningDialog(Constant.messages.getString("context.import.error", detailError));
 			} catch (Exception e1) {
-				log.debug(e1.getMessage(), e1);
+				log.error(e1.getMessage(), e1);
 				View.getSingleton().showWarningDialog(Constant.messages.getString("context.import.error", e1.getMessage()));
 			}
 	    }


### PR DESCRIPTION
Change MenuFileControl to log the exception as error when importing the
context, it's more useful to log as error, debug is not included by
default.