### PR TITLE
Use varargs on registrations in EventBus

### DIFF
--- a/src/org/parosproxy/paros/extension/history/ProxyListenerLogEventPublisher.java
+++ b/src/org/parosproxy/paros/extension/history/ProxyListenerLogEventPublisher.java
@@ -72,7 +72,7 @@ public final class ProxyListenerLogEventPublisher implements EventPublisher {
             publisher = new ProxyListenerLogEventPublisher();
             ZAP.getEventBus().registerPublisher(
                     publisher,
-                    new String[] { EVENT_ADDED });
+                    EVENT_ADDED);
         }
     }
     

--- a/src/org/parosproxy/paros/model/HistoryReferenceEventPublisher.java
+++ b/src/org/parosproxy/paros/model/HistoryReferenceEventPublisher.java
@@ -85,7 +85,7 @@ public final class HistoryReferenceEventPublisher implements EventPublisher {
             publisher = new HistoryReferenceEventPublisher();
             ZAP.getEventBus().registerPublisher(
                     publisher,
-                    new String[] { EVENT_TAG_ADDED, EVENT_TAG_REMOVED, EVENT_TAGS_SET, EVENT_NOTE_SET, EVENT_REMOVED });
+                    EVENT_TAG_ADDED, EVENT_TAG_REMOVED, EVENT_TAGS_SET, EVENT_NOTE_SET, EVENT_REMOVED);
         }
     }
 }

--- a/src/org/parosproxy/paros/model/SiteMapEventPublisher.java
+++ b/src/org/parosproxy/paros/model/SiteMapEventPublisher.java
@@ -40,7 +40,7 @@ public class SiteMapEventPublisher implements EventPublisher {
 		if (publisher == null) {
 			publisher = new SiteMapEventPublisher(); 
 	        ZAP.getEventBus().registerPublisher(publisher, 
-	        		new String[] {SITE_NODE_ADDED_EVENT, SITE_NODE_REMOVED_EVENT, SITE_ADDED_EVENT, SITE_REMOVED_EVENT});
+	        		SITE_NODE_ADDED_EVENT, SITE_NODE_REMOVED_EVENT, SITE_ADDED_EVENT, SITE_REMOVED_EVENT);
 
 		}
 		return publisher;

