### PR TITLE
Update gradle-launch4j plugin

### DIFF
--- a/build/installer/build.gradle
+++ b/build/installer/build.gradle
@@ -1,19 +1,7 @@
-buildscript {
-    repositories {
-        maven {
-            url 'http://maven.ej-technologies.com/repository'
-        }
-    }
-    dependencies {
-         classpath 'com.install4j:install4j-gradle:6.1.6'
-    }
-}
-
 plugins {
-    id 'edu.sc.seis.launch4j' version '2.4.2'
+    id 'com.install4j.gradle' version '6.1.6'
+    id 'edu.sc.seis.launch4j' version '2.4.4'
 }
-
-apply plugin: 'install4j'
 
 version file('../version.txt').getText('UTF-8')
 


### PR DESCRIPTION
Update gradle-launch4j to 2.4.4 to cope with new Java version scheme
(JEP 223).
Also, use install4j plugin from Gradle plugin portal.