### PR TITLE
Correct SSE Content-Type checks

### DIFF
--- a/src/org/parosproxy/paros/network/HttpHeader.java
+++ b/src/org/parosproxy/paros/network/HttpHeader.java
@@ -560,7 +560,7 @@ public abstract class HttpHeader implements java.io.Serializable {
      * @since TODO add version
      * @see #getNormalisedContentTypeValue()
      */
-    protected boolean hasContentType(String... contentTypes) {
+    public boolean hasContentType(String... contentTypes) {
         if (contentTypes == null || contentTypes.length == 0) {
             return true;
         }
@@ -587,7 +587,7 @@ public abstract class HttpHeader implements java.io.Serializable {
      * @since TODO add version
      * @see #hasContentType(String...)
      */
-    protected String getNormalisedContentTypeValue() {
+    public String getNormalisedContentTypeValue() {
         String contentType = getHeader(CONTENT_TYPE);
         if (contentType != null) {
             return contentType.toLowerCase(Locale.ROOT);

--- a/src/org/parosproxy/paros/network/HttpMessage.java
+++ b/src/org/parosproxy/paros/network/HttpMessage.java
@@ -982,11 +982,7 @@ public class HttpMessage implements Message {
 	public boolean isEventStream() {
 		boolean isEventStream = false;
 		if (!getResponseHeader().isEmpty()) {
-			String contentTypeHeader = getResponseHeader().getHeader("content-type");
-			if (contentTypeHeader != null && contentTypeHeader.equals("text/event-stream")) {
-				// response is an SSE stream
-				isEventStream = true;
-			}
+			isEventStream = getResponseHeader().hasContentType("text/event-stream");
 		} else {
 			// response not available
 			// is request for event-stream?

--- a/src/org/zaproxy/zap/ZapGetMethod.java
+++ b/src/org/zaproxy/zap/ZapGetMethod.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.Socket;
+import java.util.Locale;
 
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpConnection;
@@ -202,7 +203,7 @@ public class ZapGetMethod extends EntityEnclosingMethod {
 		Header header = getResponseHeader("content-type");
 		if (header != null) {
 			String contentTypeHeader = header.getValue();
-			if (contentTypeHeader != null && contentTypeHeader.equals("text/event-stream")) {
+			if (contentTypeHeader != null && contentTypeHeader.toLowerCase(Locale.ROOT).contains("text/event-stream")) {
 				return;
 			}
 		}

--- a/test/org/parosproxy/paros/network/HttpMessageUnitTest.java
+++ b/test/org/parosproxy/paros/network/HttpMessageUnitTest.java
@@ -40,6 +40,48 @@ import org.zaproxy.zap.users.User;
 public class HttpMessageUnitTest {
 
     @Test
+    public void shouldBeEventStreamIfRequestWithoutResponseAcceptsEventStream() throws Exception {
+        // Given
+        HttpMessage message = new HttpMessage(new HttpRequestHeader("GET / HTTP/1.1\r\nAccept: text/event-stream"));
+        // When
+        boolean eventStream = message.isEventStream();
+        // Then
+        assertThat(eventStream, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldNotBeEventStreamIfRequestWithoutResponseDoesNotAcceptJustEventStream() throws Exception {
+        // Given
+        HttpMessage message = new HttpMessage(new HttpRequestHeader("GET / HTTP/1.1\r\nAccept: */*"));
+        // When
+        boolean eventStream = message.isEventStream();
+        // Then
+        assertThat(eventStream, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldBeEventStreamIfResponseHasEventStreamContentType() throws Exception {
+        // Given
+        HttpMessage message = newHttpMessage();
+        message.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "text/event-stream;charset=utf-8");
+        // When
+        boolean eventStream = message.isEventStream();
+        // Then
+        assertThat(eventStream, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldNotBeEventStreamIfResponseDoesNotHaveEventStreamContentType() throws Exception {
+        // Given
+        HttpMessage message = newHttpMessage();
+        message.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "text/not-event-stream;charset=utf-8");
+        // When
+        boolean eventStream = message.isEventStream();
+        // Then
+        assertThat(eventStream, is(equalTo(false)));
+    }
+
+    @Test
     public void shouldCopyHttpMessage() throws Exception {
         // Given
         HttpMessage message = newHttpMessage();


### PR DESCRIPTION
Change HttpMessage/ZapGetMethod to check if the Content-Type contains
the SSE type/subtype instead of checking if it's equal, to allow
parameters in the media type.
Expose HttpHeader methods around Content-Type handling, now used in
prior check.
Add tests to assert the expected behaviour of HttpMessage.

Fix #5003 - SSE are not supported in some cases