### PR TITLE
Don't log creation of auth panels as info

### DIFF
--- a/src/org/zaproxy/zap/extension/authentication/ContextAuthenticationPanel.java
+++ b/src/org/zaproxy/zap/extension/authentication/ContextAuthenticationPanel.java
@@ -167,7 +167,9 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
 			return;
 		}
 
-		log.info("Creating new panel for configuring: " + newMethodType.getName());
+		if (log.isDebugEnabled()) {
+			log.debug("Creating new panel for configuring: " + newMethodType.getName());
+		}
 		this.getConfigContainerPanel().removeAll();
 
 		// show the panel according to whether the authentication type needs configuration


### PR DESCRIPTION
Change ContextAuthenticationPanel to log as debug, it's not relevant
enough to log as info.