### PR TITLE
Allow add-ons to declare a helpset

### DIFF
--- a/src/org/zaproxy/zap/control/AddOn.java
+++ b/src/org/zaproxy/zap/control/AddOn.java
@@ -294,6 +294,8 @@ public class AddOn  {
 	private List<String> files = Collections.emptyList();
 
 	private AddOnClassnames addOnClassnames = AddOnClassnames.ALL_ALLOWED;
+
+	private ClassLoader classLoader;
 	
 	private Dependencies dependencies;
 
@@ -310,6 +312,13 @@ public class AddOn  {
 	 * Might be {@code null}, if not declared.
 	 */
 	private ResourceBundle resourceBundle;
+
+	/**
+	 * The data for the HelpSet, declared in the manifest.
+	 * <p>
+	 * Never {@code null}.
+	 */
+	private HelpSetData helpSetData = HelpSetData.EMPTY_HELP_SET;
 
 	private static final Logger logger = Logger.getLogger(AddOn.class);
 	
@@ -536,6 +545,11 @@ public class AddOn  {
 		if (!bundleBaseName.isEmpty()) {
 			bundleData = new BundleData(bundleBaseName, zapAddOnXml.getBundlePrefix());
 		}
+		
+		String helpSetBaseName = zapAddOnXml.getHelpSetBaseName();
+		if (!helpSetBaseName.isEmpty()) {
+			this.helpSetData = new HelpSetData(helpSetBaseName, zapAddOnXml.getHelpSetLocaleToken());
+		}
 
 		hasZapAddOnEntry = true;
 	}
@@ -710,6 +724,28 @@ public class AddOn  {
 	
 	public void setAuthor(String author) {
 		this.author = author;
+	}
+
+	/**
+	 * Gets the class loader of the add-on.
+	 *
+	 * @return the class loader of the add-on, {@code null} if the add-on is not installed.
+	 * @since TODO add version
+	 */
+	public ClassLoader getClassLoader() {
+		return classLoader;
+	}
+
+	/**
+	 * Sets the class loader of the add-on.
+	 * <p>
+	 * <strong>Note:</strong> This method should be called only by bootstrap classes.
+	 *
+	 * @param classLoader the class loader of the add-on, might be {@code null}.
+	 * @since TODO add version
+	 */
+	public void setClassLoader(ClassLoader classLoader) {
+		this.classLoader = classLoader;
 	}
 
 	/**
@@ -1500,6 +1536,16 @@ public class AddOn  {
 	}
 
 	/**
+	 * Gets the data for the HelpSet, declared in the manifest.
+	 *
+	 * @return the HelpSet data, never {@code null}.
+	 * @since TODO add version
+	 */
+	public HelpSetData getHelpSetData() {
+		return helpSetData;
+	}
+
+	/**
 	 * Returns the IDs of the add-ons dependencies, an empty collection if none.
 	 *
 	 * @return the IDs of the dependencies.
@@ -1968,6 +2014,59 @@ public class AddOn  {
 		 */
 		public String getPrefix() {
 			return prefix;
+		}
+	}
+
+	/**
+	 * The data to load a {@link javax.help.HelpSet HelpSet}, declared in the manifest of an add-on.
+	 * <p>
+	 * Used to dynamically add/remove the help of the add-on.
+	 *
+	 * @since TODO add version
+	 */
+	public static final class HelpSetData {
+
+		private static final HelpSetData EMPTY_HELP_SET = new HelpSetData();
+
+		private final String baseName;
+		private final String localeToken;
+
+		private HelpSetData() {
+			this("", "");
+		}
+
+		private HelpSetData(String baseName, String localeToken) {
+			this.baseName = baseName;
+			this.localeToken = localeToken;
+		}
+
+		/**
+		 * Tells whether or not the the HelpSet data is empty.
+		 * <p>
+		 * An empty {@code HelpSetData} does not contain any information to load the help.
+		 *
+		 * @return {@code true} if empty, {@code false} otherwise.
+		 */
+		public boolean isEmpty() {
+			return this == EMPTY_HELP_SET;
+		}
+
+		/**
+		 * Gets the base name of the HelpSet file.
+		 *
+		 * @return the base name, or empty if not defined.
+		 */
+		public String getBaseName() {
+			return baseName;
+		}
+
+		/**
+		 * Gets the locale token.
+		 *
+		 * @return the locale token, or empty if not defined.
+		 */
+		public String getLocaleToken() {
+			return localeToken;
 		}
 	}
 

--- a/src/org/zaproxy/zap/control/AddOnLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnLoader.java
@@ -295,6 +295,7 @@ public class AddOnLoader extends URLClassLoader {
             if (idsAddOnDependencies.isEmpty()) {
                 addOnClassLoader = new AddOnClassLoader(ao.getFile().toURI().toURL(), this, ao.getAddOnClassnames());
                 this.addOnLoaders.put(ao.getId(), addOnClassLoader);
+                ao.setClassLoader(addOnClassLoader);
                 return addOnClassLoader;
             }
 
@@ -309,6 +310,7 @@ public class AddOnLoader extends URLClassLoader {
 
             addOnClassLoader = new AddOnClassLoader(ao.getFile().toURI().toURL(), this, dependencies, ao.getAddOnClassnames());
             this.addOnLoaders.put(ao.getId(), addOnClassLoader);
+            ao.setClassLoader(addOnClassLoader);
             return addOnClassLoader;
         } catch (MalformedURLException e) {
             logger.error(e.getMessage(), e);
@@ -628,6 +630,7 @@ public class AddOnLoader extends URLClassLoader {
             } catch (Exception e) {
                 logger.error("Failure while closing class loader of " + addOn.getId() + " add-on:", e);
             }
+            addOn.setClassLoader(null);
         }
     }
 

--- a/src/org/zaproxy/zap/control/ZapAddOnXmlFile.java
+++ b/src/org/zaproxy/zap/control/ZapAddOnXmlFile.java
@@ -40,6 +40,8 @@ public class ZapAddOnXmlFile extends BaseZapAddOnXmlData {
     private static final String FILES_ALL_ELEMENTS = "files/" + FILE_ELEMENT;
     private static final String BUNDLE_ELEMENT = "bundle";
     private static final String BUNDLE_PREFIX_ATT = "bundle/@prefix";
+    private static final String HELPSET_ELEMENT = "helpset";
+    private static final String HELPSET_LOCALE_TOKEN_ATT= "helpset/@localetoken";
 
     private List<String> ascanrules;
     private List<String> pscanrules;
@@ -47,6 +49,8 @@ public class ZapAddOnXmlFile extends BaseZapAddOnXmlData {
 
     private String bundleBaseName;
     private String bundlePrefix;
+    private String helpSetBaseName;
+    private String helpSetLocaleToken;
 
     public ZapAddOnXmlFile(InputStream is) throws IOException {
         super(is);
@@ -60,6 +64,8 @@ public class ZapAddOnXmlFile extends BaseZapAddOnXmlData {
 
         bundleBaseName = zapAddOnXml.getString(BUNDLE_ELEMENT, "");
         bundlePrefix = zapAddOnXml.getString(BUNDLE_PREFIX_ATT, "");
+        helpSetBaseName = zapAddOnXml.getString(HELPSET_ELEMENT, "");
+        helpSetLocaleToken = zapAddOnXml.getString(HELPSET_LOCALE_TOKEN_ATT, "");
     }
 
     public List<String> getAscanrules() {
@@ -92,5 +98,25 @@ public class ZapAddOnXmlFile extends BaseZapAddOnXmlData {
      */
     public String getBundlePrefix() {
         return bundlePrefix;
+    }
+
+    /**
+     * Gets the base name of the HelpSet file.
+     *
+     * @return the base name of the HelpSet file, never {@code null}.
+     * @since TODO add version
+     */
+    public String getHelpSetBaseName() {
+        return helpSetBaseName;
+    }
+
+    /**
+     * Gets the locale token for the HelpSet file.
+     *
+     * @return the locale token for the HelpSet file, never {@code null}.
+     * @since TODO add version
+     */
+    public String getHelpSetLocaleToken() {
+        return helpSetLocaleToken;
     }
 }


### PR DESCRIPTION
Add-ons can now declare a helpset through the manifest file:
```XML
<helpset localetoken="%LC%">com.example.help%LC%.helpset</helpset>
```
the locale token is used to indicate the places in the base name where a
locale might exist, for example, the above would match the following
files:
```
com/example/help/helpset.hs
com/example/help_es_ES/helpset_es_ES.hs
com/example/help_en_US/helpset_en_US.hs
```

The help of the add-on is dynamically added/removed to the main help
when the add-on is installed/uninstalled, ensuring the help of the
add-on is available whenever possible.

Fix #3734 - Allow add-ons without extensions to have help pages