### PR TITLE
Do not allow remove HTTP Session if none selected

### DIFF
--- a/src/org/zaproxy/zap/extension/httpsessions/PopupMenuRemoveSession.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/PopupMenuRemoveSession.java
@@ -76,8 +76,8 @@ public class PopupMenuRemoveSession extends ExtensionPopupMenuItem {
 
 	@Override
 	public boolean isEnableForComponent(Component invoker) {
-		// Only enable it for the HttpSessionsPanel and for the entries that are not already active
-		if (invoker.getName() != null && invoker.getName().equals(HttpSessionsPanel.PANEL_NAME)) {
+		if (HttpSessionsPanel.PANEL_NAME.equals(invoker.getName())) {
+			setEnabled(extension.getHttpSessionsPanel().getSelectedSession() != null);
 			return true;
 		}
 		return false;


### PR DESCRIPTION
Change PopupMenuRemoveSession to disable the menu item if no HTTP
session is selected in the HTTP Sessions panel, preventing a NPE. Also,
remove incorrect comment (referred to functionality of other menu item)
and tweak panel name check to avoid null comparison.