### PR TITLE
Bundle Messages.properties and vulnerabilities.xml

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -153,6 +153,10 @@
 			<fileset dir="${src}/lang" excludes="**/.svn/** **/_svn/**" />
 		</copy>
 
+		<copy todir="${build}/org/zaproxy/zap/resources/">
+			<fileset dir="${src}/lang" includes="Messages.properties,vulnerabilities.xml" />
+		</copy>
+
 		<copy todir="${dist}/license">
 			<fileset dir="${src}/license">
 				<exclude name="**/.svn/**" />
@@ -353,8 +357,6 @@
         <copy todir="${test.build}">
             <fileset dir="${src}" includes="lang/**" />
             <fileset dir="${test.src}/resources/" />
-            <!-- Messages.properties file loaded by I18N during functional tests. -->
-            <fileset dir="${src}/lang" includes="Messages.properties" />
         </copy>
         <echo message="Running tests..." />
         <junit printsummary="yes" haltonerror="true" failureproperty="TestsFailed">

--- a/src/org/zaproxy/zap/utils/I18N.java
+++ b/src/org/zaproxy/zap/utils/I18N.java
@@ -168,9 +168,19 @@ public class I18N {
 			return;
 		}
     	this.locale = locale;
-    	this.stdMessages = ResourceBundle.getBundle(Constant.MESSAGES_PREFIX, locale, new ZapResourceBundleControl());
+        ZapResourceBundleControl rbc = new ZapResourceBundleControl();
+        try {
+            this.stdMessages = loadResourceBundle(Constant.MESSAGES_PREFIX, rbc);
+            logger.debug("Using file system Messages resource bundle.");
+        } catch (MissingResourceException e) {
+            this.stdMessages = loadResourceBundle("org.zaproxy.zap.resources." + Constant.MESSAGES_PREFIX, rbc);
+            logger.debug("Using bundled Messages resource bundle.");
+        }
     }
 
+    private ResourceBundle loadResourceBundle(String path, ZapResourceBundleControl rbc) {
+        return ResourceBundle.getBundle(path, locale, rbc);
+    }
     
     public Locale getLocal() {
     	return this.locale;

--- a/src/org/zaproxy/zap/utils/LocaleUtils.java
+++ b/src/org/zaproxy/zap/utils/LocaleUtils.java
@@ -363,11 +363,16 @@ public final class LocaleUtils {
 
 	private static List<String> readAvailableLocales() {
 		File dir = new File(Constant.getZapInstall(), Constant.LANG_DIR);
+		if (!dir.exists()) {
+			logger.debug("Skipping read of available locales, the directory does not exist: " + dir.getAbsolutePath());
+			return new ArrayList<>(0);
+		}
+
 		FilenameFilter filter = new MessagesPropertiesFilenameFilter();
 		String[] files = dir.list(filter);
 
 		if (files == null || files.length == 0) {
-			logger.error("Failed to find any locale files in directory " + dir.getAbsolutePath());
+			logger.warn("No Messages files in directory " + dir.getAbsolutePath());
 			return new ArrayList<>(0);
 		}
 

--- a/src/org/zaproxy/zap/utils/ZapXmlConfiguration.java
+++ b/src/org/zaproxy/zap/utils/ZapXmlConfiguration.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.utils;
 
 import java.io.File;
+import java.io.InputStream;
 import java.net.URL;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -56,6 +57,18 @@ public class ZapXmlConfiguration extends XMLConfiguration {
 
 		super.setEncoding("UTF-8");
 		super.setDelimiterParsingDisabled(true);
+	}
+
+	/**
+	 * Creates a new instance of {@code ZapXmlConfiguration} with the configuration loaded from the given input stream.
+	 * 
+	 * @param in the input stream to load the configuration from.
+	 * @throws ConfigurationException if loading the configuration fails.
+	 * @since TODO add version
+	 */
+	public ZapXmlConfiguration(InputStream in) throws ConfigurationException {
+		this();
+		load(in);
 	}
 
 	/**


### PR DESCRIPTION
Change build.xml to include the files Messages.properties and
vulnerabilities.xml in the zap.jar.
Change I18N and Vulnerabilities to fallback to the bundled files if the
corresponding files are not in the file system.
Tweak LocaleUtils to not attempt to read the lang directory (for
Messages.properties) as it might no longer exist and if it exists log a
warn (instead of error) if no files are found (it would use the bundled
file).
Change VulnerabilitiesLoader to allow to load a vulnerabilities.xml file
using an InputStream (e.g. the bundled one) and return an empty list
of vulnerabilities if the lang directory is not found (to fallback to
bundled file).
Change ZapXmlConfiguration to allow to read a configuration from an
InputStream.

Part of #4771 - Bundle required files in the zap.jar