### PR TITLE
Skip dependent extensions of failed uninstallation

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnLoader.java
+++ b/src/org/zaproxy/zap/control/AddOnLoader.java
@@ -493,6 +493,9 @@ public class AddOnLoader extends URLClassLoader {
         boolean changed = false;
         for (Entry<String, AddOnClassLoader> entry : new HashMap<>(addOnLoaders).entrySet()) {
             AddOn runningAddOn = aoc.getAddOn(entry.getKey());
+            if (runningAddOn.getInstallationStatus() == AddOn.InstallationStatus.UNINSTALLATION_FAILED) {
+                continue;
+            }
             for (String extClassName : runningAddOn.getExtensionsWithDeps()) {
                 if (!runningAddOn.isExtensionLoaded(extClassName)) {
                     AddOn.AddOnRunRequirements reqs = runningAddOn.calculateExtensionRunRequirements(


### PR DESCRIPTION
Changed AddOnLoader to not try to load dependent extensions of an add-on
that failed to uninstall, the add-on is no longer in a consistent state
to load the extensions.

Related to #4815 - NullPointerException while uninstalling WebSockets
add-on with ZAP without GUI