### PR TITLE
Option to ignore warnings

### DIFF
--- a/docker/zap-baseline.py
+++ b/docker/zap-baseline.py
@@ -178,6 +178,8 @@ def main(argv):
             zap_alpha = True
         elif opt == '-i':
             info_unspecified = True
+        elif opt == '-I':
+            ignore_warn = True        
         elif opt == '-j':
             ajax = True
         elif opt == '-l':
@@ -193,9 +195,6 @@ def main(argv):
             detailed_output = False
         elif opt == '-T':
             timeout = int(arg)
-        elif opt == '-I':
-            ignore_warn = True
-        
 
     check_zap_client_version()
 

--- a/docker/zap-baseline.py
+++ b/docker/zap-baseline.py
@@ -430,7 +430,7 @@ def main(argv):
 
     if fail_count > 0:
         sys.exit(1)
-    elif (not ignore_warn) and warn_count > 0:        
+    elif (not ignore_warn) and warn_count > 0:
         sys.exit(2)
     elif pass_count > 0:
         sys.exit(0)

--- a/docker/zap-baseline.py
+++ b/docker/zap-baseline.py
@@ -87,6 +87,7 @@ def usage():
     print('    -P                specify listen port')
     print('    -D                delay in seconds to wait for passive scanning ')
     print('    -i                default rules not in the config file to INFO')
+    print('    -I                do not return failure on warning')
     print('    -j                use the Ajax spider in addition to the traditional one')
     print('    -l level          minimum level to show: PASS, IGNORE, INFO, WARN or FAIL, use with -s to hide example URLs')
     print('    -n context_file   context file which will be loaded prior to spidering the target')
@@ -94,7 +95,6 @@ def usage():
     print('    -s                short output format - dont show PASSes or example URLs')
     print('    -T                max time in minutes to wait for ZAP to start and the passive scan to run')
     print('    -z zap_options    ZAP command line options e.g. -z "-config aaa=bbb -config ccc=ddd"')
-    print('    -I                Do not return failure on warning')
     print('')
     print('For more details see https://github.com/zaproxy/zaproxy/wiki/ZAP-Baseline-Scan')
 

--- a/docker/zap-baseline.py
+++ b/docker/zap-baseline.py
@@ -94,6 +94,7 @@ def usage():
     print('    -s                short output format - dont show PASSes or example URLs')
     print('    -T                max time in minutes to wait for ZAP to start and the passive scan to run')
     print('    -z zap_options    ZAP command line options e.g. -z "-config aaa=bbb -config ccc=ddd"')
+    print('    -I                Do not return failure on warning')
     print('')
     print('For more details see https://github.com/zaproxy/zaproxy/wiki/ZAP-Baseline-Scan')
 
@@ -123,6 +124,7 @@ def main(argv):
     zap_options = ''
     delay = 0
     timeout = 0
+    ignore_warn = False
 
     pass_count = 0
     warn_count = 0
@@ -133,7 +135,7 @@ def main(argv):
     fail_inprog_count = 0
 
     try:
-        opts, args = getopt.getopt(argv, "t:c:u:g:m:n:r:J:w:x:l:hdaijp:sz:P:D:T:")
+        opts, args = getopt.getopt(argv, "t:c:u:g:m:n:r:J:w:x:l:hdaijp:sz:P:D:T:I")
     except getopt.GetoptError as exc:
         logging.warning('Invalid option ' + exc.opt + ' : ' + exc.msg)
         usage()
@@ -191,6 +193,9 @@ def main(argv):
             detailed_output = False
         elif opt == '-T':
             timeout = int(arg)
+        elif opt == '-I':
+            ignore_warn = True
+        
 
     check_zap_client_version()
 
@@ -425,7 +430,7 @@ def main(argv):
 
     if fail_count > 0:
         sys.exit(1)
-    elif warn_count > 0:
+    elif (not ignore_warn) and warn_count > 0:        
         sys.exit(2)
     elif pass_count > 0:
         sys.exit(0)


### PR DESCRIPTION
Implements : https://github.com/zaproxy/zaproxy/issues/4824

A flag to optionally ignore warnings in the response code used, to aid build pipelines. 