### PR TITLE
Set a name to shutdown threads

### DIFF
--- a/src/org/parosproxy/paros/control/Control.java
+++ b/src/org/parosproxy/paros/control/Control.java
@@ -263,7 +263,7 @@ public class Control extends AbstractControl implements SessionListener {
 	    	    }
 	    		System.exit(0);   
 	        }
-	    });
+	    }, "ZAP-Shutdown");
 
 	    if (view != null) {
 		    WaitMessageDialog dialog = view.getWaitMessageDialog(Constant.messages.getString("menu.file.shuttingDown"));	// ZAP: i18n

--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -372,7 +372,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 			}
 			return sendHttpMessage(request, getParam(params, PARAM_FOLLOW_REDIRECTS, false), name);
 		} else if (ACTION_SHUTDOWN.equals(name)) {
-			Thread thread = new Thread() {
+			Thread thread = new Thread("ZAP-Shutdown") {
 				@Override
 				public void run() {
 					try {


### PR DESCRIPTION
Change Control and CoreAPI to use a name in the threads that shutdown
ZAP.