### PR TITLE
Return proper errors in break API

### DIFF
--- a/src/org/zaproxy/zap/extension/brk/BreakAPI.java
+++ b/src/org/zaproxy/zap/extension/brk/BreakAPI.java
@@ -36,6 +36,7 @@ import org.zaproxy.zap.extension.api.ApiResponse;
 import org.zaproxy.zap.extension.api.ApiResponseElement;
 import org.zaproxy.zap.extension.api.ApiView;
 import org.zaproxy.zap.extension.httppanel.Message;
+import org.zaproxy.zap.utils.ApiUtils;
 
 public class BreakAPI extends ApiImplementor {
 
@@ -113,13 +114,14 @@ public class BreakAPI extends ApiImplementor {
 	public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
 		if (ACTION_BREAK.equals(name)) {
 			String type = params.getString(PARAM_TYPE).toLowerCase();
+			boolean state = ApiUtils.getBooleanParam(params, PARAM_STATE);
 			if (type.equals(VALUE_TYPE_HTTP_ALL)) {
-				extension.setBreakAllRequests(params.getBoolean(PARAM_STATE));
-				extension.setBreakAllResponses(params.getBoolean(PARAM_STATE));
+				extension.setBreakAllRequests(state);
+				extension.setBreakAllResponses(state);
 			} else if (type.equals(VALUE_TYPE_HTTP_REQUESTS)) {
-				extension.setBreakAllRequests(params.getBoolean(PARAM_STATE));
+				extension.setBreakAllRequests(state);
 			} else if (type.equals(VALUE_TYPE_HTTP_RESPONSES)) {
-				extension.setBreakAllResponses(params.getBoolean(PARAM_STATE));
+				extension.setBreakAllResponses(state);
 			} else {
 				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_TYPE +
 						" not in [" + VALUE_TYPE_HTTP_ALL +"," + VALUE_TYPE_HTTP_REQUESTS +"," +
@@ -186,9 +188,9 @@ public class BreakAPI extends ApiImplementor {
 						params.getString(PARAM_STRING), 
 						params.getString(PARAM_LOCATION), 
 						params.getString(PARAM_MATCH), 
-						params.getBoolean(PARAM_INVERSE), 
-						params.getBoolean(PARAM_IGNORECASE));
-			} catch (Exception e) {
+						ApiUtils.getBooleanParam(params, PARAM_INVERSE), 
+						ApiUtils.getBooleanParam(params, PARAM_IGNORECASE));
+			} catch (IllegalArgumentException e) {
 				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, e.getMessage());
 			}
 
@@ -198,9 +200,9 @@ public class BreakAPI extends ApiImplementor {
 						params.getString(PARAM_STRING), 
 						params.getString(PARAM_LOCATION), 
 						params.getString(PARAM_MATCH), 
-						params.getBoolean(PARAM_INVERSE), 
-						params.getBoolean(PARAM_IGNORECASE));
-			} catch (Exception e) {
+						ApiUtils.getBooleanParam(params, PARAM_INVERSE), 
+						ApiUtils.getBooleanParam(params, PARAM_IGNORECASE));
+			} catch (IllegalArgumentException e) {
 				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, e.getMessage());
 			}
 

--- a/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
+++ b/src/org/zaproxy/zap/extension/brk/ExtensionBreak.java
@@ -24,7 +24,6 @@ import java.awt.EventQueue;
 import java.awt.event.KeyEvent;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -248,42 +247,28 @@ public class ExtensionBreak extends ExtensionAdaptor implements SessionChangedLi
 	}
 
 	public void addHttpBreakpoint(String string, String location, String match, boolean inverse, boolean ignoreCase) {
-		Location loc;
-		Match mtch;
-		
-		try {
-			loc = Location.valueOf(location);
-		} catch (Exception e) {
-			throw new InvalidParameterException("location must be one of " + Arrays.toString(Location.values()));
-		}
-		
-		try {
-			mtch = Match.valueOf(match);
-		} catch (Exception e) {
-			throw new InvalidParameterException("match must be one of " + Arrays.toString(Match.values()));
-		}
-		
-		this.addBreakpoint(new HttpBreakpointMessage(string, loc, mtch, inverse, ignoreCase));
+		this.addBreakpoint(new HttpBreakpointMessage(string, getLocationEnum(location), getMatchEnum(match), inverse, ignoreCase));
 		
 	}
 
