### PR TITLE
Allow shortcut and callback implementors to override headers

### DIFF
--- a/src/org/zaproxy/zap/extension/api/API.java
+++ b/src/org/zaproxy/zap/extension/api/API.java
@@ -324,9 +324,11 @@ public class API {
 					}
 				}
 				msg = shortcutImpl.handleShortcut(msg);
+				impl = shortcutImpl;
 			} else if (callbackImpl != null) {
 				// Callbacks have suitably random URLs and therefore don't require keys/nonces
 				response = callbackImpl.handleCallBack(msg);
+				impl = callbackImpl;
 			} else {
 			
 				// Parse the query:


### PR DESCRIPTION
Around line 535 addCustomHeaders is only called if 'impl' is not null, meaning that it wont be called for shortcut or callback implementors.
This will allow them to override any headers they need to.