### PR TITLE
Be more lenient when parsing techs through the API

### DIFF
--- a/src/org/zaproxy/zap/extension/api/ContextAPI.java
+++ b/src/org/zaproxy/zap/extension/api/ContextAPI.java
@@ -422,11 +422,12 @@ public class ContextAPI extends ApiImplementor {
 	 * @throws ApiException the api exception
 	 */
 	private Tech getTech(String techName) throws ApiException {
+		String trimmedTechName = techName.trim();
 		for(Tech tech : Tech.builtInTech) {
-			if (tech.toString().equalsIgnoreCase(techName))
+			if (tech.toString().equalsIgnoreCase(trimmedTechName))
 				return tech;
 		}
 		throw new ApiException(Type.ILLEGAL_PARAMETER, 
-				"The tech " + techName + " does not exist");
+				"The tech '" + trimmedTechName + "' does not exist");
 	}
 }


### PR DESCRIPTION
Change ContextAPI to trim the given tech names when matching them with
the supported techs, it's expected that the string with techs have a
space after the commas that separate them (as it improves readability).