### PR TITLE
Add button to install all add-ons from marketplace

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -642,6 +642,7 @@ cfu.button.addons.browse = Manage Add-ons
 cfu.button.addons.download = Download Selected
 cfu.button.addons.info = More Info
 cfu.button.addons.install = Install Selected
+cfu.button.addons.installall = Install All
 cfu.button.addons.uninstall = Uninstall Selected
 cfu.button.addons.update = Update Selected
 cfu.button.addons.updateAll = Update All

--- a/src/org/zaproxy/zap/extension/autoupdate/UninstalledAddOnsTableModel.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/UninstalledAddOnsTableModel.java
@@ -19,7 +19,9 @@
  */
 package org.zaproxy.zap.extension.autoupdate;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.swing.Icon;
 
@@ -136,6 +138,25 @@ public class UninstalledAddOnsTableModel extends AddOnsTableModel {
     	}
     	return enable;
 	}
+	
+    public Set<AddOn> getAvailableAddOns() {
+        Set<AddOn> addOns = new HashSet<>();
+        for (AddOnWrapper aow : getAddOnWrappers()) {
+            if (aow.getInstallationStatus() == AddOn.InstallationStatus.AVAILABLE) {
+                addOns.add(aow.getAddOn());
+            }
+        }
+        return addOns;
+    }
+
+    public boolean hasAvailableAddOns() {
+        for (AddOnWrapper aow : getAddOnWrappers()) {
+            if (aow.getInstallationStatus() == AddOn.InstallationStatus.AVAILABLE) {
+                return true;
+            }
+        }
+        return false;
+    }
     
     public void addAddOn(AddOn addOn) {
         addAddOnWrapper(addOn, null);


### PR DESCRIPTION
Add a button, shown in dev mode only, to install all add-ons available
in the marketplace, to not require selecting them one by one.