### PR TITLE
Be more defensive when loading add-on class

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnLoaderUtils.java
+++ b/src/org/zaproxy/zap/control/AddOnLoaderUtils.java
@@ -94,6 +94,9 @@ final class AddOnLoaderUtils {
         } catch (ClassNotFoundException e) {
             LOGGER.error("Declared \"" + type + "\" was not found: " + classname, e);
             return null;
+        } catch (LinkageError e) {
+            LOGGER.error("Declared \"" + type + "\" could not be loaded: " + classname, e);
+            return null;
         }
 
         if (Modifier.isAbstract(cls.getModifiers()) || Modifier.isInterface(cls.getModifiers())) {


### PR DESCRIPTION
Change AddOnLoaderUtils to catch LinkageError when loading declared
add-ons classes to prevent incompatibly issues or missing classes (for
example, missing add-on dependency in ZapAddOn.xml file) from breaking
the installation/update process.