### PR TITLE
Fix CME in passive scanner

### DIFF
--- a/src/org/zaproxy/zap/extension/pscan/PassiveScannerList.java
+++ b/src/org/zaproxy/zap/extension/pscan/PassiveScannerList.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.apache.log4j.Logger;
 import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
@@ -32,7 +33,7 @@ public class PassiveScannerList {
 
 	private static final Logger logger = Logger.getLogger(PassiveScannerList.class);
 
-	private List<PassiveScanner> passiveScanners = new ArrayList<>();
+	private List<PassiveScanner> passiveScanners = new CopyOnWriteArrayList<>();
 	private Set<String> scannerNames = new HashSet<>();
 
 	protected boolean add (PassiveScanner scanner) {
@@ -72,7 +73,7 @@ public class PassiveScannerList {
             }
         }
         
-        this.passiveScanners = tempScanners;
+        this.passiveScanners = new CopyOnWriteArrayList<>(tempScanners);
     }
 
 	public PassiveScanner removeScanner(String className) {

--- a/test/org/zaproxy/zap/extension/pscan/PassiveScannerListUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscan/PassiveScannerListUnitTest.java
@@ -1,0 +1,200 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPassiveScanner proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscan;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
+
+/**
+ * Unit test for {@link PassiveScannerList}.
+ */
+public class PassiveScannerListUnitTest {
+
+    private PassiveScannerList psl;
+
+    @Before
+    public void setUp() throws Exception {
+        psl = new PassiveScannerList();
+    }
+
+    @Test
+    public void shouldHaveNoScannersByDefault() {
+        assertThat(psl.list(), is(empty()));
+    }
+
+    @Test
+    public void shouldAddPassiveScanner() {
+        // Given
+        PassiveScanner scanner = mock(PassiveScanner.class);
+        // When
+        boolean scannerAdded = psl.add(scanner);
+        // Then
+        assertThat(psl.list(), contains(scanner));
+        assertThat(scannerAdded, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldIgnorePassiveScannerWithSameName() {
+        // Given
+        PassiveScanner scanner1 = mock(PassiveScanner.class);
+        when(scanner1.getName()).thenReturn("PassiveScanner 1");
+        PassiveScanner otherScannerWithSameName = mock(PassiveScanner.class);
+        when(otherScannerWithSameName.getName()).thenReturn("PassiveScanner 1");
+        // When
+        psl.add(scanner1);
+        boolean otherScannerAdded = psl.add(otherScannerWithSameName);
+        // Then
+        assertThat(psl.list(), contains(scanner1));
+        assertThat(otherScannerAdded, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldRemovePassiveScanner() {
+        // Given
+        PassiveScanner scanner1 = mock(PassiveScanner.class);
+        psl.add(scanner1);
+        PassiveScanner scanner2 = mock(TestPassiveScanner.class);
+        when(scanner2.getName()).thenReturn("TestPassiveScanner");
+        psl.add(scanner2);
+        // When
+        PassiveScanner removedScanner = psl.removeScanner(scanner2.getClass().getName());
+        // Then
+        assertThat(psl.list(), contains(scanner1));
+        assertThat(removedScanner, is(sameInstance(scanner2)));
+    }
+
+    @Test
+    public void shouldNotRemovePassiveScannerNotAdded() {
+        // Given
+        PassiveScanner scanner = mock(PassiveScanner.class);
+        // When
+        PassiveScanner removedScanner = psl.removeScanner(scanner.getClass().getName());
+        // Then
+        assertThat(removedScanner, is(nullValue()));
+    }
+
+    @Test
+    public void shouldSetAutoTagScanners() {
+        // Given
+        List<RegexAutoTagScanner> scanners = new ArrayList<>();
+        RegexAutoTagScanner scanner1 = mock(RegexAutoTagScanner.class);
+        when(scanner1.getName()).thenReturn("RegexAutoTagScanner 1");
+        scanners.add(scanner1);
+        RegexAutoTagScanner scanner2 = mock(RegexAutoTagScanner.class);
+        when(scanner2.getName()).thenReturn("RegexAutoTagScanner 2");
+        scanners.add(scanner2);
+        // When
+        psl.setAutoTagScanners(scanners);
+        // Then
+        assertThat(psl.list(), contains(scanner1, scanner2));
+    }
+
+    @Test
+    public void shouldRemovePreviousAutoTagScannersButNotPassiveScanners() {
+        // Given
+        RegexAutoTagScanner scanner1 = mock(RegexAutoTagScanner.class);
+        when(scanner1.getName()).thenReturn("RegexAutoTagScanner 1");
+        psl.add(scanner1);
+        PassiveScanner scanner2 = mock(PassiveScanner.class);
+        when(scanner2.getName()).thenReturn("PassiveScanner 1");
+        psl.add(scanner2);
+        List<RegexAutoTagScanner> scanners = new ArrayList<>();
+        RegexAutoTagScanner scanner3 = mock(RegexAutoTagScanner.class);
+        when(scanner3.getName()).thenReturn("RegexAutoTagScanner 2");
+        scanners.add(scanner3);
+        // When
+        psl.setAutoTagScanners(scanners);
+        // Then
+        assertThat(psl.list(), contains(scanner2, scanner3));
+    }
+
+    @Test
+    public void shouldIgnoreAutoTagScannerWithSameName() {
+        // Given
+        List<RegexAutoTagScanner> scanners = new ArrayList<>();
+        RegexAutoTagScanner scanner1 = mock(RegexAutoTagScanner.class);
+        when(scanner1.getName()).thenReturn("RegexAutoTagScanner 1");
+        scanners.add(scanner1);
+        RegexAutoTagScanner otherScannerWithSameName = mock(RegexAutoTagScanner.class);
+        when(otherScannerWithSameName.getName()).thenReturn("RegexAutoTagScanner 1");
+        scanners.add(otherScannerWithSameName);
+        // When
+        psl.setAutoTagScanners(scanners);
+        // Then
+        assertThat(psl.list(), contains(scanner1));
+    }
+
+    @Test
+    public void shouldAllowToChangeListWhileIterating() {
+        // Given
+        PassiveScanner scanner1 = mock(PassiveScanner.class);
+        psl.add(scanner1);
+        RegexAutoTagScanner scanner2 = mock(RegexAutoTagScanner.class);
+        when(scanner2.getName()).thenReturn("RegexAutoTagScanner");
+        psl.add(scanner2);
+        // When
+        psl.list().forEach(e -> {
+            psl.removeScanner(e.getClass().getName());
+            psl.add(e);
+        });
+        // Then = No exception (but check the state is the expected).
+        assertThat(psl.list(), contains(scanner1, scanner2));
+    }
+
+    @Test
+    public void shouldAllowToChangeListWhileIteratingAfterSettingAutoTagScanners() {
+        // Given
+        PassiveScanner scanner1 = mock(PassiveScanner.class);
+        psl.add(scanner1);
+        RegexAutoTagScanner scanner2 = mock(RegexAutoTagScanner.class);
+        when(scanner2.getName()).thenReturn("RegexAutoTagScanner");
+        List<RegexAutoTagScanner> autoTagScanners = new ArrayList<>();
+        autoTagScanners.add(scanner2);
+        psl.setAutoTagScanners(autoTagScanners);
+        // When
+        psl.list().forEach(e -> {
+            psl.removeScanner(e.getClass().getName());
+            psl.add(e);
+        });
+        // Then = No exception (but check the state is the expected).
+        assertThat(psl.list(), contains(scanner1, scanner2));
+    }
+
+    /**
+     * An interface to mock {@code PassiveScanner}s with different class name.
+     */
+    private static interface TestPassiveScanner extends PassiveScanner {
+        // Nothing to do.
+    }
+}


### PR DESCRIPTION
Change PassiveScannerList to use a CopyOnWriteArrayList which allows
modifications while the list is being iterated, the latter happens very
frequently (each time a message is persisted) the former less often
(when add-ons with scanners are installed/updated or scan tags changed).
Add tests to assert the expected behaviour.

Fix #4911 - ConcurrentModificationException thrown in PassiveScanThread