### PR TITLE
Skip plugins if no input vectors enabled

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -361,6 +361,7 @@ ascan.progress.label.skipped.reason.techs = scanner does not target selected tec
 ascan.progress.label.skipped.reason.maxRule = exceeded max rule time
 ascan.progress.label.skipped.reason.maxScan = exceeded max scan time
 ascan.progress.label.skipped.reason.nonodes = no nodes to scan
+ascan.progress.label.skipped.reason.noinputvectors = no input vectors enabled
 ascan.progress.label.totals		= Totals
 ascan.progress.label.skipaction	= Skip active scanner
 ascan.progress.tab.chart		= Response Chart

--- a/src/org/parosproxy/paros/core/scanner/AbstractAppParamPlugin.java
+++ b/src/org/parosproxy/paros/core/scanner/AbstractAppParamPlugin.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.log4j.Logger;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
@@ -149,6 +150,11 @@ public abstract class AbstractAppParamPlugin extends AbstractAppPlugin {
 
         if ((enabledRPC & ScannerParam.RPC_USERDEF) != 0) {
             listVariant.add(new VariantUserDefined());
+        }
+
+        if (listVariant.isEmpty()) {
+            getParent().pluginSkipped(this, Constant.messages.getString("ascan.progress.label.skipped.reason.noinputvectors"));
+            return;
         }
 
         


### PR DESCRIPTION
Change AbstractAppParamPlugin to skip the plugin if there are no input
vectors enabled, no point trying to scan following messages and the user
is informed that the scanner didn't scan.