### PR TITLE
Reset caret after setting text to ZapLabel

### DIFF
--- a/src/org/zaproxy/zap/utils/ZapLabel.java
+++ b/src/org/zaproxy/zap/utils/ZapLabel.java
@@ -52,4 +52,15 @@ public class ZapLabel extends JTextArea {
 		this.setBackground(new Color(UIManager.getLookAndFeel().getDefaults().getColor("Label.background").getRGB()));
 		this.setForeground(new Color(UIManager.getLookAndFeel().getDefaults().getColor("Label.foreground").getRGB()));
 	}
+	
+	/**
+	 * {@inheritDoc}
+	 * <p>
+	 * The caret position is set to 0 after setting the text.
+	 */
+	@Override
+	public void setText(String t) {
+		super.setText(t);
+		setCaretPosition(0);
+	}
 }


### PR DESCRIPTION
Change ZapLabel to set the caret position to 0 after setting the text to
ensure the first part of the text set is visible on long single line
labels.