### PR TITLE
Keep all entries when decoding a user

### DIFF
--- a/src/org/zaproxy/zap/users/User.java
+++ b/src/org/zaproxy/zap/users/User.java
@@ -320,7 +320,7 @@ public class User extends Enableable {
 	 * @return the user
 	 */
 	protected static User decode(int contextId, String encodedString, ExtensionAuthentication authenticationExtension) {
-		String[] pieces = encodedString.split(FIELD_SEPARATOR);
+		String[] pieces = encodedString.split(FIELD_SEPARATOR, -1);
 		User user = null;
 		try {
 			int id = Integer.parseInt(pieces[0]);


### PR DESCRIPTION
Keep trailing entries when splitting the user data even if they are
empty, otherwise it would lead to ArrayIndexOutOfBoundsException.