### PR TITLE
Show message in Find dialogue if string not found

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1125,6 +1125,7 @@ dynssl.warn.cert.expired = ZAPs Root CA certificate has expired as of {0} (now: 
 edit.find.button.cancel = Cancel
 edit.find.button.find   = Find
 edit.find.label.what    = Find what:
+edit.find.label.notfound = String not found.
 edit.find.popup         = Find...
 edit.find.title         = Find
 edit.name = Edit Menu Extension


### PR DESCRIPTION
Change FindDialog to show a message (in the dialogue) if the string was
not found, also, remove hardcoded sizes to allow to resize the dialogue
at will and log the exception (instead of printing).

Fix #4935.