### PR TITLE
Do not disable break buttons if msgs still caught

### DIFF
--- a/src/org/zaproxy/zap/extension/brk/BreakPanel.java
+++ b/src/org/zaproxy/zap/extension/brk/BreakPanel.java
@@ -462,7 +462,7 @@ public class BreakPanel extends AbstractPanel implements Tab, BreakpointManageme
 
 	@Override
 	public void step() {
-		breakToolbarFactory.setStep(true);
+		breakToolbarFactory.step();
 	}
 	
 	@Override
@@ -475,7 +475,7 @@ public class BreakPanel extends AbstractPanel implements Tab, BreakpointManageme
 
 	@Override
 	public void drop() {
-		breakToolbarFactory.setDrop(true);
+		breakToolbarFactory.drop();
 	}
 
 	public void showNewBreakPointDialog() {


### PR DESCRIPTION
Change BreakPanelToolbarFactory to keep track of how many messages are
currently caught to just disable the buttons when none is left. Now the
buttons are no longer disabled after stepping/dropping only when
continuing (which forwards everything) or no messages left.
Remove the boolean parameter from setStep/setDrop and rename to step and
drop, respectively, the parameter is no longer needed the break buttons
are no longer affected (and the parameter was always the same, true).
Update BreakPanel to reflect the changes in the step/drop methods.

Fix #4623 - Message caught in Break tab but break buttons remain
disabled