### PR TITLE
Use managed ExtensionHook when removing Extension

### DIFF
--- a/src/org/parosproxy/paros/extension/Extension.java
+++ b/src/org/parosproxy/paros/extension/Extension.java
@@ -36,6 +36,7 @@
 // ZAP: 2017/05/22 Use Class<? extends Extension> for dependencies of the extension.
 // ZAP: 2017/05/25 Add JavaDoc to isEnabled/setEnabled.
 // ZAP: 2018/06/01 Add JavaDoc to getMessages/setMessages.
+// ZAP: 2018/10/09 Remove getExtensionHook and add JavaDoc to hook.
 
 package org.parosproxy.paros.extension;
 
@@ -141,19 +142,13 @@ public interface Extension {
      */
     void initXML(Session session, OptionsParam options);
     
-    void hook(ExtensionHook pluginHook);
-
     /**
-     * Gets the {@code ExtensionHook} used to hook the components during initialisation.
-     * <p>
-     * Should be called only by core functionality (e.g. to unload the hooked components).
-     * 
-     * @return the {@code ExtensionHook} used to hook the components.
-     * @since 2.6.0
-     * @see #hook(ExtensionHook)
+     * Called during extension's initialisation to allow to add new functionality to core components.
+     *
+     * @param hook the hook to add the components.
      */
-    ExtensionHook getExtensionHook();
-    
+    void hook(ExtensionHook hook);
+
     boolean isDepreciated ();
     
     int getOrder();

--- a/src/org/parosproxy/paros/extension/ExtensionAdaptor.java
+++ b/src/org/parosproxy/paros/extension/ExtensionAdaptor.java
@@ -37,6 +37,7 @@
 // ZAP: 2015/03/30 Issue 1582: Enablers for low memory option
 // ZAP: 2017/02/17 Let core code remove/unhook the extension.
 // ZAP: 2017/05/22 Update for change in Extension.getDependencies().
+// ZAP: 2018/10/09 Remove instance variable hook and method getExtensionHook.
 
 package org.parosproxy.paros.extension;
 
@@ -64,7 +65,6 @@ public abstract class ExtensionAdaptor implements Extension {
     private boolean enabled = true;
     private ResourceBundle messages = null;
     private String i18nPrefix = null;
-	private ExtensionHook hook = null;
     
     /**
      * The add-on that this extension belongs too, might be {@code null} if core extension.
@@ -187,12 +187,7 @@ public abstract class ExtensionAdaptor implements Extension {
 
     @Override
     public void hook(ExtensionHook extensionHook) {
-    	this.hook  = extensionHook;
-    }
-
-    @Override
-    public ExtensionHook getExtensionHook() {
-        return hook;
+        // Nothing to do.
     }
 
     @Override

--- a/src/org/zaproxy/zap/control/AddOnInstaller.java
+++ b/src/org/zaproxy/zap/control/AddOnInstaller.java
@@ -318,7 +318,7 @@ public final class AddOnInstaller {
                 logger.debug("Unloading ext: " + extension.getName());
                 try {
                     extension.unload();
-                    Control.getSingleton().getExtensionLoader().removeExtension(extension, extension.getExtensionHook());
+                    Control.getSingleton().getExtensionLoader().removeExtension(extension);
                     ExtensionFactory.unloadAddOnExtension(extension);
                 } catch (Exception e) {
                     logger.error("An error occurred while uninstalling the extension \"" + extension.getName()


### PR DESCRIPTION
Change ExtensionLoader to use the managed hooks when removing the
extensions, no need to get them indirectly through the extension.
Remove (internal) methods no longer needed that allowed to get the
ExtensionHook from the extension and remove an extension with one.