### PR TITLE
Catch credentials exception when authenticating

### DIFF
--- a/src/org/zaproxy/zap/users/User.java
+++ b/src/org/zaproxy/zap/users/User.java
@@ -29,6 +29,7 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.authentication.AuthenticationCredentials;
 import org.zaproxy.zap.authentication.AuthenticationMethod;
+import org.zaproxy.zap.authentication.AuthenticationMethod.UnsupportedAuthenticationCredentialsException;
 import org.zaproxy.zap.extension.authentication.ExtensionAuthentication;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.session.SessionManagementMethod;
@@ -252,8 +253,13 @@ public class User extends Enableable {
 	 */
 	public void authenticate() {
 		log.info("Authenticating user: " + this.name);
-		WebSession result = getContext().getAuthenticationMethod().authenticate(
+		WebSession result = null;
+		try {
+			result = getContext().getAuthenticationMethod().authenticate(
 				getContext().getSessionManagementMethod(), this.authenticationCredentials, this);
+		} catch (UnsupportedAuthenticationCredentialsException e) {
+			log.error("User does not have the expected type of credentials:", e);
+		}
 		// no issues appear if a simultaneous call to #queueAuthentication() is made
 		synchronized (this) {
 			this.lastSuccessfulAuthTime = System.currentTimeMillis();


### PR DESCRIPTION
Change User to catch UnsupportedAuthenticationCredentialsException when
authenticating, to prevent wrong type of credentials from breaking other
parts of the code.

e.g.:
```
189354 [Thread-29] ERROR org.zaproxy.zap.ZAP$UncaughtExceptionLogger  - Exception in thread "Thread-29"
org.zaproxy.zap.authentication.AuthenticationMethod$UnsupportedAuthenticationCredentialsException: Manual authentication credentials should be used for Manual authentication.
	at org.zaproxy.zap.authentication.ManualAuthenticationMethodType$ManualAuthenticationMethod.authenticate(ManualAuthenticationMethodType.java:111)
	at org.zaproxy.zap.users.User.authenticate(User.java:255)
	at org.zaproxy.zap.users.User.processMessageToMatchUser(User.java:171)
	at org.parosproxy.paros.network.HttpSender.sendAuthenticated(HttpSender.java:525)
	at org.parosproxy.paros.network.HttpSender.sendAuthenticated(HttpSender.java:518)
	at org.parosproxy.paros.network.HttpSender.sendAndReceive(HttpSender.java:432)
	at org.parosproxy.paros.network.HttpSender.sendAndReceive(HttpSender.java:389)
	at org.zaproxy.zap.extension.accessControl.AccessControlScannerThread.attackNode(AccessControlScannerThread.java:214)
	at org.zaproxy.zap.extension.accessControl.AccessControlScannerThread.scan(AccessControlScannerThread.java:181)
	at org.zaproxy.zap.scan.BaseScannerThread.startScan(BaseScannerThread.java:259)
	at org.zaproxy.zap.extension.accessControl.AccessControlScannerThread.startScan(AccessControlScannerThread.java:130)
	at org.zaproxy.zap.scan.BaseScannerThread.run(BaseScannerThread.java:199)
```