### PR TITLE
Stop relying on ClassLoaderUtil

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -353,6 +353,8 @@
         <copy todir="${test.build}">
             <fileset dir="${src}" includes="lang/**" />
             <fileset dir="${test.src}/resources/" />
+            <!-- Messages.properties file loaded by I18N during functional tests. -->
+            <fileset dir="${src}/lang" includes="Messages.properties" />
         </copy>
         <echo message="Running tests..." />
         <junit printsummary="yes" haltonerror="true" failureproperty="TestsFailed">

--- a/src/org/zaproxy/zap/ZAP.java
+++ b/src/org/zaproxy/zap/ZAP.java
@@ -19,11 +19,8 @@
  */
 package org.zaproxy.zap;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Enumeration;
-import java.util.Locale;
 
 import org.apache.commons.httpclient.protocol.Protocol;
 import org.apache.commons.httpclient.protocol.ProtocolSocketFactory;
@@ -31,11 +28,9 @@ import org.apache.log4j.Appender;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.CommandLine;
-import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.SSLConnector;
 import org.zaproxy.zap.eventBus.EventBus;
 import org.zaproxy.zap.eventBus.SimpleEventBus;
-import org.zaproxy.zap.utils.ClassLoaderUtil;
 
 public class ZAP {
 
@@ -94,8 +89,6 @@ public class ZAP {
             System.exit(1);
         }
 
-        initClassLoader();
-
         ZapBootstrap bootstrap = createZapBootstrap(cmdLine);
         try {
             int rc = bootstrap.start();
@@ -108,40 +101,6 @@ public class ZAP {
             System.exit(1);
         }
 
-    }
-
-    private static void initClassLoader() {
-        try {
-            // lang directory includes all of the language files
-            final File langDir = new File(Constant.getZapInstall(), "lang");
-            if (langDir.exists() && langDir.isDirectory()) {
-                ClassLoaderUtil.addFile(langDir.getAbsolutePath());
-
-            } else {
-                System.out
-                        .println("Warning: failed to load language files from "
-                                + langDir.getAbsolutePath());
-            }
-
-            // Load all of the jars in the lib directory
-            final File libDir = new File(Constant.getZapInstall(), "lib");
-            if (libDir.exists() && libDir.isDirectory()) {
-                final File[] files = libDir.listFiles();
-                for (final File file : files) {
-                    if (file.getName().toLowerCase(Locale.ENGLISH)
-                            .endsWith("jar")) {
-                        ClassLoaderUtil.addFile(file);
-                    }
-                }
-
-            } else {
-                System.out.println("Warning: failed to load jar files from "
-                        + libDir.getAbsolutePath());
-            }
-
-        } catch (final IOException e) {
-            System.out.println("Failed loading jars: " + e);
-        }
     }
 
     private static ZapBootstrap createZapBootstrap(CommandLine cmdLineArgs) {

--- a/src/org/zaproxy/zap/utils/ClassLoaderUtil.java
+++ b/src/org/zaproxy/zap/utils/ClassLoaderUtil.java
@@ -11,6 +11,11 @@ import org.apache.log4j.Logger;
 
 // Based on code from http://twit88.com/blog/2007/10/04/java-dynamic-loading-of-class-and-jar-file/
 
+/**
+ * @deprecated (TODO add version) The use of this class is discouraged, it expects a {@code URLClassLoader} as system class
+ *             loader, which is not always the case (e.g. Java 9+).
+ */
+@Deprecated
 public class ClassLoaderUtil {
 
     // Log object

--- a/test/org/zaproxy/zap/WithConfigsTest.java
+++ b/test/org/zaproxy/zap/WithConfigsTest.java
@@ -41,7 +41,6 @@ import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.testutils.TestUtils;
-import org.zaproxy.zap.utils.ClassLoaderUtil;
 import org.zaproxy.zap.utils.I18N;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -60,8 +59,6 @@ public abstract class WithConfigsTest extends TestUtils {
     @BeforeClass
     public static void beforeClass() throws Exception {
         File installDir = tempDir.newFolder("install");
-        Path langDir = Files.createDirectory(installDir.toPath().resolve("lang"));
-        Files.createFile(langDir.resolve("Messages.properties"));
         Path xmlDir = Files.createDirectory(installDir.toPath().resolve("xml"));
         Files.createFile(xmlDir.resolve("log4j.properties"));
         Path configXmlPath = Files.createFile(xmlDir.resolve("config.xml"));
@@ -82,9 +79,6 @@ public abstract class WithConfigsTest extends TestUtils {
         Constant.setZapInstall(zapInstallDir);
         Constant.setZapHome(zapHomeDir);
 
-        File langDir = new File(Constant.getZapInstall(), "lang");
-        ClassLoaderUtil.addFile(langDir.getAbsolutePath());
-        
         ExtensionLoader extLoader = Mockito.mock(ExtensionLoader.class);
         Control control = Mockito.mock(Control.class);
         Mockito.when (control.getExtensionLoader()).thenReturn(extLoader);


### PR DESCRIPTION
Deprecate ClassLoaderUtil and stop using it throughout the codebase. The
class expects a URLClassLoader as system class loader which is no longer
the case with newer Java (9+) versions (the class was already a no-op in
those cases and others like Webswing that also uses a different system
class loader).
Obviously, this change will break applications/configurations relying on
that behaviour, those applications need to be updated to include the
required resources in the classpath (e.g. Messages.properties file under
the lang dir and libraries under the lib dir).

Related to #2602 - Java 9