### PR TITLE
Made active scan progress consistent with spider, show progress of 100 if scan is stopped

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
@@ -824,7 +824,11 @@ public class ActiveScanAPI extends ApiImplementor {
 			activeScan = getActiveScan(params);
 			int progress = 0;
 			if (activeScan != null) {
-				progress = activeScan.getProgress();
+				if (activeScan.isStopped()) {
+					progress = 100;
+				} else {
+					progress = activeScan.getProgress();
+				}
 			}
 			result = new ApiResponseElement(name, String.valueOf(progress));
 			break;


### PR DESCRIPTION
Currently, if you stop an active scan, the API will report the progress as the percent it was stopped at. This behavior is not consistent with the spider, which will report the progress status of 100 in the API if it was stopped. This PR addresses that inconsistency.

