### PR TITLE
Show UI name of dependent extensions

### DIFF
--- a/src/org/zaproxy/zap/extension/autoupdate/AddOnDependencyChecker.java
+++ b/src/org/zaproxy/zap/extension/autoupdate/AddOnDependencyChecker.java
@@ -1031,7 +1031,7 @@ class AddOnDependencyChecker {
             Extension extension = extensions.get(rowIndex);
             switch (columnIndex) {
             case 0:
-                return extension.getName();
+                return extension.getUIName();
             default:
                 return "";
             }


### PR DESCRIPTION
Show the UI name when informing about dependent extensions of the add-on
being changed (e.g. updated, uninstalled), instead of the internal name.