### PR TITLE
Address compilation warnings with Java 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ jdk:
   - oraclejdk8
   - openjdk8
   - oraclejdk9
+  - oraclejdk10
 
 env:
   global:

--- a/src/org/parosproxy/paros/extension/ViewDelegate.java
+++ b/src/org/parosproxy/paros/extension/ViewDelegate.java
@@ -26,8 +26,11 @@
 // ZAP: 2016/03/22 Allow to remove ContextPanelFactory
 // ZAP: 2016/04/14 Allow to display a message
 // ZAP: 2017/10/20 Allow to obtain default delete keyboard shortcut (Issue 3626).
+// ZAP: 2018/07/17 Allow to obtain a KeyStroke with menu shortcut key mask.
 
 package org.parosproxy.paros.extension;
+
+import java.awt.Toolkit;
 
 import javax.swing.KeyStroke;
 
@@ -113,4 +116,20 @@ public interface ViewDelegate {
      * @since 2.7.0
      */
     KeyStroke getDefaultDeleteKeyStroke();
+
+    /**
+     * Convenience method that returns a key stroke with the menu shortcut key mask already applied along with the given values.
+     * 
+     * @param keyCode the keyboard key.
+     * @param modifiers the key modifiers.
+     * @param onKeyRelease {@code true} if on key release, {@code false} otherwise.
+     * @return the KeyStroke.
+     * @since TODO add version
+     * @see KeyStroke#getKeyStroke(int, int, boolean)
+     */
+    @SuppressWarnings("deprecation")
+    default KeyStroke getMenuShortcutKeyStroke(int keyCode, int modifiers, boolean onKeyRelease) {
+        // XXX Use getMenuShortcutKeyMaskEx() (and remove warn suppression) when targeting Java 10+
+        return KeyStroke.getKeyStroke(keyCode, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | modifiers, onKeyRelease);
+    }
 }

--- a/src/org/parosproxy/paros/extension/edit/ExtensionEdit.java
+++ b/src/org/parosproxy/paros/extension/edit/ExtensionEdit.java
@@ -29,10 +29,10 @@
 // ZAP: 2017/07/22 Added KeyStroke constant for consistency with other FindDialog usage
 // ZAP: 2017/08/10 Issue 3798: java.awt.Toolkit initialised in daemon mode
 // ZAP: 2017/10/18 Use Window for parent of invoked component.
+// ZAP: 2018/07/17 Use ViewDelegate.getMenuShortcutKeyStroke.
 
 package org.parosproxy.paros.extension.edit;
 
-import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.KeyEvent;
 
