### PR TITLE
Bundle DB script and ZAP/log configurations

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -157,7 +157,8 @@
 			<fileset dir="${src}/lang" includes="Messages.properties,vulnerabilities.xml" />
 			<fileset dir="${src}/license" includes="ApacheLicense-2.0.txt" />
 			<fileset dir="${src}" includes="xml/report*.xsl" />
-			<fileset dir="${src}/xml" includes="drivers.xml" />
+			<fileset dir="${src}/xml" includes="config.xml,drivers.xml,log4j.properties" />
+			<fileset dir="${src}/db" includes="zapdb.script" />
 		</copy>
 
 		<copy todir="${dist}/license">

--- a/test/org/zaproxy/zap/WithConfigsTest.java
+++ b/test/org/zaproxy/zap/WithConfigsTest.java
@@ -23,10 +23,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Locale;
 
 import org.junit.Before;
@@ -58,13 +54,7 @@ public abstract class WithConfigsTest extends TestUtils {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
-        File installDir = tempDir.newFolder("install");
-        Path xmlDir = Files.createDirectory(installDir.toPath().resolve("xml"));
-        Files.createFile(xmlDir.resolve("log4j.properties"));
-        Path configXmlPath = Files.createFile(xmlDir.resolve("config.xml"));
-        Files.write(configXmlPath, "<?xml version=\"1.0\" encoding=\"UTF-8\"?><config></config>".getBytes(StandardCharsets.UTF_8));
-
-        zapInstallDir = installDir.getAbsolutePath();
+        zapInstallDir = tempDir.newFolder("install").getAbsolutePath();
         zapHomeDir = tempDir.newFolder("home").getAbsolutePath();
     }
 


### PR DESCRIPTION
Change Constant to fallback to the bundled config.xml/log4j.properties
files if not found in the file system.
Change Modal to fallback to the bundled zapdb.script.
Change build.xml to include the above files.
Change WithConfigsTest to no longer create dummy ZAP/log configuration
files, it uses the ones bundled.

Fix #4771 - Bundle required files in the zap.jar