### PR TITLE
Adjust log msg/levels related to plugin dirs

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnCollection.java
+++ b/src/org/zaproxy/zap/control/AddOnCollection.java
@@ -161,7 +161,7 @@ public class AddOnCollection {
     		return;
     	}
     	if (! dir.exists()) {
-    		logger.warn("No such directory: " + dir.getAbsolutePath());
+    		logger.warn("Skipping enumeration of add-ons, the directory does not exist: " + dir.getAbsolutePath());
     		return;
     	}
     	if (! dir.isDirectory()) {

--- a/src/org/zaproxy/zap/control/AddOnLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnLoader.java
@@ -375,11 +375,11 @@ public class AddOnLoader extends URLClassLoader {
     		return;
     	}
     	if (! dir.exists()) {
-    		logger.error("No such directory: " + dir.getAbsolutePath());
+    		logger.debug("No such directory: " + dir.getAbsolutePath());
     		return;
     	}
     	if (! dir.isDirectory()) {
-    		logger.error("Not a directory: " + dir.getAbsolutePath());
+    		logger.warn("Not a directory: " + dir.getAbsolutePath());
     		return;
     	}
 


### PR DESCRIPTION
Change AddOnCollection to provide a more informative message when the
plugin directory does not exist.
Change AddOnLoader to use debug and warn levels instead of error when
the directory does not exist and if it's not a directory, respectively,
this only applies to loading of JARs (which are not required for ZAP
to start/work).

Related to #4771 (i.e. when running ZAP with just the JAR+libs).