### PR TITLE
Do not try to load resources for core extensions

### DIFF
--- a/src/org/zaproxy/zap/control/ExtensionFactory.java
+++ b/src/org/zaproxy/zap/control/ExtensionFactory.java
@@ -300,6 +300,11 @@ public class ExtensionFactory {
     }
 
     private static ResourceBundle getExtensionResourceBundle(Extension ext) {
+        if (ext.getAddOn() == null) {
+            // Core extensions use core resource bundle.
+            return null;
+        }
+
         String extensionPackage = ext.getClass().getPackage().getName();
         ClassLoader classLoader = ext.getClass().getClassLoader();
         try {
@@ -347,6 +352,11 @@ public class ExtensionFactory {
     }
 
     private static URL getExtensionHelpSetUrl(Extension extension) {
+        if (extension.getAddOn() == null) {
+            // Core extensions use core help.
+            return null;
+        }
+
         String extensionPackage = extension.getClass().getPackage().getName();
         String localeToken = "%LC%";
         Function<String, URL> getResource = extension.getClass().getClassLoader()::getResource;


### PR DESCRIPTION
Change ExtensionFactory to skip core extensions when loading resources
(Messages.properties and help), core extensions don't have their own
resources.