### PR TITLE
Include Alert API when generating API clients

### DIFF
--- a/src/org/zaproxy/zap/extension/api/ApiGeneratorUtils.java
+++ b/src/org/zaproxy/zap/extension/api/ApiGeneratorUtils.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.parosproxy.paros.core.scanner.ScannerParam;
 import org.parosproxy.paros.network.ConnectionParam;
+import org.zaproxy.zap.extension.alert.AlertAPI;
 import org.zaproxy.zap.extension.anticsrf.AntiCsrfAPI;
 import org.zaproxy.zap.extension.anticsrf.AntiCsrfParam;
 import org.zaproxy.zap.extension.ascan.ActiveScanAPI;
@@ -59,6 +60,8 @@ public class ApiGeneratorUtils {
 		List<ApiImplementor> imps = new ArrayList<>();
 		
 		ApiImplementor api;
+
+		imps.add(new AlertAPI(null));
 
 		api = new AntiCsrfAPI(null);
 		api.addApiOptions(new AntiCsrfParam());


### PR DESCRIPTION
Change ApiGeneratorUtils to include the Alert API, introduced in #4833.