### PR TITLE
Remove zapr from Docker images

### DIFF
--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -11,7 +11,6 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	autoconf \
 	gcc g++ \
 	openjdk-8-jdk \
-	ruby \
 	wget \
 	curl \
 	xmlstarlet \
@@ -20,7 +19,6 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	openbox \
 	xterm \
 	net-tools \
-	ruby-dev \
 	python-pip \
 	firefox \
 	vim \
@@ -28,7 +26,6 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	x11vnc && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*  && \
-	gem install zapr && \
 	pip install --upgrade pip zapcli python-owasp-zap-v2.4 && \
 	useradd -d /home/zap -m -s /bin/bash zap && \
 	echo zap:zap | chpasswd && \

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -10,7 +10,6 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	autoconf \
 	gcc g++ \
 	openjdk-8-jdk \
-	ruby \
 	wget \
 	curl \
 	xmlstarlet \
@@ -19,7 +18,6 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	openbox \
 	xterm \
 	net-tools \
-	ruby-dev \
 	python-pip \
 	firefox \
 	xvfb \
@@ -27,7 +25,6 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
 
-RUN gem install zapr
 RUN pip install --upgrade pip zapcli python-owasp-zap-v2.4
 
 RUN useradd -d /home/zap -m -s /bin/bash zap

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -10,7 +10,6 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	autoconf \
 	gcc g++ \
 	openjdk-8-jdk \
-	ruby \
 	wget \
 	curl \
 	xmlstarlet \
@@ -19,7 +18,6 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	openbox \
 	xterm \
 	net-tools \
-	ruby-dev \
 	python-pip \
 	firefox \
 	xvfb \
@@ -27,7 +25,6 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
 
-RUN gem install zapr
 RUN pip install --upgrade pip zapcli python-owasp-zap-v2.4
 
 RUN useradd -d /home/zap -m -s /bin/bash zap


### PR DESCRIPTION
The zapr command line tool no longer works properly with newer ZAP
versions (ZAP API key is required by default but it does not provide a
way to specify a key or disable it), also, the tool is no longer
actively maintained. Remove ruby (and ruby-dev), required by zapr.
The zap-cli included in the images provides similar functionality.