### PR TITLE
Allow add-ons to declare a resource bundle

### DIFF
--- a/src/org/zaproxy/zap/control/AddOn.java
+++ b/src/org/zaproxy/zap/control/AddOn.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
@@ -296,6 +297,20 @@ public class AddOn  {
 	
 	private Dependencies dependencies;
 
+	/**
+	 * The data of the bundle declared in the manifest.
+	 * <p>
+	 * Never {@code null}.
+	 */
+	private BundleData bundleData = BundleData.EMPTY_BUNDLE;
+
+	/**
+	 * The resource bundle from the declaration in the manifest.
+	 * <p>
+	 * Might be {@code null}, if not declared.
+	 */
+	private ResourceBundle resourceBundle;
+
 	private static final Logger logger = Logger.getLogger(AddOn.class);
 	
 	/**
@@ -516,6 +531,11 @@ public class AddOn  {
 		this.pscanrules = zapAddOnXml.getPscanrules();
 
 		this.addOnClassnames = zapAddOnXml.getAddOnClassnames();
+
+		String bundleBaseName = zapAddOnXml.getBundleBaseName();
+		if (!bundleBaseName.isEmpty()) {
+			bundleData = new BundleData(bundleBaseName, zapAddOnXml.getBundlePrefix());
+		}
 
 		hasZapAddOnEntry = true;
 	}
@@ -1446,6 +1466,40 @@ public class AddOn  {
 	}
 	
 	/**
+	 * Gets the data of the bundle declared in the manifest.
+	 *
+	 * @return the bundle data, never {@code null}.
+	 * @since TODO add version
+	 * @see #getResourceBundle()
+	 */
+	public BundleData getBundleData() {
+		return bundleData;
+	}
+
+	/**
+	 * Gets the resource bundle of the add-on.
+	 *
+	 * @return the resource bundle, or {@code null} if none.
+	 * @since TODO add version
+	 */
+	public ResourceBundle getResourceBundle() {
+		return resourceBundle;
+	}
+
+	/**
+	 * Sets the resource bundle of the add-on.
+	 * <p>
+	 * <strong>Note:</strong> This method should be called only by bootstrap classes.
+	 *
+	 * @param resourceBundle the resource bundle of the add-on, might be {@code null}.
+	 * @since TODO add version
+	 * @see #getBundleData()
+	 */
+	public void setResourceBundle(ResourceBundle resourceBundle) {
+		this.resourceBundle = resourceBundle;
+	}
+
+	/**
 	 * Returns the IDs of the add-ons dependencies, an empty collection if none.
 	 *
 	 * @return the IDs of the dependencies.
@@ -1860,6 +1914,60 @@ public class AddOn  {
 		 */
 		public String getClassname() {
 			return classname;
+		}
+	}
+
+	/**
+	 * The data of the bundle declared in the manifest of an add-on.
+	 * <p>
+	 * Used to load a {@link ResourceBundle}.
+	 *
+	 * @since TODO add version
+	 */
+	public static final class BundleData {
+
+		private static final BundleData EMPTY_BUNDLE = new BundleData();
+
+		private final String baseName;
+		private final String prefix;
+
+		private BundleData() {
+			this("", "");
+		}
+
+		private BundleData(String baseName, String prefix) {
+			this.baseName = baseName;
+			this.prefix = prefix;
+		}
+
+		/**
+		 * Tells whether or not the the bundle data is empty.
+		 * <p>
+		 * An empty {@code BundleData} does not contain any information to load a {@link ResourceBundle}.
+		 *
+		 * @return {@code true} if empty, {@code false} otherwise.
+		 */
+		public boolean isEmpty() {
+			return this == EMPTY_BUNDLE;
+		}
+
+		/**
+		 * Gets the base name of the bundle.
+		 *
+		 * @return the base name, or empty if not defined.
+		 */
+		public String getBaseName() {
+			return baseName;
+		}
+
+		/**
+		 * Gets the prefix of the bundle, to add into a
+		 * {@link org.zaproxy.zap.utils.I18N#addMessageBundle(String, ResourceBundle) I18N}.
+		 *
+		 * @return the prefix, or empty if not defined.
+		 */
+		public String getPrefix() {
+			return prefix;
 		}
 	}
 

--- a/src/org/zaproxy/zap/control/AddOnLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnLoader.java
@@ -239,6 +239,7 @@ public class AddOnLoader extends URLClassLoader {
             if (updatedAddOns.contains(addOn)) {
                 AddOnInstaller.updateAddOnFiles(addOnClassLoader, addOn);
             }
+            AddOnInstaller.installResourceBundle(addOnClassLoader, addOn);
         }
     }
 

