### PR TITLE
Don't open the report if it does not exist

### DIFF
--- a/src/org/parosproxy/paros/extension/report/ReportLastScan.java
+++ b/src/org/parosproxy/paros/extension/report/ReportLastScan.java
@@ -31,10 +31,12 @@
 // ZAP: 2016/09/22 Issue 2886: Support Markdown format
 // ZAP: 2017/06/21 Issue 3559: Support JSON format
 // ZAP: 2017/08/31 Use helper method I18N.getString(String, Object...).
+// ZAP: 2018/07/04 Don't open the report if it was not generated.
 
 package org.parosproxy.paros.extension.report;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.Locale;
 
 import javax.swing.JFileChooser;
@@ -232,6 +234,11 @@ public class ReportLastScan {
                 File report = generate(file.getAbsolutePath(), model, localReportType);
                 if (report == null) {
                     view.showMessageDialog(Constant.messages.getString("report.unknown.error", file.getAbsolutePath()));
+                    return;
+                }
+
+                if (Files.notExists(report.toPath())) {
+                    logger.info("Not opening report, does not exist: " + report);
                     return;
                 }
 

--- a/src/org/zaproxy/zap/extension/compare/ExtensionCompare.java
+++ b/src/org/zaproxy/zap/extension/compare/ExtensionCompare.java
@@ -23,6 +23,7 @@ import java.awt.EventQueue;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -289,6 +290,11 @@ public class ExtensionCompare extends ExtensionAdaptor implements SessionChanged
 				        ReportGenerator.stringToHtml(sb.toString(), 
 					    		Constant.getZapInstall() + File.separator + "xml" + File.separator + "reportCompare.xsl", 
 					    		outputFile.getAbsolutePath());
+
+						if (Files.notExists(outputFile.toPath())) {
+							log.info("Not opening report, does not exist: " + outputFile);
+							return;
+						}
 
 			    		try {
 							DesktopUtils.openUrlInBrowser(outputFile.toURI());


### PR DESCRIPTION
Change ExtensionCompare and ReportLastScan to not try to open the report
if it does not exist (e.g. an error occurred while generating it) as it
would lead to more (unnecessary) errors, moreover, the user is already
informed that the report was not correctly generated.