### PR TITLE
Use correct name for required fields

### DIFF
--- a/src/org/zaproxy/zap/view/DynamicFieldsPanel.java
+++ b/src/org/zaproxy/zap/view/DynamicFieldsPanel.java
@@ -91,7 +91,7 @@ public class DynamicFieldsPanel extends JPanel {
 
 		int fieldIndex = 0;
 		for (String fieldName : requiredFields) {
-			addField("* " + fieldName, fieldIndex);
+			addRequiredField(fieldName, fieldIndex);
 			fieldIndex++;
 		}
 
@@ -104,8 +104,16 @@ public class DynamicFieldsPanel extends JPanel {
 		validate();
 	}
 
+	private void addRequiredField(String fieldName, int fieldIndex) {
+		addFieldImpl("* " + fieldName, fieldName, fieldIndex);
+	}
+
 	private void addField(String fieldName, int fieldIndex) {
-		JLabel label = new JLabel(fieldName + ": ");
+		addFieldImpl(fieldName, fieldName, fieldIndex);
+	}
+
+	private void addFieldImpl(String labelText, String fieldName, int fieldIndex) {
+		JLabel label = new JLabel(labelText + ": ");
 		this.add(label, LayoutHelper.getGBC(0, fieldIndex, 1, 0.0d, 0.0d));
 
 		ZapTextField tf = new ZapTextField();


### PR DESCRIPTION
Use the name of the field not the text of the label when mapping the
required fields, otherwise the validation would fail to get the field.
Broken in #5189.

---
Reported in OWASP ZAP User Group: https://groups.google.com/d/topic/zaproxy-users/Yn8a8DQ-Zio/discussion