### PR TITLE
Fixes frozen GUI when updating alert tree in non EDT

### DIFF
--- a/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/src/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -436,6 +436,25 @@ public class ExtensionAlert extends ExtensionAdaptor implements
         if (Constant.isLowMemoryOptionSet()) {
             return;
         }
+        
+        if (getView() == null || EventQueue.isDispatchThread()) {
+        	updateAlertInTreeEventHandler(originalAlert, alert);
+        }
+        else {
+            try {
+                EventQueue.invokeAndWait(new Runnable() {
+                    @Override
+                    public void run() {
+                    	updateAlertInTreeEventHandler(originalAlert, alert);
+                    }
+                });
+            } catch (Exception e) {
+                logger.error(e.getMessage(), e);
+            }
+        }
+    }
+    
+    private void updateAlertInTreeEventHandler(Alert originalAlert, Alert alert) {
         this.getTreeModel().updatePath(originalAlert, alert);
     	if (isInFilter(alert)) {
     		this.getFilteredTreeModel().updatePath(originalAlert, alert);


### PR DESCRIPTION
This fixes #5259 by updating alert tree in a different thread when it's not in EDT
+ with the [feedback here](https://github.com/zaproxy/zaproxy/pull/5268#pullrequestreview-216613205) 

Note: This is the same PR that was previously added in #5268
