### PR TITLE
Address some JavaDoc warns

### DIFF
--- a/src/org/apache/commons/httpclient/HttpConnection.java
+++ b/src/org/apache/commons/httpclient/HttpConnection.java
@@ -57,6 +57,7 @@ import org.apache.commons.logging.LogFactory;
  * 
  * Changes:
  *  - Removed the characters "$" from the previous SVN keywords (HeadURL, Revision and Date) to avoid accidental expansions.
+ *  - Address some JavaDoc warns.
  *  - Remove use of reflection to call Socket.shutdownOutput() in shutdownOutput(), not needed by minimum Java version targeted.
  *  - Add @Deprecated annotations to deprecated methods (by JavaDoc deprecated tag).
  *  - Change method tunnelCreated() to also create the tunnel if requested by calling code.
@@ -502,7 +503,7 @@ public class HttpConnection {
      *
      * <p>To avoid side-effects, the underlying connection is wrapped by a
      * {@link BufferedInputStream}, so although data might be read, what is visible
-     * to clients of the connection will not change with this call.</p.
+     * to clients of the connection will not change with this call.</p>.
      *
      * @throws IOException if the stale connection test is interrupted.
      * 

--- a/src/org/apache/commons/httpclient/HttpMethodBase.java
+++ b/src/org/apache/commons/httpclient/HttpMethodBase.java
@@ -61,6 +61,7 @@ import org.parosproxy.paros.network.HttpHeader;
  * 
  * Changes:
  *  - Removed the characters "$" from the previous SVN keywords (HeadURL, Revision and Date) to avoid accidental expansions.
+ *  - Address some JavaDoc warns.
  *  - Always add the "?" character to the request URI (Issue 1180) in the method #generateRequestLine(HttpConnection, String, 
  *  String, String, String) to preserve the intended request URI.
  *  - Change the way cookie headers are handled when using forced user mode, put all the headers in a single line see ISSUE 1874
