### PR TITLE
Bundle license file

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -155,6 +155,7 @@
 
 		<copy todir="${build}/org/zaproxy/zap/resources/">
 			<fileset dir="${src}/lang" includes="Messages.properties,vulnerabilities.xml" />
+			<fileset dir="${src}/license" includes="ApacheLicense-2.0.txt" />
 		</copy>
 
 		<copy todir="${dist}/license">


### PR DESCRIPTION
Change LicenseFrame to fallback to the bundled license file if not found
in the file system.
Change build.xml to include the license file in the zap.jar.

Part of #4771 - Bundle required files in the zap.jar