### PR TITLE
Tidy up tests

### DIFF
--- a/test/org/parosproxy/paros/core/scanner/VariantJSONQueryUnitTest.java
+++ b/test/org/parosproxy/paros/core/scanner/VariantJSONQueryUnitTest.java
@@ -117,7 +117,7 @@ public class VariantJSONQueryUnitTest {
         assertThat(parameters.get(0).getValue(), is("bar\""));
     }
 
-    private HttpMessage getMessageWithBody(String body) throws HttpMalformedHeaderException {
+    private static HttpMessage getMessageWithBody(String body) throws HttpMalformedHeaderException {
         return new HttpMessage(
                 new HttpRequestHeader("POST / HTTP/1.1\nHost: www.example.com\nContent-Type: application/json"),
                 new HttpRequestBody(body));

--- a/test/org/parosproxy/paros/network/HttpBodyUnitTest.java
+++ b/test/org/parosproxy/paros/network/HttpBodyUnitTest.java
@@ -527,7 +527,6 @@ public class HttpBodyUnitTest extends HttpBodyTestUtils {
     @Test
     public void shouldIgnoreAppendOfNullByteArray() {
         // Given
-        byte[] chunk = { 1, 2, 3, 4, 5 };
         HttpBody httpBody = new HttpBodyImpl();
         // When
         httpBody.append(null, 5);

--- a/test/org/zaproxy/zap/VersionUnitTest.java
+++ b/test/org/zaproxy/zap/VersionUnitTest.java
@@ -33,8 +33,6 @@ import org.zaproxy.zap.Version;
  */
 public class VersionUnitTest {
 
-    private static final String VALID_VERSION = "1.0.0";
-
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowExceptionIfVersionIsNull() {
         // Given

--- a/test/org/zaproxy/zap/authentication/UsernamePasswordAuthenticationCredentialsUnitTest.java
+++ b/test/org/zaproxy/zap/authentication/UsernamePasswordAuthenticationCredentialsUnitTest.java
@@ -74,7 +74,7 @@ public class UsernamePasswordAuthenticationCredentialsUnitTest {
         // Given
         UsernamePasswordAuthenticationCredentials credentials = new UsernamePasswordAuthenticationCredentials(username, null);
         // When
-        boolean isConfigured = notConfiguredInstance.isConfigured();
+        boolean isConfigured = credentials.isConfigured();
         // Then
         assertThat(isConfigured, is(false));
     }

--- a/test/org/zaproxy/zap/extension/alert/ExtensionAlertUnitTest.java
+++ b/test/org/zaproxy/zap/extension/alert/ExtensionAlertUnitTest.java
@@ -46,7 +46,7 @@ public class ExtensionAlertUnitTest {
         extAlert = new ExtensionAlert();
     }
     
-    private Alert newAlert (int pluginId) {
+    private static Alert newAlert (int pluginId) {
         Alert alert = new Alert(pluginId);
         alert.setName(ORIGINAL_NAME);
         alert.setDescription(ORIGINAL_DESC);

--- a/test/org/zaproxy/zap/extension/api/APIUnitTest.java
+++ b/test/org/zaproxy/zap/extension/api/APIUnitTest.java
@@ -448,7 +448,7 @@ public class APIUnitTest {
         }
     }
 
-    private List<DomainMatcher> createPermittedAddresses(String... addresses) {
+    private static List<DomainMatcher> createPermittedAddresses(String... addresses) {
         if (addresses == null || addresses.length == 0) {
             return new ArrayList<>();
         }

--- a/test/org/zaproxy/zap/extension/api/ApiResponseConversionUtilsUnitTest.java
+++ b/test/org/zaproxy/zap/extension/api/ApiResponseConversionUtilsUnitTest.java
@@ -119,11 +119,11 @@ public class ApiResponseConversionUtilsUnitTest {
 		assertThat(response.getValues(), hasEntry("responseBody", responseBody.toString()));
 	}
 	
-	private byte[] gzip(byte[] raw) throws Exception {
+	private static byte[] gzip(byte[] raw) throws Exception {
 		ByteArrayOutputStream bytes = new ByteArrayOutputStream(raw.length);
-		GZIPOutputStream zip = new GZIPOutputStream(bytes);
-		zip.write(raw);
-		zip.close();
+		try (GZIPOutputStream zip = new GZIPOutputStream(bytes)) {
+			zip.write(raw);
+		}
 		return bytes.toByteArray();
 		
 	}

--- a/test/org/zaproxy/zap/model/SessionUtilsUnitTest.java
+++ b/test/org/zaproxy/zap/model/SessionUtilsUnitTest.java
@@ -77,7 +77,7 @@ public class SessionUtilsUnitTest {
         return tempFolder.newFile(name).toPath();
     }
 
-    private Path pathWith(String baseDir, String... paths) {
+    private static Path pathWith(String baseDir, String... paths) {
         return Paths.get(baseDir, paths);
     }
 

--- a/test/org/zaproxy/zap/spider/filters/DefaultFetchFilterUnitTest.java
+++ b/test/org/zaproxy/zap/spider/filters/DefaultFetchFilterUnitTest.java
@@ -249,7 +249,7 @@ public class DefaultFetchFilterUnitTest {
         }
     }
 
-    private List<DomainAlwaysInScopeMatcher> domainsAlwaysInScope(String... domains) {
+    private static List<DomainAlwaysInScopeMatcher> domainsAlwaysInScope(String... domains) {
         if (domains == null || domains.length == 0) {
             return Collections.emptyList();
         }
@@ -261,7 +261,7 @@ public class DefaultFetchFilterUnitTest {
         return domainsAlwaysInScope;
     }
 
-    private List<String> excludeRegexes(String... regexes) {
+    private static List<String> excludeRegexes(String... regexes) {
         if (regexes == null || regexes.length == 0) {
             return Collections.emptyList();
         }

--- a/test/org/zaproxy/zap/spider/parser/SpiderHtmlFormParserUnitTest.java
+++ b/test/org/zaproxy/zap/spider/parser/SpiderHtmlFormParserUnitTest.java
@@ -986,12 +986,11 @@ public class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
         // Given
         TestValueGenerator valueGenerator = new TestValueGenerator();
         SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser(valueGenerator);
-        TestSpiderParserListener listener = createTestSpiderParserListener();
         HttpMessage msg = createMessageWith("FormsForValueGenerator.html");
         Source source = createSource(msg);
         int fieldIndex = 0;
         // When
-        boolean completelyParsed = htmlParser.parseResource(msg, source, BASE_DEPTH);
+        htmlParser.parseResource(msg, source, BASE_DEPTH);
         // Then
         assertThat(valueGenerator.getFields(), hasSize(9));
         assertThat(
@@ -1218,11 +1217,11 @@ public class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
         return new SimpleDateFormat(format).format(date);
     }
 
-    private SpiderHtmlFormParser createSpiderHtmlFormParser() {
+    private static SpiderHtmlFormParser createSpiderHtmlFormParser() {
         return createSpiderHtmlFormParser(new DefaultValueGenerator());
     }
 
-    private SpiderHtmlFormParser createSpiderHtmlFormParser(ValueGenerator valueGenerator) {
+    private static SpiderHtmlFormParser createSpiderHtmlFormParser(ValueGenerator valueGenerator) {
         SpiderParam spiderOptions = createSpiderParamWithConfig();
         spiderOptions.setProcessForm(true);
         spiderOptions.setPostForm(true);

--- a/test/org/zaproxy/zap/users/UserUnitTest.java
+++ b/test/org/zaproxy/zap/users/UserUnitTest.java
@@ -94,7 +94,6 @@ public class UserUnitTest {
 		assertEquals(user.getContextId(), result.getContextId());
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void shouldGenerateUniqueIds() {
 		// Given

--- a/test/org/zaproxy/zap/users/UsersTableModelUnitTest.java
+++ b/test/org/zaproxy/zap/users/UsersTableModelUnitTest.java
@@ -469,7 +469,7 @@ public class UsersTableModelUnitTest extends TableModelTestUtils {
         return new User(1, name);
     }
 
-    private User createEnabledUser() {
+    private static User createEnabledUser() {
         User user = createUser();
         user.setEnabled(true);
         return user;

--- a/test/org/zaproxy/zap/view/widgets/UsersListModelUnitTest.java
+++ b/test/org/zaproxy/zap/view/widgets/UsersListModelUnitTest.java
@@ -108,7 +108,7 @@ public class UsersListModelUnitTest extends ListModelTestUtils {
         UsersListModel usersListModel = new UsersListModel(createUsersTableModel(0));
         usersListModel.setCustomUsers(new User[] { createUser(), createUser() });
         // When
-        User user = usersListModel.getElementAt(2);
+        usersListModel.getElementAt(2);
         // Then = ArrayIndexOutOfBoundsException
     }
 
@@ -654,7 +654,6 @@ public class UsersListModelUnitTest extends ListModelTestUtils {
         usersListModel.setSelectedItem(tableModel.getUsers().get(1));
         TestListDataListener listener = createTestListDataListener();
         usersListModel.addListDataListener(listener);
-        User user = createUser();
         // When
         tableModel.clear();
         // Then
@@ -694,7 +693,6 @@ public class UsersListModelUnitTest extends ListModelTestUtils {
         UsersListModel usersListModel = new UsersListModel(tableModel);
         TestListDataListener listener = createTestListDataListener();
         usersListModel.addListDataListener(listener);
-        User user = createUser();
         // When
         tableModel.clear();
         // Then
@@ -714,7 +712,6 @@ public class UsersListModelUnitTest extends ListModelTestUtils {
         usersListModel.setSelectedItem(tableModel.getUsers().get(1));
         TestListDataListener listener = createTestListDataListener();
         usersListModel.addListDataListener(listener);
-        User user = createUser();
         // When
         tableModel.removeElement(1);
         // Then
@@ -753,7 +750,6 @@ public class UsersListModelUnitTest extends ListModelTestUtils {
         usersListModel.setSelectedItem(tableModel.getUsers().get(1));
         TestListDataListener listener = createTestListDataListener();
         usersListModel.addListDataListener(listener);
-        User user = createUser();
         // When
         tableModel.removeElement(0);
         // Then
@@ -771,7 +767,6 @@ public class UsersListModelUnitTest extends ListModelTestUtils {
         UsersListModel usersListModel = new UsersListModel(tableModel);
         TestListDataListener listener = createTestListDataListener();
         usersListModel.addListDataListener(listener);
-        User user = createUser();
         // When
         tableModel.removeElement(0);
         // Then


### PR DESCRIPTION
Remove unused variables and unnecessary warning suppression.
Make some helper methods static and use try-with-resource statement in
one of them.
Correct variable used in credentials test, when checking the with null
password.