### PR TITLE
Ignore breakpoint UI manager changes with no view

### DIFF
--- a/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
+++ b/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
@@ -225,12 +225,18 @@ public class ExtensionBreak extends ExtensionAdaptor implements SessionChangedLi
     }
     
     public void addBreakpointsUiManager(BreakpointsUiManagerInterface uiManager) {
+        if (getView() == null) {
+            return;
+        }
         mapBreakpointUiManager.put(uiManager.getBreakpointClass(), uiManager);
         mapMessageUiManager.put(uiManager.getMessageClass(), uiManager);
     }
 
 
 	public void removeBreakpointsUiManager(BreakpointsUiManagerInterface uiManager) {
+        if (getView() == null) {
+            return;
+        }
         mapBreakpointUiManager.remove(uiManager.getBreakpointClass());
         mapMessageUiManager.remove(uiManager.getMessageClass());		
 	}


### PR DESCRIPTION
Change ExtensionBreak to check and ignore changes (addition/removal) to
breakpoint UI managers if the view is not initialised.

Related to #4815 - NullPointerException while uninstalling WebSockets
add-on with ZAP without GUI