### PR TITLE
Correct copy task in Docker live image

### DIFF
--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -63,7 +63,7 @@ RUN git clone --depth 1 https://github.com/zaproxy/zaproxy.git && \
 	cd ../zaproxy && \
 	ant -f build/build.xml deploy-weekly-addons && \
 	cd ../zap-hud/ && \
-	./gradlew copyAddOn && \
+	./gradlew copyZapAddOn && \
 	cd ../zap-core-help/ && \
 	./gradlew copyWeeklyAddOns && \
 	cd ../zaproxy && \


### PR DESCRIPTION
Correct the task used to copy the HUD add-on, it was renamed when the
HUD repo started to use the published Gradle plugin (done in zaproxy/zap-hud#398).