### PR TITLE
Update API generator

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -308,9 +308,8 @@
 
 	</target>
 
-	<target name="generate-apis" description="Generates the client APIs">
+	<target name="generate-apis" depends="dist" description="Generates the client APIs">
 		<path id="classpath">
-			<pathelement location="../bin" />
 			<pathelement location="./zap/${zap.jar}" />
 			<pathelement location="./zap" />
 			<fileset dir="../lib" includes="**/*.jar" />

--- a/src/org/zaproxy/zap/extension/api/AbstractAPIGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/AbstractAPIGenerator.java
@@ -27,6 +27,7 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 
 import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.utils.I18N;
 
 /**
  * The base class for ZAP API client generators.
@@ -83,6 +84,7 @@ abstract class AbstractAPIGenerator {
                         "lang." + Constant.MESSAGES_PREFIX,
                         Locale.ENGLISH,
                         ResourceBundle.Control.getControl(ResourceBundle.Control.FORMAT_PROPERTIES));
+        Constant.messages = new I18N(Locale.ENGLISH);
     }
 
     /**


### PR DESCRIPTION
Change AbstractAPIGenerator to initialise Constant.messages, now
required by CoreAPI to load some deprecation messages.
Change build target generate-apis to depend on dist (to ensure the ZAP
jar is built/available) and remove unnecessary directory from the
classpath (classes are provided by the ZAP jar).