### PR TITLE
Improve error handling on shutdown

### DIFF
--- a/src/org/parosproxy/paros/control/Control.java
+++ b/src/org/parosproxy/paros/control/Control.java
@@ -69,6 +69,7 @@
 // ZAP: 2017/08/31 Use helper method I18N.getString(String, Object...).
 // ZAP: 2018/01/04 Do not notify extensions if failed to change the session.
 // ZAP: 2018/01/12 Save configurations as last shutdown action.
+// ZAP: 2019/03/14 Improve error handling on shutdown
 
 package org.parosproxy.paros.control;
 
@@ -250,18 +251,23 @@ public class Control extends AbstractControl implements SessionListener {
 	        @Override
 	        public void run() {
 	            // ZAP: Changed to use the option compact database.
-	            control.shutdown(Model.getSingleton().getOptionsParam().getDatabaseParam().isCompactDatabase());
-	    	    log.info(Constant.PROGRAM_TITLE + " terminated.");
-	    	    
-	    	    if (openOnExit != null && Desktop.isDesktopSupported()) {
-					try {
-			    	    log.info("Openning file " + openOnExit.getAbsolutePath());
-						Desktop.getDesktop().open(openOnExit);
-					} catch (IOException e) {
-						log.error("Failed to open file " + openOnExit.getAbsolutePath(), e);
-					}
-	    	    }
-	    		System.exit(0);   
+                try {
+                    control.shutdown(Model.getSingleton().getOptionsParam().getDatabaseParam().isCompactDatabase());
+                    log.info(Constant.PROGRAM_TITLE + " terminated.");
+
+                    if (openOnExit != null && Desktop.isDesktopSupported()) {
+                        try {
+                            log.info("Openning file " + openOnExit.getAbsolutePath());
+                            Desktop.getDesktop().open(openOnExit);
+                        } catch (IOException e) {
+                            log.error("Failed to open file " + openOnExit.getAbsolutePath(), e);
+                        }
+                    }
+                } catch (Throwable e) {
+                    log.error("An error occurred while shutting down:", e);
+                } finally {
+                    System.exit(0);
+                }
 	        }
 	    }, "ZAP-Shutdown");
 

--- a/src/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/src/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -393,9 +393,14 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 					} catch (InterruptedException e) {
 						// Ignore
 					}
-					Control.getSingleton().shutdown(Model.getSingleton().getOptionsParam().getDatabaseParam().isCompactDatabase());
-					logger.info(Constant.PROGRAM_TITLE + " terminated.");
-					System.exit(0);
+					try {
+						Control.getSingleton().shutdown(Model.getSingleton().getOptionsParam().getDatabaseParam().isCompactDatabase());
+						logger.info(Constant.PROGRAM_TITLE + " terminated.");
+					} catch (Throwable e) {
+						logger.error("An error occurred while shutting down:", e);
+					} finally {
+						System.exit(0);
+					}
 				}
 			};
 			thread.start();


### PR DESCRIPTION
Change Control and CoreAPI to exit in a finally block, to ensure ZAP
exits even in case of errors, also, catch and log the error.

---
Happened after upgrading JxBrowser and then exit ZAP:
```
[ZAP-Shutdown] ERROR org.zaproxy.zap.ZAP$UncaughtExceptionLogger  - Exception in thread "ZAP-Shutdown"
java.lang.NoClassDefFoundError: org/zaproxy/zap/extension/jxbrowserlinux64/selenium/JxBrowserProvider$2
	at org.zaproxy.zap.extension.jxbrowserlinux64.selenium.JxBrowserProvider.cleanUpBrowser(JxBrowserProvider.java:242)
	at org.zaproxy.zap.extension.jxbrowserlinux64.selenium.JxBrowserProvider.access$100(JxBrowserProvider.java:73)
	at org.zaproxy.zap.extension.jxbrowserlinux64.selenium.JxBrowserProvider$1.quit(JxBrowserProvider.java:202)
	at org.zaproxy.zap.extension.selenium.ExtensionSelenium.stop(ExtensionSelenium.java:211)
	at org.parosproxy.paros.extension.ExtensionLoader.stopAllExtension(ExtensionLoader.java:803)
	at org.parosproxy.paros.control.AbstractControl.shutdown(AbstractControl.java:76)
	at org.parosproxy.paros.control.Control.shutdown(Control.java:193)
	at org.parosproxy.paros.control.Control$1.run(Control.java:253)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.ClassNotFoundException
	at org.zaproxy.zap.control.AddOnClassLoader.findClass(AddOnClassLoader.java:269)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 9 more
```