### PR TITLE
Make Passive Scan Tags management cleaner

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1872,22 +1872,20 @@ pscan.options.header                        = <html><body><p>The following passi
 
 pscan.options.level.label	   = Passive Alert Threshold:
 
-pscan.options.dialog.scanner.field.label.config                  = Configuration:
+pscan.options.dialog.scanner.field.label.config                  = Tag:
 pscan.options.dialog.scanner.field.label.editRequestHeaderRegex  = Request Header Regex:
 pscan.options.dialog.scanner.field.label.editRequestUrlRegex     = Request URL Regex:
 pscan.options.dialog.scanner.field.label.editResponseBodyRegex   = Response Body Regex:
 pscan.options.dialog.scanner.field.label.editResponseHeaderRegex = Response Header Regex:
 pscan.options.dialog.scanner.field.label.enabled                 = Enabled:
 pscan.options.dialog.scanner.field.label.name                    = Name:
-pscan.options.dialog.scanner.field.label.type                    = Type:
 pscan.options.main.name = Passive Scanner
 pscan.options.main.label.scanOnlyInScope = Only scan messages in scope
 pscan.options.main.label.scanFuzzerMessages = Include traffic from the Fuzzer when passive scanning
 pscan.options.name                          = Passive Scan Tags
 pscan.options.table.header.enabled                 = Enabled
 pscan.options.table.header.name                    = Name
-pscan.options.table.header.type                    = Type
-pscan.options.table.header.configuration = Configuration
+pscan.options.table.header.configuration = Tag
 pscan.options.dialog.scanner.add.button.confirm             = Add
 pscan.options.dialog.scanner.add.title                      = Add Passive Scan Tag Rule
 pscan.options.dialog.scanner.modify.title                = Modify Passive Scan Tag Rule