+    private static Location getLocationEnum(String location) {
+        try {
+            return Location.valueOf(location);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("location must be one of " + Arrays.toString(Location.values()));
+        }
+    }
+
+    private static Match getMatchEnum(String match) {
+        try {
+            return Match.valueOf(match);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("match must be one of " + Arrays.toString(Match.values()));
+        }
+    }
+
 	public void removeHttpBreakpoint(String string, String location, String match, boolean inverse, boolean ignoreCase) {
-		Location loc;
-		Match mtch;
-		
-		try {
-			loc = Location.valueOf(location);
-		} catch (Exception e) {
-			throw new InvalidParameterException("location must be one of " + Arrays.toString(Location.values()));
-		}
-		
-		try {
-			mtch = Match.valueOf(match);
-		} catch (Exception e) {
-			throw new InvalidParameterException("match must be one of " + Arrays.toString(Match.values()));
-		}
-		
-		this.removeBreakpoint(new HttpBreakpointMessage(string, loc, mtch, inverse, ignoreCase));
+		this.removeBreakpoint(new HttpBreakpointMessage(string, getLocationEnum(location), getMatchEnum(match), inverse, ignoreCase));
 		
 	}
 

--- a/src/org/zaproxy/zap/utils/ApiUtils.java
+++ b/src/org/zaproxy/zap/utils/ApiUtils.java
@@ -56,6 +56,29 @@ public final class ApiUtils {
 	}
 
 	/**
+	 * Gets a boolean from the parameter with the given name.
+	 * 
+	 * @param params the API parameters
+	 * @param paramName the name of the parameter
+	 * @return the boolean value
+	 * @throws ApiException if the parameter is missing
+	 *             ({@link org.zaproxy.zap.extension.api.ApiException.Type#MISSING_PARAMETER MISSING_PARAMETER}) or not a
+	 *             boolean ({@link org.zaproxy.zap.extension.api.ApiException.Type#ILLEGAL_PARAMETER ILLEGAL_PARAMETER}).
+	 * @since TODO add version
+	 */
+	public static boolean getBooleanParam(JSONObject params, String paramName) throws ApiException {
+		if (!params.containsKey(paramName)) {
+			throw new ApiException(ApiException.Type.MISSING_PARAMETER, paramName);
+		}
+
+		try {
+			return params.getBoolean(paramName);
+		} catch (JSONException e) {
+			throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, paramName, e);
+		}
+	}
+
+	/**
 	 * Gets an optional string param, returning null if the parameter was not found.
 	 *
 	 * @param params the params

--- a/test/org/zaproxy/zap/utils/ApiUtilsUnitTest.java
+++ b/test/org/zaproxy/zap/utils/ApiUtilsUnitTest.java
@@ -87,6 +87,57 @@ public class ApiUtilsUnitTest {
     }
 
     @Test(expected = NullPointerException.class)
+    public void shouldThrowNullPointerExceptionWhenGettingBooleanFromNullParams() throws Exception {
+        // Given
+        JSONObject params = null;
+        // When
+        ApiUtils.getBooleanParam(params, "name");
+        // Then = NullPointerException
+    }
+
+    @Test
+    public void shouldThrowMissingParameterWhenGettingBooleanIfMissingParam() {
+        // Given
+        String name = "ParamNotInObject";
+        JSONObject params = new JSONObject();
+        try {
+            // When
+            ApiUtils.getBooleanParam(params, name);
+        } catch (ApiException e) {
+            // Then
+            assertThat(e.getType(), is(equalTo(ApiException.Type.MISSING_PARAMETER)));
+        }
+    }
+
+    @Test
+    public void shouldThrowIllegalParameterWhenGettingBooleanIfParamNotBoolean() {
+        // Given
+        String name = "ParamNotBoolean";
+        JSONObject params = new JSONObject();
+        params.put(name, "String");
+        try {
+            // When
+            ApiUtils.getBooleanParam(params, name);
+        } catch (ApiException e) {
+            // Then
+            assertThat(e.getType(), is(equalTo(ApiException.Type.ILLEGAL_PARAMETER)));
+        }
+    }
+
+    @Test
+    public void shouldReturnBooleanValueWhenGettingBoolean() throws Exception {
+        // Given
+        String name = "ParamBoolean";
+        boolean value = true;
+        JSONObject params = new JSONObject();
+        params.put(name, value);
+        // When
+        boolean obtainedValue = ApiUtils.getBooleanParam(params, name);
+        // Then
+        assertThat(obtainedValue, is(equalTo(value)));
+    }
+
+    @Test(expected = NullPointerException.class)
     public void shouldThrowExceptionWhenGettingAuthorityFromNullSite() {
         // Given
         String nullSite = null;


### PR DESCRIPTION
Change ExtensionBreak to throw IllegalArgumentException when the
Location/Match are not correct, also, extract methods to reduce code
duplication.
Add helper method to ApiUtils to get a mandatory boolean from the API
parameters.
Change BreakAPI to catch IllegalArgumentException instead of Exception
when adding/removing HTTP breakpoints to not hide other unexpected
exceptions, also, use the helper method when getting booleans for proper
error handling.