### PR TITLE
Be more defensive when instantiating add-on class

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnLoaderUtils.java
+++ b/src/org/zaproxy/zap/control/AddOnLoaderUtils.java
@@ -110,7 +110,7 @@ final class AddOnLoaderUtils {
             @SuppressWarnings("unchecked")
             Constructor<T> c = (Constructor<T>) cls.getConstructor();
             return c.newInstance();
-        } catch (ExceptionInInitializerError | Exception e) {
+        } catch (LinkageError | Exception e) {
             LOGGER.error("Failed to initialise: " + classname, e);
         }
         return null;


### PR DESCRIPTION
Change AddOnLoaderUtils to catch LinkageError when instantiating
declared add-ons classes (ZapAddOn.xml file) to prevent incompatibly
issues in one add-on (class) to affect other add-ons. For example, the
SOAP add-on running in Java 9 (and above) would prevent active scanners
from other add-ons from being added.

Improves #4323.
Related to #4037 - SOAP Scanner add-on leads to errors with Java 9