### PR TITLE
Show add-on details in a panel instead of tool tip

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -728,6 +728,7 @@ cfu.label.oldzap = This version of ZAP was created over a year ago!\nZAP is upda
 running with an out of date release.\n\nCheck for a new version now?\n\n
 cfu.label.outofdateaddons = Add-ons out of date?
 cfu.label.outofdatezap = ZAP out of date!
+cfu.label.selectAddOnForDetails = Select an add-on above to see more details.
 cfu.label.zap.border   = ZAP Core
 cfu.manage.title    		   = Manage Add-ons
 cfu.options.dialog.dirs.remove.title	= Remove Add-on Directories
@@ -770,6 +771,7 @@ cfu.table.header.changes  = Changes
 cfu.table.header.desc  = Description
 cfu.table.header.download = Download
 cfu.table.header.id    = Id
+cfu.table.header.info = Info
 cfu.table.header.select  = Select
 cfu.table.header.name  = Name
 cfu.table.header.notbefore = Not Before Version

--- a/src/org/zaproxy/zap/control/AddOn.java
+++ b/src/org/zaproxy/zap/control/AddOn.java
@@ -553,6 +553,7 @@ public class AddOn  {
 		this.notBeforeVersion = zapAddOnXml.getNotBeforeVersion();
 		this.notFromVersion = zapAddOnXml.getNotFromVersion();
 		this.dependencies = zapAddOnXml.getDependencies();
+		this.info = createInfoUrl(zapAddOnXml.getUrl());
 
 		this.ascanrules = zapAddOnXml.getAscanrules();
 		this.extensions = zapAddOnXml.getExtensions();
@@ -607,18 +608,21 @@ public class AddOn  {
 		this.size = addOnData.getSize();
 		this.notBeforeVersion = addOnData.getNotBeforeVersion();
 		this.notFromVersion = addOnData.getNotFromVersion();
-		if (addOnData.getInfo() != null && !addOnData.getInfo().isEmpty()) {
-			try {
-				this.info = new URL(addOnData.getInfo());
-			} catch (Exception ignore) {
-				if (logger.isDebugEnabled()) {
-					logger.debug("Wrong info URL for add-on \"" + name + "\":", ignore);
-				}
-			}
-		}
+		this.info = createInfoUrl(addOnData.getInfo());
 		this.hash = addOnData.getHash();
 		
 		loadManifestFile();
+	}
+
+	private URL createInfoUrl(String url) {
+		if (url != null && !url.isEmpty()) {
+			try {
+				return new URL(url);
+			} catch (Exception e) {
+				logger.warn("Invalid info URL for add-on \"" + id + "\":", e);
+			}
+		}
+		return null;
 	}
 
 	public String getId() {

--- a/src/org/zaproxy/zap/utils/ZapLabel.java
+++ b/src/org/zaproxy/zap/utils/ZapLabel.java
@@ -23,6 +23,7 @@ import java.awt.Color;
 
 import javax.swing.JTextArea;
 import javax.swing.UIManager;
+import javax.swing.text.DefaultCaret;
 
 /**
  * An alternative to JLabel which disables HTML and supports wrapping.
@@ -51,16 +52,7 @@ public class ZapLabel extends JTextArea {
 		this.setBorder(null);
 		this.setBackground(new Color(UIManager.getLookAndFeel().getDefaults().getColor("Label.background").getRGB()));
 		this.setForeground(new Color(UIManager.getLookAndFeel().getDefaults().getColor("Label.foreground").getRGB()));
-	}
 	
-	/**
-	 * {@inheritDoc}
-	 * <p>
-	 * The caret position is set to 0 after setting the text.
-	 */
-	@Override
-	public void setText(String t) {
-		super.setText(t);
-		setCaretPosition(0);
+		((DefaultCaret) getCaret()).setUpdatePolicy(DefaultCaret.NEVER_UPDATE);
 	}
 }


### PR DESCRIPTION
Change Manage Add-ons dialogue to show the add-on details in a bottom
panel in the tabs Installed and Marketplace, to give more space and
properly render the changes of the add-ons (e.g. word wrap, links).
Change ZapLabel to disable caret updates instead of resetting the
position after setting the text to avoid scroll jumps.
Change AddOn to read the info URL also when creating the add-on from a
file.