### PR TITLE
Check allowed initiators in HTTP Sessions

### DIFF
--- a/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
+++ b/src/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
@@ -662,11 +662,7 @@ public class ExtensionHttpSessions extends ExtensionAdaptor implements SessionCh
 
 	@Override
 	public void onHttpResponseReceive(HttpMessage msg, int initiator, HttpSender sender) {
-		if (initiator == HttpSender.ACTIVE_SCANNER_INITIATOR || initiator == HttpSender.SPIDER_INITIATOR
-				|| initiator == HttpSender.AJAX_SPIDER_INITIATOR || initiator == HttpSender.FORCED_BROWSE_INITIATOR
-				|| initiator == HttpSender.CHECK_FOR_UPDATES_INITIATOR || initiator == HttpSender.FUZZER_INITIATOR
-				|| initiator == HttpSender.AUTHENTICATION_INITIATOR || initiator == HttpSender.TOKEN_GENERATOR_INITIATOR
-				|| initiator == HttpSender.ACCESS_CONTROL_SCANNER_INITIATOR) {
+		if (initiator != HttpSender.PROXY_INITIATOR && initiator != HttpSender.MANUAL_REQUEST_INITIATOR) {
 			// Not a session we care about
 			return;
 		}


### PR DESCRIPTION
Change ExtensionHttpSessions to check the allowed initiators when
processing the response instead of checking the disallowed ones, less to
check and it's clearer which ones are allowed, moreover it disallows
initiators that should have been (i.e. `BEAN_SHELL_INITIATOR`,
`WEB_SOCKET_INITIATOR`, and `AUTHENTICATION_HELPER_INITIATOR`).