### PR TITLE
Update docker images to use more recent ubuntu

### DIFF
--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -1,6 +1,8 @@
 # This dockerfile builds a 'live' zap docker image using the latest files in the repos
-FROM ubuntu:16.04
+FROM ubuntu:latest
 LABEL maintainer="psiinon@gmail.com"
+
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
 	make \
@@ -26,7 +28,6 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	x11vnc && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*  && \
-
 	gem install zapr && \
 	pip install --upgrade pip zapcli python-owasp-zap-v2.4 && \
 	useradd -d /home/zap -m -s /bin/bash zap && \

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -1,6 +1,8 @@
 # This dockerfile builds the zap stable release
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 LABEL maintainer="psiinon@gmail.com"
+
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
 	make \

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -1,6 +1,8 @@
 # This dockerfile builds the zap weekly release
-FROM ubuntu:16.04
+FROM ubuntu:latest
 LABEL maintainer="psiinon@gmail.com"
+
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
 	make \


### PR DESCRIPTION
Fixes #5045

The ENV VAR is needed to prevent a command line prompt, and docker is now complaining about empty continuation lines.