### PR TITLE
Fix NPE in ExtensionLog4j in non dev mode

### DIFF
--- a/src/org/zaproxy/zap/extension/log4j/ExtensionLog4j.java
+++ b/src/org/zaproxy/zap/extension/log4j/ExtensionLog4j.java
@@ -78,7 +78,10 @@ public class ExtensionLog4j extends ExtensionAdaptor {
 
 	    if (getView() != null) {	        
 	        extensionHook.getHookMenu().addToolsMenuItem(getMenuGarbageCollect());
-	        extensionHook.addSessionListener(new ResetCounterOnSessionChange(scanStatus));
+
+	        if (scanStatus != null) {
+	            extensionHook.addSessionListener(new ResetCounterOnSessionChange(scanStatus));
+	        }
 	    }
 
 	}


### PR DESCRIPTION
Change ExtensionLog4j to only add the session listener if the scan
status label was created (which is only created in dev mode).