@@ -44,6 +44,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.view.FindDialog;
+import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.ZapMenuItem;
 
 public class ExtensionEdit extends ExtensionAdaptor {
@@ -119,8 +120,7 @@ public class ExtensionEdit extends ExtensionAdaptor {
      */
     public static KeyStroke getFindDefaultKeyStroke() {
         if (findDefaultKeyStroke == null) {
-            findDefaultKeyStroke = KeyStroke
-                    .getKeyStroke(KeyEvent.VK_F, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false);
+            findDefaultKeyStroke = View.getSingleton().getMenuShortcutKeyStroke(KeyEvent.VK_F, 0, false);
         }
         return findDefaultKeyStroke;
     }

--- a/src/org/parosproxy/paros/extension/history/LogPanel.java
+++ b/src/org/parosproxy/paros/extension/history/LogPanel.java
@@ -45,12 +45,12 @@
 // ZAP: 2017/09/02 Use KeyEvent instead of Event (deprecated in Java 9).
 // ZAP: 2017/10/20 Add action/shortcut to delete history entries (Issue 3626).
 // ZAP: 2018/01/29 Make getHistoryReferenceTable protected (Issue 4000).
+// ZAP: 2018/07/17 Use ViewDelegate.getMenuShortcutKeyStroke.
 
 package org.parosproxy.paros.extension.history;
 
 import java.awt.BorderLayout;
 import java.awt.GridBagConstraints;
-import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.util.List;
@@ -61,7 +61,6 @@ import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JToggleButton;
 import javax.swing.JTree;
-import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
@@ -135,7 +134,7 @@ public class LogPanel extends AbstractPanel {
 	    }
 		this.add(getHistoryPanel(), java.awt.BorderLayout.CENTER);
 		
-		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_H, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
+		this.setDefaultAccelerator(view.getMenuShortcutKeyStroke(KeyEvent.VK_H, KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("history.panel.mnemonic"));
 		
 	}

--- a/src/org/parosproxy/paros/extension/manualrequest/http/impl/ManualHttpRequestEditorDialog.java
+++ b/src/org/parosproxy/paros/extension/manualrequest/http/impl/ManualHttpRequestEditorDialog.java
@@ -25,13 +25,13 @@
 // ZAP: 2015/08/07 Issue 1768: Update to use a more recent default user agent
 // ZAP: 2017/08/10 Issue 3798: java.awt.Toolkit initialised in daemon mode
 // ZAP: 2018/02/14 Remove unnecessary boxing / unboxing
+// ZAP: 2018/07/17 Use ViewDelegate.getMenuShortcutKeyStroke.
 
 package org.parosproxy.paros.extension.manualrequest.http.impl;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.HeadlessException;
-import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -46,7 +46,6 @@ import javax.swing.JSplitPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
-import javax.swing.KeyStroke;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
@@ -60,6 +59,7 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.PersistentConnectionListener;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
 import org.zaproxy.zap.extension.httppanel.HttpPanel;
@@ -260,7 +260,7 @@ public class ManualHttpRequestEditorDialog extends ManualRequestEditorDialog imp
 	public ZapMenuItem getMenuItem() {
 		if (menuItem == null) {
 			menuItem = new ZapMenuItem("menu.tools.manReq",
-					KeyStroke.getKeyStroke(KeyEvent.VK_M, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
+					View.getSingleton().getMenuShortcutKeyStroke(KeyEvent.VK_M, 0, false));
 			menuItem.addActionListener(new ActionListener() {
 				@Override
 				public void actionPerformed(ActionEvent e) {

--- a/src/org/parosproxy/paros/view/MainMenuBar.java
+++ b/src/org/parosproxy/paros/view/MainMenuBar.java
@@ -32,19 +32,18 @@
 // ZAP: 2017/05/10 Issue 3460: Add Show Support Info help menuitem
 // ZAP: 2017/06/27 Issue 2375: Added option to change ZAP mode in edit menu
 // ZAP: 2017/09/02 Use KeyEvent instead of Event (deprecated in Java 9).
+// ZAP: 2018/07/17 Use ViewDelegate.getMenuShortcutKeyStroke.
 
 package org.parosproxy.paros.view;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
 import javax.swing.JOptionPane;
-import javax.swing.KeyStroke;
 import javax.swing.JRadioButtonMenuItem;
 import javax.swing.JMenuItem;
 import javax.swing.ButtonGroup;
@@ -224,7 +223,7 @@ public class MainMenuBar extends JMenuBar {
 	private ZapMenuItem getMenuToolsOptions() {
 		if (menuToolsOptions == null) {
 			menuToolsOptions = new ZapMenuItem("menu.tools.options",
-					KeyStroke.getKeyStroke(KeyEvent.VK_O, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK, false));
+					View.getSingleton().getMenuShortcutKeyStroke(KeyEvent.VK_O, KeyEvent.ALT_DOWN_MASK, false));
 			menuToolsOptions.addActionListener(new java.awt.event.ActionListener() { 
 				@Override
 				public void actionPerformed(java.awt.event.ActionEvent e) {    
@@ -283,7 +282,7 @@ public class MainMenuBar extends JMenuBar {
 	private javax.swing.JMenuItem getMenuFileNewSession() {
 		if (menuFileNewSession == null) {
 			menuFileNewSession = new ZapMenuItem("menu.file.newSession",
-					KeyStroke.getKeyStroke(KeyEvent.VK_N, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
+					View.getSingleton().getMenuShortcutKeyStroke(KeyEvent.VK_N, 0, false));
 			menuFileNewSession.addActionListener(new java.awt.event.ActionListener() { 
 				@Override
 				public void actionPerformed(java.awt.event.ActionEvent e) {    
@@ -311,7 +310,7 @@ public class MainMenuBar extends JMenuBar {
 	private javax.swing.JMenuItem getMenuFileOpen() {
 		if (menuFileOpen == null) {
 			menuFileOpen = new ZapMenuItem("menu.file.openSession",
-					KeyStroke.getKeyStroke(KeyEvent.VK_O, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
+					View.getSingleton().getMenuShortcutKeyStroke(KeyEvent.VK_O, 0, false));
 			menuFileOpen.addActionListener(new java.awt.event.ActionListener() { 
 				@Override
 				public void actionPerformed(java.awt.event.ActionEvent e) {
@@ -433,7 +432,7 @@ public class MainMenuBar extends JMenuBar {
 	private ZapMenuItem getMenuFileProperties() {
 		if (menuFileProperties == null) {
 			menuFileProperties = new ZapMenuItem("menu.file.properties",
-					KeyStroke.getKeyStroke(KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK, false));
+					View.getSingleton().getMenuShortcutKeyStroke(KeyEvent.VK_P, KeyEvent.ALT_DOWN_MASK, false));
 			menuFileProperties.setText(Constant.messages.getString("menu.file.properties")); // ZAP: i18n
 			menuFileProperties.addActionListener(new java.awt.event.ActionListener() { 
 				@Override

--- a/src/org/parosproxy/paros/view/OutputPanel.java
+++ b/src/org/parosproxy/paros/view/OutputPanel.java
@@ -28,13 +28,13 @@
 // ZAP: 2015/02/10 Issue 1528: Support user defined font size
 // ZAP: 2017/02/20 Issue 3221: Some icons not scaled correctly
 // ZAP: 2017/09/02 Use KeyEvent instead of Event (deprecated in Java 9).
+// ZAP: 2018/07/17 Use ViewDelegate.getMenuShortcutKeyStroke.
 
 package org.parosproxy.paros.view;
 
 
 import java.awt.BorderLayout;
 import java.awt.EventQueue;
-import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 
 import javax.swing.ImageIcon;
@@ -42,7 +42,6 @@ import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JToolBar;
-import javax.swing.KeyStroke;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.log4j.Logger;
@@ -84,7 +83,7 @@ public class OutputPanel extends AbstractPanel {
 	    }
         // ZAP: Added Output (doc) icon
 		this.setIcon(new ImageIcon(OutputPanel.class.getResource("/resource/icon/16/172.png")));	// 'doc' icon
-		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
+		this.setDefaultAccelerator(View.getSingleton().getMenuShortcutKeyStroke(KeyEvent.VK_O, KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("output.panel.mnemonic"));
 
         this.add(getMainPanel(), BorderLayout.CENTER);

--- a/src/org/parosproxy/paros/view/SiteMapPanel.java
+++ b/src/org/parosproxy/paros/view/SiteMapPanel.java
@@ -46,6 +46,7 @@
 // ZAP: 2017/12/22 Select context on row click.
 // ZAP: 2018/03/26 Expand node of selected context.
 // ZAP: 2018/04/12 Keep panel of selected context selected.
+// ZAP: 2018/07/17 Use ViewDelegate.getMenuShortcutKeyStroke.
 
 package org.parosproxy.paros.view;
 
@@ -55,7 +56,6 @@ import java.awt.EventQueue;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.util.ArrayList;
@@ -158,7 +158,7 @@ public class SiteMapPanel extends AbstractPanel {
 		this.setHideable(false);
 	    this.setIcon(new ImageIcon(View.class.getResource("/resource/icon/16/094.png")));
 	    this.setName(Constant.messages.getString("sites.panel.title"));
-		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
+		this.setDefaultAccelerator(getView().getMenuShortcutKeyStroke(KeyEvent.VK_S, KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("sites.panel.mnemonic"));
 
 	    if (Model.getSingleton().getOptionsParam().getViewParam().getWmUiHandlingOption() == 0) {

--- a/src/org/parosproxy/paros/view/View.java
+++ b/src/org/parosproxy/paros/view/View.java
@@ -78,11 +78,11 @@
 // ZAP: 2018/01/08 Expand first context added.
 // ZAP: 2018/03/30 Check if resource message exists (for changes in I18N).
 // ZAP: 2018/07/13 Added canGetFocus option
+// ZAP: 2018/07/17 Use getMenuShortcutKeyStroke.
 
 package org.parosproxy.paros.view;
 
 import java.awt.Component;
-import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -627,8 +627,7 @@ public class View implements ViewDelegate {
             requestPanel.setName(Constant.messages.getString("http.panel.request.title"));	// ZAP: i18n
             requestPanel.setEnableViewSelect(true);
             requestPanel.loadConfig(Model.getSingleton().getOptionsParam().getConfig());
-            requestPanel.setDefaultAccelerator(KeyStroke.getKeyStroke(
-                    KeyEvent.VK_R, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
+            requestPanel.setDefaultAccelerator(getMenuShortcutKeyStroke(KeyEvent.VK_R, KeyEvent.SHIFT_DOWN_MASK, false));
             requestPanel.setMnemonic(Constant.messages.getChar("http.panel.request.mnemonic"));
 
         }
@@ -645,8 +644,8 @@ public class View implements ViewDelegate {
             responsePanel.setName(Constant.messages.getString("http.panel.response.title"));	// ZAP: i18n
             responsePanel.setEnableViewSelect(false);
             responsePanel.loadConfig(Model.getSingleton().getOptionsParam().getConfig());
-            responsePanel.setDefaultAccelerator(KeyStroke.getKeyStroke(
-                    KeyEvent.VK_R, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
+            responsePanel.setDefaultAccelerator(
+                    getMenuShortcutKeyStroke(KeyEvent.VK_R, KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
             responsePanel.setMnemonic(Constant.messages.getChar("http.panel.response.mnemonic"));
         }
         return responsePanel;

--- a/src/org/zaproxy/zap/extension/alert/AlertPanel.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertPanel.java
@@ -27,7 +27,6 @@ import java.awt.EventQueue;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Point;
-import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -50,7 +49,6 @@ import javax.swing.JSplitPane;
 import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
 import javax.swing.JTree;
-import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
@@ -166,7 +164,7 @@ public class AlertPanel extends AbstractPanel {
 
         this.add(getPanelCommand(), getPanelCommand().getName());
 			
-		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_A, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
+		this.setDefaultAccelerator(view.getMenuShortcutKeyStroke(KeyEvent.VK_A, KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("alerts.panel.mnemonic"));
 		this.setShowByDefault(true);
 	}

--- a/src/org/zaproxy/zap/extension/ascan/ActiveScanPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScanPanel.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.ascan;
 
 import java.awt.EventQueue;
-import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -32,7 +31,6 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
 import javax.swing.JToolBar;
-import javax.swing.KeyStroke;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -92,8 +90,8 @@ public class ActiveScanPanel extends ScanPanel2<ActiveScan, ScanController<Activ
     	// 'fire' icon
         super("ascan", new ImageIcon(ActiveScanPanel.class.getResource("/resource/icon/16/093.png")), extension);
         this.extension = extension;
-		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
-				KeyEvent.VK_A, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
+		this.setDefaultAccelerator(extension.getView().getMenuShortcutKeyStroke(
+				KeyEvent.VK_A, KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("ascan.panel.mnemonic"));
     }
 

--- a/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/src/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.extension.ascan;
 
 import java.awt.Dimension;
 import java.awt.EventQueue;
-import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
@@ -36,7 +35,6 @@ import java.util.List;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JOptionPane;
-import javax.swing.KeyStroke;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.log4j.Logger;
@@ -308,7 +306,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
     private ZapMenuItem getMenuItemPolicy() {
         if (menuItemPolicy == null) {
             menuItemPolicy = new ZapMenuItem("menu.analyse.scanPolicy",
-                    KeyStroke.getKeyStroke(KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
+                    getView().getMenuShortcutKeyStroke(KeyEvent.VK_P, 0, false));
 
             menuItemPolicy.addActionListener(new java.awt.event.ActionListener() {
                 @Override
@@ -354,7 +352,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor implements
     private ZapMenuItem getMenuItemCustomScan() {
         if (menuItemCustomScan == null) {
             menuItemCustomScan = new ZapMenuItem("menu.tools.ascanadv",
-                    KeyStroke.getKeyStroke(KeyEvent.VK_A, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK, false));
+                    getView().getMenuShortcutKeyStroke(KeyEvent.VK_A, KeyEvent.ALT_DOWN_MASK, false));
             menuItemCustomScan.setEnabled(Control.getSingleton().getMode() != Mode.safe);
 
             menuItemCustomScan.addActionListener(e -> showCustomScanDialog((Target) null));

--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.autoupdate;
 import java.awt.EventQueue;
-import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -50,7 +49,6 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
-import javax.swing.KeyStroke;
 import javax.swing.SwingWorker;
 import javax.swing.filechooser.FileFilter;
 
@@ -197,7 +195,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 	private ZapMenuItem getMenuItemCheckUpdate() {
 		if (menuItemCheckUpdate == null) {
 			menuItemCheckUpdate = new ZapMenuItem("cfu.help.menu.check", 
-					KeyStroke.getKeyStroke(KeyEvent.VK_U, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
+					getView().getMenuShortcutKeyStroke(KeyEvent.VK_U, 0, false));
 			menuItemCheckUpdate.setText(Constant.messages.getString("cfu.help.menu.check"));
 			menuItemCheckUpdate.addActionListener(new java.awt.event.ActionListener() { 
 				@Override
@@ -213,7 +211,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 	private ZapMenuItem getMenuItemLoadAddOn() {
 		if (menuItemLoadAddOn == null) {
 			menuItemLoadAddOn = new ZapMenuItem("cfu.file.menu.loadaddon", 
-					KeyStroke.getKeyStroke(KeyEvent.VK_L, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
+					getView().getMenuShortcutKeyStroke(KeyEvent.VK_L, 0, false));
 			menuItemLoadAddOn.addActionListener(new java.awt.event.ActionListener() { 
 				@Override
 				public void actionPerformed(java.awt.event.ActionEvent e) {

--- a/src/org/zaproxy/zap/extension/brk/BreakPanel.java
+++ b/src/org/zaproxy/zap/extension/brk/BreakPanel.java
@@ -23,7 +23,6 @@ package org.zaproxy.zap.extension.brk;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.EventQueue;
-import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 
 import javax.swing.BorderFactory;
@@ -34,7 +33,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
-import javax.swing.KeyStroke;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -114,7 +112,7 @@ public class BreakPanel extends AbstractPanel implements Tab, BreakpointManageme
 		
 		this.setIcon(new ImageIcon(BreakPanel.class.getResource("/resource/icon/16/101grey.png")));	// 'grey X' icon
 
-		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_B, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
+		this.setDefaultAccelerator(extension.getView().getMenuShortcutKeyStroke(KeyEvent.VK_B, KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("brk.panel.mnemonic"));
 		
 		this.setLayout(new BorderLayout());

--- a/src/org/zaproxy/zap/extension/brk/BreakpointsPanel.java
+++ b/src/org/zaproxy/zap/extension/brk/BreakpointsPanel.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.extension.brk;
 import java.awt.CardLayout;
 import java.awt.EventQueue;
 import java.awt.GridBagConstraints;
-import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -31,7 +30,6 @@ import java.util.prefs.Preferences;
 
 import javax.swing.ImageIcon;
 import javax.swing.JScrollPane;
-import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import javax.swing.table.TableColumn;
 
@@ -75,8 +73,8 @@ public class BreakpointsPanel extends AbstractPanel {
         this.setSize(474, 251);
         this.setName(Constant.messages.getString("brk.panel.title"));
 		this.setIcon(new ImageIcon(BreakpointsPanel.class.getResource("/resource/icon/16/101.png")));	// 'red X' icon
-		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
-				KeyEvent.VK_B, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
+		this.setDefaultAccelerator(extension.getView().getMenuShortcutKeyStroke(
+				KeyEvent.VK_B, KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("brk.panel.mnemonic"));
         this.add(getPanelCommand(), getPanelCommand().getName());
 	}

--- a/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
+++ b/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.extension.brk;
 
 import java.awt.Component;
 import java.awt.EventQueue;
-import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -34,7 +33,6 @@ import java.util.Map;
 
 import javax.swing.JList;
 import javax.swing.JTree;
-import javax.swing.KeyStroke;
 import javax.swing.tree.TreePath;
 
 import org.apache.log4j.Logger;
@@ -359,7 +357,7 @@ public class ExtensionBreak extends ExtensionAdaptor implements SessionChangedLi
     private ZapMenuItem getMenuToggleBreakOnRequests() {
         if (menuBreakOnRequests == null) {
             menuBreakOnRequests = new ZapMenuItem("menu.tools.brk.req",
-            		KeyStroke.getKeyStroke(KeyEvent.VK_B, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
+            		getView().getMenuShortcutKeyStroke(KeyEvent.VK_B, 0, false));
             menuBreakOnRequests.addActionListener(new java.awt.event.ActionListener() {
                 @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
@@ -379,7 +377,7 @@ public class ExtensionBreak extends ExtensionAdaptor implements SessionChangedLi
     private ZapMenuItem getMenuToggleBreakOnResponses() {
         if (menuBreakOnResponses == null) {
             menuBreakOnResponses = new ZapMenuItem("menu.tools.brk.resp",
-            		KeyStroke.getKeyStroke(KeyEvent.VK_B, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK, false));
+            		getView().getMenuShortcutKeyStroke(KeyEvent.VK_B, KeyEvent.ALT_DOWN_MASK, false));
             menuBreakOnResponses.addActionListener(new java.awt.event.ActionListener() {
                 @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
@@ -399,7 +397,7 @@ public class ExtensionBreak extends ExtensionAdaptor implements SessionChangedLi
     private ZapMenuItem getMenuStep() {
         if (menuStep == null) {
             menuStep = new ZapMenuItem("menu.tools.brk.step",
-            		KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
+            		getView().getMenuShortcutKeyStroke(KeyEvent.VK_S, 0, false));
             menuStep.addActionListener(new java.awt.event.ActionListener() {
                 @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
@@ -416,7 +414,7 @@ public class ExtensionBreak extends ExtensionAdaptor implements SessionChangedLi
     private ZapMenuItem getMenuContinue() {
         if (menuContinue == null) {
             menuContinue = new ZapMenuItem("menu.tools.brk.cont",
-            		KeyStroke.getKeyStroke(KeyEvent.VK_C, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
+            		getView().getMenuShortcutKeyStroke(KeyEvent.VK_C, 0, false));
             menuContinue.addActionListener(new java.awt.event.ActionListener() {
                 @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
@@ -433,7 +431,7 @@ public class ExtensionBreak extends ExtensionAdaptor implements SessionChangedLi
     private ZapMenuItem getMenuDrop() {
         if (menuDrop == null) {
             menuDrop = new ZapMenuItem("menu.tools.brk.drop",
-            		KeyStroke.getKeyStroke(KeyEvent.VK_X, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
+            		getView().getMenuShortcutKeyStroke(KeyEvent.VK_X, 0, false));
             menuDrop.addActionListener(new java.awt.event.ActionListener() {
                 @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
@@ -450,7 +448,7 @@ public class ExtensionBreak extends ExtensionAdaptor implements SessionChangedLi
     private ZapMenuItem getMenuAddHttpBreakpoint() {
         if (menuHttpBreakpoint == null) {
         	menuHttpBreakpoint = new ZapMenuItem("menu.tools.brk.custom",
-            		KeyStroke.getKeyStroke(KeyEvent.VK_A, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
+            		getView().getMenuShortcutKeyStroke(KeyEvent.VK_A, 0, false));
         	menuHttpBreakpoint.addActionListener(new java.awt.event.ActionListener() {
                 @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {

--- a/src/org/zaproxy/zap/extension/encoder2/ExtensionEncoder2.java
+++ b/src/org/zaproxy/zap/extension/encoder2/ExtensionEncoder2.java
@@ -20,12 +20,10 @@
 package org.zaproxy.zap.extension.encoder2;
 
 import java.awt.Frame;
-import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import javax.swing.KeyStroke;
 import javax.swing.text.JTextComponent;
 
 import org.parosproxy.paros.Constant;
@@ -76,7 +74,7 @@ public class ExtensionEncoder2 extends ExtensionAdaptor implements OptionsChange
 	private ZapMenuItem getToolsMenuItemEncoder() {
 		if (toolsMenuEncoder == null) {
 			toolsMenuEncoder = new ZapMenuItem("enc2.tools.menu.encdec",
-					KeyStroke.getKeyStroke(KeyEvent.VK_E, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
+					getView().getMenuShortcutKeyStroke(KeyEvent.VK_E, 0, false));
 
 			toolsMenuEncoder.addActionListener(new java.awt.event.ActionListener() { 
 				@Override

--- a/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsPanel.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/HttpSessionsPanel.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.extension.httpsessions;
 import java.awt.CardLayout;
 import java.awt.EventQueue;
 import java.awt.GridBagConstraints;
-import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
@@ -37,7 +36,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JToolBar;
-import javax.swing.KeyStroke;
 
 import org.jdesktop.swingx.JXTable;
 import org.jdesktop.swingx.renderer.DefaultTableRenderer;
@@ -107,8 +105,8 @@ public class HttpSessionsPanel extends AbstractPanel {
 		this.setSize(474, 251);
 		this.setName(Constant.messages.getString("httpsessions.panel.title"));
 		this.setIcon(new ImageIcon(HttpSessionsPanel.class.getResource("/resource/icon/16/session.png")));
-		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
-				KeyEvent.VK_H, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
+		this.setDefaultAccelerator(extension.getView().getMenuShortcutKeyStroke(
+				KeyEvent.VK_H, KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("httpsessions.panel.mnemonic"));
 		this.add(getPanelCommand(), getPanelCommand().getName());
 	}

--- a/src/org/zaproxy/zap/extension/params/ParamsPanel.java
+++ b/src/org/zaproxy/zap/extension/params/ParamsPanel.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.extension.params;
 import java.awt.CardLayout;
 import java.awt.Component;
 import java.awt.GridBagConstraints;
-import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import javax.swing.ImageIcon;
 import javax.swing.JComboBox;
@@ -30,7 +29,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JToolBar;
-import javax.swing.KeyStroke;
 import javax.swing.table.DefaultTableColumnModel;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
@@ -81,7 +79,7 @@ public class ParamsPanel extends AbstractPanel{
         this.setSize(474, 251);
         this.setName(Constant.messages.getString("params.panel.title"));
 		this.setIcon(new ImageIcon(ParamsPanel.class.getResource("/resource/icon/16/179.png")));	// 'form' icon
-		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
+		this.setDefaultAccelerator(extension.getView().getMenuShortcutKeyStroke(KeyEvent.VK_P, KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("params.panel.mnemonic"));
         this.add(getPanelCommand(), getPanelCommand().getName());
 	}

--- a/src/org/zaproxy/zap/extension/search/ExtensionSearch.java
+++ b/src/org/zaproxy/zap/extension/search/ExtensionSearch.java
@@ -20,14 +20,11 @@
 package org.zaproxy.zap.extension.search;
 
 import java.awt.EventQueue;
-import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
-
-import javax.swing.KeyStroke;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -212,7 +209,7 @@ public class ExtensionSearch extends ExtensionAdaptor {
 	private ZapMenuItem getMenuSearch() {
         if (menuSearch == null) {
         	menuSearch = new ZapMenuItem("menu.edit.search",
-        			KeyStroke.getKeyStroke(KeyEvent.VK_H, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
+        			getView().getMenuShortcutKeyStroke(KeyEvent.VK_H, 0, false));
 
         	menuSearch.addActionListener(new java.awt.event.ActionListener() {
                 @Override
@@ -227,7 +224,7 @@ public class ExtensionSearch extends ExtensionAdaptor {
     private ZapMenuItem getMenuNext() {
         if (menuNext == null) {
         	menuNext = new ZapMenuItem("menu.edit.next", 
-        			KeyStroke.getKeyStroke(KeyEvent.VK_G, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
+        			getView().getMenuShortcutKeyStroke(KeyEvent.VK_G, 0, false));
 
         	menuNext.addActionListener(new java.awt.event.ActionListener() {
                 @Override

--- a/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
+++ b/src/org/zaproxy/zap/extension/spider/ExtensionSpider.java
@@ -23,7 +23,6 @@ package org.zaproxy.zap.extension.spider;
 
 import java.awt.Dimension;
 import java.awt.EventQueue;
-import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -35,7 +34,6 @@ import java.util.List;
 
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
-import javax.swing.KeyStroke;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.lang.StringUtils;
@@ -817,7 +815,7 @@ public class ExtensionSpider extends ExtensionAdaptor implements SessionChangedL
     private ZapMenuItem getMenuItemCustomScan() {
         if (menuItemCustomScan  == null) {
             menuItemCustomScan = new ZapMenuItem("menu.tools.spider",
-                    KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK, false));
+                    getView().getMenuShortcutKeyStroke(KeyEvent.VK_S, KeyEvent.ALT_DOWN_MASK, false));
             menuItemCustomScan.setEnabled(Control.getSingleton().getMode() != Mode.safe);
 
             menuItemCustomScan.addActionListener(e -> showSpiderDialog((Target) null));

--- a/src/org/zaproxy/zap/extension/spider/SpiderPanel.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderPanel.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.extension.spider;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.EventQueue;
-import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -36,7 +35,6 @@ import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JToolBar;
-import javax.swing.KeyStroke;
 import javax.swing.ListSelectionModel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -210,8 +208,8 @@ public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderSca
 		});
 
 		this.extension = extension;
-		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
-				KeyEvent.VK_D, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
+		this.setDefaultAccelerator(
+				extension.getView().getMenuShortcutKeyStroke(KeyEvent.VK_D, KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("spider.panel.mnemonic"));
 
 	}


### PR DESCRIPTION
Address compilation warning with usage of ToolKit.getMenuShortcutKeyMask
by suppressing it (the new method is only available in Java 10).
Add a getter to ViewDelegate for KeyStroke with menu shortcut key mask,
to reduce the occurrences of the above method (and slightly reduce code
duplication).
Update codebase to use the new method.
Change .travis.yml to also run the build with Java 10.