### PR TITLE
Expose the local add-ons through the ZAP API

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -537,6 +537,7 @@ autoupdate.api.action.uninstallAddon = Uninstalls the specified add-on
 autoupdate.api.view.latestVersionNumber = Returns the latest version number
 autoupdate.api.view.isLatestVersion = Returns 'true' if ZAP is on the latest version
 autoupdate.api.view.installedAddons = Return a list of all of the installed add-ons
+autoupdate.api.view.localAddons = Returns a list with all local add-ons, installed or not.
 autoupdate.api.view.newAddons = Return a list of any add-ons that have been added to the Marketplace since the last check for updates
 autoupdate.api.view.updatedAddons = Return a list of any add-ons that have been changed in the Marketplace since the last check for updates
 autoupdate.api.view.marketplaceAddons = Return a list of all of the add-ons on the ZAP Marketplace (this information is read once and then cached)

--- a/src/org/zaproxy/zap/extension/autoupdate/AutoUpdateAPI.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/AutoUpdateAPI.java
@@ -53,6 +53,7 @@ public class AutoUpdateAPI extends ApiImplementor {
 	private static final String VIEW_LATEST_VERSION_NUMBER = "latestVersionNumber";
 	private static final String VIEW_IS_LATEST_VERSION = "isLatestVersion";
 	private static final String VIEW_INSTALLED_ADDONS = "installedAddons";
+	private static final String VIEW_LOCAL_ADDONS = "localAddons";
 	private static final String VIEW_NEW_ADDONS = "newAddons";
 	private static final String VIEW_UPDATED_ADDONS = "updatedAddons";
 	private static final String VIEW_MARKETPLACE_ADDONS = "marketplaceAddons";
@@ -72,6 +73,7 @@ public class AutoUpdateAPI extends ApiImplementor {
 		this.addApiView(new ApiView(VIEW_LATEST_VERSION_NUMBER));
 		this.addApiView(new ApiView(VIEW_IS_LATEST_VERSION));
 		this.addApiView(new ApiView(VIEW_INSTALLED_ADDONS));
+		this.addApiView(new ApiView(VIEW_LOCAL_ADDONS));
 		this.addApiView(new ApiView(VIEW_NEW_ADDONS));
 		this.addApiView(new ApiView(VIEW_UPDATED_ADDONS));
 		this.addApiView(new ApiView(VIEW_MARKETPLACE_ADDONS));
@@ -149,36 +151,30 @@ public class AutoUpdateAPI extends ApiImplementor {
 		} else if (VIEW_IS_LATEST_VERSION.equals(name)) {
 			result = new ApiResponseElement(name, Boolean.toString(this.isLatestVersion()));
 		} else if (VIEW_INSTALLED_ADDONS.equals(name)) {
-			final ApiResponseList resultList = new ApiResponseList(name);
-			for (AddOn ao : extension.getInstalledAddOns()) {
-				resultList.addItem(addonToSet(ao));
-			}
-			result = resultList;
+			result = createResponseList(name, extension.getInstalledAddOns());
+		} else if (VIEW_LOCAL_ADDONS.equals(name)) {
+			result = createResponseList(name, extension.getLocalAddOns());
 		} else if (VIEW_NEW_ADDONS.equals(name)) {
-			final ApiResponseList resultList = new ApiResponseList(name);
-			for (AddOn ao : extension.getNewAddOns()) {
-				resultList.addItem(addonToSet(ao));
-			}
-			result = resultList;
+			result = createResponseList(name, extension.getNewAddOns());
 		} else if (VIEW_UPDATED_ADDONS.equals(name)) {
-			final ApiResponseList resultList = new ApiResponseList(name);
-			for (AddOn ao : extension.getUpdatedAddOns()) {
-				resultList.addItem(addonToSet(ao));
-			}
-			result = resultList;
+			result = createResponseList(name, extension.getUpdatedAddOns());
 		} else if (VIEW_MARKETPLACE_ADDONS.equals(name)) {
-			final ApiResponseList resultList = new ApiResponseList(name);
-			for (AddOn ao : extension.getMarketplaceAddOns()) {
-				resultList.addItem(addonToSet(ao));
-			}
-			result = resultList;
+			result = createResponseList(name, extension.getMarketplaceAddOns());
 		} else {
 			throw new ApiException(ApiException.Type.BAD_VIEW);
 		}
 		return result;
 	}
 	
-	private ApiResponseSet<String> addonToSet(AddOn ao) {
+	private static ApiResponseList createResponseList(String name, List<AddOn> addOns) {
+		ApiResponseList response = new ApiResponseList(name);
+		for (AddOn ao : addOns) {
+			response.addItem(addonToSet(ao));
+		}
+		return response;
+	}
+
+	private static ApiResponseSet<String> addonToSet(AddOn ao) {
 		Map<String, String> map = new HashMap<>();
 		map.put("id", ao.getId());
 		map.put("name", ao.getName());
@@ -191,6 +187,7 @@ public class AutoUpdateAPI extends ApiImplementor {
 		map.put("status", ao.getStatus().toString());
 		map.put("url", ObjectUtils.toString(ao.getUrl()));
 		map.put("version", ObjectUtils.toString(ao.getVersion()));
+		map.put("installationStatus", ObjectUtils.toString(ao.getInstallationStatus()));
 		return new ApiResponseSet<String>("addon", map);
 	}
 	

--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -996,6 +996,10 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
         return getLocalVersionInfo().getInstalledAddOns();
     }
 
+    protected List<AddOn> getLocalAddOns() {
+        return getLocalVersionInfo().getAddOns();
+    }
+
 	protected List<AddOn> getMarketplaceAddOns() {
         AddOnCollection aoc = this.getLatestVersionInfo();
         if (aoc != null) {


### PR DESCRIPTION
Allow to obtain all the local add-ons, installed or not. Also, provide
the installation status.
Extract a method to reduce code duplication.