### PR TITLE
Allow to enable dev mode through the command line

### DIFF
--- a/src/org/parosproxy/paros/CommandLine.java
+++ b/src/org/parosproxy/paros/CommandLine.java
@@ -40,6 +40,7 @@
 // ZAP: 2017/08/31 Use helper method I18N.getString(String, Object...).
 // ZAP: 2017/11/21 Validate that -cmd and -daemon are not set at the same time (they are mutually exclusive).
 // ZAP: 2017/12/26 Remove unused command line arg SP.
+// ZAP: 2018/06/29 Add command line to run ZAP in dev mode.
 
 package org.parosproxy.paros;
 
@@ -88,6 +89,21 @@ public class CommandLine {
      */
     public static final String NOSTDOUT = "-nostdout";
 
+    /**
+     * Command line option to enable "dev mode".
+     * <p>
+     * With this option development related utilities/functionalities are enabled. For example, it's shown an error counter in
+     * the footer tool bar and license is implicitly accepted (thus not requiring to show/accept the license each time a new
+     * home is used).
+     * <p>
+     * <strong>Note:</strong> this mode is always enabled when running ZAP directly from source (i.e. not packaged in a JAR) or
+     * using a dev build.
+     * 
+     * @see #isDevMode()
+     * @since TODO add version
+     */
+    public static final String DEV_MODE = "-dev";
+
     static final String NO_USER_AGENT = "-nouseragent";
 
     private boolean GUI = true;
@@ -107,6 +123,11 @@ public class CommandLine {
      * Flag that indicates whether or not the default logging through standard output should be disabled.
      */
     private boolean noStdOutLog;
+
+    /**
+     * Flag that indicates whether or not the "dev mode" is enabled.
+     */
+    private boolean devMode;
 
     public CommandLine(String[] args) throws Exception {
         this.args = args == null ? new String[0] : args;
@@ -323,6 +344,9 @@ public class CommandLine {
             displaySupportInfo = true;
             setDaemon(false);
             setGUI(false);
+        } else if (checkSwitch(args, DEV_MODE, i)) {
+            devMode = true;
+            Constant.setDevMode(true);
         }
 
         return result;
@@ -477,6 +501,17 @@ public class CommandLine {
      */
     public boolean isNoStdOutLog() {
         return noStdOutLog;
+    }
+
+    /**
+     * Tells whether or not the "dev mode" should be enabled.
+     *
+     * @return {@code true} if the "dev mode" should be enabled, {@code false} otherwise.
+     * @since TODO add version
+     * @see #DEV_MODE
+     */
+    public boolean isDevMode() {
+        return devMode;
     }
 
     public static String getHelp(List<CommandLineArgument[]> cmdList) {

--- a/src/org/parosproxy/paros/Constant.java
+++ b/src/org/parosproxy/paros/Constant.java
@@ -78,6 +78,7 @@
 // ZAP: 2018/03/16 Use equalsIgnoreCase (Issue 4327).
 // ZAP: 2018/04/16 Keep backup of malformed config file.
 // ZAP: 2018/06/13 Correct install dir detection from JAR.
+// ZAP: 2018/06/29 Allow to check if in dev mode.
 
 package org.parosproxy.paros;
 
@@ -292,6 +293,13 @@ public final class Constant {
      * @since 2.4.0
      */
     public static final String VULNERABILITIES_EXTENSION = ".xml";
+
+    /**
+     * Flag that indicates whether or not the "dev mode" is enabled.
+     * 
+     * @see #isDevMode()
+     */
+    private static boolean devMode;
     
     // ZAP: Added dirbuster dir
     public String DIRBUSTER_DIR = "dirbuster";
@@ -346,7 +354,7 @@ public final class Constant {
     	}
     	
         if (incDevOption) {
-	        if (isDevBuild() || isDailyBuild()) {
+	        if (isDevMode() || isDailyBuild()) {
 	        	// Default to a different home dir to prevent messing up full releases
 	        	return zapStd + "_D";
 	        }
@@ -358,7 +366,7 @@ public final class Constant {
     public void copyDefaultConfigs(File f, boolean forceReset) throws IOException, ConfigurationException {
         FileCopier copier = new FileCopier();
         File oldf;
-        if (isDevBuild() || isDailyBuild()) {
+        if (isDevMode() || isDailyBuild()) {
             // try standard location
             oldf = new File (getDefaultHomeDirectory(false) + FILE_SEPARATOR + FILE_CONFIG_NAME);
         } else {
@@ -371,7 +379,7 @@ public final class Constant {
             LOG.info("Copying defaults from " + oldf.getAbsolutePath() + " to " + FILE_CONFIG);
             copier.copy(oldf,f);
             
-            if (isDevBuild() || isDailyBuild()) {
+            if (isDevMode() || isDailyBuild()) {
                 ZapXmlConfiguration newConfig = new ZapXmlConfiguration(f);
                 newConfig.setProperty(OptionsParamCheckForUpdates.DOWNLOAD_DIR, Constant.FOLDER_LOCAL_PLUGIN);
                 newConfig.save();
@@ -496,7 +504,7 @@ public final class Constant {
 	            
 	            if (ver == VERSION_TAG) {
 	            	// Nothing to do
-	            } else if (isDevBuild() || isDailyBuild()) {
+	            } else if (isDevMode() || isDailyBuild()) {
 	            	// Nothing to do
 	            } else {
 	            	// Backup the old one
@@ -1136,7 +1144,36 @@ public final class Constant {
     	}
     	return null;
     }
+
+    /**
+     * Tells whether or not the "dev mode" should be enabled.
+     * <p>
+     * Should be used to enable development related utilities/functionalities.
+     * 
+     * @return {@code true} if the "dev mode" should be enabled, {@code false} otherwise.
+     * @since TODO add version
+     */
+    public static boolean isDevMode() {
+        return devMode || isDevBuild();
+    }
+
+    /**
+     * Sets whether or not the "dev mode" should be enabled.
+     * <p>
+     * <strong>Note:</strong> This method should be called only by bootstrap classes.
+     * 
+     * @param devMode {@code true} if the "dev mode" should be enabled, {@code false} otherwise.
+     */
+    public static void setDevMode(boolean devMode) {
+        Constant.devMode = devMode;
+    }
     
+    /**
+     * Tells whether or not ZAP is running from a dev build.
+     *
+     * @return {@code true} if it's a dev build, {@code false} otherwise.
+     * @see #isDevMode()
+     */
     public static boolean isDevBuild() {
     	return isDevBuild(PROGRAM_VERSION);
     }

--- a/src/org/parosproxy/paros/model/SiteMap.java
+++ b/src/org/parosproxy/paros/model/SiteMap.java
@@ -387,7 +387,7 @@ public class SiteMap extends SortedTreeModel {
     		throw new InvalidParameterException("SiteMap should not be accessed when the low memory option is set");
     	}
 
-    	if (View.isInitialised() && Constant.isDevBuild() && ! EventQueue.isDispatchThread()) {
+    	if (View.isInitialised() && Constant.isDevMode() && ! EventQueue.isDispatchThread()) {
     		// In developer mode log an error if we're not on the EDT
     		// Adding to the site tree on GUI ('initial') threads causes problems
     		log.error("SiteMap.addPath not on EDT " + Thread.currentThread().getName(), new Exception());

--- a/src/org/zaproxy/zap/GuiBootstrap.java
+++ b/src/org/zaproxy/zap/GuiBootstrap.java
@@ -200,7 +200,7 @@ public class GuiBootstrap extends ZapBootstrap {
                     initControlAndPostViewInit();
 
                 } catch (Throwable e) {
-                    if (!Constant.isDevBuild()) {
+                    if (!Constant.isDevMode()) {
                         ErrorInfo errorInfo = new ErrorInfo(
                                 Constant.messages.getString("start.gui.dialog.fatal.error.title"),
                                 Constant.messages.getString("start.gui.dialog.fatal.error.message"),
@@ -568,11 +568,15 @@ public class GuiBootstrap extends ZapBootstrap {
      * Tells whether or not ZAP license should be shown, if the license was already accepted it does not need to be shown again.
      * <p>
      * The license is considered accepted if a file named {@link Constant#ACCEPTED_LICENSE_DEFAULT AcceptedLicense} exists in
-     * the installation and/or home directory.
+     * the installation and/or home directory, or if running ZAP in "dev mode".
      *
      * @return {@code true} if the license should be shown, {@code false} otherwise.
      */
-    private static boolean isShowLicense() {
+    private boolean isShowLicense() {
+        if (getArgs().isDevMode()) {
+            return false;
+        }
+
         Path acceptedLicenseFile = Paths.get(Constant.getZapInstall(), Constant.getInstance().ACCEPTED_LICENSE_DEFAULT);
         if (Files.exists(acceptedLicenseFile)) {
             return false;

--- a/src/org/zaproxy/zap/extension/log4j/ExtensionLog4j.java
+++ b/src/org/zaproxy/zap/extension/log4j/ExtensionLog4j.java
@@ -49,8 +49,8 @@ public class ExtensionLog4j extends ExtensionAdaptor {
         super(NAME);
         this.setOrder(56);
 
-		if (Constant.isDevBuild() && View.isInitialised()) {
-			// Only enable if this is a developer build, ie build from source
+		if (Constant.isDevMode() && View.isInitialised()) {
+			// Only enable if this is a developer build, ie build from source, or explicitly enabled
         
 	        scanStatus = new ScanStatus(
 					new ImageIcon(


### PR DESCRIPTION
Add a command line option, `-dev`, to enable "dev mode", that is, enable
development related utilities/functionalities. For example, show the
error counter in the footer tool bar and have the license implicitly
accepted (thus not requiring to show/accept the license each time a
new home is used). This allows to use those functionalities even if
using a weekly or main release, when developing add-ons.