### PR TITLE
Enhancement: Spider handle Hyperlink Auditing Functionality

### DIFF
--- a/src/org/zaproxy/zap/spider/parser/SpiderHtmlParser.java
+++ b/src/org/zaproxy/zap/spider/parser/SpiderHtmlParser.java
@@ -122,12 +122,14 @@ public class SpiderHtmlParser extends SpiderParser {
 		List<Element> elements = source.getAllElements(HTMLElementName.A);
 		for (Element el : elements) {
 			resourcesfound |= processAttributeElement(message, depth, baseURL, el, "href");
+			resourcesfound |= processAttributeElement(message, depth, baseURL, el, "ping");
 		}
 
 		// Process AREA elements
 		elements = source.getAllElements(HTMLElementName.AREA);
 		for (Element el : elements) {
 			resourcesfound |= processAttributeElement(message, depth, baseURL, el, "href");
+			resourcesfound |= processAttributeElement(message, depth, baseURL, el, "ping");
 		}
 
 		// Process Frame Elements
@@ -204,7 +206,15 @@ public class SpiderHtmlParser extends SpiderParser {
 			return false;
 		}
 
-		processURL(message, depth, localURL, baseURL);
+		if (!attributeName.equalsIgnoreCase("ping")) {
+			processURL(message, depth, localURL, baseURL);
+		} else {
+			for (String pingURL : localURL.split("\\s")) {
+				if (!pingURL.isEmpty()) {
+					processURL(message, depth, pingURL, baseURL);
+				}
+			}
+		}
 		return true;
 	}
 

--- a/test/org/zaproxy/zap/spider/parser/SpiderHtmlParserUnitTest.java
+++ b/test/org/zaproxy/zap/spider/parser/SpiderHtmlParserUnitTest.java
@@ -166,6 +166,99 @@ public class SpiderHtmlParserUnitTest extends SpiderParserTestUtils {
     }
 
     @Test
+    public void shouldFindUrlsInAnchorPingElements() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("AElementsWithPingSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(23)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        // a URLs followed by ping URLs
+                        "http://a.example.com/base/scheme",
+                        "http://ping.example.com/base/scheme",
+                        "http://a.example.com:8000/b",
+                        "http://ping.example.com:8000/b",
+                        "https://a.example.com/c?a=b",
+                        "https://ping.example.com/c?a=b",
+                        "http://example.com/sample/a/relative",
+                        "http://example.com/sample/a/relative/ping",
+                        "http://example.com/a/absolute",
+                        "http://example.com/a/absolute/ping",
+                        "ftp://a.example.com/",
+                        "https://ping.example.com/ping",
+                        //Ping first, is parsed href before ping
+                        "http://b.example.com/",
+                        "https://ping.first.com/",
+                        //Ignored anchors but picked pings
+                        "http://ping.example.com/mailping",
+                        "http://ping.example.com/jsping",
+                        "http://ping.example.com/ping",
+                        //Multiple ping URLs
+                        "http://a.example.com/",
+                        "http://ping.example.com/",
+                        "http://pong.example.com/",
+                        //Mutiple ping URLs with tab in the middle
+                        "http://a.example.com/",
+                        "http://ping.example.com/",
+                        "http://pong.example.com/"));//Trailing slash is added on host
+    }
+
+    @Test
+    public void shouldFindUrlsInAreaPingElements() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("AreaElementsWithPingSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed = htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(23)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        // area URLs followed by ping URLs
+                        "http://a.example.com/base/scheme",
+                        "http://ping.example.com/base/scheme",
+                        "http://a.example.com:8000/b",
+                        "http://ping.example.com:8000/b",
+                        "https://a.example.com/c?a=b",
+                        "https://ping.example.com/c?a=b",
+                        "http://example.com/sample/a/relative",
+                        "http://example.com/sample/a/relative/ping",
+                        "http://example.com/a/absolute",
+                        "http://example.com/a/absolute/ping",
+                        "ftp://a.example.com/",
+                        "https://ping.example.com/ping",
+                        //Ping first, is parsed href before ping
+                        "http://b.example.com/",
+                        "https://ping.first.com/",
+                        //Ignored anchors but picked pings
+                        "http://ping.example.com/mailping",
+                        "http://ping.example.com/jsping",
+                        "http://ping.example.com/ping",
+                        //Multiple ping URLs
+                        "http://a.example.com/",
+                        "http://ping.example.com/",
+                        "http://pong.example.com/",
+                        //Mutiple ping URLs with tab in the middle
+                        "http://a.example.com/",
+                        "http://ping.example.com/",
+                        "http://pong.example.com/"));//Trailing slash is added on host
+    }
+
+
+    @Test
     public void shouldUseMessageUriIfNoBaseElement() {
         // Given
         SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());