@@ -218,7 +219,7 @@ public abstract class HttpMethodBase implements HttpMethod {
     /**
      * Constructor specifying a URI.
      * It is responsibility of the caller to ensure that URI elements
-     * (path & query parameters) are properly encoded (URL safe).
+     * (path &amp; query parameters) are properly encoded (URL safe).
      *
      * @param uri either an absolute or relative URI. The URI is expected
      *            to be URL-encoded

--- a/src/org/apache/commons/httpclient/URI.java
+++ b/src/org/apache/commons/httpclient/URI.java
@@ -51,6 +51,7 @@ import org.apache.commons.httpclient.util.EncodingUtil;
  * 
  * Changes:
  *  - Removed the characters "$" from the previous SVN keywords (HeadURL, Revision and Date) to avoid accidental expansions;
+ *  - Address some JavaDoc warns.
  *  - Add missing override and deprecated annotations;
  *  - Fix unchecked/rawtypes warnings (required by lint checks).
  *  - Allow to use underscores in hostnames.
@@ -84,7 +85,7 @@ import org.apache.commons.httpclient.util.EncodingUtil;
  * URI Syntactic Components
  * <p><blockquote><pre>
  * - In general, written as follows:
- *   Absolute URI = &lt;scheme&gt:&lt;scheme-specific-part&gt;
+ *   Absolute URI = &lt;scheme&gt;:&lt;scheme-specific-part&gt;
  *   Generic URI = &lt;scheme&gt;://&lt;authority&gt;&lt;path&gt;?&lt;query&gt;
  *
  * - Syntax
@@ -1671,7 +1672,7 @@ public class URI implements Cloneable, Comparable<Object>, Serializable {
      * This is a two mapping, one from original characters to octets, and
      * subsequently a second from octets to URI characters:
      * <p><blockquote><pre>
-     *   original character sequence->octet sequence->URI character sequence
+     *   original character sequence-&gt;octet sequence-&gt;URI character sequence
      * </pre></blockquote><p>
      *
      * An escaped octet is encoded as a character triplet, consisting of the
@@ -1719,7 +1720,7 @@ public class URI implements Cloneable, Comparable<Object>, Serializable {
      * This is a two mapping, one from URI characters to octets, and
      * subsequently a second from octets to original characters:
      * <p><blockquote><pre>
-     *   URI character sequence->octet sequence->original character sequence
+     *   URI character sequence-&gt;octet sequence-&gt;original character sequence
      * </pre></blockquote><p>
      *
      * A URI must be separated into its components before the escaped
@@ -1757,7 +1758,7 @@ public class URI implements Cloneable, Comparable<Object>, Serializable {
      * This is a two mapping, one from URI characters to octets, and
      * subsequently a second from octets to original characters:
      * <p><blockquote><pre>
-     *   URI character sequence->octet sequence->original character sequence
+     *   URI character sequence-&gt;octet sequence-&gt;original character sequence
      * </pre></blockquote><p>
      *
      * A URI must be separated into its components before the escaped

--- a/src/org/parosproxy/paros/core/scanner/VariantDdnPath.java
+++ b/src/org/parosproxy/paros/core/scanner/VariantDdnPath.java
@@ -33,7 +33,7 @@ import org.zaproxy.zap.model.SessionStructure;
 
 /**
  * Variant class used for URL path elements that are defined as Data Driven Nodes.
- * For a URL like: http://www.example.com/aaa/bbb/ccc?ddd=eee&fff=ggg
+ * For a URL like: {@literal http://www.example.com/aaa/bbb/ccc?ddd=eee&fff=ggg}
  * parameter	position
  *      aaa     1
  *      bbb     2
@@ -42,8 +42,8 @@ import org.zaproxy.zap.model.SessionStructure;
  *      https://www.example.com/en-US/container/item/itemA
  *      https://www.example.com/en-US/container/item/itemB
  * Defined as:
- *      https://www.example.com/en-US/container/item/<<DDN1>>
- * Test/inject <<DDN1>>
+ *      {@literal https://www.example.com/en-US/container/item/<<DDN1>>}
+ * Test/inject {@literal <<DDN1>>}
  */
 public class VariantDdnPath implements Variant {
 

--- a/src/org/parosproxy/paros/core/scanner/VariantODataIdQuery.java
+++ b/src/org/parosproxy/paros/core/scanner/VariantODataIdQuery.java
@@ -33,7 +33,7 @@ import org.parosproxy.paros.network.HttpMessage;
  * It's focused on OData v2
  *
  * Example of query having a single unnamed id:<br/>
- * http://services.odata.org/OData/OData.svc/Category(1)/Products?$top=2&$orderby=name
+ * {@literal http://services.odata.org/OData/OData.svc/Category(1)/Products?$top=2&$orderby=name}
  * <p/>
  * Example of query having a composite (named) id:<br/>
  * http://services.odata.org/OData/OData.svc/DisplayItem(key1=2L,key2='B0EB1CA')

--- a/src/org/parosproxy/paros/core/scanner/VariantURLPath.java
+++ b/src/org/parosproxy/paros/core/scanner/VariantURLPath.java
@@ -32,7 +32,7 @@ import org.parosproxy.paros.network.HttpMessage;
 
 /**
  * Variant class used for URL path elements. For a URL like:
- * http://www.example.com/aaa/bbb/ccc?ddd=eee&fff=ggg it will handle: aaa, bbb
+ * {@literal http://www.example.com/aaa/bbb/ccc?ddd=eee&fff=ggg} it will handle: aaa, bbb
  * and ccc
  *
  * @author psiinon

--- a/src/org/parosproxy/paros/extension/option/DatabaseParam.java
+++ b/src/org/parosproxy/paros/extension/option/DatabaseParam.java
@@ -258,7 +258,7 @@ public class DatabaseParam extends AbstractParam {
 	 * 
 	 * @return {@code true} if database's recovery log is enabled, {@code false} otherwise
 	 * @see #setRecoveryLogEnabled(boolean)
-	 * @version 2.5.0
+	 * @since 2.5.0
 	 */
 	public boolean isRecoveryLogEnabled() {
 		return recoveryLogEnabled;
@@ -269,7 +269,7 @@ public class DatabaseParam extends AbstractParam {
 	 * 
 	 * @param enabled {@code true} if database's recovery log should be enabled, {@code false} otherwise
 	 * @see #isRecoveryLogEnabled()
-	 * @version 2.5.0
+	 * @since 2.5.0
 	 */
 	public void setRecoveryLogEnabled(boolean enabled) {
 		this.recoveryLogEnabled = enabled;

--- a/src/org/parosproxy/paros/network/HttpStatusCode.java
+++ b/src/org/parosproxy/paros/network/HttpStatusCode.java
@@ -19,6 +19,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
+// ZAP: 2018/07/27 Address JavaDoc warns.
 package org.parosproxy.paros.network;
 
 public final class HttpStatusCode {
@@ -86,7 +87,7 @@ public final class HttpStatusCode {
 		GATEWAY_TIEMOUT, HTTP_VERSION_NOT_SUPPORTED};
 	
 	/**
-	 * Check if a status code is informational.  (100 <= status < 200)
+	 * Check if a status code is informational.  (100 &le; status &lt; 200)
 	 * @param statusCode
 	 * @return true if informational
 	 */
@@ -99,7 +100,7 @@ public final class HttpStatusCode {
 
 
 	/**
-	 * Check if a HTTP status code is successful.  (200 <= status < 300)
+	 * Check if a HTTP status code is successful.  (200 &le; status &lt; 300)
 	 * @param statusCode
 	 * @return
 	 */
@@ -111,7 +112,7 @@ public final class HttpStatusCode {
 	}
 
 	/**
-	 * Check if a HTTP status code is redirection.  (300 <= status < 400)
+	 * Check if a HTTP status code is redirection.  (300 &le; status &lt; 400)
 	 * @param statusCode
 	 * @return
 	 */
@@ -124,7 +125,7 @@ public final class HttpStatusCode {
 	}
 
 	/**
-	 * Check if a HTTP status code is client error (400 <= status <500)
+	 * Check if a HTTP status code is client error (400 &le; status &lt; 500)
 	 * @param statusCode
 	 * @return
 	 */
@@ -136,7 +137,7 @@ public final class HttpStatusCode {
 	}
 
 	/**
-	 * Check if a HTTP status code is server error (500 <= status)
+	 * Check if a HTTP status code is server error (500 &le; status)
 	 * @param statusCode
 	 * @return
 	 */

--- a/src/org/parosproxy/paros/network/SSLConnector.java
+++ b/src/org/parosproxy/paros/network/SSLConnector.java
@@ -259,7 +259,7 @@ public class SSLConnector implements SecureProtocolSocketFactory {
 
 
 	/**
-	 * @deprecated (2.3.0) No longer supported since it's no longer required/called by Commons HttpClient library (version >= 
+	 * @deprecated (2.3.0) No longer supported since it's no longer required/called by Commons HttpClient library (version &ge;
 	 *             3.0). Throws {@code UnsupportedOperationException}.
 	 */
 	@Override
@@ -488,7 +488,7 @@ public class SSLConnector implements SecureProtocolSocketFactory {
 	}
 
 	/**
-	 * @deprecated (2.3.0) No longer supported since it's no longer required/called by Commons HttpClient library (version >= 
+	 * @deprecated (2.3.0) No longer supported since it's no longer required/called by Commons HttpClient library (version &ge;
 	 *             3.0). Throws {@code UnsupportedOperationException}.
 	 */
 	@Override


### PR DESCRIPTION
Address warnings "invalid usage of tag" by using the HTML entity or
literal tag.
Correct tag used in some methods, since instead of version.