### PR TITLE
Issue 4548 - ATTACK Mode Enablement Enhancement

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -215,6 +215,8 @@ ascan.attack.scan			= Attack Mode Scanner
 ascan.attack.prompt			= Rescan all of the nodes when scope changes?\n\
 If you select this option then ZAP will scan all nodes currently in scope\n\
 and will rescan all of the nodes in scope if the scope changes.
+ascan.attack.prompt.no.scope	= \n\nNOTE: There is currently nothing in scope.\n\
+Create or enable scope for one or more contexts to take advantage of {0}.\n
 ascan.custom.button.pt.add	= Add
 ascan.custom.button.pt.rem	= Remove
 ascan.custom.button.reset	= Reset

--- a/src/org/zaproxy/zap/extension/ascan/AttackModeScanner.java
+++ b/src/org/zaproxy/zap/extension/ascan/AttackModeScanner.java
@@ -48,6 +48,7 @@ import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.extension.log4j.ExtensionLog4j;
 import org.zaproxy.zap.extension.ruleconfig.ExtensionRuleConfig;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
+import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.view.ScanStatus;
 
 public class AttackModeScanner implements EventConsumer {
@@ -152,9 +153,21 @@ public class AttackModeScanner implements EventConsumer {
         		SwingUtilities.invokeLater(new Runnable() {
 					@Override
 					public void run() {
+						boolean anyInScope = false;
+						for (Context ctx: Model.getSingleton().getSession().getContexts()) {
+							if (ctx.isInScope() && (ctx.getIncludeInContextRegexs() != null
+									&& !ctx.getIncludeInContextRegexs().isEmpty())) {
+								anyInScope = true;
+								break;
+							}
+						}
+						String promptMsg = anyInScope ? Constant.messages.getString("ascan.attack.prompt")
+								: Constant.messages.getString("ascan.attack.prompt")
+										+ Constant.messages.getString("ascan.attack.prompt.no.scope",
+												Constant.messages.getString("view.toolbar.mode.attack.select"));
 						int res = View.getSingleton().showYesNoRememberDialog(
 								View.getSingleton().getMainFrame(), 
-								Constant.messages.getString("ascan.attack.prompt"));
+								promptMsg);
 
 		        		if (View.getSingleton().isRememberLastDialogChosen()) {
 		        			extension.getScannerParam().setPromptInAttackMode(false);


### PR DESCRIPTION
The "Rescan" dialog now displays a different message if there isn't a context flagged in-scope with something defined as in-context".

Fixes zaproxy/zaproxy#4548