### PR TITLE
Provide more details on ascan API URL errors

### DIFF
--- a/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
+++ b/src/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
@@ -753,11 +753,11 @@ public class ActiveScanAPI extends ApiImplementor {
 			try {
 				startURI = new URI(url, true);
 			} catch (URIException e) {
-				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_URL);
+				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_URL, e);
 			}
 			String scheme = startURI.getScheme();
 			if (scheme == null || (!scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https"))) {
-				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_URL);
+				throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_URL + " does not have a scheme.");
 			}
 
 			try {


### PR DESCRIPTION
Include the exception when failed to parse the start URL and indicate
that the scheme is missing in the exception message.