### PR TITLE
Prefer latest built add-on

### DIFF
--- a/src/org/zaproxy/zap/control/AddOn.java
+++ b/src/org/zaproxy/zap/control/AddOn.java
@@ -1114,10 +1114,23 @@ public class AddOn  {
 		if (! this.isSameAddOn(addOn)) {
 			throw new IllegalArgumentException("Different addons: " + this.getId() + " != " + addOn.getId());
 		}
-		if (this.getVersion().compareTo(addOn.getVersion()) > 0) {
+		int result = this.getVersion().compareTo(addOn.getVersion());
+		if (result != 0) {
+			return result > 0;
+		}
+
+		result = this.getStatus().compareTo(addOn.getStatus());
+		if (result != 0) {
+			return result > 0;
+		}
+
+		if (getFile() == null) {
+			return false;
+		}
+		if (addOn.getFile() == null) {
 			return true;
 		}
-		return this.getStatus().ordinal() > addOn.getStatus().ordinal();
+		return getFile().lastModified() > addOn.getFile().lastModified();
 	}
 	
 	/**

--- a/test/org/zaproxy/zap/control/AddOnUnitTest.java
+++ b/test/org/zaproxy/zap/control/AddOnUnitTest.java
@@ -150,6 +150,92 @@ public class AddOnUnitTest extends TestUtils {
 		addOnA2.isUpdateTo(addOnA1);
 		// Then = Exception
 	}
+
+	@Test
+	public void shouldBeUpdateIfSameVersionWithHigherStatus() throws Exception {
+		// Given
+		String name = "addon.zap";
+		String version = "1.0.0";
+		AddOn addOn = new AddOn(createAddOnFile(name, "beta", version));
+		AddOn addOnHigherStatus = new AddOn(createAddOnFile(name, "release", version));
+		// When
+		boolean update = addOnHigherStatus.isUpdateTo(addOn);
+		// Then
+		assertThat(update, is(equalTo(true)));
+	}
+
+	@Test
+	public void shouldNotBeUpdateIfSameVersionWithLowerStatus() throws Exception {
+		// Given
+		String name = "addon.zap";
+		String version = "1.0.0";
+		AddOn addOn = new AddOn(createAddOnFile(name, "beta", version));
+		AddOn addOnHigherStatus = new AddOn(createAddOnFile(name, "release", version));
+		// When
+		boolean update = addOn.isUpdateTo(addOnHigherStatus);
+		// Then
+		assertThat(update, is(equalTo(false)));
+	}
+
+	@Test
+	public void shouldBeUpdateIfFileIsNewerWithSameStatusAndVersion() throws Exception {
+		// Given
+		String name = "addon.zap";
+		String status = "release";
+		String version = "1.0.0";
+		AddOn addOn = new AddOn(createAddOnFile(name, status, version));
+		AddOn newestAddOn = new AddOn(createAddOnFile(name, status, version));
+		newestAddOn.getFile().setLastModified(System.currentTimeMillis() + 1000);
+		// When
+		boolean update = newestAddOn.isUpdateTo(addOn);
+		// Then
+		assertThat(update, is(equalTo(true)));
+	}
+
+	@Test
+	public void shouldNotBeUpdateIfFileIsOlderWithSameStatusAndVersion() throws Exception {
+		// Given
+		String name = "addon.zap";
+		String status = "release";
+		String version = "1.0.0";
+		AddOn addOn = new AddOn(createAddOnFile(name, status, version));
+		AddOn newestAddOn = new AddOn(createAddOnFile(name, status, version));
+		newestAddOn.getFile().setLastModified(System.currentTimeMillis() + 1000);
+		// When
+		boolean update = addOn.isUpdateTo(newestAddOn);
+		// Then
+		assertThat(update, is(equalTo(false)));
+	}
+
+	@Test
+	public void shouldBeUpdateIfOtherAddOnDoesNotHaveFileWithSameStatusAndVersion() throws Exception {
+		// Given
+		String name = "addon.zap";
+		String status = "release";
+		String version = "1.0.0";
+		AddOn addOn = new AddOn(createAddOnFile(name, status, version));
+		AddOn addOnWithoutFile = new AddOn(createAddOnFile(name, status, version));
+		addOnWithoutFile.setFile(null);
+		// When
+		boolean update = addOn.isUpdateTo(addOnWithoutFile);
+		// Then
+		assertThat(update, is(equalTo(true)));
+	}
+
+	@Test
+	public void shouldNotBeUpdateIfCurrentAddOnDoesNotHaveFileWithSameStatusAndVersion() throws Exception {
+		// Given
+		String name = "addon.zap";
+		String status = "release";
+		String version = "1.0.0";
+		AddOn addOn = new AddOn(createAddOnFile(name, status, version));
+		AddOn addOnWithoutFile = new AddOn(createAddOnFile(name, status, version));
+		addOnWithoutFile.setFile(null);
+		// When
+		boolean update = addOnWithoutFile.isUpdateTo(addOn);
+		// Then
+		assertThat(update, is(equalTo(false)));
+	}
 	
 	@Test
 	@SuppressWarnings("deprecation")
@@ -770,7 +856,7 @@ public class AddOnUnitTest extends TestUtils {
 
 	private Path createAddOnFile(String fileName, String status, String version, String javaVersion, Consumer<StringBuilder> manifestConsumer) {
 		try {
-			File file = tempDir.newFile(fileName);
+			File file = new File(tempDir.newFolder(), fileName);
 			try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(file))) {
 				ZipEntry manifest = new ZipEntry(AddOn.MANIFEST_FILE_NAME);
 				zos.putNextEntry(manifest);


### PR DESCRIPTION
Consider newer (by modification date) add-on to be update to older
add-on when both have the same name, status, and version to ensure that
the latest built add-on is always used even if deployed to a different
plugin dir (e.g. home, install, or additional add-on dirs).