### PR TITLE
Restore info message in Input Vectors tab

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
+++ b/src/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
@@ -96,8 +96,6 @@ public class CustomScanDialog extends StandardFieldsDialog {
     private static final String FIELD_RECURSE = "ascan.custom.label.recurse";
     private static final String FIELD_ADVANCED = "ascan.custom.label.adv";
     
-    private static final String FIELD_DISABLE_VARIANTS_MSG = "variant.options.disable";
-
     private static final Logger logger = Logger.getLogger(CustomScanDialog.class);
     private static final long serialVersionUID = 1L;
 
@@ -434,6 +432,7 @@ public class CustomScanDialog extends StandardFieldsDialog {
     private OptionsVariantPanel getVariantPanel() {
         if (variantPanel == null) {
             variantPanel = new OptionsVariantPanel();            
+            variantPanel.setReasonVariantsDisabled(Constant.messages.getString("ascan.custom.warn.disabled"));
         }
         
         return variantPanel;
@@ -559,24 +558,8 @@ public class CustomScanDialog extends StandardFieldsDialog {
     private JCheckBox getDisableNonCustomVectors() {
         if (disableNonCustomVectors == null) {
             disableNonCustomVectors = new JCheckBox(Constant.messages.getString("ascan.custom.label.disableiv"));
-            disableNonCustomVectors.addActionListener(new ActionListener() {
-                
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    // Enable/disable all of the input vector options as appropriate
-                    getVariantPanel().setAllInjectableAndRPC(!disableNonCustomVectors.isSelected());
-
-                    if (disableNonCustomVectors.isSelected()) {
-                        setFieldValue(FIELD_DISABLE_VARIANTS_MSG,
-                                Constant.messages.getString("ascan.custom.warn.disabled"));
-                    
-                    } else {
-                        setFieldValue(FIELD_DISABLE_VARIANTS_MSG, "");
-                    }
-
-                }
-            });
-
+            disableNonCustomVectors
+                    .addActionListener(e -> getVariantPanel().setAllInjectableAndRPC(!disableNonCustomVectors.isSelected()));
         }
         return disableNonCustomVectors;
     }

--- a/src/org/zaproxy/zap/extension/ascan/OptionsVariantPanel.java
+++ b/src/org/zaproxy/zap/extension/ascan/OptionsVariantPanel.java
@@ -25,6 +25,7 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
+import java.util.Objects;
 
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
@@ -85,10 +86,33 @@ public class OptionsVariantPanel extends AbstractParamPanel {
     private ExcludedParameterTableModel excludedParamModel = null;
 
     /**
+     * The reason why the variants are disabled.
+     * <p>
+     * Never {@code null}.
+     * 
+     * @see #labelReasonVariantsDisabled
+     */
+    private String reasonVariantsDisabled;
+
+    /**
+     * The label that shows the {@link #reasonVariantsDisabled reason} why the variants are disabled.
+     * <p>
+     * The label is only shown if the reason is non-empty.
+     * 
+     * @see #setAllInjectableAndRPC(boolean)
+     */
+    private JLabel labelReasonVariantsDisabled;
+    
+    /**
      * General Constructor
      */
     public OptionsVariantPanel() {
         super();
+
+        reasonVariantsDisabled = "";
+        labelReasonVariantsDisabled = new JLabel();
+        labelReasonVariantsDisabled.setVisible(false);
+
         initialize();
     }
 
@@ -180,16 +204,20 @@ public class OptionsVariantPanel extends AbstractParamPanel {
                     this.getChkRPCCustom(), 
                     LayoutHelper.getGBC(0, 2, 2, 1.0D, 0, GridBagConstraints.HORIZONTAL, new Insets(16, 2, 2, 2)));            
 
+            panelVariant.add(
+                    labelReasonVariantsDisabled,
+                    LayoutHelper.getGBC(0, 3, 2, 1.0D, 1.0D, GridBagConstraints.BOTH, new Insets(2, 2, 2, 2)));
+
             // Excluded Parameters
             panelVariant.add(
                     new JLabel(Constant.messages.getString("variant.options.excludedparam.label.tokens")), 
-                    LayoutHelper.getGBC(0, 3, 2, 1.0D, 0, GridBagConstraints.HORIZONTAL, new Insets(16, 2, 2, 2)));
+                    LayoutHelper.getGBC(0, 4, 2, 1.0D, 0, GridBagConstraints.HORIZONTAL, new Insets(16, 2, 2, 2)));
             
             // Set an header on it
             excludedParamPanel = new ExcludedParameterPanel(getExcludedParameterModel());
             panelVariant.add(
                     excludedParamPanel,
-                    LayoutHelper.getGBC(0, 4, 2, 1.0D, 1.0D, GridBagConstraints.BOTH, new Insets(2, 2, 2, 2)));            
+                    LayoutHelper.getGBC(0, 5, 2, 1.0D, 1.0D, GridBagConstraints.BOTH, new Insets(2, 2, 2, 2)));            
         }
         
         return panelVariant;
@@ -311,6 +339,7 @@ public class OptionsVariantPanel extends AbstractParamPanel {
     /**
      * Set all checkbox to a specific value
      * @param enabled true if all the checkbox should be enabled, false otherwise
+     * @see #setReasonVariantsDisabled(String)
      */
     public void setAllInjectableAndRPC(boolean enabled) {
         
@@ -329,6 +358,10 @@ public class OptionsVariantPanel extends AbstractParamPanel {
         this.getChkRPCoData().setEnabled(enabled);
         this.getChkRPCDWR().setEnabled(enabled);
         this.getChkRPCCustom().setEnabled(enabled && isExtensionScriptEnabled());
+
+        if (!reasonVariantsDisabled.isEmpty()) {
+            labelReasonVariantsDisabled.setVisible(!enabled);
+        }
     }
     
     /**
@@ -346,6 +379,23 @@ public class OptionsVariantPanel extends AbstractParamPanel {
     @Override
     public String getHelpIndex() {
         return "ui.dialogs.options.ascaninput";
+    }
+
+    /**
+     * Sets the reason to show when the the variants are disabled.
+     *
+     * @param reason the reason that indicates why the variants are disabled.
+     * @since TODO add version
+     * @throws NullPointerException if the given {@code reason} is {@code null}.
+     * @see #setAllInjectableAndRPC(boolean)
+     */
+    public void setReasonVariantsDisabled(String reason) {
+        reasonVariantsDisabled = Objects.requireNonNull(reason);
+
+        labelReasonVariantsDisabled.setText(reasonVariantsDisabled);
+        if (reasonVariantsDisabled.isEmpty() && labelReasonVariantsDisabled.isVisible()) {
+            labelReasonVariantsDisabled.setVisible(false);
+        }
     }
 
     private JCheckBox getChkInjectableQueryString() {


### PR DESCRIPTION
Restore message lost in previous changes, change CustomScanDialog to set
the reason why the Input Vectors are disabled to OptionsVariantPanel.
Change OptionsVariantPanel to show the reason when the variants are
disabled.