### PR TITLE
Don't save add-ons' runnable state if not changed

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnLoader.java
@@ -635,7 +635,7 @@ public class AddOnLoader extends URLClassLoader {
     }
 
     private void unloadDependentExtensions(AddOn ao) {
-        boolean changed = true;
+        boolean changed = false;
         for (Entry<String, AddOnClassLoader> entry : new HashMap<>(addOnLoaders).entrySet()) {
             AddOn runningAddOn = aoc.getAddOn(entry.getKey());
             for (Extension ext : runningAddOn.getLoadedExtensionsWithDeps()) {


### PR DESCRIPTION
Correct initial value of the flag to avoid saving the runnable state if
it has not changed.