### PR TITLE
Remove JavaFX runtime library

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -29,7 +29,6 @@
 	<classpathentry kind="lib" path="lib/jdom.jar"/>
 	<classpathentry kind="lib" path="lib/jericho-html-3.1.jar"/>
 	<classpathentry kind="lib" path="lib/jfreechart-1.0.13.jar"/>
-	<classpathentry kind="lib" path="lib/jfxrt.jar"/>
 	<classpathentry kind="lib" path="lib/jgrapht-core-0.9.0.jar"/>
 	<classpathentry kind="lib" path="lib/jh.jar"/>
 	<classpathentry kind="lib" path="lib/json-lib-2.4-jdk15.jar"/>

--- a/LEGALNOTICE.md
+++ b/LEGALNOTICE.md
@@ -62,7 +62,6 @@ and subject to their respective licenses.
 | jdom.jar                      | BSD                       |
 | jericho-html-3.1.jar          | EPL / LGPL dual license   |
 | jfreechart-1.0.13.jar         | LGPL                      |
-| jfxrt.jar                     | Oracle Binary Code        |
 | jgrapht-core-0.9.0.jar        | LGPL 2.1                  |
 | jh.jar                        | GPL + classpath exception |
 | json-lib-2.4-jdk15.jar        | MIT + "Good, Not Evil"    |


### PR DESCRIPTION
The library is not used by core. Only one add-on (Browser View) is using
it, moreover the add-on already copes with the missing library and when
missing it informs the user that JavaFX is required.
Remove the library from LEGALNOTICE.md.
Update the classpath and remove the library.

Part of #4780 - Tidy up dependencies