### PR TITLE
Add Java 11 to Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ script: ant -buildfile build/build.xml test
 jdk:
   - oraclejdk8
   - openjdk8
-  - oraclejdk9
-  - oraclejdk10
+  - openjdk11
 
 env:
   global:


### PR DESCRIPTION
Change .travis.yml to run the build with Java 11, also, remove Java 9
and 10 as they will be soon superseded by Java 11.