### PR TITLE
Allow to reinstall (local) add-on

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -796,7 +796,8 @@ cfu.warn.addon.with.missing.requirements.unknown = Unknown (refer to log file fo
 cfu.warn.addon.with.missing.requirements.javaversion = Minimum Java version: {0} (found: "{1}")
 cfu.warn.addon.with.missing.requirements.javaversion.dependency = Minimum Java version: {0} (found: "{1}") by dependency: "{2}"
 cfu.warn.addon.with.missing.requirements.javaversion.unknown = unknown
-cfu.warn.addOnOlderVersion = Add-on not installed!\n\nA newer (or same) version of the add-on is already installed:\nInstalled: {0} ({1})\nBeing installed: {2} ({3})
+cfu.warn.addOnOlderVersion = Add-on not installed!\n\nA newer version of the add-on is already installed:\nInstalled: {0} ({1})\nBeing installed: {2} ({3})
+cfu.warn.addOnSameVersion = The same version of the add-on is already installed:\nInstalled: {0} ({1})\nBeing installed: {2} ({3})\n\nReinstall the add-on?
 cfu.warn.addOnNotRunnable.message = The add-on will not run until the following requirements are fulfilled:
 cfu.warn.addOnNotRunnable.question = Continue with the installation?
 cfu.warn.cantload      = Can not load the specified add-on\:\nNot before \= {0}\nNot from \= {1}


### PR DESCRIPTION
Change ExtensionAutoUpdate to allow to reinstall the add-on even if it
has the same version, it reduces the steps required to try dev changes
as it does not require to manually uninstall the add-on each time.