### PR TITLE
Params Tab - Add/Remove Param Name as Anti-CSRF Token for Any Param

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1823,8 +1823,8 @@ options.script.dialog.dirs.remove.title                = Remove Script Directori
 output.panel.mnemonic		= o
 output.panel.title 			= Output
 
-params.anticrsf.add.popup	= Flag as Anti-CSRF token
-params.anticrsf.remove.popup	= Unflag as Anti-CSRF token
+params.anticrsf.add.popup	= Add Name as Anti-CSRF Token
+params.anticrsf.remove.popup	= Remove Name as Anti-CSRF Token
 params.api.view.params		= Shows the parameters for the specified site, or for all sites if the site is not specified
 params.desc                 = Summarise and analyse FORM and URL parameters as well as cookies
 params.name = Parameters Extension

--- a/src/org/zaproxy/zap/extension/params/PopupMenuAddAntiCSRF.java
+++ b/src/org/zaproxy/zap/extension/params/PopupMenuAddAntiCSRF.java
@@ -58,17 +58,12 @@ public class PopupMenuAddAntiCSRF extends ExtensionPopupMenuItem {
         	
         	HtmlParameterStats item = extension.getParamsPanel().getSelectedParam();
         	// Note that only form params are currently supported
-        	if (item != null) {
-        		if (HtmlParameter.Type.form.equals(item.getType())) {
-        			if (! item.getFlags().contains(HtmlParameter.Flags.anticsrf.name())) {
-                		this.setEnabled(true);
-                		return true;
-        			}
-        			return false;
-        		}
-            	this.setEnabled(false);
+        	if (item != null && !item.getFlags().contains(HtmlParameter.Flags.anticsrf.name())) {
+        		this.setEnabled(true);
         		return true;
         	}
+        	this.setEnabled(false);
+    		return true;
         }
         return false;
     }

--- a/src/org/zaproxy/zap/extension/params/PopupMenuRemoveAntiCSRF.java
+++ b/src/org/zaproxy/zap/extension/params/PopupMenuRemoveAntiCSRF.java
@@ -58,8 +58,7 @@ public class PopupMenuRemoveAntiCSRF extends ExtensionPopupMenuItem {
             }
         	
         	HtmlParameterStats item = extension.getParamsPanel().getSelectedParam();
-        	// Note that only form params are currently supported
-        	if (item != null && HtmlParameter.Type.form.equals(item.getType()) && 
+        	if (item != null && 
         			item.getFlags().contains(HtmlParameter.Flags.anticsrf.name())) {
         		this.setEnabled(true);
                 return true;


### PR DESCRIPTION
Messages.properties > Address zaproxy/zaproxy#2000 title caps issues and clarify that the menu item simply adds the 'param' name as a known Anti-CSRF token.
PopupMenuAddAntiCSRF/PopupMenuAddAntiCSRF > Change conditional in isEnableForComponent to accommodate all types of params.

The java files contain mixed indentation, I tried to keep it consistent.

Fixes zaproxy/zaproxy#4729