### PR TITLE
Use default user agent in all default messages

### DIFF
--- a/src/org/parosproxy/paros/extension/manualrequest/http/impl/ManualHttpRequestEditorDialog.java
+++ b/src/org/parosproxy/paros/extension/manualrequest/http/impl/ManualHttpRequestEditorDialog.java
@@ -26,6 +26,7 @@
 // ZAP: 2017/08/10 Issue 3798: java.awt.Toolkit initialised in daemon mode
 // ZAP: 2018/02/14 Remove unnecessary boxing / unboxing
 // ZAP: 2018/07/17 Use ViewDelegate.getMenuShortcutKeyStroke.
+// ZAP: 2018/08/10 Use non-deprecated HttpRequestHeader constructor (Issue 4846).
 
 package org.parosproxy.paros.extension.manualrequest.http.impl;
 
@@ -290,8 +291,7 @@ public class ManualHttpRequestEditorDialog extends ManualRequestEditorDialog imp
 		try {
 			URI uri = new URI("http://www.any_domain_name.org/path", true);
 			msg.setRequestHeader(
-					new HttpRequestHeader(HttpRequestHeader.GET, uri, HttpHeader.HTTP10,
-							Model.getSingleton().getOptionsParam().getConnectionParam()));
+					new HttpRequestHeader(HttpRequestHeader.GET, uri, HttpHeader.HTTP10));
 			setMessage(msg);
 		} catch (HttpMalformedHeaderException e) {
 			logger.error(e.getMessage(), e);

--- a/src/org/parosproxy/paros/network/ConnectionParam.java
+++ b/src/org/parosproxy/paros/network/ConnectionParam.java
@@ -42,6 +42,7 @@
 // ZAP: 2017/06/19 Do not allow to set negative timeout values and expose the default value.
 // ZAP: 2017/09/26 Use helper methods to read the configurations.
 // ZAP: 2018/02/14 Remove unnecessary boxing / unboxing
+// ZAP: 2018/08/10 Set the default user agent to HttpRequestHeader (Issue 4846).
 
 package org.parosproxy.paros.network;
 
@@ -215,6 +216,7 @@ public class ConnectionParam extends AbstractParam {
 		setHttpStateEnabledImpl(getBoolean(HTTP_STATE_ENABLED, false));
 
 		this.defaultUserAgent = getString(DEFAULT_USER_AGENT, DEFAULT_DEFAULT_USER_AGENT);
+		HttpRequestHeader.setDefaultUserAgent(defaultUserAgent);
         
         loadSecurityProtocolsEnabled();
 	}
@@ -746,6 +748,7 @@ public class ConnectionParam extends AbstractParam {
 	}
 	public void setDefaultUserAgent(String defaultUserAgent) {
 		this.defaultUserAgent = defaultUserAgent;
+		HttpRequestHeader.setDefaultUserAgent(defaultUserAgent);
 		getConfig().setProperty(DEFAULT_USER_AGENT, defaultUserAgent);
 	}
 

--- a/src/org/parosproxy/paros/network/HttpMessage.java
+++ b/src/org/parosproxy/paros/network/HttpMessage.java
@@ -49,6 +49,7 @@
 // ZAP: 2017/08/23 queryEquals correct comparison and add JavaDoc. equalType update JavaDoc.
 // ZAP: 2018/03/13 Added toEventData()
 // ZAP: 2018/04/04 Add a copy constructor.
+// ZAP: 2018/08/10 Use non-deprecated HttpRequestHeader constructor (Issue 4846).
 
 package org.parosproxy.paros.network;
 
@@ -154,12 +155,46 @@ public class HttpMessage implements Message {
 	public HttpMessage() {
 	}
 
+	/**
+	 * Constructs a {@code HttpMessage} with a HTTP/1.1 GET request to the given URI.
+	 * <p>
+	 * The following headers are automatically added:
+	 * <ul>
+	 * <li>{@code Host}, with the domain and port from the given URI.</li>
+	 * <li>{@code User-Agent}, using the {@link HttpRequestHeader#getDefaultUserAgent()}.</li>
+	 * <li>{@code Pragma: no-cache}</li>
+	 * <li>{@code Cache-Control: no-cache}, if version is HTTP/1.1</li>
+	 * <li>{@code Content-Type: application/x-www-form-urlencoded}, if the method is POST or PUT.</li>
+	 * </ul>
+	 *
+	 * @param uri the request target.
+	 * @throws HttpMalformedHeaderException if the resulting HTTP header is malformed.
+	 */
 	public HttpMessage(URI uri) throws HttpMalformedHeaderException {
-		this(uri, null);
+		setRequestHeader(new HttpRequestHeader(HttpRequestHeader.GET, uri, HttpHeader.HTTP11));
 	}
 	
+	/**
+	 * Constructs a {@code HttpMessage} with a HTTP/1.1 GET request to the given URI.
+	 * <p>
+	 * The following headers are automatically added:
+	 * <ul>
+	 * <li>{@code Host}, with the domain and port from the given URI.</li>
+	 * <li>{@code User-Agent}, using the {@link HttpRequestHeader#getDefaultUserAgent()}.</li>
+	 * <li>{@code Pragma: no-cache}</li>
+	 * <li>{@code Cache-Control: no-cache}, if version is HTTP/1.1</li>
+	 * <li>{@code Content-Type: application/x-www-form-urlencoded}, if the method is POST or PUT.</li>
+	 * </ul>
+	 *
+	 * @param uri the request target.
+	 * @param params unused.
+	 * @throws HttpMalformedHeaderException if the resulting HTTP header is malformed.
+	 * @deprecated (TODO add version) Use {@link #HttpMessage(URI)} instead.
+	 * @since 2.4.2
+	 */
+	@Deprecated
 	public HttpMessage(URI uri, ConnectionParam params) throws HttpMalformedHeaderException {
-	    setRequestHeader(new HttpRequestHeader(HttpRequestHeader.GET, uri, HttpHeader.HTTP11, params));
+		this(uri);
 	}
 
 	/**

--- a/src/org/parosproxy/paros/network/HttpRequestHeader.java
+++ b/src/org/parosproxy/paros/network/HttpRequestHeader.java
@@ -47,6 +47,7 @@
 // ZAP: 2017/11/22 Address a NPE in isImage().
 // ZAP: 2018/01/10 Tweak how cookie header is reconstructed from HtmlParameter(s).
 // ZAP: 2018/02/06 Make the upper case changes locale independent (Issue 4327).
+// ZAP: 2018/08/10 Allow to set the user agent used by default request headers (Issue 4846).
 
 package org.parosproxy.paros.network;
 
@@ -94,6 +95,12 @@ public class HttpRequestHeader extends HttpHeader {
     //	= Pattern.compile("([^:]+)\\s*?:?\\s*?(\\d*?)");
     private static final Pattern patternImage = Pattern.compile("\\.(bmp|ico|jpg|jpeg|gif|tiff|tif|png)\\z", Pattern.CASE_INSENSITIVE);
     private static final Pattern patternPartialRequestLine = Pattern.compile("\\A *(OPTIONS|GET|HEAD|POST|PUT|DELETE|TRACE|CONNECT)\\b", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * The user agent used by {@link #HttpRequestHeader(String, URI, String) default request header}.
+     */
+    private static String defaultUserAgent;
+
     private String mMethod;
     private URI mUri;
     private String mHostName;
@@ -162,12 +169,24 @@ public class HttpRequestHeader extends HttpHeader {
 
     }
 
+    /**
+     * Constructs a {@code HttpRequestHeader} with the given method, URI, and version.
+     * <p>
+     * The following headers are automatically added:
+     * <ul>
+     * <li>{@code Host}, with the domain and port from the given URI.</li>
+     * <li>{@code User-Agent}, using the {@link #getDefaultUserAgent()}.</li>
+     * <li>{@code Pragma: no-cache}</li>
+     * <li>{@code Cache-Control: no-cache}, if version is HTTP/1.1</li>
+     * <li>{@code Content-Type: application/x-www-form-urlencoded}, if the method is POST or PUT.</li>
+     * </ul>
+     *
+     * @param method the request method.
+     * @param uri the request target.
+     * @param version the version, for example, {@code HTTP/1.1}.
+     * @throws HttpMalformedHeaderException if the resulting HTTP header is malformed.
+     */
     public HttpRequestHeader(String method, URI uri, String version) throws HttpMalformedHeaderException {
-        this(method, uri, version, null);
-    }
-
-    public HttpRequestHeader(String method, URI uri, String version,
-    		ConnectionParam params) throws HttpMalformedHeaderException {
         this(method + " " + uri.toString() + " " + version.toUpperCase(Locale.ROOT) + CRLF + CRLF);
         
         try {
@@ -177,10 +196,7 @@ public class HttpRequestHeader extends HttpHeader {
             log.error(e.getMessage(), e);
         }
         
-        String userAgent = params != null
-                ? params.getDefaultUserAgent()
-                : "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0;)";
-        setHeader(USER_AGENT, userAgent);
+        setHeader(USER_AGENT, defaultUserAgent);
         setHeader(PRAGMA, "no-cache");
         
         // ZAP: added the Cache-Control header field to comply with HTTP/1.1
@@ -200,6 +216,32 @@ public class HttpRequestHeader extends HttpHeader {
             setContentLength(0);
         }
 
+    }
+
+    /**
+     * Constructs a {@code HttpRequestHeader} with the given method, URI, and version.
+     * <p>
+     * The following headers are automatically added:
+     * <ul>
+     * <li>{@code Host}, with the domain and port from the given URI.</li>
+     * <li>{@code User-Agent}, using the {@link #getDefaultUserAgent()}.</li>
+     * <li>{@code Pragma: no-cache}</li>
+     * <li>{@code Cache-Control: no-cache}, if version is HTTP/1.1</li>
+     * <li>{@code Content-Type: application/x-www-form-urlencoded}, if the method is POST or PUT.</li>
+     * </ul>
+     *
+     * @param method the request method.
+     * @param uri the request target.
+     * @param version the version, for example, {@code HTTP/1.1}.
+     * @param params unused.
+     * @throws HttpMalformedHeaderException if the resulting HTTP header is malformed.
+     * @deprecated (TODO add version) Use {@link #HttpRequestHeader(String, URI, String)} instead.
+     * @since 2.4.2
+     */
+    @Deprecated
+    public HttpRequestHeader(String method, URI uri, String version,
+           ConnectionParam params) throws HttpMalformedHeaderException {
+        this(method, uri, version);
     }
 
     /**
@@ -797,4 +839,25 @@ public class HttpRequestHeader extends HttpHeader {
         return senderAddress;
     }
     
+    /**
+     * Sets the user agent used by {@link #HttpRequestHeader(String, URI, String) default request header}.
+     * <p>
+     * This is expected to be called only by core code, when the corresponding option is changed.
+     *
+     * @param defaultUserAgent the default user agent.
+     * @since TODO add version
+     */
+    public static void setDefaultUserAgent(String defaultUserAgent) {
+        HttpRequestHeader.defaultUserAgent = defaultUserAgent;
+    }
+
+    /**
+     * Gets the user agent used by {@link #HttpRequestHeader(String, URI, String) default request header}.
+     *
+     * @return the default user agent.
+     * @since TODO add version
+     */
+    public static String getDefaultUserAgent() {
+        return defaultUserAgent;
+    }
 }

--- a/src/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodType.java
@@ -245,8 +245,7 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
 				String method = (requestBody != null) ? HttpRequestHeader.POST : HttpRequestHeader.GET;
 				requestMessage = new HttpMessage();
 				requestMessage.setRequestHeader(
-						new HttpRequestHeader(method, requestURI, HttpHeader.HTTP10,
-								Model.getSingleton().getOptionsParam().getConnectionParam()));
+						new HttpRequestHeader(method, requestURI, HttpHeader.HTTP10));
 				if (requestBody != null) {
 					requestMessage.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, contentType);
 					requestMessage.getRequestBody().setBody(requestBody);

--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -366,8 +366,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 						new HttpRequestHeader(
 								HttpRequestHeader.GET,
 								uri,
-								HttpHeader.HTTP11,
-								Model.getSingleton().getOptionsParam().getConnectionParam()));
+								HttpHeader.HTTP11));
 			} catch (HttpMalformedHeaderException e) {
 				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_URL, e);
 			}

