### PR TITLE
Exit on exception during GUI start

### DIFF
--- a/src/org/zaproxy/zap/GuiBootstrap.java
+++ b/src/org/zaproxy/zap/GuiBootstrap.java
@@ -174,7 +174,9 @@ public class GuiBootstrap extends ZapBootstrap {
                         Constant.messages.getString("start.title.error"),
                         JOptionPane.ERROR_MESSAGE);
             }
-            logger.fatal(e.getMessage(), e);
+            logger.fatal("Failed to initialise: " + e.getMessage(), e);
+            System.err.println(e.getMessage());
+            System.exit(1);
         }
 
         OptionsParam options = Model.getSingleton().getOptionsParam();


### PR DESCRIPTION
Change GuiBootstrap to exit instead of attempting to continue if an
exception happened while initialising core classes, it would most likely
lead to more exceptions (caused by missing files or classes).