### PR TITLE
Correct generated certificates' validity period

### DIFF
--- a/src/org/parosproxy/paros/security/SslCertificateServiceImpl.java
+++ b/src/org/parosproxy/paros/security/SslCertificateServiceImpl.java
@@ -38,6 +38,7 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPrivateKey;
+import java.time.Duration;
 import java.util.Date;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
@@ -134,8 +135,8 @@ public final class SslCertificateServiceImpl implements SslCertificateService {
 		X509v3CertificateBuilder certGen = new JcaX509v3CertificateBuilder (
 				new X509CertificateHolder(caCert.getEncoded()).getSubject(),
 				BigInteger.valueOf(serial.getAndIncrement()),
-				new Date(System.currentTimeMillis() - 1000L * 60 * 60 * 24 * 30),
-				new Date(System.currentTimeMillis() + 100*(1000L * 60 * 60 * 24 * 30)),
+				new Date(System.currentTimeMillis() - Duration.ofDays(30).toMillis()),
+				new Date(System.currentTimeMillis() + Duration.ofDays(1000).toMillis()),
 				namebld.build(),
 				pubKey
 			);

--- a/src/org/zaproxy/zap/extension/dynssl/SslCertificateUtils.java
+++ b/src/org/zaproxy/zap/extension/dynssl/SslCertificateUtils.java
@@ -42,6 +42,7 @@ import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.Calendar;
 import java.util.Date;
@@ -97,7 +98,7 @@ public class SslCertificateUtils {
 	 */
 	public static final String END_PRIVATE_KEY_TOKEN = "-----END PRIVATE KEY-----";
 
-	private static final long DEFAULT_VALID_DAYS = 365L;
+	private static final long DEFAULT_VALIDITY_IN_MS = Duration.ofDays(365).toMillis();
 
 	/**
 	 * Creates a new Root CA certificate and returns private and public key as
@@ -111,7 +112,7 @@ public class SslCertificateUtils {
 	 */
 	public static final KeyStore createRootCA() throws NoSuchAlgorithmException {
 		final Date startDate = Calendar.getInstance().getTime();
-		final Date expireDate = new Date(startDate.getTime()+ (DEFAULT_VALID_DAYS * 24L * 60L * 60L * 1000L));
+		final Date expireDate = new Date(startDate.getTime()+ DEFAULT_VALIDITY_IN_MS);
 
 		final KeyPairGenerator g = KeyPairGenerator.getInstance("RSA");
 		g.initialize(2048, SecureRandom.getInstance("SHA1PRNG"));


### PR DESCRIPTION
Change SslCertificateServiceImpl to generate the certs with expire date
of 1000 days as mentioned in the help pages (not 3000 days).
For consistency change all certificate dates to use Duration, which is
easier to read and avoids conversion/calculation errors.

Per #4673 - Allow to configure validity period of generated certificates