### PR TITLE
Do not show main release notes for daily release

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -657,7 +657,7 @@ cfu.check.upd.downloading  = Downloading updates. You can close this dialog and 
 cfu.check.zap.downloaded   = ZAP downloaded to {0}
 cfu.check.zap.downloading  = Downloading ZAP. You can close this dialog and the download will carry on in the background.
 cfu.check.zap.latest   = ZAP is on the latest version
-cfu.check.zap.newer    = There is a more recent version of OWASP ZAP:
+cfu.check.zap.newer    = There is a more recent version of OWASP ZAP: {0}
 
 cfu.cmdline.addondown		= Add-on downloaded to: {0}
 cfu.cmdline.addondown.failed = Add-on download failed for: {0}

--- a/src/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
@@ -233,12 +233,7 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
 				corePanel.add(this.getCheckForUpdatesButton(), LayoutHelper.getGBC(2, 0, 1, 0.0D));
 				
 			} else if (this.latestInfo.getZapRelease().isNewerThan(this.currentVersion)) {
-				corePanel.add(new JLabel(Constant.messages.getString("cfu.check.zap.newer")), LayoutHelper.getGBC(0, 0, 1, 0.0D));
-				corePanel.add(new JLabel(this.latestInfo.getZapRelease().getVersion()), LayoutHelper.getGBC(1, 0, 1, 0.1D));
-				corePanel.add(new JLabel(""), LayoutHelper.getGBC(2, 0, 1, 0.8D));
-				corePanel.add(this.getDownloadProgress(), LayoutHelper.getGBC(3, 0, 1, 0.2D));
-				corePanel.add(this.getCoreNotesButton(), LayoutHelper.getGBC(4, 0, 1, 0.0D));
-				corePanel.add(this.getDownloadZapButton(), LayoutHelper.getGBC(5, 0, 1, 0.0D));
+				addNewerVersionComponents(corePanel);
 				
 			} else {
 				corePanel.add(new JLabel(this.currentVersion + " : " + Constant.messages.getString("cfu.check.zap.latest")), LayoutHelper.getGBC(0, 0, 1, 1.0D));
@@ -248,12 +243,7 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
 			corePanel.removeAll();
 
 			if (this.latestInfo.getZapRelease().isNewerThan(this.currentVersion)) {
-				corePanel.add(new JLabel(Constant.messages.getString("cfu.check.zap.newer")), LayoutHelper.getGBC(0, 0, 1, 0.0D));
-				corePanel.add(new JLabel(this.latestInfo.getZapRelease().getVersion()), LayoutHelper.getGBC(1, 0, 1, 0.1D));
-				corePanel.add(new JLabel(""), LayoutHelper.getGBC(2, 0, 1, 0.8D));
-				corePanel.add(this.getDownloadProgress(), LayoutHelper.getGBC(3, 0, 1, 0.2D));
-				corePanel.add(this.getCoreNotesButton(), LayoutHelper.getGBC(4, 0, 1, 0.0D));
-				corePanel.add(this.getDownloadZapButton(), LayoutHelper.getGBC(5, 0, 1, 0.0D));
+				addNewerVersionComponents(corePanel);
 			} else {
 				corePanel.add(new JLabel(this.currentVersion + " : " + Constant.messages.getString("cfu.check.zap.latest")), LayoutHelper.getGBC(0, 0, 1, 1.0D));
 			}
@@ -262,6 +252,19 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
 		
 		
 		return corePanel;
+	}
+
+	private void addNewerVersionComponents(JPanel panel) {
+		int x = 0;
+		panel.add(
+				new JLabel(Constant.messages.getString("cfu.check.zap.newer", this.latestInfo.getZapRelease().getVersion())),
+				LayoutHelper.getGBC(x, 0, 1, 0.0D));
+		panel.add(new JLabel(""), LayoutHelper.getGBC(++x, 0, 1, 0.8D));
+		panel.add(this.getDownloadProgress(), LayoutHelper.getGBC(++x, 0, 1, 0.2D));
+		if (!Constant.isDailyBuild()) {
+			panel.add(this.getCoreNotesButton(), LayoutHelper.getGBC(++x, 0, 1, 0.0D));
+		}
+		panel.add(this.getDownloadZapButton(), LayoutHelper.getGBC(++x, 0, 1, 0.0D));
 	}
 
 	private JPanel getInstalledAddOnsPanel() {


### PR DESCRIPTION
Change ManageAddOnsDialog to not show the release notes button for daily
release, the release notes shown belong to main release not daily. Also,
tweak the message that shows the latest version to have a space before
the version.
Extract a method to reduce code duplication when adding the components
of the newer version.