### PR TITLE
Copy the add-on installed through the API

### DIFF
--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -278,6 +278,19 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 			}
 		}
 
+		File addOnFile;
+		try {
+			addOnFile = copyAddOnFileToLocalPluginFolder(ao);
+		} catch (FileAlreadyExistsException e) {
+			logger.warn("Unable to copy add-on, a file with the same name already exists.", e);
+			return false;
+		} catch (IOException e) {
+			logger.warn("Unable to copy add-on to local plugin folder.", e);
+			return false;
+		}
+
+		ao.setFile(addOnFile);
+
 		return install(ao);
 	}
 	


### PR DESCRIPTION
Copy the add-on to local plugin directory to install it permanently,
like the other ways of installing an add-on do, to avoid surprises when
ZAP is started again.