### PR TITLE
Correct Docker scripts' -u argument

### DIFF
--- a/docker/zap-api-scan.py
+++ b/docker/zap-api-scan.py
@@ -263,7 +263,8 @@ def main(argv):
     elif config_url:
         # load config file from url
         try:
-            load_config(urlopen(config_url).read().decode('UTF-8'), config_dict, config_msg, out_of_scope_dict)
+            config_data = urlopen(config_url).read().decode('UTF-8').splitlines()
+            load_config(config_data, config_dict, config_msg, out_of_scope_dict)
         except ValueError as e:
             logging.warning("Failed to read configs from " + config_url + " " + str(e))
             sys.exit(3)

--- a/docker/zap-baseline.py
+++ b/docker/zap-baseline.py
@@ -241,7 +241,8 @@ def main(argv):
     elif config_url:
         # load config file from url
         try:
-            load_config(urlopen(config_url).read().decode('UTF-8'), config_dict, config_msg, out_of_scope_dict)
+            config_data = urlopen(config_url).read().decode('UTF-8').splitlines()
+            load_config(config_data, config_dict, config_msg, out_of_scope_dict)
         except ValueError as e:
             logging.warning("Failed to read configs from " + config_url + " " + str(e))
             sys.exit(3)

--- a/docker/zap-full-scan.py
+++ b/docker/zap-full-scan.py
@@ -241,7 +241,8 @@ def main(argv):
     elif config_url:
         # load config file from url
         try:
-            load_config(urlopen(config_url).read().decode('UTF-8'), config_dict, config_msg, out_of_scope_dict)
+            config_data = urlopen(config_url).read().decode('UTF-8').splitlines()
+            load_config(config_data, config_dict, config_msg, out_of_scope_dict)
         except ValueError as e:
             logging.warning("Failed to read configs from " + config_url + " " + str(e))
             sys.exit(3)

--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -144,6 +144,7 @@ def load_config(config, config_dict, config_msg, out_of_scope_dict):
                     config_msg[key] = usermsg
                 else:
                     config_msg[key] = ''
+    logging.debug('Loaded config: {0}'.format(config_dict))
 
 
 def is_in_scope(plugin_id, url, out_of_scope_dict):


### PR DESCRIPTION
Split the lines of the configuration obtained through the URL before
parsing it, otherwise the contents would be iterated by characters thus
failing to parse anything useful.
The argument broke in the changes to support Python 3.
Add debug log statement after parsing the configuration, to make it
easier to check what's being used.

Fix #4972 - Docker scripts don't honor -u argument