### PR TITLE
Remove redundant add-on validations

### DIFF
--- a/src/org/zaproxy/zap/control/AddOn.java
+++ b/src/org/zaproxy/zap/control/AddOn.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.zip.ZipEntry;
@@ -438,6 +439,26 @@ public class AddOn  {
 		}
 	}
 
+	/**
+	 * Convenience method that attempts to create an {@code AddOn} from the given file.
+	 * <p>
+	 * A warning is logged if the add-on is invalid and an error if an error occurred while creating it.
+	 * 
+	 * @param file the file of the add-on.
+	 * @return a container with the {@code AddOn}, or empty if not valid or an error occurred while creating it.
+	 * @since TODO add version
+	 */
+	public static Optional<AddOn> createAddOn(Path file) {
+		try {
+			return Optional.of(new AddOn(file));
+		} catch (AddOn.InvalidAddOnException e) {
+			logger.warn("Invalid add-on: " + file.toString(), e);
+		} catch (Exception e) {
+			logger.error("Failed to create an add-on from: " + file.toString(), e);
+		}
+		return Optional.empty();
+	}
+	
 	/**
 	 * Constructs an {@code AddOn} with the given file name.
 	 *

--- a/src/org/zaproxy/zap/control/AddOnCollection.java
+++ b/src/org/zaproxy/zap/control/AddOnCollection.java
@@ -172,11 +172,7 @@ public class AddOnCollection {
     	// Load the addons
     	try (DirectoryStream<Path> addOnFiles = Files.newDirectoryStream(dir.toPath(), "*" + AddOn.FILE_EXTENSION)) {
         	for (Path addOnFile : addOnFiles) {
-        		if (AddOn.isAddOn(addOnFile)) {
-	            	AddOn ao = createAddOn(addOnFile);
-                    if (ao == null) {
-                        continue;
-                    }
+                AddOn.createAddOn(addOnFile).ifPresent(ao -> {
 
 	            	boolean add = true;
 	            	for (AddOn addOn : addOns) {
@@ -209,20 +205,11 @@ public class AddOnCollection {
 	            		logger.debug("Found addon " + ao.getId() + " version " + ao.getVersion());
 	            		this.addOns.add(ao);
 	            	}
-        		}
+        		});
 	        }
         }
     }
 
-    private static AddOn createAddOn(Path addOnFile) {
-        try {
-            return new AddOn(addOnFile);
-        } catch (Exception e) {
-            logger.warn("Failed to create add-on for: " + addOnFile.toString(), e);
-        }
-        return null;
-    }
-    
     /**
      * Gets all add-ons of this add-on collection.
      *


### PR DESCRIPTION
Remove validations done before creating add-ons since the creation of
the add-on already validates it.
Add a convenience method to AddOn that attempts to create the add-on and
change AddOnCollection and ExtensionAutoUpdate to use it, while removing
the redundant add-on validations done beforehand (for the latter class
keep the file name validation to differentiate from ZAP packages).