### PR TITLE
Copy scripts also for stable/weekly Docker images

### DIFF
--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -64,6 +64,8 @@ ENV HOME /home/zap/
 COPY zap* /zap/
 COPY webswing.config /zap/webswing/
 COPY policies /home/zap/.ZAP/policies/
+# The scan script loads the scripts from dev home dir.
+COPY scripts /home/zap/.ZAP_D/scripts/
 COPY .xinitrc /home/zap/
 
 #Copy doesn't respect USER directives so we need to chown and to do that we need to be root

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -65,6 +65,7 @@ ENV HOME /home/zap/
 COPY zap* /zap/
 COPY webswing.config /zap/webswing/
 COPY policies /home/zap/.ZAP_D/policies/
+COPY scripts /home/zap/.ZAP_D/scripts/
 COPY .xinitrc /home/zap/
 
 #Copy doesn't respect USER directives so we need to chown and to do that we need to be root


### PR DESCRIPTION
Copy the helper API scan scripts also for stable/weekly Docker images,
the scan script needs them in those images as well.

---
From OWASP ZAP User Group: https://groups.google.com/d/msg/zaproxy-users/QEOnJmMVldM/_7QtKfkuCwAJ