### PR TITLE
Include installation directory in support info

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -2350,6 +2350,7 @@ stdexts.copyurls.popup = Copy URLs to Clipboard
 stdexts.desc = A set of common popup menus for miscellaneous tasks
 
 support.home.directory.label = ZAP Home Directory:
+support.install.directory.label = ZAP Installation Directory:
 support.installed.addons.label = Installed Add-ons:
 support.java.version.label = Java Version:
 support.laf.label = Look and Feel:

--- a/src/org/zaproxy/zap/utils/ZapSupportUtils.java
+++ b/src/org/zaproxy/zap/utils/ZapSupportUtils.java
@@ -61,6 +61,16 @@ public final class ZapSupportUtils {
 		return Constant.messages.getString("support.home.directory.label") + " " + Constant.getZapHome();
 	}
 
+	/**
+	 * Gets the installation directory (preceded with the corresponding label).
+	 *
+	 * @return the installation directory
+	 * @since TODO add version
+	 */
+	public static String getZapInstallDirectory() {
+		return Constant.messages.getString("support.install.directory.label") + " " + Constant.getZapInstall();
+	}
+
 	public static String getOperatingSystem() {
 		return Constant.messages.getString("support.operating.system.label") + " " + System.getProperty("os.name");
 	}
@@ -128,6 +138,7 @@ public final class ZapSupportUtils {
 		supportDetailsBuilder.append(getLocaleDisplay()).append(NEWLINE);
 		supportDetailsBuilder.append(getLocaleFormat()).append(NEWLINE);
 		supportDetailsBuilder.append(getZapHomeDirectory()).append(NEWLINE);
+		supportDetailsBuilder.append(getZapInstallDirectory()).append(NEWLINE);
 		supportDetailsBuilder.append(getLookAndFeel()).append(NEWLINE);
 		
 		return supportDetailsBuilder.toString();


### PR DESCRIPTION
Change ZapSupportUtils to include the installation directory, easier and
quicker to know which directory ZAP is using.