--- a/test/resources/org/zaproxy/zap/spider/parser/html/AElementsWithPingSpiderHtmlParser.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/html/AElementsWithPingSpiderHtmlParser.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://example.com/sample/">
+<meta charset="UTF-8">
+<title>A Elements - Spider HTML Parser</title>
+</head>
+<body>
+
+<a href="//a.example.com/base/scheme" ping="//ping.example.com/base/scheme">sub-domain using base scheme</a><br />
+<a href="http://a.example.com:8000/b" ping="http://ping.example.com:8000/b">sub-domain (http)</a><br />
+<a href="https://a.example.com/c?a=b#fragment" ping="https://ping.example.com/c?a=b#fragment">sub-domain (https)</a><br />
+<a href="a/relative" ping="a/relative/ping">relative</a><br />
+<a href="/a/absolute" ping="/a/absolute/ping">absolute</a><br />
+<a href="ftp://a.example.com/" ping="https://ping.example.com/ping">ftp</a><br />
+<a ping="https://ping.first.com/" href="http://b.example.com/">ping first</a><br />
+
+Ignored anchors but picked pings:<br />
+<a>no href</a><br />
+<a href="mailto:a@example.com" ping="http://ping.example.com/mailping">mailto:</a><br />
+<a href="javascript:hello();" ping="http://ping.example.com/jsping">javascript:</a><br />
+<a href="scheme://a.example.com/invalid" ping="http://ping.example.com/ping">scheme:</a>
+
+Ignored anchors and pings:<br />
+<a>no href</a><br />
+<a href="mailto:a@example.com" ping="mailto:fred@ping.com">mailto:</a><br />
+<a href="javascript:hello();" ping="javascript:function("ping.com")">javascript:</a><br />
+<a href="scheme://a.example.com/invalid" ping="scheme://ping.example.com">scheme:</a>
+
+Should find multiple ping URLs:<br />
+<a href="http://a.example.com/" ping="http://ping.example.com/  http://pong.example.com/">Multiple with spaces</a><br />
+<a href="http://a.example.com/" ping="http://ping.example.com/ 	 http://pong.example.com/">Multiple with spaces</a><br />
+
+
+</body>
+</html>

--- a/test/resources/org/zaproxy/zap/spider/parser/html/AreaElementsWithPingSpiderHtmlParser.html
+++ b/test/resources/org/zaproxy/zap/spider/parser/html/AreaElementsWithPingSpiderHtmlParser.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://example.com/sample/">
+<meta charset="UTF-8">
+<title>Area Elements - Spider HTML Parser</title>
+</head>
+<body>
+
+<map>
+<area href="//a.example.com/base/scheme" ping="//ping.example.com/base/scheme" />
+<area href="http://a.example.com:8000/b" ping="http://ping.example.com:8000/b" />
+<area href="https://a.example.com/c?a=b#fragment" ping="https://ping.example.com/c?a=b#fragment" />
+<area href="a/relative" ping="a/relative/ping" />
+<area href="/a/absolute" ping="/a/absolute/ping" />
+<area href="ftp://a.example.com/" ping="https://ping.example.com/ping"/>
+<area ping="https://ping.first.com/" href="http://b.example.com/"/>
+
+Ignored anchors but picked pings:<br />
+<a>no href</a><br />
+<area href="mailto:a@example.com" ping="http://ping.example.com/mailping" />
+<area href="javascript:hello();" ping="http://ping.example.com/jsping" />
+<area href="scheme://a.example.com/invalid" ping="http://ping.example.com/ping" />
+
+Ignored anchors and pings:<br />
+<a>no href</a><br />
+<area href="mailto:a@example.com" ping="mailto:fred@ping.com" />
+<area href="javascript:hello();" ping="javascript:function("ping.com")" />
+<area href="scheme://a.example.com/invalid" ping="scheme://ping.example.com" />
+
+Should find multiple ping URLs:<br />
+<area href="http://a.example.com/" ping="http://ping.example.com/  http://pong.example.com/" />
+<area href="http://a.example.com/" ping="http://ping.example.com/ 	 http://pong.example.com/" />
+
+</body>
+</html>


### PR DESCRIPTION
After having come across:
* https://www.bleepingcomputer.com/news/software/major-browsers-to-prevent-disabling-of-click-tracking-privacy-risk/
* https://html.spec.whatwg.org/multipage/links.html#hyperlink-auditing

I thought I would add this.