### PR TITLE
Remove workaround for script engine name match

### DIFF
--- a/src/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/src/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -364,18 +364,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 			return false;
 		}
 
-		if (name.equals(engineName)) {
-			return true;
-		}
-
-		// Nasty, but sometime the engine names are reported differently, eg 'Mozilla Rhino' vs 'Rhino'
-		if (name.endsWith(engineName)) {
-			return true;
-		}
-		if (engineName.endsWith(name)) {
-			return true;
-		}
-		return false;
+		return name.equals(engineName);
 	}
 
 	/**


### PR DESCRIPTION
The workaround used to match the script engine names does not seem to be
needed anymore, the engines currently used have always the same name,
also, the workaround was causing the wrong engine to be set to some of
the scripts.