### PR TITLE
Fix XML configuration's indentation with Java 9+

### DIFF
--- a/test/org/zaproxy/zap/utils/ZapXmlConfigurationUnitTest.java
+++ b/test/org/zaproxy/zap/utils/ZapXmlConfigurationUnitTest.java
@@ -1,0 +1,80 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.utils;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+/**
+ * Unit test for {@link ZapXmlConfiguration}.
+ */
+public class ZapXmlConfigurationUnitTest {
+
+    private static final String INDENTED_XML =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + 
+            "<a>\n" + 
+            "    <b>1</b>\n" + 
+            "    <c/>\n" + 
+            "    <d>\n" + 
+            "        <e/>\n" + 
+            "        <f>2</f>\n" + 
+            "    </d>\n" + 
+            "</a>\n";
+
+    @Test
+    public void shouldSaveNewConfigurationIndented() throws Exception {
+        // Given
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ZapXmlConfiguration conf = new ZapXmlConfiguration();
+        conf.setRootElementName("a");
+        conf.setProperty("b", "1");
+        conf.setProperty("c", "");
+        conf.setProperty("d.e", "");
+        conf.setProperty("d.f", "2");
+        // When
+        conf.save(outputStream);
+        // Then
+        assertThat(contents(outputStream), is(equalTo(INDENTED_XML)));
+    }
+
+    @Test
+    public void shouldSaveLoadedConfigurationIndented() throws Exception {
+        // Given
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(INDENTED_XML.getBytes(StandardCharsets.UTF_8));
+        ZapXmlConfiguration conf = new ZapXmlConfiguration(inputStream);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        // When
+        conf.save(outputStream);
+        // Then
+        assertThat(contents(outputStream), is(equalTo(INDENTED_XML)));
+    }
+
+    private static String contents(ByteArrayOutputStream outputStream) throws UnsupportedEncodingException {
+        return outputStream.toString(StandardCharsets.UTF_8.name()).replaceAll(System.lineSeparator(), "\n");
+    }
+}


### PR DESCRIPTION
Change ZapXmlConfiguration to force the creation of new nodes after
loading the configuration, to ensure just the configuration nodes are
persisted when saved (i.e. without any text nodes that would be indented
again).
Add tests to assert the expected behaviour.

Part of #2602.
Fix #4194 - Size of the configuration file keeps increasing each time
ZAP is started with Java 9+