### PR TITLE
Add all dangling event consumers

### DIFF
--- a/src/org/zaproxy/zap/eventBus/SimpleEventBus.java
+++ b/src/org/zaproxy/zap/eventBus/SimpleEventBus.java
@@ -66,16 +66,16 @@ public class SimpleEventBus implements EventBus {
 
 			RegisteredPublisher regProd = new RegisteredPublisher(publisher, eventTypes);
 
-			this.nameToPublisher.put(publisher.getPublisherName(), regProd);
-
 			// Check to see if there are any cached consumers
-			for (RegisteredConsumer regCon : this.danglingConsumers) {
+			danglingConsumers.removeIf(regCon -> {
 				if (regCon.getPublisherName().equals(publisher.getPublisherName())) {
 					regProd.addConsumer(regCon);
-					this.danglingConsumers.remove(regCon);
-					break;
+					return true;
 				}
-			}
+				return false;
+			});
+
+			this.nameToPublisher.put(publisher.getPublisherName(), regProd);
 		} finally {
 			regMgmtLock.unlock();
 		}

--- a/test/org/zaproxy/zap/eventBus/SimpleEventBusUnitTest.java
+++ b/test/org/zaproxy/zap/eventBus/SimpleEventBusUnitTest.java
@@ -19,7 +19,9 @@
  */
 package org.zaproxy.zap.eventBus;
 
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -168,6 +170,23 @@ public class SimpleEventBusUnitTest {
         assertFalse(cons.getEvents().contains(eventp1e3));
         assertFalse(cons.getEvents().contains(eventp2e3));
         assertFalse(cons.getEvents().contains(eventp3e3));
+    }
+
+    @Test
+    public void consumersShouldReceiveEventsEvenIfRegisteredBeforePublisher() {
+        // Given
+        TestEventConsumer consumer1 = new TestEventConsumer();
+        TestEventConsumer consumer2 = new TestEventConsumer();
+        seb.registerConsumer(consumer1, "publisher");
+        seb.registerConsumer(consumer2, "publisher");
+        TestEventPublisher publisher = new TestEventPublisher("publisher");
+        Event event = new Event(publisher, "event", null);
+        // When
+        seb.registerPublisher(publisher, new String[] { "event" });
+        seb.publishSyncEvent(publisher, event);
+        // Then
+        assertThat(consumer1.getEvents(), contains(event));
+        assertThat(consumer2.getEvents(), contains(event));
     }
     
     private class TestEventConsumer implements EventConsumer {


### PR DESCRIPTION
Change SimpleEventBus to add all dangling consumers, not just the first
found, also, delay the (actual) registration of the publisher to finish
adding all dangling consumers.
Add test to assert the expected behaviour.