### PR TITLE
Fix copy of default file from source with new home

### DIFF
--- a/src/org/parosproxy/paros/Constant.java
+++ b/src/org/parosproxy/paros/Constant.java
@@ -406,7 +406,7 @@ public final class Constant {
     }
 
     private static void copyFileToHome(Path targetFile, String sourceFilePath, String fallbackResource) throws IOException {
-        Path defaultConfig = Paths.get(zapInstall, sourceFilePath);
+        Path defaultConfig = Paths.get(getZapInstall(), sourceFilePath);
         if (Files.exists(defaultConfig)) {
             Files.copy(defaultConfig, targetFile, StandardCopyOption.REPLACE_EXISTING);
         } else {


### PR DESCRIPTION
Use the getter to force the initialisation of the installation directory
when copying default files, otherwise they would not be found and ZAP
would fail to start when running from source if the develop home did not
exist.

----
Reported in Slack ZAP channel (and it was also reported in dev group but the thread no longer exists).