### PR TITLE
Bundle files for report generation

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -156,6 +156,7 @@
 		<copy todir="${build}/org/zaproxy/zap/resources/">
 			<fileset dir="${src}/lang" includes="Messages.properties,vulnerabilities.xml" />
 			<fileset dir="${src}/license" includes="ApacheLicense-2.0.txt" />
+			<fileset dir="${src}" includes="xml/report*.xsl" />
 		</copy>
 
 		<copy todir="${dist}/license">

--- a/src/org/parosproxy/paros/extension/report/ReportGenerator.java
+++ b/src/org/parosproxy/paros/extension/report/ReportGenerator.java
@@ -26,6 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // ZAP: 2016/04/18 Issue 2127: Added return statements & GUI dialogs after IOExceptions
 // ZAP: 2016/06/25 pull 2561: It specifies the Charset of stringToHtml to UTF-8
 // ZAP: 2017/06/21 Issue 3559: Support JSON format
+// ZAP: 2018/07/04 Allow to use a custom StreamSource for the XSL.
 
 package org.parosproxy.paros.extension.report;
 
@@ -98,18 +99,20 @@ public class ReportGenerator {
 	}
 
 	public static File stringToHtml(String inxml, String infilexsl, String outfilename) {
-		if (infilexsl != null) {
+		return stringToHtml(inxml, infilexsl != null ? new StreamSource(new File(infilexsl)) : null, outfilename);
+	}
+
+	public static File stringToHtml(String inxml, StreamSource stylesource, String outfilename) {
+		if (stylesource != null) {
 			Document doc = null;
 	
 			// factory.setNamespaceAware(true);
 			// factory.setValidating(true);
-			File stylesheet = null;
 			File outfile = null;
 			StringReader inReader = new StringReader(inxml);
 			String tempOutfilename = outfilename + ".temp"; 
 	
 			try {
-				stylesheet = new File(infilexsl);
 				outfile = new File(tempOutfilename);
 	
 				DocumentBuilder builder = XmlUtils.newXxeDisabledDocumentBuilderFactory().newDocumentBuilder();
@@ -117,7 +120,6 @@ public class ReportGenerator {
 	
 				// Use a Transformer for output
 				TransformerFactory tFactory = TransformerFactory.newInstance();
-				StreamSource stylesource = new StreamSource(stylesheet);
 				Transformer transformer = tFactory.newTransformer(stylesource);
 	
 				DOMSource source = new DOMSource(doc);
@@ -225,23 +227,22 @@ public class ReportGenerator {
 	}
 
 	public static String stringToHtml(String inxml, String infilexsl) {
+		return stringToHtml(inxml, new StreamSource(new File(infilexsl)));
+	}
+
+	public static String stringToHtml(String inxml, StreamSource stylesource) {
 		Document doc = null;
 
-		// factory.setNamespaceAware(true);
-		// factory.setValidating(true);
-		File stylesheet = null;
 		StringReader inReader = new StringReader(inxml);
 		StringWriter writer = new StringWriter();
 
 		try {
-			stylesheet = new File(infilexsl);
 
 			DocumentBuilder builder = XmlUtils.newXxeDisabledDocumentBuilderFactory().newDocumentBuilder();
 			doc = builder.parse(new InputSource(inReader));
 
 			// Use a Transformer for output
 			TransformerFactory tFactory = TransformerFactory.newInstance();
-			StreamSource stylesource = new StreamSource(stylesheet);
 			Transformer transformer = tFactory.newTransformer(stylesource);
 
 			DOMSource source = new DOMSource(doc);

--- a/src/org/parosproxy/paros/extension/report/ReportLastScan.java
+++ b/src/org/parosproxy/paros/extension/report/ReportLastScan.java
@@ -32,15 +32,21 @@
 // ZAP: 2017/06/21 Issue 3559: Support JSON format
 // ZAP: 2017/08/31 Use helper method I18N.getString(String, Object...).
 // ZAP: 2018/07/04 Don't open the report if it was not generated.
+// ZAP: 2018/07/04 Fallback to bundled XSL files.
 
 package org.parosproxy.paros.extension.report;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Locale;
 
 import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
+import javax.xml.transform.stream.StreamSource;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -60,7 +66,7 @@ import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
 public class ReportLastScan {
 
-    private Logger logger = Logger.getLogger(ReportLastScan.class);
+    private static final Logger logger = Logger.getLogger(ReportLastScan.class);
     
     private static final String HTM_FILE_EXTENSION=".htm";
     private static final String HTML_FILE_EXTENSION=".html";
@@ -84,27 +90,34 @@ public class ReportLastScan {
     }
 
     public File generate(String fileName, Model model, ReportType reportType) throws Exception {
-        String xslFile = "";
-        switch(reportType) {
-            case XML:   // Don't use XSLT for XML/JSON
-            case JSON:
-                xslFile = null;
-                break;
-            case MD:
-                xslFile = (Constant.getZapInstall() + "/xml/report.md.xsl");
-                break;
-            case HTML:
-            default:
-                xslFile = (Constant.getZapInstall() + "/xml/report.html.xsl");
-                break;
-        }
-
         StringBuilder sb = new StringBuilder(500);
         this.generate(sb, model);
         if (reportType == ReportType.JSON) {
             return ReportGenerator.stringToJson(sb.toString(), fileName);
         }
-        return ReportGenerator.stringToHtml(sb.toString(), xslFile, fileName);
+
+        if (reportType == ReportType.XML) {
+            return ReportGenerator.stringToHtml(sb.toString(), (String) null, fileName);
+        }
+
+        String xslFileName = reportType == ReportType.MD ? "report.md.xsl" : "report.html.xsl";
+        return generateReportWithXsl(sb.toString(), fileName, xslFileName);
+    }
+
+    private static File generateReportWithXsl(String report, String reportFile, String xslFileName) throws IOException {
+        Path xslFile = Paths.get(Constant.getZapInstall(), "xml", xslFileName);
+        if (Files.exists(xslFile)) {
+            return ReportGenerator.stringToHtml(report, xslFile.toString(), reportFile);
+        }
+
+        String path = "/org/zaproxy/zap/resources/xml/" + xslFileName;
+        try (InputStream is = ReportLastScan.class.getResourceAsStream(path)) {
+            if (is == null) {
+                logger.error("Bundled file not found: " + path);
+                return new File(reportFile);
+            }
+            return ReportGenerator.stringToHtml(report, new StreamSource(is), reportFile);
+        }
     }
 
     public void generate(StringBuilder report, Model model) throws Exception {

--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.api;
 import java.awt.EventQueue;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -41,6 +42,7 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import javax.swing.tree.TreeNode;
+import javax.xml.transform.stream.StreamSource;
 
 import net.sf.json.JSON;
 import net.sf.json.JSONException;
@@ -1487,21 +1489,33 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 			response = report.toString();
 		} else if (ScanReportType.MD == reportType) {
 			msg.setResponseHeader(API.getDefaultResponseHeader("text/markdown; charset=UTF-8"));
-			response = ReportGenerator.stringToHtml(
-					report.toString(),
-					Paths.get(Constant.getZapInstall(), "xml/report.md.xsl").toString());
+			response = generateReportWithXsl(report.toString(), "report.md.xsl");
 		} else if (ScanReportType.JSON == reportType) {
 			msg.setResponseHeader(API.getDefaultResponseHeader("application/json; charset=UTF-8"));
 			response = ReportGenerator.stringToJson(report.toString());
 		} else {
 			msg.setResponseHeader(API.getDefaultResponseHeader("text/html; charset=UTF-8"));
-			response = ReportGenerator.stringToHtml(
-					report.toString(),
-					Paths.get(Constant.getZapInstall(), "xml/report.html.xsl").toString());
+			response = generateReportWithXsl(report.toString(), "report.html.xsl");
 		}
 
 		msg.setResponseBody(response);
 		msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
+	}
+
+	private static String generateReportWithXsl(String report, String xslFileName) throws IOException {
+		Path xslFile = Paths.get(Constant.getZapInstall(), "xml", xslFileName);
+		if (Files.exists(xslFile)) {
+			return ReportGenerator.stringToHtml(report, xslFile.toString());
+		}
+
+		String path = "/org/zaproxy/zap/resources/xml/" + xslFileName;
+		try (InputStream is = ReportLastScan.class.getResourceAsStream(path)) {
+			if (is == null) {
+				logger.error("Bundled file not found: " + path);
+				return "";
+			}
+			return ReportGenerator.stringToHtml(report, new StreamSource(is));
+		}
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/compare/ExtensionCompare.java
+++ b/src/org/zaproxy/zap/extension/compare/ExtensionCompare.java
@@ -21,9 +21,12 @@ package org.zaproxy.zap.extension.compare;
 
 import java.awt.EventQueue;
 import java.io.File;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -34,6 +37,7 @@ import javax.swing.JFileChooser;
 import javax.swing.JMenuItem;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
+import javax.xml.transform.stream.StreamSource;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.log4j.Logger;
@@ -287,9 +291,20 @@ public class ExtensionCompare extends ExtensionAdaptor implements SessionChanged
 					    sb.append("</report>");	
 					    sb.append(CRLF);
 					    
-				        ReportGenerator.stringToHtml(sb.toString(), 
-					    		Constant.getZapInstall() + File.separator + "xml" + File.separator + "reportCompare.xsl", 
-					    		outputFile.getAbsolutePath());
+                        String fileName = "reportCompare.xsl";
+                        Path xslFile = Paths.get(Constant.getZapInstall(), "xml", fileName);
+                        if (Files.exists(xslFile)) {
+                            ReportGenerator.stringToHtml(sb.toString(), xslFile.toString(), outputFile.getAbsolutePath());
+                        } else {
+                            String path = "/org/zaproxy/zap/resources/xml/" + fileName;
+                            try (InputStream is = ExtensionCompare.class.getResourceAsStream(path)) {
+                                if (is == null) {
+                                    log.error("Bundled file not found: " + path);
+                                    return;
+                                }
+                                ReportGenerator.stringToHtml(sb.toString(), new StreamSource(is), outputFile.getAbsolutePath());
+                            }
+                        }
 
 						if (Files.notExists(outputFile.toPath())) {
 							log.info("Not opening report, does not exist: " + outputFile);


### PR DESCRIPTION
Change CoreAPI, ExtensionCompare, and ReportLastScan to fallback to the
bundled XSL files if not found in the file system.
Change ReportGenerator to allow to use a custom StreamSource (for the
XSL data).
Change build.xml to include the XSL files used for report generation.

Related to #4771 - Bundle required files in the zap.jar