### PR TITLE
Correct break events with multiple messages

### DIFF
--- a/src/org/zaproxy/zap/extension/brk/BreakEventPublisher.java
+++ b/src/org/zaproxy/zap/extension/brk/BreakEventPublisher.java
@@ -35,7 +35,19 @@ import org.zaproxy.zap.extension.httppanel.Message;
 public class BreakEventPublisher implements EventPublisher {
 
     private static BreakEventPublisher publisher = null;
+    /**
+     * Indicates that a message hit a breakpoint.
+     */
+    public static final String BREAK_POINT_HIT = "break.hit";
+    /**
+     * Indicates the message currently being changed (active).
+     * <p>
+     * Only one message can be active at the same time.
+     */
     public static final String BREAK_POINT_ACTIVE = "break.active";
+    /**
+     * Indicates that the active message no longer is, it might have been dropped or forwarded.
+     */
     public static final String BREAK_POINT_INACTIVE = "break.inactive";
 
     public static final String MESSAGE_TYPE = "messageType";
@@ -48,9 +60,13 @@ public class BreakEventPublisher implements EventPublisher {
     public static synchronized BreakEventPublisher getPublisher() {
         if (publisher == null) {
             publisher = new BreakEventPublisher();
-            ZAP.getEventBus().registerPublisher(publisher, new String[] { BREAK_POINT_ACTIVE, BREAK_POINT_INACTIVE });
+            ZAP.getEventBus().registerPublisher(publisher, new String[] { BREAK_POINT_HIT, BREAK_POINT_ACTIVE, BREAK_POINT_INACTIVE });
         }
         return publisher;
+    }
+
+    public void publishHitEvent(Message msg) {
+        this.publishEvent(BREAK_POINT_HIT, msg, msg.toEventData());
     }
 
     public void publishActiveEvent(Message msg) {

--- a/src/org/zaproxy/zap/extension/brk/BreakpointMessageHandler2.java
+++ b/src/org/zaproxy/zap/extension/brk/BreakpointMessageHandler2.java
@@ -70,16 +70,17 @@ public class BreakpointMessageHandler2 {
         // Do this outside of the semaphore loop so that the 'continue' button can apply to all queued break points
         // but be reset when the next break point is hit
         breakMgmt.breakpointHit();
-        BreakEventPublisher.getPublisher().publishActiveEvent(aMessage);
+        BreakEventPublisher.getPublisher().publishHitEvent(aMessage);
 
         synchronized(SEMAPHORE) {
             if (breakMgmt.isHoldMessage(aMessage)) {
+                BreakEventPublisher.getPublisher().publishActiveEvent(aMessage);
                 setBreakDisplay(aMessage, true);
                 waitUntilContinue(aMessage, true);
+                BreakEventPublisher.getPublisher().publishInactiveEvent(aMessage);
             }
         }
         breakMgmt.clearAndDisableRequest();
-        BreakEventPublisher.getPublisher().publishInactiveEvent(aMessage);
         return ! breakMgmt.isToBeDropped();
     }
     
@@ -98,16 +99,17 @@ public class BreakpointMessageHandler2 {
         // Do this outside of the semaphore loop so that the 'continue' button can apply to all queued break points
         // but be reset when the next break point is hit
         breakMgmt.breakpointHit();
-        BreakEventPublisher.getPublisher().publishActiveEvent(aMessage);
+        BreakEventPublisher.getPublisher().publishHitEvent(aMessage);
 
         synchronized(SEMAPHORE) {
             if (breakMgmt.isHoldMessage(aMessage)) {
+                BreakEventPublisher.getPublisher().publishActiveEvent(aMessage);
                 setBreakDisplay(aMessage, false);
                 waitUntilContinue(aMessage, false);
+                BreakEventPublisher.getPublisher().publishInactiveEvent(aMessage);
             }
         }
         breakMgmt.clearAndDisableResponse();
-        BreakEventPublisher.getPublisher().publishInactiveEvent(aMessage);
         return ! breakMgmt.isToBeDropped();
     }
     


### PR DESCRIPTION
Change BreakpointMessageHandler2 to only send the active/inactive events
when the message is actually active/inactive not when a breakpoint is
hit, otherwise it would mislead the consumers by sending multiple active
events (when only one message is active).
Add a new event to BreakEventPublisher for when a breakpoint is hit.