### PR TITLE
Uninstall before copying the local add-on

### DIFF
--- a/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -276,6 +276,10 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor implements CheckForUpd
 				logger.warn("An error occurred while checking the add-ons' files: " + e.getMessage(), e);
 				return false;
 			}
+
+			if (!uninstallAddOn(null, installedAddOn, true)) {
+				return false;
+			}
 		}
 
 		File addOnFile;


### PR DESCRIPTION
Uninstall the add-on before copying it when installing the local add-on
through the API, to not fail when reinstalling (as the add-on would
already exist in the plugin directory).