### PR TITLE
Do not add auth context menus in daemon mode

### DIFF
--- a/src/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodType.java
+++ b/src/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodType.java
@@ -859,6 +859,9 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
 
 	@Override
 	public void hook(ExtensionHook extensionHook) {
+		if (!View.isInitialised()) {
+			return;
+		}
 		extensionHook.getHookMenu().addPopupMenuItem(getPopupFlagLoginRequestMenuFactory());
 	}
 


### PR DESCRIPTION
Change PostBasedAuthenticationMethodType to check first if ZAP has view
to add the context menu.