### PR TITLE
Delay initialisation of keyboard mappings

### DIFF
--- a/src/org/zaproxy/zap/extension/keyboard/ExtensionKeyboard.java
+++ b/src/org/zaproxy/zap/extension/keyboard/ExtensionKeyboard.java
@@ -48,13 +48,7 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
 	private KeyboardAPI api = null;
 
 	public ExtensionKeyboard() {
-		super();
-		initialize();
-	}
-
-	private void initialize() {
-        this.setName(NAME);
-        this.setOrder(2000);	// Really want this to be added late on
+		super(NAME);
 	}
 
 	@Override
@@ -83,7 +77,7 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
 	}
 
 	@Override
-	public void optionsLoaded() {
+	public void postInit() {
 		if (View.isInitialised()) {
 			logger.info("Initializing keyboard shortcuts");
 			initAllMenuItems(View.getSingleton().getMainFrame().getMainMenuBar().getMenuFile());


### PR DESCRIPTION
Change ExtensionKeyboard to initialise the keyboard mappings in postInit
(instead of optionsLoaded) to ensure other extensions are already loaded
and its menus added, otherwise the menus of unordered extensions or with
later order would not be properly registered and the shortcuts would not
be configurable, for example:
ERROR ExtensionKeyboard  - No mapping found for keyboard shortcut:
 - fuzz.menu.tools.fuzz
 - replacer.topmenu.tools.shortcut
 - help.menu.guide

Remove the order from the extension, it's no longer needed.