### PR TITLE
Correct log message

### DIFF
--- a/src/org/zaproxy/zap/extension/history/PopupMenuExportURLs.java
+++ b/src/org/zaproxy/zap/extension/history/PopupMenuExportURLs.java
@@ -118,7 +118,7 @@ public class PopupMenuExportURLs extends ExtensionPopupMenuItem {
             }
 
         } catch (Exception e1) {
-            log.warn(e1.getStackTrace(), e1);
+            log.warn("An error occurred while writing the URLs:", e1);
             extension.getView().showWarningDialog(Constant.messages.getString("file.save.error") + file.getAbsolutePath());
         } finally {
             try {


### PR DESCRIPTION
Change PopupMenuExportURLs to use a more informative message than the
address of the stack trace array (e.g. [LStackTraceElement;@cfd0f94),
moreover the stack trace is already being included with the following
parameter.