### PR TITLE
Ignore (and log) duplicated default accelerators

### DIFF
--- a/src/org/zaproxy/zap/extension/keyboard/KeyboardMapping.java
+++ b/src/org/zaproxy/zap/extension/keyboard/KeyboardMapping.java
@@ -63,6 +63,19 @@ class KeyboardMapping {
     	return null;
     }
 
+    /**
+     * Gets the default accelerator of the menu item.
+     *
+     * @return the default accelerator.
+     * @since TODO add version
+     */
+    public KeyStroke getDefaultKeyStroke() {
+        if (this.menuItem != null) {
+            return this.menuItem.getDefaultAccelerator();
+        }
+        return null;
+    }
+
     public String getKeyStrokeKeyCodeString() {
     	if (this.menuItem == null || this.menuItem.getAccelerator() == null) {
     		return "";


### PR DESCRIPTION
Change ExtensionKeyboard to ignore menu items with duplicated default
accelerators, also, log an error if in dev mode and warn otherwise.
Add method to obtain default accelerator from KeyboardMapping.

Part of #3519 - Keyboard Shortcuts Issue