### PR TITLE
Improve error message when failed to connect to outgoing proxy

### DIFF
--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -901,6 +901,7 @@ conn.options.proxy.auth.required = Outgoing proxy server requires authentication
 conn.options.proxy.auth.username = User Name:
 conn.options.proxy.port          = Port (eg 8080):
 conn.options.proxy.skipAddresses = Skip IP address or domain names
+conn.options.proxy.error.response.msg=\tYour "Options / Connection / Use Proxy Chain" settings might be incorrect.
 conn.options.proxy.excluded.domain.add.title = Add Domain Exclusion
 conn.options.proxy.excluded.domain.add.button.confirm = Add
 conn.options.proxy.excluded.domain.field.label.domain = Domain:


### PR DESCRIPTION
Update `ProxyThread.setErrorResponse(HttpMessage msg, String responseStatus, Exception cause, String errorType)` to check the type of exception, if proxy chain is enabled, and if the error has the same hostname as the outbound proxy.

Fixes zaproxy/zaproxy#5304