### PR TITLE
Tweak log on missing file with user agents

### DIFF
--- a/src/org/zaproxy/zap/model/CommonUserAgents.java
+++ b/src/org/zaproxy/zap/model/CommonUserAgents.java
@@ -65,7 +65,7 @@ public class CommonUserAgents {
 				logger.error(e.getMessage(), e);
 			}
 		} else {
-			logger.error("Failed to read common user agents from " + f.getAbsolutePath());
+			logger.info("No common user agents will be suggested, file does not exist: " + f.getAbsolutePath());
 		}
 	}
 	


### PR DESCRIPTION
Change CommonUserAgents to reduce the level (from error to info) and
tweak the message when the file with common user agents is missing, the
file is not required for ZAP to run, the user can still provide its own.