### PR TITLE
Dynamically add/remove extensions' help

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnInstaller.java
+++ b/src/org/zaproxy/zap/control/AddOnInstaller.java
@@ -330,7 +330,7 @@ public final class AddOnInstaller {
             }
             callback.extensionRemoved(extUiName);
         } else {
-            ExtensionFactory.removeAddOnExtension(extension);
+            ExtensionFactory.unloadAddOnExtension(extension);
         }
         addOn.removeLoadedExtension(extension);
 


### PR DESCRIPTION
Move extensions' help management from ExtensionFactory to ExtensionHelp,
to dynamically add/remove the help when the (main) help add-on is
installed/uninstalled, not just when ZAP is started or the extension
removed, ensuring the help is always available (whenever possible).