### PR TITLE
Inform if passive scanner is still running

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1865,6 +1865,7 @@ proxies.options.table.header.address	= Address
 proxies.options.table.header.port		= Port
 proxies.options.title					= Local Proxies
 
+pscan.activeAction = Passive scanning {0} messages
 pscan.api.action.setEnabled = Sets whether or not the passive scanning is enabled (Note: the enabled state is not persisted).
 pscan.api.action.setScanOnlyInScope = Sets whether or not the passive scan should be performed only on messages that are in scope.
 pscan.api.action.enableAllScanners = Enables all passive scanners

--- a/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/src/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -130,6 +130,18 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
         getPassiveScannerList().setAutoTagScanners(getPassiveScanParam().getAutoTagScanners());
     }
 
+    @Override
+    public List<String> getActiveActions() {
+        int recordsToScan = getRecordsToScan();
+        if (recordsToScan == 0) {
+            return Collections.emptyList();
+        }
+
+        List<String> activeActions = new ArrayList<>(1);
+        activeActions.add(Constant.messages.getString("pscan.activeAction", recordsToScan));
+        return activeActions;
+    }
+
     /**
      * @deprecated (2.4.3) Use {@link #addPluginPassiveScanner(PluginPassiveScanner)} instead, the status of the
      *             scanner is not properly set.


### PR DESCRIPTION
Change ExtensionPassiveScan to report if the passive scanner is still
running so that the user is informed when changing the session or on
shutdown.

---
As talked in IRC.