### PR TITLE
Remove obsolete Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,3 @@ notifications:
     on_failure: always
     on_start: false
 
-sudo: false


### PR DESCRIPTION
Remove the `sudo` configuration, the builds run now always in the same
(new) infrastructure regardless of the configuration.