### PR TITLE
Don't require lang dir on the classpath

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry including="Messages*.properties" kind="src" path="lang"/>
 	<classpathentry kind="src" path="test/resources"/>
 	<classpathentry excluding="resources/" kind="src" path="test"/>
 	<classpathentry kind="lib" path="lib/orange-extensions-1.3.0.jar"/>

--- a/.project
+++ b/.project
@@ -14,11 +14,4 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<linkedResources>
-		<link>
-			<name>lang</name>
-			<type>2</type>
-			<locationURI>PROJECT_LOC/src/lang</locationURI>
-		</link>
-	</linkedResources>
 </projectDescription>

--- a/build/build.xml
+++ b/build/build.xml
@@ -210,7 +210,6 @@
 				<fileset dir="${dist}/lib">
 					<include name="**/*.jar" />
 				</fileset>
-				<path location="${dist}/lang/" />
 			</classpath>
 		</manifestclasspath>
 


### PR DESCRIPTION
Change I18N to use a custom class loader when obtaining the resource
bundle from file system (lang dir) to make it easier to run ZAP directly
from source (no longer needs extra configurations to include the lang
dir).
Remove the lang dir from Eclipse project files and from JAR manifest.