### PR TITLE
Deprecate unused active scan callback classes

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/ChallengeCallbackAPI.java
+++ b/src/org/zaproxy/zap/extension/ascan/ChallengeCallbackAPI.java
@@ -37,7 +37,9 @@ import org.zaproxy.zap.extension.api.ApiImplementor;
  * General Abstract class for Challenge/Response Active Plugin management
  * 
  * @author yhawke (2014)
+ * @deprecated (TODO add version) Superseded by {@link org.zaproxy.zap.extension.callback.CallbackImplementor}.
  */
+@Deprecated
 public abstract class ChallengeCallbackAPI extends ApiImplementor {
 
     // This are the result contents that should be returned by the API

--- a/src/org/zaproxy/zap/extension/ascan/ChallengeCallbackPlugin.java
+++ b/src/org/zaproxy/zap/extension/ascan/ChallengeCallbackPlugin.java
@@ -24,7 +24,9 @@ import org.parosproxy.paros.network.HttpMessage;
  * Callback API
  * 
  * @author yhawke (2014)
+ * @deprecated (TODO add version) Superseded by {@link org.zaproxy.zap.extension.callback.CallbackImplementor}.
  */
+@Deprecated
 public interface ChallengeCallbackPlugin {
     
     public void notifyCallback(String challenge, HttpMessage msg);

--- a/src/org/zaproxy/zap/extension/callback/CallbackImplementor.java
+++ b/src/org/zaproxy/zap/extension/callback/CallbackImplementor.java
@@ -26,7 +26,7 @@ import org.parosproxy.paros.network.HttpMessage;
 /**
  * @since 2.6.0
  * @author psiinon
- *
+ * @see ExtensionCallback#registerCallbackImplementor(CallbackImplementor)
  */
 public interface CallbackImplementor {
 


### PR DESCRIPTION
The callback classes in active scan package are no longer in use, they
were replaced with the classes from the callback extension.