### PR TITLE
Move AntiCsrfParam to its extension

### DIFF
--- a/src/org/parosproxy/paros/model/OptionsParam.java
+++ b/src/org/parosproxy/paros/model/OptionsParam.java
@@ -38,6 +38,7 @@
 // ZAP: 2015/04/09 Generify getParamSet(Class) to avoid unnecessary casts
 // ZAP: 2016/11/17 Issue 2701 Support Factory Reset
 // ZAP: 2016/12/06 Add ExtensionParam
+// ZAP: 2018/08/15 Move AntiCsrfParam to ExtensionAntiCSRF
 
 package org.parosproxy.paros.model;
 
@@ -79,7 +80,6 @@ public class OptionsParam extends AbstractParam {
 	private OptionsParamCertificate certificateParam = new OptionsParamCertificate();
 	// ZAP: Added many instance variables for new functionality.
 	private OptionsParamCheckForUpdates checkForUpdatesParam = new OptionsParamCheckForUpdates();
-	private AntiCsrfParam antiCsrfParam = new AntiCsrfParam();
 	private OptionsParamApi apiParam = new OptionsParamApi();
 	private GlobalExcludeURLParam globalExcludeURLParam = new GlobalExcludeURLParam();
 	private OptionsParamExperimentalSliSupport experimentalFeatuesParam = new OptionsParamExperimentalSliSupport();
@@ -193,7 +193,6 @@ public class OptionsParam extends AbstractParam {
 		getCertificateParam().load(getConfig());
 		getViewParam().load(getConfig());
 		getCheckForUpdatesParam().load(getConfig());
-		getAntiCsrfParam().load(getConfig());
 		getApiParam().load(getConfig());
 		getGlobalExcludeURLParam().load(getConfig());
 		getExperimentalFeaturesParam().load(getConfig());
@@ -260,8 +259,16 @@ public class OptionsParam extends AbstractParam {
 		}
     }
 
+	/**
+	 * Gets the anti-csrf extension's options.
+	 *
+	 * @return the anti-csrf options.
+	 * @deprecated (TODO add version) Use {@link org.zaproxy.zap.extension.anticsrf.ExtensionAntiCSRF ExtensionAntiCSRF} to
+	 *             manage the tokens, if the {@code AntiCsrfParam} is really needed use {@link #getParamSet(Class)} instead.
+	 */
+	@Deprecated
 	public AntiCsrfParam getAntiCsrfParam() {
-		return antiCsrfParam;
+		return getParamSet(AntiCsrfParam.class);
 	}
 	
 	// ZAP: Added getter.

--- a/src/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRF.java
+++ b/src/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRF.java
@@ -50,7 +50,6 @@ import org.parosproxy.paros.extension.encoder.Encoder;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.extension.history.HistoryFilter;
 import org.parosproxy.paros.model.HistoryReference;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
@@ -71,6 +70,7 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
 
 	private static Logger log = Logger.getLogger(ExtensionAntiCSRF.class);
 
+	private AntiCsrfParam antiCsrfParam;
 	private AntiCsrfDetectScanner antiCsrfDetectScanner;
 
 	private HistoryReferenceFactory historyReferenceFactory;
@@ -92,6 +92,7 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
 
     @Override
     public void init() {
+        antiCsrfParam = new AntiCsrfParam();
         antiCsrfDetectScanner = new AntiCsrfDetectScanner(this);
     }
     
@@ -103,6 +104,8 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
 	@Override
 	public void hook(ExtensionHook extensionHook) {
 	    super.hook(extensionHook);
+
+	    extensionHook.addOptionsParamSet(antiCsrfParam);
 
 		final ExtensionHistory extensionHistory = Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
 		if (extensionHistory != null) {
@@ -167,7 +170,7 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
 	}
 	
 	protected AntiCsrfParam getParam() {
-        return Model.getSingleton().getOptionsParam().getAntiCsrfParam();
+        return antiCsrfParam;
 	}
 	
 	public List<String> getAntiCsrfTokenNames() {

--- a/src/org/zaproxy/zap/extension/anticsrf/OptionsAntiCsrfPanel.java
+++ b/src/org/zaproxy/zap/extension/anticsrf/OptionsAntiCsrfPanel.java
@@ -72,7 +72,7 @@ public class OptionsAntiCsrfPanel extends AbstractParamPanel {
 	@Override
     public void initParam(Object obj) {
 	    OptionsParam optionsParam = (OptionsParam) obj;
-	    AntiCsrfParam param = optionsParam.getAntiCsrfParam();
+	    AntiCsrfParam param = optionsParam.getParamSet(AntiCsrfParam.class);
 	    getAntiCsrfModel().setTokens(param.getTokens());
 	    tokensOptionsPanel.setRemoveWithoutConfirmation(!param.isConfirmRemoveToken());
     }
@@ -83,7 +83,7 @@ public class OptionsAntiCsrfPanel extends AbstractParamPanel {
     @Override
     public void saveParam(Object obj) throws Exception {
 	    OptionsParam optionsParam = (OptionsParam) obj;
-	    AntiCsrfParam antiCsrfParam = optionsParam.getAntiCsrfParam();
+	    AntiCsrfParam antiCsrfParam = optionsParam.getParamSet(AntiCsrfParam.class);
 	    antiCsrfParam.setTokens(getAntiCsrfModel().getElements());
 	    antiCsrfParam.setConfirmRemoveToken(!tokensOptionsPanel.isRemoveWithoutConfirmation());
     }


### PR DESCRIPTION
Move AntiCsrfParam from OptionsParam to ExtensionAntiCSRF, to keep
extension's options out of the core options.