### PR TITLE
Add tests for SpiderRobotstxtParser

### DIFF
--- a/src/org/zaproxy/zap/spider/parser/SpiderRobotstxtParser.java
+++ b/src/org/zaproxy/zap/spider/parser/SpiderRobotstxtParser.java
@@ -1,10 +1,13 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2012 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -14,28 +17,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.zaproxy.zap.spider.parser;
 
-import java.util.Locale;
+import java.util.Objects;
 import java.util.StringTokenizer;
 
 import net.htmlparser.jericho.Source;
 
-import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.spider.SpiderParam;
 
 /**
  * The Class SpiderRobotstxtParser used for parsing Robots.txt files.
+ * 
+ * @since 2.0.0
  */
 public class SpiderRobotstxtParser extends SpiderParser {
 
-	private static final String PATTERNS_USERAGENT = "(?i)^User-agent:.*";
+	private static final String COMMENT_TOKEN = "#";
+
 	private static final String PATTERNS_DISALLOW = "(?i)Disallow:.*";
 	private static final String PATTERNS_ALLOW = "(?i)Allow:.*";
 
-	private static final int PATTERNS_USERAGENT_LENGTH = 11;
 	private static final int PATTERNS_DISALLOW_LENGTH = 9;
 	private static final int PATTERNS_ALLOW_LENGTH = 6;
 
@@ -46,37 +49,30 @@ public class SpiderRobotstxtParser extends SpiderParser {
 	 * Instantiates a new spider robotstxt parser.
 	 * 
 	 * @param params the params
+	 * @throws NullPointerException if {@code params} is null.
 	 */
 	public SpiderRobotstxtParser(SpiderParam params) {
 		super();
-		this.params = params;
+		this.params = Objects.requireNonNull(params, "Parameter params must not be null.");
 	}
 
+	/**
+	 * @throws NullPointerException if {@code message} is null.
+	 */
 	@Override
 	public boolean parseResource(HttpMessage message, Source source, int depth) {
-		if (message == null || !params.isParseRobotsTxt()) {
+		if (!params.isParseRobotsTxt()) {
 			return false;
 		}
 		log.debug("Parsing a robots.txt resource...");
 
-		// Get the response content
-		String content = message.getResponseBody().toString();
+		String baseURL = message.getRequestHeader().getURI().toString();
 
-		// Get the context (base url)
-		String baseURL;
-		baseURL = message.getRequestHeader().getURI().toString();
-
-		@SuppressWarnings("unused")
-		// for now...
-		boolean inMatchingUserAgent = false;
-
-		// Parse each line in the Spider.txt file
-		StringTokenizer st = new StringTokenizer(content, "\n");
+		StringTokenizer st = new StringTokenizer(message.getResponseBody().toString(), "\n");
 		while (st.hasMoreTokens()) {
 			String line = st.nextToken();
 
-			// Remove comments
-			int commentStart = line.indexOf("#");
+			int commentStart = line.indexOf(COMMENT_TOKEN);
 			if (commentStart != -1) {
 				line = line.substring(0, commentStart);
 			}
@@ -85,58 +81,15 @@ public class SpiderRobotstxtParser extends SpiderParser {
 			line = line.replaceAll("<[^>]+>", "");
 			line = line.trim();
 
-			// If nothing's left, skip
-			if (line.length() == 0) {
+			if (line.isEmpty()) {
 				continue;
 			}
 			log.debug("Processing robots.txt line: " + line);
 
-			// If the line is for defining the user agent
-			if (line.matches(PATTERNS_USERAGENT)) {
-				String ua = line.substring(PATTERNS_USERAGENT_LENGTH).trim().toLowerCase(Locale.ENGLISH);
-				if (ua.equals("*") || ua.contains(Constant.USER_AGENT)) {
-					log.debug("Parsing robots.txt file. Starting section applying to spider.");
-					inMatchingUserAgent = true;
-				} else {
-					log.debug("Parsing robots.txt file. Start section not applying to spider.");
-					inMatchingUserAgent = false;
-				}
-				// If the line is for defining a DISALLOW pattern
-			} else if (line.matches(PATTERNS_DISALLOW)) {
-				// The spider should explore URIs no matter who the pattern applies to
-				// if (!inMatchingUserAgent) {
-				// continue;
-				// }
-				String path = line.substring(PATTERNS_DISALLOW_LENGTH).trim();
-
-				// Clean the path
-				if (path.endsWith("*")) {
-					path = path.substring(0, path.length() - 1);
-				}
-				path = path.trim();
-
-				// Submit the found url
-				if (path.length() > 0) {
-					processURL(message, depth, path, baseURL);
-				}
-				// If the line is for defining an ALLOW pattern
+			if (line.matches(PATTERNS_DISALLOW)) {
+				processPath(message, depth, line.substring(PATTERNS_DISALLOW_LENGTH), baseURL);
 			} else if (line.matches(PATTERNS_ALLOW)) {
-				// The spider should explore URIs no matter who the pattern applies to
-				// if (!inMatchingUserAgent) {
-				// continue;
-				// }
-
-				// Get the cleaned path
-				String path = line.substring(PATTERNS_ALLOW_LENGTH).trim();
-				if (path.endsWith("*")) {
-					path = path.substring(0, path.length() - 1);
-				}
-				path = path.trim();
-
-				// Submit the found url
-				if (path.length() > 0) {
-					processURL(message, depth, path, baseURL);
-				}
+				processPath(message, depth, line.substring(PATTERNS_ALLOW_LENGTH), baseURL);
 			}
 		}
 
@@ -144,9 +97,20 @@ public class SpiderRobotstxtParser extends SpiderParser {
 		return true;
 	}
 
+	private void processPath(HttpMessage message, int depth, String path, String baseURL) {
+		String processedPath = path.trim();
+		if (processedPath.endsWith("*")) {
+			processedPath = processedPath.substring(0, processedPath.length() - 1).trim();
+		}
+
+		if (!processedPath.isEmpty()) {
+			processURL(message, depth, processedPath, baseURL);
+		}
+	}
+
 	@Override
 	public boolean canParseResource(HttpMessage message, String path, boolean wasAlreadyParsed) {
 		// If it's a robots.txt file
-		return path != null && path.equalsIgnoreCase("/robots.txt");
+		return "/robots.txt".equalsIgnoreCase(path);
 	}
 }

--- a/test/org/zaproxy/zap/spider/parser/SpiderRobotstxtParserUnitTest.java
+++ b/test/org/zaproxy/zap/spider/parser/SpiderRobotstxtParserUnitTest.java
@@ -1,0 +1,221 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.spider.parser;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.apache.log4j.Logger;
+import org.apache.log4j.varia.NullAppender;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.spider.SpiderParam;
+
+/**
+ * Unit test for {@link SpiderRobotstxtParser}.
+ */
+public class SpiderRobotstxtParserUnitTest extends SpiderParserTestUtils {
+
+    private static final String ROOT_PATH = "/";
+    private static final String ROBOTS_TXT_PATH = "/robots.txt";
+    private static final int BASE_DEPTH = 0;
+
+    @BeforeClass
+    public static void suppressLogging() {
+        Logger.getRootLogger().addAppender(new NullAppender());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldRequireNonNullSpiderParam() {
+        // Given
+        SpiderParam spiderParam = null;
+        // When
+        new SpiderRobotstxtParser(spiderParam);
+        // Then = NullPointerException
+    }
+
+    @Test
+    public void shouldNotFailToEvaluateAnUndefinedPath() {
+        // Given
+        String path = null;
+        SpiderRobotstxtParser spiderParser = new SpiderRobotstxtParser(new SpiderParam());
+        // When
+        spiderParser.canParseResource(null, path, false);
+        // Then = No Exception.
+    }
+
+    @Test
+    public void shouldParseRobotsTxtPath() {
+        // Given
+        SpiderRobotstxtParser spiderParser = new SpiderRobotstxtParser(new SpiderParam());
+        // When
+        boolean canParse = spiderParser.canParseResource(null, ROBOTS_TXT_PATH, false);
+        // Then
+        assertThat(canParse, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldParseRobotsTxtPathWithDifferentCase() {
+        // Given
+        SpiderRobotstxtParser spiderParser = new SpiderRobotstxtParser(new SpiderParam());
+        // When
+        boolean canParse = spiderParser.canParseResource(null, "/RoBoTs.TxT", false);
+        // Then
+        assertThat(canParse, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldParseRobotsTxtPathEvenIfAlreadyParsed() {
+        // Given
+        SpiderRobotstxtParser spiderParser = new SpiderRobotstxtParser(new SpiderParam());
+        boolean parsed = true;
+        // When
+        boolean canParse = spiderParser.canParseResource(null, ROBOTS_TXT_PATH, parsed);
+        // Then
+        assertThat(canParse, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldNotParseNonRobotsTxtPath() {
+        // Given
+        SpiderRobotstxtParser spiderParser = new SpiderRobotstxtParser(new SpiderParam());
+        // When
+        boolean canParse = spiderParser.canParseResource(null, ROOT_PATH, false);
+        // Then
+        assertThat(canParse, is(equalTo(false)));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldFailToParseAnUndefinedMessage() {
+        // Given
+        HttpMessage undefinedMessage = null;
+        SpiderRobotstxtParser spiderParser = new SpiderRobotstxtParser(new SpiderParam());
+        // When
+        spiderParser.parseResource(undefinedMessage, null, BASE_DEPTH);
+        // Then = NullPointerException
+    }
+
+    @Test
+    public void shouldNotBeCompletelyParsedIfParseDisabled() {
+        // Given
+        SpiderParam spiderParam = createSpiderParamWithConfig();
+        spiderParam.setParseRobotsTxt(false);
+        SpiderRobotstxtParser spiderParser = new SpiderRobotstxtParser(spiderParam);
+        HttpMessage message = createMessageWith("");
+        // When
+        boolean completelyParsed = spiderParser.parseResource(message, null, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldBeAlwaysCompletelyParsedIfParseEnabled() {
+        // Given
+        SpiderRobotstxtParser spiderParser = new SpiderRobotstxtParser(new SpiderParam());
+        HttpMessage message = createMessageWith("");
+        // When
+        boolean completelyParsed = spiderParser.parseResource(message, null, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldNotFindUrlsIfThereIsNone() {
+        // Given
+        SpiderRobotstxtParser spiderParser = new SpiderRobotstxtParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        spiderParser.addSpiderParserListener(listener);
+        HttpMessage message = createMessageWith(
+                body(
+                        "# Just Comments & User-Agents...",
+                        "User-Agent: *",
+                        "# Disallow: /x/y/z",
+                        "User-Agent: bot",
+                        "<pre>",
+                        "# Allow: /a/b/c",
+                        "",
+                        "# ...",
+                        "Allow:   # no path"));
+        // When
+        spiderParser.parseResource(message, null, BASE_DEPTH);
+        // Then
+        assertThat(listener.getUrlsFound(), is(empty()));
+    }
+
+    @Test
+    public void shouldFindUrls() {
+        // Given
+        SpiderRobotstxtParser spiderParser = new SpiderRobotstxtParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        spiderParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith(
+                body(
+                        "User-Agent: *",
+                        "Disallow: /x/y/z    # Comment",
+                        " User-Agent: bot     # Comment",
+                        "Allow: /a/b/c.html",
+                        "<pre> Allow: /nohtmltags/",
+                        "  Allow:    /%  ",
+                        "Allow: /%20file.txt",
+                        "Allow: /abc/*"));
+        // When
+        spiderParser.parseResource(messageHtmlResponse, null, BASE_DEPTH);
+        // Then
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "http://example.com/x/y/z",
+                        "http://example.com/a/b/c.html",
+                        "http://example.com/nohtmltags/",
+                        "http://example.com/%25",
+                        "http://example.com/%20file.txt",
+                        "http://example.com/abc/"));
+    }
+
+    private static HttpMessage createMessageWith(String body) {
+        HttpMessage message = new HttpMessage();
+        try {
+            message.setRequestHeader("GET / HTTP/1.1\r\nHost: example.com\r\n");
+            message.setResponseHeader("HTTP/1.1 200 OK\r\nContent-Length: " + body.length());
+            message.setResponseBody(body);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return message;
+    }
+
+    private static String body(String... strings) {
+        if (strings == null || strings.length == 0) {
+            return "";
+        }
+        StringBuilder strBuilder = new StringBuilder(strings.length * 25);
+        for (String string : strings) {
+            if (strBuilder.length() > 0) {
+                strBuilder.append("\n");
+            }
+            strBuilder.append(string);
+        }
+        return strBuilder.toString();
+    }
+}


### PR DESCRIPTION
Add tests to assert the expected behaviour of SpiderRobotstxtParser.
Other changes were done to "normalise" the behaviour/expectations of the
parser:
 - Throw an exception when creating an instance with null SpiderParam,
 it's required to check if the file should be parsed;
 - Expect always a message when parsing, letting a NullPointerException
 be thrown if not;
 - Remove unnecessary code comments describing the statements;
 - Remove unused handling of User-Agent directive and related commented
 code;
 - Extract a method that processes the path from the Allowed/Disallowed
 directives;
 - Swap path test to avoid a null check.

Normalise the license header.