### PR TITLE
Assert the script engine exists when testing

### DIFF
--- a/test/org/zaproxy/zap/VerifyScriptTemplates.java
+++ b/test/org/zaproxy/zap/VerifyScriptTemplates.java
@@ -51,6 +51,7 @@ public class VerifyScriptTemplates {
         // Given
         List<Path> templates = getScriptTemplates(".js");
         Compilable se = (Compilable) new ScriptEngineManager().getEngineByName("ECMAScript");
+        assertThat("No ECMAScript script engine found.", se, is(not(nullValue())));
         for (Path template : templates) {
             try (Reader reader = Files.newBufferedReader(template, StandardCharsets.UTF_8)) {
                 // When / Then


### PR DESCRIPTION
Change VerifyScriptTemplates to assert that the engine exists before
verifying the templates.