### PR TITLE
Lazily initialise ExtensionHook[Menu|View]

### DIFF
--- a/src/org/parosproxy/paros/extension/ExtensionHook.java
+++ b/src/org/parosproxy/paros/extension/ExtensionHook.java
@@ -56,8 +56,25 @@ import org.zaproxy.zap.view.SiteMapListener;
 
 public class ExtensionHook {
 
-    private ExtensionHookMenu hookMenu = new ExtensionHookMenu();
-    private ExtensionHookView hookView = new ExtensionHookView();
+    /**
+     * The hook for menus.
+     * <p>
+     * Lazily initialised.
+     * 
+     * @see #getHookMenu()
+     * @see #getHookMenuNoInit()
+     */
+    private ExtensionHookMenu hookMenu;
+
+    /**
+     * The hook for view components.
+     * <p>
+     * Lazily initialised.
+     * 
+     * @see #getHookView()
+     * @see #getHookViewNoInit()
+     */
+    private ExtensionHookView hookView;
     private Model model = null;
     private Vector<OptionsChangedListener> optionsListenerList = new Vector<>();
 
@@ -253,17 +270,49 @@ public class ExtensionHook {
     }
 
     /**
-     * @return Returns the hookMenu.
+     * Gets the hook for menus.
+     * 
+     * @return the hook for menus, never {@code null}.
      */
     public ExtensionHookMenu getHookMenu() {
+        if (hookMenu == null) {
+            hookMenu = new ExtensionHookMenu();
+        }
         return hookMenu;
     }
+
     /**
-     * @return Returns the hookView.
+     * Gets the hook for menus, without initialising it.
+     *
+     * @return the hook for menus, might be {@code null}.
+     * @since TODO add version
+     */
+    ExtensionHookMenu getHookMenuNoInit() {
+        return hookMenu;
+    }
+
+    /**
+     * Gets the hook for view components.
+     * 
+     * @return the hook for view components, never {@code null}.
      */
     public ExtensionHookView getHookView() {
+        if (hookView == null) {
+            hookView = new ExtensionHookView();
+        }
         return hookView;
     }
+
+    /**
+     * Gets the hook for view components, without initialising it.
+     *
+     * @return the hook for view components, might be {@code null}.
+     * @since TODO add version
+     */
+    ExtensionHookView getHookViewNoInit() {
+        return hookView;
+    }
+
     /**
      * @return Returns the model.
      */

--- a/src/org/parosproxy/paros/extension/ExtensionHookView.java
+++ b/src/org/parosproxy/paros/extension/ExtensionHookView.java
@@ -22,24 +22,74 @@
  // addSessionPanel.
 // ZAP: 2016/04/08 Allow to add ContextPanelFactory
 // ZAP: 2017/02/19 Allow to add components to the main tool bar.
+// ZAP: 2018/10/05 Lazily initialise the lists and add JavaDoc.
 package org.parosproxy.paros.extension;
 
 import java.awt.Component;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Vector;
 
 import org.parosproxy.paros.view.AbstractParamPanel;
 import org.zaproxy.zap.view.ContextPanelFactory;
 
+/**
+ * The object to add/hook components to the main UI components.
+ * <p>
+ * The components added through the hook are removed when the extension is unloaded.
+ * <p>
+ * <strong>Note:</strong> This class is not thread-safe, the components should be added only through the thread that
+ * {@link Extension#hook(ExtensionHook) hooks the extension}.
+ *
+ * @since 1.0.0
+ */
 public class ExtensionHookView {
 
-    private Vector<AbstractPanel> workPanelList = new Vector<>();
-    private Vector<AbstractPanel> statusPanelList = new Vector<>();
-    private Vector<AbstractPanel> selectPanelList = new Vector<>();
-    private Vector<AbstractParamPanel> sessionPanelList = new Vector<>();
-    private Vector<AbstractParamPanel> optionPanelList = new Vector<>();
+    /**
+     * The work panels added to this extension hook.
+     * <p>
+     * Lazily initialised.
+     * 
+     * @see #addWorkPanel(AbstractPanel)
+     * @see #getWorkPanel()
+     */
+    private List<AbstractPanel> workPanelList;
+    /**
+     * The status panels added to this extension hook.
+     * <p>
+     * Lazily initialised.
+     * 
+     * @see #addWorkPanel(AbstractPanel)
+     * @see #getWorkPanel()
+     */
+    private List<AbstractPanel> statusPanelList;
+    /**
+     * The work panels added to this extension hook.
+     * <p>
+     * Lazily initialised.
+     * 
+     * @see #addWorkPanel(AbstractPanel)
+     * @see #getWorkPanel()
+     */
+    private List<AbstractPanel> selectPanelList;
+    /**
+     * The session panels added to this extension hook.
+     * <p>
+     * Lazily initialised.
+     * 
+     * @see #addSessionPanel(AbstractParamPanel)
+     * @see #getSessionPanel()
+     */
+    private List<AbstractParamPanel> sessionPanelList;
+    /**
+     * The options panels added to this extension hook.
+     * <p>
+     * Lazily initialised.
+     * 
+     * @see #addOptionPanel(AbstractParamPanel)
+     * @see #getOptionsPanel()
+     */
+    private List<AbstractParamPanel> optionPanelList;
     
     /**
      * The {@link ContextPanelFactory}s added to this extension hook.
@@ -64,60 +114,109 @@ public class ExtensionHookView {
     public ExtensionHookView() {
     }
     
+    /**
+     * Adds the given {@link AbstractPanel} to the view hook, to be later added to the
+     * {@link org.parosproxy.paros.view.WorkbenchPanel WorkbenchPanel} as a
+     * {@link org.parosproxy.paros.view.WorkbenchPanel.PanelType#WORK work} panel.
+     *
+     * @param panel the panel that will be added to the {@code WorkbenchPanel}.
+     * @see org.parosproxy.paros.view.View#getWorkbench()
+     */
     public void addWorkPanel(AbstractPanel panel) {
+        if (workPanelList == null) {
+            workPanelList = createList();
+        }
         workPanelList.add(panel);
     }
     
+    /**
+     * Adds the given {@link AbstractPanel} to the view hook, to be later added to the
+     * {@link org.parosproxy.paros.view.WorkbenchPanel WorkbenchPanel} as a
+     * {@link org.parosproxy.paros.view.WorkbenchPanel.PanelType#SELECT select} panel.
+     *
+     * @param panel the panel that will be added to the {@code WorkbenchPanel}.
+     * @see org.parosproxy.paros.view.View#getWorkbench()
+     */
     public void addSelectPanel(AbstractPanel panel) {
+        if (selectPanelList == null) {
+            selectPanelList = createList();
+        }
         selectPanelList.add(panel);
     }
     
+    /**
+     * Adds the given {@link AbstractPanel} to the view hook, to be later added to the
+     * {@link org.parosproxy.paros.view.WorkbenchPanel WorkbenchPanel} as a
+     * {@link org.parosproxy.paros.view.WorkbenchPanel.PanelType#STATUS status} panel.
+     *
+     * @param panel the panel that will be added to the {@code WorkbenchPanel}.
+     * @see org.parosproxy.paros.view.View#getWorkbench()
+     */
     public void addStatusPanel(AbstractPanel panel) {
+        if (statusPanelList == null) {
+            statusPanelList = createList();
+        }
         statusPanelList.add(panel);
     }
     
-    // ZAP: Changed the type of the parameter "panel" from AbstractPanel to
-    // AbstractParamPanel.
+    /**
+     * Adds the given {@link AbstractParamPanel} to the view hook, to be later added to the
+     * {@link org.parosproxy.paros.view.SessionDialog Session Properties dialogue}.
+     *
+     * @param panel the {@code AbstractParamPanel} that will be added to the Options dialogue.
+     * @see org.parosproxy.paros.view.View#getSessionDialog()
+     */
     public void addSessionPanel(AbstractParamPanel panel) {
+        if (sessionPanelList == null) {
+            sessionPanelList = createList();
+        }
         sessionPanelList.add(panel);
     }
     
+    /**
+     * Adds the given {@link AbstractParamPanel} to the view hook, to be later added to the
+     * {@link org.parosproxy.paros.view.OptionsDialog Options dialogue}.
+     *
+     * @param panel the {@code AbstractParamPanel} that will be added to the Options dialogue.
+     * @see org.parosproxy.paros.view.View#getOptionsDialog(String)
+     */
     public void addOptionPanel(AbstractParamPanel panel) {
+        if (optionPanelList == null) {
+            optionPanelList = createList();
+        }
         optionPanelList.add(panel);
     }
     
     List<AbstractPanel> getWorkPanel() {
-        return workPanelList;
+        return unmodifiableList(workPanelList);
     }
         
     List<AbstractPanel> getSelectPanel() {
-        return selectPanelList;
+        return unmodifiableList(selectPanelList);
     }
     
     List<AbstractPanel> getStatusPanel() {
-        return statusPanelList;
+        return unmodifiableList(statusPanelList);
     }
 
     List<AbstractParamPanel> getSessionPanel() {
-        return sessionPanelList;
+        return unmodifiableList(sessionPanelList);
     }
     
     List<AbstractParamPanel> getOptionsPanel() {
-        return optionPanelList;
+        return unmodifiableList(optionPanelList);
     }
     
     /**
      * Adds the given {@link ContextPanelFactory} to the view hook, to be later added to the
      * {@link org.parosproxy.paros.view.View View}.
-     * <p>
-     * By default, the {@code ContextPanelFactory}s added are removed from the {@code View} when the extension is unloaded.
      *
      * @param contextPanelFactory the {@code ContextPanelFactory} that will be added to the {@code View}
      * @since 2.5.0
      */
     public void addContextPanelFactory(ContextPanelFactory contextPanelFactory) {
         if (contextPanelFactories == null) {
-            contextPanelFactories = new ArrayList<>();
+            contextPanelFactories = createList();
         }
         contextPanelFactories.add(contextPanelFactory);
     }
@@ -129,18 +228,13 @@ public class ExtensionHookView {
      * @since 2.5.0
      */
     List<ContextPanelFactory> getContextPanelFactories() {
-        if (contextPanelFactories == null) {
-            return Collections.emptyList();
-        }
-        return Collections.unmodifiableList(contextPanelFactories);
+        return unmodifiableList(contextPanelFactories);
     }
 
     /**
      * Adds the given {@link Component} (usually {@link javax.swing.JButton JButton}, {@link javax.swing.JToggleButton
      * JToggleButton}, {@link javax.swing.JToolBar.Separator JToolBar.Separator}) to the view hook, to be later added to the
      * main tool bar panel.
-     * <p>
-     * By default, the {@code Component}s added are removed from the main tool bar panel when the extension is unloaded.
      *
      * @param component the {@code component} that will be added to the main tool bar panel
      * @since 2.6.0
@@ -149,7 +243,7 @@ public class ExtensionHookView {
      */
     public void addMainToolBarComponent(Component component) {
         if (mainToolBarComponents == null) {
-            mainToolBarComponents = new ArrayList<>();
+            mainToolBarComponents = createList();
         }
         mainToolBarComponents.add(component);
     }
@@ -161,9 +255,30 @@ public class ExtensionHookView {
      * @since 2.6.0
      */
     List<Component> getMainToolBarComponents() {
-        if (mainToolBarComponents == null) {
+        return unmodifiableList(mainToolBarComponents);
+    }
+
+    /**
+     * Creates an {@link ArrayList} with initial capacity of 1.
+     * <p>
+     * Majority of extensions just add one element.
+     *
+     * @return the {@code ArrayList}.
+     */
+    private static <T> List<T> createList() {
+        return new ArrayList<>(1);
+    }
+
+    /**
+     * Gets an unmodifiable list from the given list.
+     *
+     * @param list the list, might be {@code null}.
+     * @return an unmodifiable list, never {@code null}.
+     */
+    private static <T> List<T> unmodifiableList(List<T> list) {
+        if (list == null) {
             return Collections.emptyList();
         }
-        return Collections.unmodifiableList(mainToolBarComponents);
+        return Collections.unmodifiableList(list);
     }
 }

--- a/src/org/parosproxy/paros/extension/ExtensionLoader.java
+++ b/src/org/parosproxy/paros/extension/ExtensionLoader.java
@@ -73,6 +73,7 @@
 // ZAP: 2017/10/31 Add JavaDoc to ExtensionLoader.getExtension(String).
 // ZAP: 2018/04/25 Allow to add ProxyServer to automatically add/remove proxy related listeners to it.
 // ZAP: 2018/07/18 Tweak logging.
+// ZAP: 2018/10/05 Get menu/view hooks without initialising them.
 
 package org.parosproxy.paros.extension;
 
@@ -963,7 +964,7 @@ public class ExtensionLoader {
             return;
         }
 
-        ExtensionHookMenu hookMenu = hook.getHookMenu();
+        ExtensionHookMenu hookMenu = hook.getHookMenuNoInit();
         if (hookMenu == null) {
             return;
         }
@@ -1026,7 +1027,7 @@ public class ExtensionLoader {
             return;
         }
 
-        ExtensionHookMenu hookMenu = hook.getHookMenu();
+        ExtensionHookMenu hookMenu = hook.getHookMenuNoInit();
         if (hookMenu == null) {
             return;
         }
@@ -1107,7 +1108,7 @@ public class ExtensionLoader {
             return;
         }
 
-        ExtensionHookView pv = hook.getHookView();
+        ExtensionHookView pv = hook.getHookViewNoInit();
         if (pv == null) {
             return;
         }
@@ -1143,7 +1144,7 @@ public class ExtensionLoader {
             return;
         }
 
-        ExtensionHookView pv = hook.getHookView();
+        ExtensionHookView pv = hook.getHookViewNoInit();
         if (pv == null) {
             return;
         }


### PR DESCRIPTION
The view related hooks are not necessary when running in daemon mode,
moreover, lazily initialise the lists used in the menu/view hooks since
just a couple of them are actually used by a single extension.