--- a/src/org/zaproxy/zap/eventBus/EventBus.java
+++ b/src/org/zaproxy/zap/eventBus/EventBus.java
@@ -31,7 +31,7 @@ public interface EventBus {
 	 * @param publisher the publisher
 	 * @param eventTypes the full set of event types the publisher can publish
 	 */
-	void registerPublisher(EventPublisher publisher, String[] eventTypes);
+	void registerPublisher(EventPublisher publisher, String... eventTypes);
 	
 	/**
 	 * Unregister the publisher
@@ -53,7 +53,7 @@ public interface EventBus {
 	 * @param publisherName the name of the publisher
 	 * @param eventTypes the event types
 	 */
-	void registerConsumer (EventConsumer consumer, String publisherName, String[] eventTypes);
+	void registerConsumer (EventConsumer consumer, String publisherName, String... eventTypes);
 	
 	/**
 	 * Unregister the consumer from all publishers

--- a/src/org/zaproxy/zap/eventBus/SimpleEventBus.java
+++ b/src/org/zaproxy/zap/eventBus/SimpleEventBus.java
@@ -31,7 +31,7 @@ public class SimpleEventBus implements EventBus {
 	private static Logger log = Logger.getLogger(SimpleEventBus.class);
 
 	@Override
-	public void registerPublisher(EventPublisher publisher, String[] eventTypes) {
+	public void registerPublisher(EventPublisher publisher, String... eventTypes) {
 		if (publisher == null) {
 			throw new InvalidParameterException("Publisher must not be null");
 		}
@@ -88,12 +88,12 @@ public class SimpleEventBus implements EventBus {
 
 	@Override
 	public void registerConsumer(EventConsumer consumer, String publisherName) {
-		this.registerConsumer(consumer, publisherName, null);
+		this.registerConsumer(consumer, publisherName, (String[]) null);
 	}
 
 	@Override
 	public void registerConsumer(EventConsumer consumer, String publisherName,
-			String[] eventTypes) {
+			String... eventTypes) {
 		if (consumer == null) {
 			throw new InvalidParameterException("Consumer must not be null");
 		}

--- a/src/org/zaproxy/zap/extension/alert/AlertEventPublisher.java
+++ b/src/org/zaproxy/zap/extension/alert/AlertEventPublisher.java
@@ -59,7 +59,7 @@ public class AlertEventPublisher implements EventPublisher {
 		if (publisher == null) {
 			publisher = new AlertEventPublisher(); 
 	        ZAP.getEventBus().registerPublisher(publisher, 
-	        		new String[] {ALERT_ADDED_EVENT, ALERT_CHANGED_EVENT, ALERT_REMOVED_EVENT, ALL_ALERTS_REMOVED_EVENT});
+	        		ALERT_ADDED_EVENT, ALERT_CHANGED_EVENT, ALERT_REMOVED_EVENT, ALL_ALERTS_REMOVED_EVENT);
 
 		}
 		return publisher;

--- a/src/org/zaproxy/zap/extension/ascan/ActiveScanEventPublisher.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScanEventPublisher.java
@@ -37,7 +37,7 @@ public class ActiveScanEventPublisher extends ScanEventPublisher {
     public static synchronized ActiveScanEventPublisher getPublisher() {
         if (publisher == null) {
             publisher = new ActiveScanEventPublisher();
-            ZAP.getEventBus().registerPublisher(publisher, ScanEventPublisher.EVENTS);
+            ZAP.getEventBus().registerPublisher(publisher, getEvents());
         }
         return publisher;
     }

--- a/src/org/zaproxy/zap/extension/brk/BreakEventPublisher.java
+++ b/src/org/zaproxy/zap/extension/brk/BreakEventPublisher.java
@@ -60,7 +60,7 @@ public class BreakEventPublisher implements EventPublisher {
     public static synchronized BreakEventPublisher getPublisher() {
         if (publisher == null) {
             publisher = new BreakEventPublisher();
-            ZAP.getEventBus().registerPublisher(publisher, new String[] { BREAK_POINT_HIT, BREAK_POINT_ACTIVE, BREAK_POINT_INACTIVE });
+            ZAP.getEventBus().registerPublisher(publisher, BREAK_POINT_HIT, BREAK_POINT_ACTIVE, BREAK_POINT_INACTIVE);
         }
         return publisher;
     }

--- a/src/org/zaproxy/zap/extension/spider/SpiderEventPublisher.java
+++ b/src/org/zaproxy/zap/extension/spider/SpiderEventPublisher.java
@@ -37,7 +37,7 @@ public class SpiderEventPublisher extends ScanEventPublisher {
     public static synchronized SpiderEventPublisher getPublisher() {
         if (publisher == null) {
             publisher = new SpiderEventPublisher();
-            ZAP.getEventBus().registerPublisher(publisher, ScanEventPublisher.EVENTS);
+            ZAP.getEventBus().registerPublisher(publisher, getEvents());
         }
         return publisher;
     }

--- a/src/org/zaproxy/zap/model/ScanEventPublisher.java
+++ b/src/org/zaproxy/zap/model/ScanEventPublisher.java
@@ -20,6 +20,7 @@
 
 package org.zaproxy.zap.model;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,13 +38,22 @@ public abstract class ScanEventPublisher implements EventPublisher {
     public static final String SCAN_COMPLETED_EVENT = "scan.completed";
     public static final String SCAN_PROGRESS_EVENT = "scan.progress";
 
-    public static final String[] EVENTS = { SCAN_STARTED_EVENT, SCAN_STOPPED_EVENT, SCAN_PAUSED_EVENT,
-            SCAN_RESUMED_EVENT, SCAN_COMPLETED_EVENT, SCAN_PROGRESS_EVENT };
-
     public static final String SCAN_ID = "scanId";
     public static final String SCAN_PROGRESS = "scanProgress";
     public static final String USER_ID = "userId";
     public static final String USER_NAME = "userName";
+
+    private static final String[] EVENTS = { SCAN_STARTED_EVENT, SCAN_STOPPED_EVENT, SCAN_PAUSED_EVENT,
+            SCAN_RESUMED_EVENT, SCAN_COMPLETED_EVENT, SCAN_PROGRESS_EVENT };
+
+    /**
+     * Returns a new array with all events.
+     *
+     * @return an array containing all events.
+     */
+    protected static String[] getEvents() {
+        return Arrays.copyOf(EVENTS, EVENTS.length);
+    }
 
     @Override
     public String getPublisherName() {


### PR DESCRIPTION
Change EventBus to use vararg for events when registering publishers and
consumers, to make the registrations less verbose (i.e. don't require
the explicit creation of an array).
Change existing registrations to not create the array.
Change ScanEventPublisher to not expose the array of events to avoid
accidental changes to its contents, update usages accordingly.