### PR TITLE
Inform when the add-on has finished installing

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -736,6 +736,7 @@ cfu.options.updates.border = Add-on updates
 cfu.options.zap.border	= ZAP Releases
 cfu.output.downloading = Downloading {0} to {1}
 cfu.output.installing  = Installing new add-on {0} version {1}
+cfu.output.installing.finished = Finished installing new add-on {0} version {1}
 cfu.output.replacing  = Replacing add-on {0} version {1}
 cfu.output.replace.failed = Failed to dynamically replace add-on {0} version {1} - the new version will be loaded when ZAP is next restarted
 cfu.output.uninstalled  = Uninstalled add-on {0} version {1}

--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -1061,6 +1061,13 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 
 		ExtensionFactory.getAddOnLoader().addAddon(ao);
 
+		logger.info("Finished installing new addon " + ao.getId() + " v" + ao.getVersion());
+		if (View.isInitialised()) {
+			// Report info to the Output tab
+			View.getSingleton().getOutputPanel().append(
+					Constant.messages.getString("cfu.output.installing.finished", ao.getName(), ao.getVersion()) + "\n");
+		}
+		
         if (latestVersionInfo != null) {
             AddOn addOn = latestVersionInfo.getAddOn(ao.getId());
             if (addOn != null && AddOn.InstallationStatus.DOWNLOADING == addOn.getInstallationStatus()) {


### PR DESCRIPTION
Change ExtensionAutoUpdate to log and write to Output tab when the
add-on has finished installing otherwise it's not obvious from the
previous message (i.e. "Installing new add-on ...") when and if it has
finished.