### PR TITLE
Test add-on validations

### DIFF
--- a/src/org/zaproxy/zap/control/AddOn.java
+++ b/src/org/zaproxy/zap/control/AddOn.java
@@ -403,7 +403,7 @@ public class AddOn  {
 	 * @param file the file to be checked.
 	 * @return the result of the validation.
 	 * @since TODO add version
-	 * @see #isValidAddOn(Path)
+	 * @see #isAddOn(Path)
 	 */
 	public static ValidationResult isValidAddOn(Path file) {
 		if (file == null || file.getNameCount() == 0) {


### PR DESCRIPTION
Add tests to cover all the validations done in AddOn.isValidAddOn(Path).
Correct method reference in isValidAddOn's JavaDoc.