### PR TITLE
Updated an alert reference link

### DIFF
--- a/examples/ZAP_2.4.3_report-merged.html
+++ b/examples/ZAP_2.4.3_report-merged.html
@@ -2855,7 +2855,7 @@ Host: localhost:8080
 <tr bgcolor="#e8e8e8" valign="top">
 <td width="20%"><font size="2" face="Arial, Helvetica, sans-serif">
 <p>Reference</p>
-</font></td><td width="80%"><font size="2" face="Arial, Helvetica, sans-serif"><p>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet</p><p>https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/</p></font></td>
+</font></td><td width="80%"><font size="2" face="Arial, Helvetica, sans-serif"><p>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet</p><p>https://www.veracode.com/blog/2014/03/guidelines-for-setting-security-headers/</p></font></td>
 </tr>
   
 <tr bgcolor="#e8e8e8" valign="top">

--- a/examples/ZAP_2.4.3_report-merged.xml
+++ b/examples/ZAP_2.4.3_report-merged.xml
@@ -71,7 +71,7 @@
   <count>58</count>
   <solution>&lt;p&gt;Ensure that the web browser&apos;s XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to &apos;1&apos;.&lt;/p&gt;</solution>
   <otherinfo>&lt;p&gt;The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser&apos;s XSS protection mechanism. The following values would attempt to enable it: &lt;/p&gt;&lt;p&gt;X-XSS-Protection: 1; mode=block&lt;/p&gt;&lt;p&gt;X-XSS-Protection: 1; report=http://www.example.com/xss&lt;/p&gt;&lt;p&gt;The following values would disable it:&lt;/p&gt;&lt;p&gt;X-XSS-Protection: 0&lt;/p&gt;&lt;p&gt;The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).&lt;/p&gt;&lt;p&gt;Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).&lt;/p&gt;</otherinfo>
-  <reference>&lt;p&gt;https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet&lt;/p&gt;&lt;p&gt;https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/&lt;/p&gt;</reference>
+  <reference>&lt;p&gt;https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet&lt;/p&gt;&lt;p&gt;https://www.veracode.com/blog/2014/03/guidelines-for-setting-security-headers/&lt;/p&gt;</reference>
   <cweid>933</cweid>
   <wascid>14</wascid>
 </alertitem>


### PR DESCRIPTION
The old reference link for the alert "Web Browser XSS Protection Not Enabled" no longer works. Updated with a new link.