### PR TITLE
Add proxy related listeners to alternative proxies

### DIFF
--- a/src/org/zaproxy/zap/extension/proxies/ExtensionProxies.java
+++ b/src/org/zaproxy/zap/extension/proxies/ExtensionProxies.java
@@ -38,7 +38,6 @@ import org.parosproxy.paros.core.proxy.ProxyServer;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.OptionsChangedListener;
-import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.OptionsParam;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
@@ -182,16 +181,15 @@ public class ExtensionProxies extends ExtensionAdaptor implements OptionsChanged
         proxyServer.setConnectionParam(getModel().getOptionsParam().getConnectionParam());
         // Note that if this is _not_ set then the proxy will go into a nasty loop if you point a browser at it
         proxyServer.setEnableApi(true);
-        if (proxyServer.startServer(address, port, false) > 0) {
-            Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class).registerProxy(proxyServer);
-        }
+        Control.getSingleton().getExtensionLoader().addProxyServer(proxyServer);
+        proxyServer.startServer(address, port, false);
         return proxyServer;
     }
 
     private void stopProxyServer(String proxyKey, ProxyServer proxyServer) {
         log.info("Stopping alt proxy server: " + proxyKey);
-        Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class).unregisterProxy(proxyServer);
         proxyServer.stopServer();
+        Control.getSingleton().getExtensionLoader().removeProxyServer(proxyServer);
     }
 
     public List<ProxiesParamProxy> getAdditionalProxies() {


### PR DESCRIPTION
Change ExtensionLoader to allow to add ProxyServer to have the proxy
related listeners automatically added/removed to/from it.
Change ExtensionProxies to add/remove the ProxyServers to the
ExtensionLoader.
This ensures the alternative proxies have exactly the same functionality
as the main one, WebSocket connections, intercept/break messages...