### PR TITLE
Be more defensive when installing add-ons

### DIFF
--- a/src/org/zaproxy/zap/control/AddOnInstaller.java
+++ b/src/org/zaproxy/zap/control/AddOnInstaller.java
@@ -278,7 +278,8 @@ public final class AddOnInstaller {
             logger.debug("Starting extension " + ext.getName());
             try {
                 extensionLoader.startLifeCycle(ext);
-            } catch (Exception e) {
+            } catch (Throwable e) {
+                // Catch Throwable to (try) prevent extensions' issues from breaking the installation process.
                 logger.error("An error occurred while installing the add-on: " + addOn.getId(), e);
             }
         }


### PR DESCRIPTION
Change AddOnInstaller to catch Throwable when installing the extensions
of add-ons to prevent issues in those extensions from breaking the
installation process (e.g. a failure in one would prevent other add-ons
from being installed).

Related to #3944 - Update JRuby library