### PR TITLE
Ensure The Scan Policy Sticks Between Active Scan Runs

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
+++ b/src/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
@@ -234,9 +234,6 @@ public class CustomScanDialog extends StandardFieldsDialog {
 
         setTechSet(techTreeState);
 
-        // Policy panel
-        policyPanel.resetAndSetPolicy(scanPolicy.getName());
-
         this.setCustomTabPanel(4, policyPanel);
         
         // add custom panels
@@ -685,6 +682,7 @@ public class CustomScanDialog extends StandardFieldsDialog {
         techTreeState = null;
 
         if (refreshUi) {
+            policyPanel.resetAndSetPolicy(scanPolicyName);
             init(target);
             repaint();
         }


### PR DESCRIPTION
I find this handy, hopefully others do to. It's meant to be more user friendly when running multiple or repeated scans.

Unfortunately as discussed in the ticket there are still other changes needed on other panels for consistency. (Even with this change the "Cancel" behavior is not intuitive.)

See zaproxy/zaproxy#3538 for further details.