--- a/src/org/zaproxy/zap/control/ExtensionFactory.java
+++ b/src/org/zaproxy/zap/control/ExtensionFactory.java
@@ -290,21 +290,25 @@ public class ExtensionFactory {
     }
 
     private static void loadMessages(Extension ext) {
+        AddOn addOn = ext.getAddOn();
+        if (addOn == null) {
+            // Core extensions use core resource bundle.
+            ext.setMessages(Constant.messages.getCoreResourceBundle());
+            return;
+        }
+
         ResourceBundle msg = getExtensionResourceBundle(ext);
         if (msg != null) {
             ext.setMessages(msg);
             Constant.messages.addMessageBundle(ext.getI18nPrefix(), ext.getMessages());
+        } else if (addOn.getResourceBundle() != null) {
+            ext.setMessages(addOn.getResourceBundle());
         } else {
             ext.setMessages(Constant.messages.getCoreResourceBundle());
         }
     }
 
     private static ResourceBundle getExtensionResourceBundle(Extension ext) {
-        if (ext.getAddOn() == null) {
-            // Core extensions use core resource bundle.
-            return null;
-        }
-
         String extensionPackage = ext.getClass().getPackage().getName();
         ClassLoader classLoader = ext.getClass().getClassLoader();
         try {
@@ -317,7 +321,7 @@ public class ExtensionFactory {
             try {
                 return getPropertiesResourceBundle(oldLocation, classLoader);
             } catch (MissingResourceException ignoreAgain) {
-                // It will be using the standard message bundle
+                // It will be using a fallback message bundle
             }
         }
         return null;

--- a/src/org/zaproxy/zap/control/ZapAddOnXmlFile.java
+++ b/src/org/zaproxy/zap/control/ZapAddOnXmlFile.java
@@ -38,10 +38,15 @@ public class ZapAddOnXmlFile extends BaseZapAddOnXmlData {
     private static final String PSCANRULES_ALL_ELEMENTS = "pscanrules/" + PSCANRULE_ELEMENT;
     private static final String FILE_ELEMENT = "file";
     private static final String FILES_ALL_ELEMENTS = "files/" + FILE_ELEMENT;
+    private static final String BUNDLE_ELEMENT = "bundle";
+    private static final String BUNDLE_PREFIX_ATT = "bundle/@prefix";
 
     private List<String> ascanrules;
     private List<String> pscanrules;
     private List<String> files;
+
+    private String bundleBaseName;
+    private String bundlePrefix;
 
     public ZapAddOnXmlFile(InputStream is) throws IOException {
         super(is);
@@ -52,6 +57,9 @@ public class ZapAddOnXmlFile extends BaseZapAddOnXmlData {
         ascanrules = getStrings(zapAddOnXml, ASCANRULES_ALL_ELEMENTS, ASCANRULE_ELEMENT);
         pscanrules = getStrings(zapAddOnXml, PSCANRULES_ALL_ELEMENTS, PSCANRULE_ELEMENT);
         files = getStrings(zapAddOnXml, FILES_ALL_ELEMENTS, FILE_ELEMENT);
+
+        bundleBaseName = zapAddOnXml.getString(BUNDLE_ELEMENT, "");
+        bundlePrefix = zapAddOnXml.getString(BUNDLE_PREFIX_ATT, "");
     }
 
     public List<String> getAscanrules() {
@@ -64,5 +72,25 @@ public class ZapAddOnXmlFile extends BaseZapAddOnXmlData {
 
     public List<String> getFiles() {
         return files;
+    }
+
+    /**
+     * Gets the base name of the bundle.
+     *
+     * @return the base name of the bundle, never {@code null}.
+     * @since TODO add version
+     */
+    public String getBundleBaseName() {
+        return bundleBaseName;
+    }
+
+    /**
+     * Gets the prefix of the bundle.
+     *
+     * @return the prefix of the bundle, never {@code null}.
+     * @since TODO add version
+     */
+    public String getBundlePrefix() {
+        return bundlePrefix;
     }
 }


### PR DESCRIPTION
Add-ons can now declare a resource bundle through the manifest file:
```XML
<bundle prefix="example">com.example.Messages</bundle>
```
the prefix is used to add the ResourceBundle into the I18N instance in
the Constant class. The bundle is also accessible through the add-on
itself.

The extensions of the add-on will use the declared bundle if none is
found in the default location.

Fix #3841 - Allow add-ons without extensions to have resource messages