### PR TITLE
Save form data even if not able to extract user

### DIFF
--- a/src/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -607,13 +608,15 @@ public class FormBasedAuthenticationMethodType extends AuthenticationMethodType 
 								&& !password.contains(FormBasedAuthenticationMethod.MSG_PASS_PATTERN)) {
 							// Add the user based on the details provided
 							// Note that right now application/x-www-form-urlencoded forms are supported 
-							String userStr = URLDecoder.decode(username, "UTF8");
-							String passwdStr = URLDecoder.decode(password, "UTF8");
-							User user = new User(context.getIndex(), userStr);
-							UsernamePasswordAuthenticationCredentials upac = 
-									new UsernamePasswordAuthenticationCredentials(userStr, passwdStr);
-							user.setAuthenticationCredentials(upac);
-							getUserExt().getContextUserAuthManager(context.getIndex()).addUser(user);
+							String userStr = decodeValue(username);
+							String passwdStr = decodeValue(password);
+							if (!userStr.isEmpty() && !passwdStr.isEmpty()) {
+								User user = new User(context.getIndex(), userStr);
+								UsernamePasswordAuthenticationCredentials upac = 
+										new UsernamePasswordAuthenticationCredentials(userStr, passwdStr);
+								user.setAuthenticationCredentials(upac);
+								getUserExt().getContextUserAuthManager(context.getIndex()).addUser(user);
+							}
 						}
 					}
 					
@@ -626,6 +629,17 @@ public class FormBasedAuthenticationMethodType extends AuthenticationMethodType 
 			} catch (Exception e) {
 				log.error(e.getMessage(), e);
 			}
+		}
+
+		private static String decodeValue(String value) {
+			try {
+				return URLDecoder.decode(value, StandardCharsets.UTF_8.name());
+			} catch (UnsupportedEncodingException ignore) {
+				// Standard charset.
+			} catch (IllegalArgumentException e) {
+				log.debug("Failed to URL decode: " + value, e);
+			}
+			return "";
 		}
 
 		@Override


### PR DESCRIPTION
Change FormBasedAuthenticationMethodType to use/save the form data set
even if the extracted username/password are not properly URL encoded,
instead of "silently" (an exception was logged) discard all the data.
The username and password are replaced by the authentication tokens so
the remaining data is still usable.