### PR TITLE
Correct API response on failed installations

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -648,6 +648,7 @@ cfu.cmdline.addondown		= Add-on downloaded to: {0}
 cfu.cmdline.addondown.failed = Add-on download failed for: {0}
 cfu.cmdline.addoninst		= Add-on already installed: {0}
 cfu.cmdline.addonurl		= Downloading add-on from: {0}
+cfu.cmdline.addoninst.error = It's recommended to restart ZAP. Not all add-ons were successfully installed.
 cfu.cmdline.addoninst.uninstalls.required = Not installing add-on(s). The installation would require uninstalling the following add-ons: {0}
 cfu.cmdline.addonuninst.uninstalls.required = Not uninstalling add-on(s). The uninstallation would require uninstalling the following add-ons: {0}
 cfu.cmdline.install.help	= Install the specified add-on from the ZAP Marketplace


### PR DESCRIPTION
Change ExtensionAutoUpdate to return an error message if an error
occurred while installing the add-ons, for example, an older version
failed to uninstall to return a proper error through the API.