### PR TITLE
Ignore null script engine when listing engines

### DIFF
--- a/src/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/src/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -240,7 +240,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 			engineNames.add(engine.getLanguageName() + LANG_ENGINE_SEP + engine.getEngineName());
 		}
 		for (ScriptEngineWrapper sew : this.engineWrappers) {
-			if (! engines.contains(sew.getFactory())) {
+			if (sew.isVisible() && ! engines.contains(sew.getFactory())) {
 				engineNames.add(sew.getLanguageName() + LANG_ENGINE_SEP + sew.getEngineName());
 			}
 		}

--- a/src/org/zaproxy/zap/extension/script/ScriptEngineWrapper.java
+++ b/src/org/zaproxy/zap/extension/script/ScriptEngineWrapper.java
@@ -79,6 +79,25 @@ public abstract class ScriptEngineWrapper {
 	public List<String> getExtensions() {
 		return factory.getExtensions();
 	}
+
+	/**
+	 * Tells whether or not this engine should be visible to the user.
+	 * <p>
+	 * Engines that are not visible are not shown in the GUI nor listed through the API.
+	 * <p>
+	 * Engines are visible by default.
+	 *
+	 * @return {@code true} if the engine should be visible to the user, {@code false} otherwise.
+	 * @since TODO add version
+	 */
+	public boolean isVisible() {
+		// TODO remove the if statement once NullScriptEngineWrapper implements this method.
+		// NullScriptEngineWrapper is not a functional engine.
+		if ("Null".equals(getEngineName())) {
+			return false;
+		}
+		return true;
+	}
 	
 	public abstract boolean isRawEngine();
 	


### PR DESCRIPTION
Change ScriptEngineWrapper to allow to tell if the engine should be
visible. Also, add workaround to have NullScriptEngineWrapper as not
visible, it's not a functional engine and it shouldn't be visible (it's
already hidden in the UI but was returned through the API as " : Null").
Change ExtensionScript to not include engines that are not visible when
listing engines.