### PR TITLE
Do not check for updates on start up in dev mode

### DIFF
--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -723,6 +723,10 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
     }
     
     public void alertIfNewVersions() {
+        if (Constant.isDevMode()) {
+            return;
+        }
+
     	// Kicks off a thread and pops up a window if there are new versions.
     	// Depending on the options the user has chosen.
     	// Only expect this to be called on startup and in desktop mode


### PR DESCRIPTION
Unnecessary, in dev mode it is assumed that ZAP and/or the add-ons are
being developed and should be the latest.