### PR TITLE
Show Version in Marketplace Installed Addons Tab

### DIFF
--- a/src/org/zaproxy/zap/extension/autoupdate/InstalledAddOnsTableModel.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/InstalledAddOnsTableModel.java
@@ -40,6 +40,7 @@ public class InstalledAddOnsTableModel extends AddOnsTableModel {
 	private static final String[] COLUMN_NAMES = {
 		"", // Column for warning of running issues (e.g. incorrect Java version, missing dependency...)
 		Constant.messages.getString("cfu.table.header.name"),
+		Constant.messages.getString("cfu.table.header.version"),
 		Constant.messages.getString("cfu.table.header.desc"),
 		Constant.messages.getString("cfu.table.header.update"),
 		""};
@@ -77,7 +78,7 @@ public class InstalledAddOnsTableModel extends AddOnsTableModel {
 
     @Override
     public Class<?> getColumnClass(int columnIndex) {
-        if (columnIndex == 0 || columnIndex == 4) {
+        if (columnIndex == 0 || columnIndex == 5) {
             return Boolean.class;
         }
         return String.class;
@@ -94,8 +95,10 @@ public class InstalledAddOnsTableModel extends AddOnsTableModel {
         case 1:
             return aow.getAddOn().getName();
         case 2:
-            return aow.getAddOn().getDescription();
+            return aow.getAddOn().getVersion();
         case 3:
+            return aow.getAddOn().getDescription();
+        case 4:
         	int progress = aow.getProgress();
         	if (aow.isFailed()) {
         		return Constant.messages.getString("cfu.table.label.failed");
@@ -109,7 +112,7 @@ public class InstalledAddOnsTableModel extends AddOnsTableModel {
         	} else {
         		return "";
         	}
-        case 4:
+        case 5:
             return getAddOnWrapper(rowIndex).isEnabled();
         }
         return null;
@@ -117,7 +120,7 @@ public class InstalledAddOnsTableModel extends AddOnsTableModel {
     
     @Override
     public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
-        if (columnIndex != 4) {
+        if (columnIndex != 5) {
             return;
         }
 
@@ -137,7 +140,7 @@ public class InstalledAddOnsTableModel extends AddOnsTableModel {
     
     @Override
     public boolean isCellEditable(int rowIndex, int columnIndex) {
-        if (columnIndex != 4) {
+        if (columnIndex != 5) {
             return false;
         }
 

--- a/src/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
@@ -399,12 +399,14 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
 			installedAddOnsTable.getColumnModel().getColumn(0).setMaxWidth(20);//icon
 			installedAddOnsTable.getColumnExt(0).setSortable(false);//icon doesn't need to be sortable
 			installedAddOnsTable.getColumnModel().getColumn(1).setPreferredWidth(200);//name
-			installedAddOnsTable.getColumnModel().getColumn(2).setPreferredWidth(400);//description
-			installedAddOnsTable.getColumnExt(2).setSortable(false);//description doesn't need to be sortable
-			installedAddOnsTable.getColumnModel().getColumn(3).setPreferredWidth(60);//update
-			installedAddOnsTable.getColumnExt(3).setSortable(false);//update doesn't need to be sortable
-			installedAddOnsTable.getColumnModel().getColumn(4).setPreferredWidth(40);
-			installedAddOnsTable.getColumnExt(4).setSortable(false);//checkbox doesn't need to be sortable
+			installedAddOnsTable.getColumnModel().getColumn(2).setPreferredWidth(60);//version
+			installedAddOnsTable.getColumnExt(2).setSortable(false);//version doesn't need to be sortable
+			installedAddOnsTable.getColumnModel().getColumn(3).setPreferredWidth(400);//description
+			installedAddOnsTable.getColumnExt(3).setSortable(false);//description doesn't need to be sortable
+			installedAddOnsTable.getColumnModel().getColumn(4).setPreferredWidth(60);//update
+			installedAddOnsTable.getColumnExt(4).setSortable(false);//update doesn't need to be sortable
+			installedAddOnsTable.getColumnModel().getColumn(5).setPreferredWidth(40);
+			installedAddOnsTable.getColumnExt(5).setSortable(false);//checkbox doesn't need to be sortable
           
             //Default sort by name (column 1)
             List<RowSorter.SortKey> sortKeys = new ArrayList<RowSorter.SortKey>(1);


### PR DESCRIPTION
I noticed this morning that the hover text shows the details of the update if one is available. I believe this change makes things clearer in the dialog and will also simplify: 
https://github.com/zaproxy/zaproxy/wiki/FAQAddonVersions

Before:
![image](https://user-images.githubusercontent.com/7570458/46154011-466d5300-c242-11e8-982d-5f641eccb7d8.png)

After:
![image](https://user-images.githubusercontent.com/7570458/46153263-c397c880-c240-11e8-853a-cb63a2a964e5.png)
