### PR TITLE
Tweak Eclipse classpath to include Messages files

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry including="Messages*.properties" kind="src" path="lang"/>
 	<classpathentry kind="src" path="test/resources"/>
 	<classpathentry excluding="resources/" kind="src" path="test"/>
 	<classpathentry kind="lib" path="lib/orange-extensions-1.3.0.jar"/>

--- a/.project
+++ b/.project
@@ -14,4 +14,11 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<linkedResources>
+		<link>
+			<name>lang</name>
+			<type>2</type>
+			<locationURI>PROJECT_LOC/src/lang</locationURI>
+		</link>
+	</linkedResources>
 </projectDescription>


### PR DESCRIPTION
Change .classpath to include the Messages.properties files (main and
translations) to not require further configurations to run ZAP.
Change .project to create a link for the lang directory to allow the
above.

Related to #4755 - Stop relying on ClassLoaderUtil

---
As discussed in IRC.