### PR TITLE
Correct update of old CFU option

### DIFF
--- a/src/org/parosproxy/paros/Constant.java
+++ b/src/org/parosproxy/paros/Constant.java
@@ -80,6 +80,7 @@
 // ZAP: 2018/06/13 Correct install dir detection from JAR.
 // ZAP: 2018/06/29 Allow to check if in dev mode.
 // ZAP: 2018/07/19 Fallback to bundled config.xml and log4j.properties.
+// ZAP: 2019/03/14 Move and correct update of old options.
 
 package org.parosproxy.paros;
 
@@ -149,6 +150,7 @@ public final class Constant {
     private static final long V_2_5_0_TAG = 2005000;
     private static final long V_2_4_3_TAG = 2004003;
     private static final long V_2_3_1_TAG = 2003001;
+    private static final long V_2_2_2_TAG = 2002002;
     private static final long V_2_2_0_TAG = 2002000;
     private static final long V_2_1_0_TAG = 2001000;
     private static final long V_2_0_0_TAG = 2000000;
@@ -585,6 +587,9 @@ public final class Constant {
 	            	if (ver <= V_2_2_0_TAG) {
 	            		upgradeFrom2_2_0(config);
 	            	}
+	            	if (ver <= V_2_2_2_TAG) {
+                        upgradeFrom2_2_2(config);
+	            	}
 	            	if (ver <= V_2_3_1_TAG) {
 	            		upgradeFrom2_3_1(config);
 	            	}
@@ -863,22 +868,23 @@ public final class Constant {
     }
 
     private void upgradeFrom2_2_0(XMLConfiguration config) {
-    	try {
-			if ( ! config.getBoolean(OptionsParamCheckForUpdates.CHECK_ON_START, false)) {
-				/*
-				 * Check-for-updates on start set to false - force another prompt to ask the user,
-				 * as this option can have been unset incorrectly before.
-				 * And we want to encourage users to use this ;)
-				 */
-				config.setProperty(OptionsParamCheckForUpdates.DAY_LAST_CHECKED, "");
-			}
-		} catch (Exception e) {
-			// At one stage this was an integer, which will cause an exception to be thrown
+		if ( config.getInt(OptionsParamCheckForUpdates.CHECK_ON_START, 0) == 0) {
+			/*
+			 * Check-for-updates on start disabled - force another prompt to ask the user,
+			 * as this option can have been unset incorrectly before.
+			 * And we want to encourage users to use this ;)
+			 */
 			config.setProperty(OptionsParamCheckForUpdates.DAY_LAST_CHECKED, "");
 		}
 		// Clear the block list - addons were incorrectly added to this if an update failed
 		config.setProperty(AddOnLoader.ADDONS_BLOCK_LIST, "");
     	
+    }
+
+    private void upgradeFrom2_2_2(XMLConfiguration config) {
+        // Change the type of the option from int to boolean.
+        int oldValue = config.getInt(OptionsParamCheckForUpdates.CHECK_ON_START, 1);
+        config.setProperty(OptionsParamCheckForUpdates.CHECK_ON_START, oldValue != 0);
     }
 
     private void upgradeFrom2_3_1(XMLConfiguration config) {

--- a/src/org/zaproxy/zap/extension/autoupdate/OptionsParamCheckForUpdates.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/OptionsParamCheckForUpdates.java
@@ -28,7 +28,6 @@ import java.util.Date;
 import java.util.List;
 
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.ConversionException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.common.AbstractParam;
@@ -74,8 +73,6 @@ public class OptionsParamCheckForUpdates extends AbstractParam {
 
     @Override
     protected void parse() {
-        updateOldOptions();
-        
 	    checkOnStart = getBoolean(CHECK_ON_START, true);
 	    dayLastChecked = getString(DAY_LAST_CHECKED, "");
 	    dayLastInstallWarned = getString(DAY_LAST_INSTALL_WARNED, "");
@@ -102,15 +99,6 @@ public class OptionsParamCheckForUpdates extends AbstractParam {
 		}
 		setDownloadDirectory(new File(getString(DOWNLOAD_DIR, Constant.FOLDER_LOCAL_PLUGIN)), false);
     }
-
-	private void updateOldOptions() {
-		try {
-			int oldValue = getConfig().getInt(CHECK_ON_START, 0);
-			getConfig().setProperty(CHECK_ON_START, oldValue != 0);
-		} catch(ConversionException ignore) {
-			// Option already using boolean type.
-		}
-	}
 
 	/**
 	 * Sets whether or not the "check for updates on start up" is enabled.

--- a/test/org/zaproxy/zap/extension/autoupdate/OptionsParamCheckForUpdatesUnitTest.java
+++ b/test/org/zaproxy/zap/extension/autoupdate/OptionsParamCheckForUpdatesUnitTest.java
@@ -1,0 +1,71 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.autoupdate;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+
+import org.apache.commons.configuration.FileConfiguration;
+import org.junit.Test;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/**
+ * Unit test for {@link OptionsParamCheckForUpdates}.
+ */
+public class OptionsParamCheckForUpdatesUnitTest {
+
+    @Test
+    public void shouldNotHaveConfigByDefault() {
+        // Given / When
+        OptionsParamCheckForUpdates param = new OptionsParamCheckForUpdates();
+        // Then
+        assertThat(param.getConfig(), is(equalTo(null)));
+    }
+
+    @Test
+    public void shouldParseEmptyConfig() {
+        // Given
+        OptionsParamCheckForUpdates param = new OptionsParamCheckForUpdates();
+        FileConfiguration config = new ZapXmlConfiguration();
+        // When
+        param.load(config);
+        // Then
+        assertThat(param.isCheckOnStart(), is(true));
+        assertThat(param.getDayLastChecked(), is(nullValue()));
+        assertThat(param.getDayLastInstallWarned(), is(nullValue()));
+        assertThat(param.getDayLastUpdateWarned(), is(nullValue()));
+        assertThat(param.isDownloadNewRelease(), is(false));
+        assertThat(param.isCheckAddonUpdates(), is(true));
+        assertThat(param.isInstallAddonUpdates(), is(false));
+        assertThat(param.isInstallScannerRules(), is(false));
+        assertThat(param.isReportReleaseAddons(), is(false));
+        assertThat(param.isReportBetaAddons(), is(false));
+        assertThat(param.isReportAlphaAddons(), is(false));
+        assertThat(param.getAddonDirectories(), is(empty()));
+        assertThat(param.getDownloadDirectory(), is(equalTo(new File(Constant.FOLDER_LOCAL_PLUGIN))));
+    }
+
+}


### PR DESCRIPTION
Move the update to Constant so that it's done just once, when needed.
Also, tweak a previous update to use the correct type (int instead of
boolean).
The update was changing the expected default value of the option.
Add tests to assert the expected behaviour.