### PR TITLE
Allow to listen for script output

### DIFF
--- a/src/org/zaproxy/zap/extension/script/ScriptOutputListener.java
+++ b/src/org/zaproxy/zap/extension/script/ScriptOutputListener.java
@@ -1,0 +1,40 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.script;
+
+/**
+ * A listener for scripts' output.
+ *
+ * @since TODO add version
+ * @see ExtensionScript#addScriptOutputListener(ScriptOutputListener)
+ */
+@FunctionalInterface
+public interface ScriptOutputListener {
+
+    /**
+     * Called each time a script writes some output.
+     * <p>
+     * Can be called concurrently.
+     *
+     * @param script the source of the output.
+     * @param output the new output.
+     */
+    void output(ScriptWrapper script, String output);
+}


### PR DESCRIPTION
Add a listener for script output, which provides the script and the
output being written.

Part of #5113 - Allow to differentiate scripts' output