### PR TITLE
Validate login URL not empty in form-based auth

### DIFF
--- a/src/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
@@ -427,6 +427,10 @@ public class FormBasedAuthenticationMethodType extends AuthenticationMethodType 
 	}
 
 	private static boolean isValidLoginUrl(String loginUrl) {
+		if (loginUrl.isEmpty()) {
+			return false;
+		}
+
 		try {
 			createLoginUrl(loginUrl, "", "");
 			return true;


### PR DESCRIPTION
Change FormBasedAuthenticationMethodType to also check if the login URL
is not empty when validating it, the login URL is a required field.