### PR TITLE
Correct redirections for GET requests

### DIFF
--- a/src/org/parosproxy/paros/network/HttpSender.java
+++ b/src/org/parosproxy/paros/network/HttpSender.java
@@ -579,7 +579,7 @@ public class HttpSender {
 		// no more retry
 		modifyUserAgent(msg);
 		method = helper.createRequestMethod(msg.getRequestHeader(), msg.getRequestBody(), params);
-		if (!(method instanceof EntityEnclosingMethod)) {
+		if (!(method instanceof EntityEnclosingMethod) || method instanceof ZapGetMethod) {
 			// cant do this for EntityEnclosingMethod methods - it will fail
 			method.setFollowRedirects(isFollowRedirect);
 		}


### PR DESCRIPTION
Change HttpSender to set the redirection flag for ZapGetMethod, to
follow the redirections if set. The flag was not set as before because
the GET method now has an enclosing entity.

Related to #4352 - Allow to send a message body with all methods