### PR TITLE
Restore the accessible name in Sites' nodes

### DIFF
--- a/src/org/zaproxy/zap/view/SiteMapTreeCellRenderer.java
+++ b/src/org/zaproxy/zap/view/SiteMapTreeCellRenderer.java
@@ -68,6 +68,7 @@ public class SiteMapTreeCellRenderer extends DefaultTreeCellRenderer {
 		this.listeners = listeners;
 		this.component = new JPanel(new FlowLayout(FlowLayout.CENTER, 4, 2));
 		component.setOpaque(false);
+		this.setLabelFor(component);
 		this.putClientProperty("html.disable", Boolean.TRUE);
 	}
 


### PR DESCRIPTION
Change SiteMapTreeCellRenderer to use the renderer itself as the label
for the component (JPanel) returned by the renderer to ensure it has
an accessible name (the text of the tree node).

Fix #4711 - sites tree no longer accessible