### PR TITLE
Let fields in StandardFieldsDialog get all space

### DIFF
--- a/src/org/zaproxy/zap/view/StandardFieldsDialog.java
+++ b/src/org/zaproxy/zap/view/StandardFieldsDialog.java
@@ -200,7 +200,6 @@ public abstract class StandardFieldsDialog extends AbstractDialog {
 		}
 		this.setDefaultCloseOperation(javax.swing.WindowConstants.DO_NOTHING_ON_CLOSE);
 		this.setTitle(Constant.messages.getString(titleLabel));
-		this.setXWeights(0.4D, 0.6D);	// Looks a bit better..
 		this.initialize(dim, tabLabels);
 		this.hideOnSave = true;
 	}


### PR DESCRIPTION
Remove the statement that let labels get extra space, the fields usually
occupy more space and contain more data than the labels (for example,
Zest script dialogues) thus it reduces the need to resize the dialogues
to see all the contents.