### PR TITLE
Use AddOn's validation error in exception message

### DIFF
--- a/src/org/zaproxy/zap/control/AddOn.java
+++ b/src/org/zaproxy/zap/control/AddOn.java
@@ -2118,7 +2118,7 @@ public class AddOn  {
 		private final ValidationResult validationResult;
 
 		private InvalidAddOnException(ValidationResult validationResult) {
-			super(getRootCauseMessage(validationResult.getException()), validationResult.getException());
+			super(getRootCauseMessage(validationResult), validationResult.getException());
 			this.validationResult = validationResult;
 		}
 
@@ -2132,9 +2132,10 @@ public class AddOn  {
 		}
 	}
 
-	private static String getRootCauseMessage(Exception exception) {
+	private static String getRootCauseMessage(ValidationResult validationResult) {
+		Exception exception = validationResult.getException();
 		if (exception == null) {
-			return null;
+			return validationResult.getValidity().toString();
 		}
 		Throwable root = ExceptionUtils.getRootCause(exception);
 		return root == null ? exception.getLocalizedMessage() : root.getLocalizedMessage();


### PR DESCRIPTION
Change AddOn.InvalidAddOnException to use the validation error for the
exception message if there's no exception, to not leave it empty.