### PR TITLE
Fix misaligned custom vectors indices

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/src/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -148,9 +148,6 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
     public void init(HttpMessage msg, HostProcess parent) {
         this.msg = msg.cloneAll();
         this.parent = parent;
-        if (this.parent.getScannerParam().isInjectPluginIdInHeader()) {
-    		this.msg.getRequestHeader().setHeader(HttpHeader.X_ZAP_SCAN_ID, Integer.toString(getId()));
-    	}
         init();
     }
 
@@ -272,6 +269,10 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
                 }
             }
         }
+
+        if (this.parent.getScannerParam().isInjectPluginIdInHeader()) {
+    		this.msg.getRequestHeader().setHeader(HttpHeader.X_ZAP_SCAN_ID, Integer.toString(getId()));
+    	}
 
         // always get the fresh copy
         message.getRequestHeader().setHeader(HttpHeader.IF_MODIFIED_SINCE, null);


### PR DESCRIPTION
This is related to #5060 

The injection of the X-ZAP-Scan-ID header happens at the `init` phase of `AbstractPlugin` altering the payload before setting the parameters. 

I moved it to the `sendAndReceive` where it is called after the `setParameter`. As a result, the parameters are now interpolated correctly.

Cheers