### PR TITLE
Correct char escaping for XML report

### DIFF
--- a/src/org/parosproxy/paros/extension/report/ReportGenerator.java
+++ b/src/org/parosproxy/paros/extension/report/ReportGenerator.java
@@ -53,7 +53,7 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
 import net.sf.json.xml.XMLSerializer;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.view.View;
 import org.parosproxy.paros.Constant;
@@ -317,7 +317,7 @@ public class ReportGenerator {
 
 		// The escapeXml function doesn't cope with some 'special' chrs
 
-		return StringEscapeUtils.escapeXml(XMLStringUtil.escapeControlChrs(result));
+		return StringEscapeUtils.escapeXml10(XMLStringUtil.escapeControlChrs(result));
 	}
 
 	/**

--- a/test/org/parosproxy/paros/extension/report/ReportGeneratorUnitTest.java
+++ b/test/org/parosproxy/paros/extension/report/ReportGeneratorUnitTest.java
@@ -1,0 +1,93 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPassiveScanner proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.extension.report;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.xml.transform.stream.StreamSource;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.zaproxy.zap.testutils.TestUtils;
+
+/**
+ * Unit test for {@link ReportGenerator}.
+ */
+public class ReportGeneratorUnitTest extends TestUtils {
+
+    @ClassRule
+    public static TemporaryFolder tempDir = new TemporaryFolder();
+
+    @Test
+    public void shouldNotEntityEncodeHigherUnicodeChars() {
+        // Given
+        String chars = "J/ψ → VP";
+        // When
+        String encoded = ReportGenerator.entityEncode(chars);
+        // Then
+        assertThat(encoded, is(equalTo(chars)));
+    }
+
+    @Test
+    public void shouldWriteReportWithWellformedXml() throws Exception {
+        // Given
+        String data = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><data>J/ψ → VP</data>\n";
+        Path report = tempDir.newFile().toPath();
+        // When
+        ReportGenerator.stringToHtml(data, identityXsl(), report.toString());
+        // Then
+        assertThat(contents(report), is(equalTo(data)));
+    }
+
+    @Test
+    public void shouldFailToWriteReportWithMalformedXml() throws Exception {
+        // Given
+        String data = "J/ψ → VP</data>";
+        Path report = tempDir.newFile().toPath();
+        // When
+        ReportGenerator.stringToHtml(data, identityXsl(), report.toString());
+        // Then = nothing written.
+        assertThat(contents(report), is(equalTo("")));
+    }
+
+    private static String contents(Path path) throws IOException {
+        return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+    }
+
+    private static StreamSource identityXsl() {
+        String xslt = "<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">\n"
+                + "  <xsl:template match=\"@*|node()\">\n"
+                + "    <xsl:copy>\n"
+                + "      <xsl:apply-templates select=\"@*|node()\"/>\n"
+                + "    </xsl:copy>\n"
+                + "  </xsl:template>\n"
+                + "</xsl:stylesheet>";
+        return new StreamSource(new StringReader(xslt));
+    }
+}


### PR DESCRIPTION
Change ReportLastScan to use a newer version of XML escape which does
not incorrectly escape higher Unicode characters.
Add tests to assert the expected behaviour.

Fix #2998 - Zap Report Generation Bug