### PR TITLE
Reinstate the one year warn

### DIFF
--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -686,6 +686,13 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
     	
     	final OptionsParamCheckForUpdates options = getModel().getOptionsParam().getCheckForUpdatesParam();
     	
+        if (View.isInitialised()) {
+            if (!options.isCheckOnStart()) {
+                alertIfOutOfDate(false);
+                return;
+            }
+        }
+
 		if (! options.checkOnStart()) {
 			// Top level option not set, dont do anything, unless already downloaded last release
 			if (View.isInitialised() && this.getPreviousVersionInfo() != null) {


### PR DESCRIPTION
Change ExtensionAutoUpdate to check again if ZAP is too old (#2084),
accidentally removed in a previous change.