### PR TITLE
Provide details of why the add-on is not valid

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -803,7 +803,14 @@ cfu.warn.addOnSameVersion = The same version of the add-on is already installed:
 cfu.warn.addOnNotRunnable.message = The add-on will not run until the following requirements are fulfilled:
 cfu.warn.addOnNotRunnable.question = Continue with the installation?
 cfu.warn.cantload      = Can not load the specified add-on\:\nNot before \= {0}\nNot from \= {1}
-cfu.warn.invalidAddOn = The selected file is not a valid ZAP add-on.
+cfu.warn.invalidAddOn = The selected file is not a valid ZAP add-on{0}
+cfu.warn.invalidAddOn.invalidPath = :\nThe path is not valid.
+cfu.warn.invalidAddOn.noZapExtension = :\nThe file does not have a "zap" extension.
+cfu.warn.invalidAddOn.notReadable = :\nThe file is not readable.
+cfu.warn.invalidAddOn.errorZip = .\nA ZIP error occurred while reading the file:\n{0}
+cfu.warn.invalidAddOn.ioError = .\nAn I/O error occurred while reading the file:\n{0}
+cfu.warn.invalidAddOn.missingManifest = :\nThe manifest (ZapAddOn.xml) is missing.
+cfu.warn.invalidAddOn.invalidManifest = .\nThe manifest (ZapAddOn.xml) is invalid:\n{0}
 cfu.warn.addOnAlreadExists = Add-on not installed!\n\nAn add-on with the same name already exists in the ZAP home "plugin" directory:\nSource: {0}\nTarget: {1}
 cfu.warn.unableToCopyAddOn = Add-on not installed!\n\nUnable to copy add-on to ZAP home "plugin" directory.\nMake sure that you have write permissions for directory:\n{0}
 cfu.warn.nolaunch      = The latest ZAP release: {0} has been downloaded to\n{1}\nYou will need to open this file manually.

--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -253,16 +253,41 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 	}
 	
 	private void installLocalAddOn(Path file) throws Exception {
-		if (!AddOn.isAddOn(file)) {
-			showWarningMessageInvalidAddOnFile();
-			return;
-		}
-
 		AddOn ao;
 		try {
 			ao = new AddOn(file);
-		} catch (Exception e) {
-			showWarningMessageInvalidAddOnFile();
+		} catch (AddOn.InvalidAddOnException e) {
+			AddOn.ValidationResult result = e.getValidationResult();
+			switch (result.getValidity()) {
+			case INVALID_PATH:
+				showWarningMessageInvalidAddOnFile(Constant.messages.getString("cfu.warn.invalidAddOn.invalidPath"));
+				break;
+			case INVALID_FILE_NAME:
+				showWarningMessageInvalidAddOnFile(Constant.messages.getString("cfu.warn.invalidAddOn.noZapExtension"));
+				break;
+			case FILE_NOT_READABLE:
+				showWarningMessageInvalidAddOnFile(Constant.messages.getString("cfu.warn.invalidAddOn.notReadable"));
+				break;
+			case UNREADABLE_ZIP_FILE:
+				showWarningMessageInvalidAddOnFile(
+						Constant.messages.getString("cfu.warn.invalidAddOn.errorZip", e.getMessage()));
+				break;
+			case IO_ERROR_FILE:
+				showWarningMessageInvalidAddOnFile(
+						Constant.messages.getString("cfu.warn.invalidAddOn.ioError", e.getMessage()));
+				break;
+			case MISSING_MANIFEST:
+				showWarningMessageInvalidAddOnFile(Constant.messages.getString("cfu.warn.invalidAddOn.missingManifest"));
+				break;
+			case INVALID_MANIFEST:
+				showWarningMessageInvalidAddOnFile(
+						Constant.messages.getString("cfu.warn.invalidAddOn.invalidManifest", e.getMessage()));
+				break;
+			default:
+				showWarningMessageInvalidAddOnFile(e.getMessage());
+				logger.warn(e);
+				break;
+			}
 			return;
 		}
 
@@ -368,8 +393,8 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 		install(ao);
 	}
 
-	private void showWarningMessageInvalidAddOnFile() {
-		View.getSingleton().showWarningDialog(Constant.messages.getString("cfu.warn.invalidAddOn"));
+	private void showWarningMessageInvalidAddOnFile(String reason) {
+		View.getSingleton().showWarningDialog(Constant.messages.getString("cfu.warn.invalidAddOn", reason));
 	}
 
 	private void showWarningMessageCantLoadAddOn(AddOn ao) {


### PR DESCRIPTION
Change ExtensionAutoUpdate to provide details of why an add-on is not
valid when installing a local add-on, before it would just say that the
add-on is not valid, now it will show the actual reason why it is not
valid.
Change AddOn to provide the result of the validation to allow callers to
show a more appropriate message, also, avoid reading the manifest twice
by using the manifest already read when validating.