### PR TITLE
Allow active/passive scripts to provide references

### DIFF
--- a/src/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/src/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -59,6 +59,7 @@
 // ZAP: 2017/12/29 Rely on HostProcess to validate the redirections.
 // ZAP: 2018/02/02 Add helper method to check if any of several techs is in scope.
 // ZAP: 2018/08/15 Implemented hashCode
+// ZAP: 2019/03/22 Add bingo with references.
 
 package org.parosproxy.paros.core.scanner;
 
@@ -464,6 +465,13 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
     protected void bingo(int risk, int confidence, String name, String description, String uri,
             String param, String attack, String otherInfo, String solution,
             String evidence, int cweId, int wascId, HttpMessage msg) {
+        bingo(risk, confidence, name, description, uri, param, attack,
+                otherInfo, solution, evidence, this.getReference(), cweId, wascId, msg);
+    }
+
+    protected void bingo(int risk, int confidence, String name, String description, String uri,
+            String param, String attack, String otherInfo, String solution,
+            String evidence, String reference, int cweId, int wascId, HttpMessage msg) {
        
         log.debug("New alert pluginid=" + +this.getId() + " " + name + " uri=" + uri);
         Alert alert = new Alert(this.getId(), risk, confidence, name);
@@ -476,7 +484,7 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
             param = "";
         }
         
-        alert.setDetail(description, uri, param, attack, otherInfo, solution, this.getReference(),
+        alert.setDetail(description, uri, param, attack, otherInfo, solution, reference,
                 evidence, cweId, wascId, msg);
         
         parent.alertFound(alert);

--- a/src/org/zaproxy/zap/extension/ascan/ScriptsActiveScanner.java
+++ b/src/org/zaproxy/zap/extension/ascan/ScriptsActiveScanner.java
@@ -225,6 +225,13 @@ public class ScriptsActiveScanner extends AbstractAppParamPlugin {
 				otherInfo, solution, evidence, cweId, wascId, msg);
 	}
 
+	public void raiseAlert(int risk, int confidence, String name, String description, String uri,
+			String param, String attack, String otherInfo, String solution, String evidence,
+			String reference, int cweId, int wascId, HttpMessage msg) {
+		super.bingo(risk, confidence, name, description, uri, param, attack,
+				otherInfo, solution, evidence, reference, cweId, wascId, msg);
+	}
+
 	@Override
 	public int getRisk() {
 		return Alert.RISK_INFO;

--- a/src/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
+++ b/src/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
@@ -124,10 +124,18 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
 			String param, String attack, String otherInfo, String solution, String evidence, 
 			int cweId, int wascId, HttpMessage msg) {
 		
+		raiseAlert(risk, confidence, name, description, uri, param, attack,
+				otherInfo, solution, evidence, null, cweId, wascId, msg);
+	}
+
+	public void raiseAlert(int risk, int confidence, String name, String description, String uri,
+			String param, String attack, String otherInfo, String solution, String evidence,
+			String reference, int cweId, int wascId, HttpMessage msg) {
+		
 		Alert alert = new Alert(getPluginId(), risk, confidence, name);
 		     
 		alert.setDetail(description, msg.getRequestHeader().getURI().toString(), 
-				param, attack, otherInfo, solution, null, evidence, cweId, wascId, msg);		// Left out reference to match ScriptsActiveScanner
+				param, attack, otherInfo, solution, reference, evidence, cweId, wascId, msg);
 
 		this.parent.raiseAlert(currentHRefId, alert);
 	}

--- a/src/scripts/templates/active/Active default template.js
+++ b/src/scripts/templates/active/Active default template.js
@@ -75,7 +75,7 @@ function scan(as, msg, param, value) {
 		// confidence: 0: falsePositive, 1: low, 2: medium, 3: high, 4: confirmed
 		as.raiseAlert(1, 1, 'Active Vulnerability title', 'Full description', 
 		msg.getRequestHeader().getURI().toString(), 
-			param, 'Your attack', 'Any other info', 'The solution ', '', 0, 0, msg);
+			param, 'Your attack', 'Any other info', 'The solution ', '', 'References', 0, 0, msg);
 	}
 }
 

--- a/src/scripts/templates/passive/Passive default template.js
+++ b/src/scripts/templates/passive/Passive default template.js
@@ -26,7 +26,7 @@ function scan(ps, msg, src) {
 		// confidence: 0: falsePositive, 1: low, 2: medium, 3: high, 4: confirmed
 		ps.raiseAlert(1, 1, 'Passive Vulnerability title', 'Full description', 
 			msg.getRequestHeader().getURI().toString(), 
-			'The param', 'Your attack', 'Any other info', 'The solution', '', 0, 0, msg);
+			'The param', 'Your attack', 'Any other info', 'The solution', '', 'References', 0, 0, msg);
 		
 		//addTag(String tag)
 		ps.addTag('tag')			


### PR DESCRIPTION
Add a method to `ScriptsActiveScanner` and `ScriptsPassiveScanner` to
allow to raise alerts with references.
Change `AbstractPlugin` to support the above case.
Update default template scripts to call the new methods.

Fix #5277 - Active Scan Scripts - References Functionality