### PR TITLE
added _csrf to default ACSRF token names

### DIFF
--- a/src/org/zaproxy/zap/extension/anticsrf/AntiCsrfParam.java
+++ b/src/org/zaproxy/zap/extension/anticsrf/AntiCsrfParam.java
@@ -44,7 +44,7 @@ public class AntiCsrfParam extends AbstractParam {
     
     private static final String[] DEFAULT_TOKENS_NAMES = { "anticsrf",
             "CSRFToken", "__RequestVerificationToken", "csrfmiddlewaretoken", "authenticity_token", "OWASP_CSRFTOKEN", "anoncsrf",
-            "csrf_token"};
+            "csrf_token", "_csrf"};
 
     private List<AntiCsrfParamToken> tokens = null;
     private List<String> enabledTokensNames = null;


### PR DESCRIPTION
SpringBoot applications use `_csrf` as the default ACSRF token name

https://github.com/KajanM/login-schemes/blob/9f0fb5be5970feb7c5ae6bc2b2c3c7624ecb7db1/form-based-acsrf/src/main/java/com/kajan/SecurityConfig.java#L22