### PR TITLE
TLS 1.3 UI Components

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1226,6 +1226,7 @@ generic.options.panel.security.protocols.ssl3.label = SSL 3
 generic.options.panel.security.protocols.tlsv1.label = TLS 1
 generic.options.panel.security.protocols.tlsv1.1.label = TLS 1.1
 generic.options.panel.security.protocols.tlsv1.2.label = TLS 1.2
+generic.options.panel.security.protocols.tlsv1.3.label = TLS 1.3
 generic.options.panel.security.protocols.protocol.not.supported.tooltip = Protocol not supported by JRE
 generic.options.panel.security.protocols.error.no.protocols.selected = You must select at least one security protocol.
 generic.options.panel.security.protocols.error.just.sslv2hello.selected = SSLv2Hello must be selected in conjunction with other security protocols.

--- a/src/org/parosproxy/paros/extension/option/SecurityProtocolsPanel.java
+++ b/src/org/parosproxy/paros/extension/option/SecurityProtocolsPanel.java
@@ -87,6 +87,11 @@ public class SecurityProtocolsPanel extends JPanel {
         checkBox.setEnabled(false);
         checkBoxesSslTlsProtocols.put(SSLConnector.SECURITY_PROTOCOL_TLS_V1_2, checkBox);
         add(checkBox, gbc);
+
+        checkBox = new JCheckBox(Constant.messages.getString("generic.options.panel.security.protocols.tlsv1.3.label"));
+        checkBox.setEnabled(false);
+        checkBoxesSslTlsProtocols.put(SSLConnector.SECURITY_PROTOCOL_TLS_V1_3, checkBox);
+        add(checkBox, gbc);
     }
 
     public void setSecurityProtocolsEnabled(String[] selectedProtocols) {

--- a/src/org/parosproxy/paros/network/SSLConnector.java
+++ b/src/org/parosproxy/paros/network/SSLConnector.java
@@ -97,12 +97,14 @@ public class SSLConnector implements SecureProtocolSocketFactory {
 	public static final String SECURITY_PROTOCOL_TLS_V1 = "TLSv1";
 	public static final String SECURITY_PROTOCOL_TLS_V1_1 = "TLSv1.1";
 	public static final String SECURITY_PROTOCOL_TLS_V1_2 = "TLSv1.2";
+	public static final String SECURITY_PROTOCOL_TLS_V1_3 = "TLSv1.3";
 
 	private static final String[] DEFAULT_ENABLED_PROTOCOLS = {
 		SECURITY_PROTOCOL_SSL_V3,
 		SECURITY_PROTOCOL_TLS_V1,
 		SECURITY_PROTOCOL_TLS_V1_1,
-		SECURITY_PROTOCOL_TLS_V1_2 };
+		SECURITY_PROTOCOL_TLS_V1_2,
+		SECURITY_PROTOCOL_TLS_V1_3 };
 
 	private static final String[] FAIL_SAFE_DEFAULT_ENABLED_PROTOCOLS = { SECURITY_PROTOCOL_TLS_V1 };
 


### PR DESCRIPTION
Setup necessary bits for supporting TLS 1.3 (when it becomes available ... likely Java 11?)

Currently:
![image](https://user-images.githubusercontent.com/7570458/40622237-933e2594-626e-11e8-8dcc-d4c3b43a53d6.png)

<sub>Refs: 
http://openjdk.java.net/jeps/332
https://www.java.com/en/jre-jdk-cryptoroadmap.html
</sub>