--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -851,8 +851,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 
     private ZapXmlConfiguration getRemoteConfigurationUrl(String url) throws 
     		IOException, ConfigurationException, InvalidCfuUrlException {
-        HttpMessage msg = new HttpMessage(new URI(url, true), 
-        		Model.getSingleton().getOptionsParam().getConnectionParam());
+        HttpMessage msg = new HttpMessage(new URI(url, true));
         getHttpSender().sendAndReceive(msg,true);
         if (msg.getResponseHeader().getStatusCode() != HttpStatusCode.OK) {
             throw new IOException(

--- a/src/org/zaproxy/zap/spider/Spider.java
+++ b/src/org/zaproxy/zap/spider/Spider.java
@@ -410,10 +410,6 @@ public class Spider {
 		return spiderParam;
 	}
 
-	protected ConnectionParam getConnectionParam() {
-		return connectionParam;
-	}
-
 	/**
 	 * Gets the controller.
 	 * 

--- a/src/org/zaproxy/zap/spider/SpiderTask.java
+++ b/src/org/zaproxy/zap/spider/SpiderTask.java
@@ -153,7 +153,7 @@ public class SpiderTask implements Runnable {
 		// HistoryReference
 		try {
 			HttpRequestHeader requestHeader = 
-					new HttpRequestHeader(method, uri, HttpHeader.HTTP11, parent.getConnectionParam());
+					new HttpRequestHeader(method, uri, HttpHeader.HTTP11);
 			if (sourceUri != null && parent.getSpiderParam().isSendRefererHeader()) {
 				requestHeader.setHeader(HttpRequestHeader.REFERER, sourceUri.toString());
 			}


### PR DESCRIPTION
Change ConnectionParam to set the default user agent into the
HttpRequestHeader to be used in the default request headers, instead of
requiring users to pass a ConnectionParam, the latter is error prone.
Change HttpRequestHeader to allow to set (and use) the default user
agent and deprecate the constructor that accepts a ConnectionParam.
Change codebase to no longer use the (now) deprecated constructor.

Fix #4846- User-Agent changes from configured value