### PR TITLE
Fix and tweaks to global excludes

### DIFF
--- a/src/org/zaproxy/zap/extension/globalexcludeurl/DialogAddToken.java
+++ b/src/org/zaproxy/zap/extension/globalexcludeurl/DialogAddToken.java
@@ -123,7 +123,7 @@ class DialogAddToken extends AbstractFormDialog {
     protected boolean validateFields() {
         String tokenName = getRegexTextField().getText();
         for (GlobalExcludeURLParamToken t : tokens) {
-            if (tokenName.equalsIgnoreCase(t.getRegex())) {
+            if (tokenName.equals(t.getRegex())) {
                 JOptionPane.showMessageDialog(this, TEXT_NAME_REPEATED_DIALOG,
                         TITLE_NAME_REPEATED_DIALOG,
                         JOptionPane.INFORMATION_MESSAGE);
@@ -145,6 +145,7 @@ class DialogAddToken extends AbstractFormDialog {
         getRegexTextField().setText("");
         getRegexTextField().discardAllEdits();
         getDescTextField().setText("");
+        getDescTextField().discardAllEdits();
     }
 
     public GlobalExcludeURLParamToken getToken() {

--- a/src/org/zaproxy/zap/extension/globalexcludeurl/DialogModifyToken.java
+++ b/src/org/zaproxy/zap/extension/globalexcludeurl/DialogModifyToken.java
@@ -60,6 +60,7 @@ class DialogModifyToken extends DialogAddToken {
 
         getEnabledCheckBox().setSelected(token.isEnabled());
         getDescTextField().setText(token.getDescription());
+        getDescTextField().discardAllEdits();
     }
 
 }

--- a/src/org/zaproxy/zap/extension/globalexcludeurl/GlobalExcludeURLParamToken.java
+++ b/src/org/zaproxy/zap/extension/globalexcludeurl/GlobalExcludeURLParamToken.java
@@ -20,6 +20,8 @@
  */
 package org.zaproxy.zap.extension.globalexcludeurl;
 
+import java.util.Objects;
+
 import org.zaproxy.zap.utils.Enableable;
 
 class GlobalExcludeURLParamToken extends Enableable {
@@ -36,7 +38,7 @@ class GlobalExcludeURLParamToken extends Enableable {
     }
 
     public GlobalExcludeURLParamToken(String regex, boolean enabled) {
-        this(regex, "", false);
+        this(regex, "", enabled);
     }
 
     public GlobalExcludeURLParamToken(String regex, String description, boolean enabled) {
@@ -68,11 +70,10 @@ class GlobalExcludeURLParamToken extends Enableable {
 
     @Override
     public int hashCode() {
-        return 31 * super.hashCode() + ((regex == null) ? 0 : regex.hashCode());
+        return Objects.hash(isEnabled(), regex, description);
     }
 
     @Override
-    /** If the regexs are equal, then the objects are equal; description is not compared. */
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;
@@ -84,11 +85,10 @@ class GlobalExcludeURLParamToken extends Enableable {
             return false;
         }
         GlobalExcludeURLParamToken other = (GlobalExcludeURLParamToken) obj;
-        if (regex == null) {
-            if (other.regex != null) {
-                return false;
-            }
-        } else if (!regex.equals(other.regex)) {
+        if (!Objects.equals(regex, other.regex)) {
+            return false;
+        }
+        if (!Objects.equals(description, other.description)) {
             return false;
         }
         return true;


### PR DESCRIPTION
Change GlobalExcludeURLParamToken to:
 - Properly implement equals method to ensure the changes done to the
 description are applied. Update hashCode accordingly.
 - Use the enabled parameter passed in the constructor.

Change DialogAddToken/DialogModifyToken to discard the edits of the
description after being set, also, for DialogAddToken do not ignore the
case when comparing the regular expression, the case matters.

Fix #5118 - Global Excludes Modify Description Doesn't Work