### PR TITLE
Don't parse (plain) API parameters as JSON

### DIFF
--- a/src/org/zaproxy/zap/extension/api/API.java
+++ b/src/org/zaproxy/zap/extension/api/API.java
@@ -53,6 +53,7 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.view.View;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.zaproxy.zap.utils.JsonUtil;
 
 import net.sf.json.JSONObject;
 
@@ -734,7 +735,7 @@ public class API {
 				try {
 					key = URLDecoder.decode(keyValue[i].substring(0,pos), "UTF-8");
 					value = URLDecoder.decode(keyValue[i].substring(pos+1), "UTF-8");
-					jp.put(key, value);
+					jp.put(key, JsonUtil.getJsonFriendlyString(value));
 				} catch (UnsupportedEncodingException | IllegalArgumentException e) {
 					// Carry on anyway
 					Exception apiException = new ApiException(ApiException.Type.ILLEGAL_PARAMETER, params, e);

--- a/src/org/zaproxy/zap/utils/JsonUtil.java
+++ b/src/org/zaproxy/zap/utils/JsonUtil.java
@@ -24,23 +24,33 @@ import java.util.Iterator;
 import java.util.List;
 
 import net.sf.json.JSONArray;
-import net.sf.json.JSONException;
-import net.sf.json.JSONSerializer;
+import net.sf.json.JSONObject;
+import net.sf.json.util.JSONUtils;
 
+/**
+ * Utilities to workaround "quirks" of {@link JSONObject} and related classes.
+ *
+ * @since TODO add version
+ */
 public final class JsonUtil {
 	
 	private JsonUtil() {
 	}
 
+	/**
+	 * Gets the given value in a form that can be safely put in a {@code JSONObject}.
+	 * <p>
+	 * {@code JSONObject} automatically parses strings that look like JSON arrays/objects, so they need to be processed (quoted)
+	 * to prevent that behaviour.
+	 *
+	 * @param value the value to process.
+	 * @return the value that can be safely put in a {@code JSONObject}.
+	 */
 	public static String getJsonFriendlyString(String value) {
-		try {
-			JSONSerializer.toJSON(value);
-			// Its valid JSON so escape
+		if (!"null".equals(value) && JSONUtils.mayBeJSON(value)) {
 			return "'" + value + "'";
-		} catch (JSONException e) {
-			// Its not a valid JSON object so can add as is
-			return value;
 		}
+		return value;
 	}
 	
 	

--- a/test/org/zaproxy/zap/utils/JsonUtilUnitTest.java
+++ b/test/org/zaproxy/zap/utils/JsonUtilUnitTest.java
@@ -1,0 +1,126 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.utils;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import net.sf.json.JSONObject;
+
+/**
+ * Unit test for {@link JsonUtil}.
+ */
+public class JsonUtilUnitTest {
+
+    @Test
+    public void shouldQuoteValueThatLooksLikeAnArray() {
+        // Given
+        String value = "[ 1, 2, 3, 4]";
+        // When
+        String processedValue = JsonUtil.getJsonFriendlyString(value);
+        // Then
+        assertThat(processedValue, is(equalTo(quoted(value))));
+        assertValueAfterJsonObject(processedValue, value);
+    }
+
+    @Test
+    public void shouldQuoteValueThatLooksLikeAnObject() {
+        // Given
+        String value = "{ \"1\" : \"2\", \"3\" : \"4\" }";
+        // When
+        String processedValue = JsonUtil.getJsonFriendlyString(value);
+        // Then
+        assertThat(processedValue, is(equalTo(quoted(value))));
+        assertValueAfterJsonObject(processedValue, value);
+    }
+
+    @Test
+    public void shouldNotQuoteValueThatLooksLikeAnArrayButStartsWithSpace() {
+        // Given
+        String value = " [ 1, 2, 3, 4]";
+        // When
+        String processedValue = JsonUtil.getJsonFriendlyString(value);
+        // Then
+        assertThat(processedValue, is(equalTo(value)));
+        assertValueAfterJsonObject(processedValue, value);
+    }
+
+    @Test
+    public void shouldNotQuoteValueThatLooksLikeAnObjectButStartsWithSpace() {
+        // Given
+        String value = " { \"1\" : \"2\", \"3\" : \"4\" }";
+        // When
+        String processedValue = JsonUtil.getJsonFriendlyString(value);
+        // Then
+        assertThat(processedValue, is(equalTo(value)));
+        assertValueAfterJsonObject(processedValue, value);
+    }
+
+    @Test
+    public void shouldNotQuoteSingleQuotedValue() {
+        // Given
+        String value = "'value'";
+        // When
+        String processedValue = JsonUtil.getJsonFriendlyString(value);
+        // Then
+        assertThat(processedValue, is(equalTo(value)));
+        assertValueAfterJsonObject(processedValue, value);
+    }
+
+    @Test
+    public void shouldNotQuoteDoubleQuotedValue() {
+        // Given
+        String value = "\"value\"";
+        // When
+        String processedValue = JsonUtil.getJsonFriendlyString(value);
+        // Then
+        assertThat(processedValue, is(equalTo(value)));
+        assertValueAfterJsonObject(processedValue, value);
+    }
+
+    @Test
+    public void shouldNotQuoteNullLiteralValue() {
+        // Given
+        String value = "null";
+        // When
+        String processedValue = JsonUtil.getJsonFriendlyString(value);
+        // Then
+        assertThat(processedValue, is(equalTo(value)));
+        assertValueAfterJsonObject(processedValue, value);
+    }
+
+    private static void assertValueAfterJsonObject(String processedValue, String value) {
+        // Given processedValue
+        String key = "key";
+        JSONObject jsonObject = new JSONObject();
+        // When
+        jsonObject.put(key, processedValue);
+        // Then
+        assertThat(jsonObject.getString(key), is(equalTo(value)));
+    }
+
+    private static String quoted(String value) {
+        return "'" + value + "'";
+    }
+
+}


### PR DESCRIPTION
Change API to use the utility class to process the API parameters before
putting them in the JSONObject, to avoid parsing them as JSON (for the
API they are plain text data, it's up to the actual endpoints to parse
them if needed).
Add some JavaDoc to JsonUtil and tweak the quoting method to use the
same logic as the AbstractJSON._processValue, faster than parsing the
whole value.
Add tests to assert the expected behaviour.

---
From OWASP ZAP User Group: https://groups.google.com/d/topic/zaproxy-users/vNfAfWvrCQ0/discussion
Also related to #4580.