### PR TITLE
Allow to change proxy's hostname already bound

### DIFF
--- a/src/org/zaproxy/zap/extension/proxies/DialogModifyProxy.java
+++ b/src/org/zaproxy/zap/extension/proxies/DialogModifyProxy.java
@@ -50,7 +50,7 @@ class DialogModifyProxy extends DialogAddProxy {
     @Override
     protected boolean validateFields() {
         ProxiesParamProxy testProxy = proxyPanel.getProxy();
-        if (testProxy.getAddress().equals(proxy.getAddress()) && testProxy.getPort() == proxy.getPort()) {
+        if (ExtensionProxies.isSameAddress(testProxy.getAddress(), proxy.getAddress()) && testProxy.getPort() == proxy.getPort()) {
             // No change, assume its ok
             return true;
         }

--- a/src/org/zaproxy/zap/extension/proxies/OptionsProxiesPanel.java
+++ b/src/org/zaproxy/zap/extension/proxies/OptionsProxiesPanel.java
@@ -105,7 +105,7 @@ public class OptionsProxiesPanel extends AbstractParamPanel {
         String newAddress = mainProxy.getAddress();
         int newPort = mainProxy.getPort();
 
-        if (!this.currentAddress.equals(newAddress) || this.currentPort != newPort) {
+        if (!ExtensionProxies.isSameAddress(this.currentAddress, newAddress) || this.currentPort != newPort) {
             // Only check if they've changed, otherwise we'll still be listening on them
             if (!extension.canListenOn(newAddress, newPort) || extension.getAdditionalProxy(newAddress, newPort) != null) {
                 throw new Exception(


### PR DESCRIPTION
Change OptionsProxiesPanel and DialogModifyProxy to handle proxies with
same address but different hostname as the same proxy configuration
(e.g. allow change from localhost to 127.0.0.1).
Change ExtensionProxies to stop the proxies with old configurations
before starting the new ones to free the address/port if already in use.

 ---
Reported in IRC channel.