### PR TITLE
Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/3rd_party_addon.md
+++ b/.github/ISSUE_TEMPLATE/3rd_party_addon.md
@@ -1,0 +1,30 @@
+---
+name: '3rd party add-on '
+about: Tell us about a 3rd party add-on that we should add or update in the ZAP Marketplace
+
+---
+
+**Add-on repo**
+The URL of the repository for the add-on.
+
+**Your contact details**
+Email, twitter, whatever works for you.
+
+**Are you one of the authors**
+Yes / No
+
+**Licence**
+If not clearly stated in the repo.
+
+**Build instructions**
+If not in the repo.
+
+**Link to more information**
+
+**Twitter handle for tool or author(s)**
+Will be used in the announcement tweet from @zaproxy
+
+**Promote to Beta or Release?**
+Note that all new add-ons start at Alpha status.
+
+**Anything else we should know**

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Software versions**
+ - ZAP: [note that we typically only support the latest version of ZAP]
+ - OS: [e.g. Windows 10]
+ - Java: [e.g. openjdk version "1.8.0_171"]
+ - Browser: [e.g. chrome 66, firefox 59, safari 11.1]
+
+**Errors from the zap.log file**
+See https://github.com/zaproxy/zaproxy/wiki/FAQconfig for the location of the zap.log file for your OS.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
See https://help.github.com/articles/manually-creating-a-single-issue-template-for-your-repository/ for details of supporting multiple issue templates.
Basically we'll need to provide a link in a suitable place referencing this template.
Was thinking we could create templates for other cases as well, such as promoting one of our add-ons.