--- a/src/org/zaproxy/zap/extension/pscan/DialogAddAutoTagScanner.java
+++ b/src/org/zaproxy/zap/extension/pscan/DialogAddAutoTagScanner.java
@@ -45,7 +45,6 @@ class DialogAddAutoTagScanner extends AbstractFormDialog {
     private static final String CONFIRM_BUTTON_LABEL = Constant.messages.getString("pscan.options.dialog.scanner.add.button.confirm");
 
     private static final String NAME_FIELD_LABEL = Constant.messages.getString("pscan.options.dialog.scanner.field.label.name");
-    private static final String TYPE_FIELD_LABEL = Constant.messages.getString("pscan.options.dialog.scanner.field.label.type");
     private static final String CONFIGURATION_FIELD_LABEL = Constant.messages.getString("pscan.options.dialog.scanner.field.label.config");
     private static final String REQUEST_URL_REGEX_FIELD_LABEL = Constant.messages.getString("pscan.options.dialog.scanner.field.label.editRequestUrlRegex");
     private static final String REQUEST_HEADER_REGEX_FIELD_LABEL = Constant.messages.getString("pscan.options.dialog.scanner.field.label.editRequestHeaderRegex");
@@ -63,7 +62,6 @@ class DialogAddAutoTagScanner extends AbstractFormDialog {
     private static final String MESSAGE_INVALID_RESPONSE_HEADER_REGEX = Constant.messages.getString("pscan.options.dialog.scanner.warning.invalid.responseHeaderRegex");
 
     private ZapTextField nameTextField;
-    private ZapTextField typeTextField;
     private ZapTextField configurationTextField;
     private ZapTextField requestUrlRegexTextField;
     private ZapTextField requestHeaderRegexTextField;
@@ -94,7 +92,6 @@ class DialogAddAutoTagScanner extends AbstractFormDialog {
         layout.setAutoCreateContainerGaps(true);
         
         JLabel nameLabel = new JLabel(NAME_FIELD_LABEL);
-        JLabel typeLabel = new JLabel(TYPE_FIELD_LABEL);
         JLabel configurationLabel = new JLabel(CONFIGURATION_FIELD_LABEL);
         JLabel requestUrlRegexLabel = new JLabel(REQUEST_URL_REGEX_FIELD_LABEL);
         JLabel requestHeaderRegexLabel = new JLabel(REQUEST_HEADER_REGEX_FIELD_LABEL);
@@ -105,7 +102,6 @@ class DialogAddAutoTagScanner extends AbstractFormDialog {
         layout.setHorizontalGroup(layout.createSequentialGroup()
             .addGroup(layout.createParallelGroup(GroupLayout.Alignment.TRAILING)
                 .addComponent(nameLabel)
-                .addComponent(typeLabel)
                 .addComponent(configurationLabel)
                 .addComponent(requestUrlRegexLabel)
                 .addComponent(requestHeaderRegexLabel)
@@ -114,7 +110,6 @@ class DialogAddAutoTagScanner extends AbstractFormDialog {
                 .addComponent(enabledLabel))
             .addGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
                 .addComponent(getNameTextField())
-                .addComponent(getTypeTextField())
                 .addComponent(getConfigurationTextField())
                 .addComponent(getRequestUrlRegexTextField())
                 .addComponent(getRequestHeaderRegexTextField())
@@ -127,9 +122,6 @@ class DialogAddAutoTagScanner extends AbstractFormDialog {
             .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
                 .addComponent(nameLabel)
                 .addComponent(getNameTextField()))
-            .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
-                .addComponent(typeLabel)
-                .addComponent(getTypeTextField()))
             .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
                 .addComponent(configurationLabel)
                 .addComponent(getConfigurationTextField()))
@@ -258,16 +250,6 @@ class DialogAddAutoTagScanner extends AbstractFormDialog {
         }
         
         return nameTextField;
-    }
-
-    protected ZapTextField getTypeTextField() {
-        if (typeTextField == null) {
-            typeTextField = new ZapTextField();
-            typeTextField.setEditable(false);
-            typeTextField.setText(RegexAutoTagScanner.TYPE.TAG.name());
-        }
-
-        return typeTextField;
     }
     
     protected ZapTextField getConfigurationTextField() {

--- a/src/org/zaproxy/zap/extension/pscan/DialogModifyAutoTagScanner.java
+++ b/src/org/zaproxy/zap/extension/pscan/DialogModifyAutoTagScanner.java
@@ -56,10 +56,7 @@ class DialogModifyAutoTagScanner extends DialogAddAutoTagScanner {
     @Override
     protected void init() {
         getNameTextField().setText(scanner.getName());
-        getRequestUrlRegexTextField().discardAllEdits();
-        
-        getTypeTextField().setText(scanner.getType().name());
-        getRequestUrlRegexTextField().discardAllEdits();
+        getNameTextField().discardAllEdits();
         
         getConfigurationTextField().setText(scanner.getConf());
         getConfigurationTextField().discardAllEdits();

--- a/src/org/zaproxy/zap/extension/pscan/OptionsPassiveScanTableModel.java
+++ b/src/org/zaproxy/zap/extension/pscan/OptionsPassiveScanTableModel.java
@@ -34,7 +34,6 @@ public class OptionsPassiveScanTableModel extends AbstractMultipleOptionsTableMo
 	private static final String[] COLUMN_NAMES = {
 		Constant.messages.getString("pscan.options.table.header.enabled"),
 		Constant.messages.getString("pscan.options.table.header.name"),
-		Constant.messages.getString("pscan.options.table.header.type"),
 		Constant.messages.getString("pscan.options.table.header.configuration")};
     
 	private static final int COLUMN_COUNT = COLUMN_NAMES.length;
@@ -94,8 +93,6 @@ public class OptionsPassiveScanTableModel extends AbstractMultipleOptionsTableMo
         case 1:
             return getElement(rowIndex).getName();
         case 2:
-            return getElement(rowIndex).getType().toString();
-        case 3:
             return getElement(rowIndex).getConf();
         }
         return null;


### PR DESCRIPTION
Delete the "Type" field from table and modify/add dialogs because it's always TAG. The contents of the UI element weren't even used before, so functionally nothing changed. Rename "Configuration" field to "Tag" to be less general and more clear.