### PR TITLE
Fix NPE after error loading a session

### DIFF
--- a/src/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
+++ b/src/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
@@ -233,6 +233,9 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
 	}
 	
 	protected int getRecordsToScan() {
+		if (historyTable == null) {
+			return 0;
+		}
 		return this.getLastHistoryId() - getLastScannedId();
 	}
 


### PR DESCRIPTION
Change PassiveScanThread to return 0 records to scan if the history
table is not available, for example, if no session is currently open
because of an error loading a session.