### PR TITLE
Test Downloader validation

### DIFF
--- a/test/org/zaproxy/zap/extension/autoupdate/DownloaderUnitTest.java
+++ b/test/org/zaproxy/zap/extension/autoupdate/DownloaderUnitTest.java
@@ -1,0 +1,126 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.autoupdate;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.Proxy;
+import java.net.URL;
+import org.apache.commons.io.FileUtils;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Unit test for {@link Downloader}. */
+public class DownloaderUnitTest {
+
+    private static final String FILE_CONTENTS = "0123456789ABCDEF";
+
+    @ClassRule public static TemporaryFolder tempDir = new TemporaryFolder();
+
+    private static URL downloadUrl;
+
+    @BeforeClass
+    public static void setUp() throws IOException {
+        File file = tempDir.newFile();
+        FileUtils.write(file, FILE_CONTENTS);
+        downloadUrl = file.toURI().toURL();
+    }
+
+    @Test
+    public void shouldValidateDownloadWithEqualSha1Hash() throws Exception {
+        // Given
+        String hash = "SHA1:ce27cb141098feb00714e758646be3e99c185b71";
+        Downloader downloader = noProxyDownloader(downloadUrl, hash);
+        // When
+        downloader.start();
+        // Then
+        waitDownloadFinish(downloader);
+        assertThat(downloader.isValidated(), is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldNotValidateDownloadWithDifferentSha1Hash() throws Exception {
+        // Given
+        String hash = "SHA1:ce27cb";
+        Downloader downloader = noProxyDownloader(downloadUrl, hash);
+        // When
+        downloader.start();
+        // Then
+        waitDownloadFinish(downloader);
+        assertThat(downloader.isValidated(), is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldValidateDownloadWithEqualSha256Hash() throws Exception {
+        // Given
+        String hash = "SHA-256:2125b2c332b1113aae9bfc5e9f7e3b4c91d828cb942c2df1eeb02502eccae9e9";
+        Downloader downloader = noProxyDownloader(downloadUrl, hash);
+        // When
+        downloader.start();
+        // Then
+        waitDownloadFinish(downloader);
+        assertThat(downloader.isValidated(), is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldNotValidateDownloadWithDifferentSha256Hash() throws Exception {
+        // Given
+        String hash = "SHA-256:2125bc";
+        Downloader downloader = noProxyDownloader(downloadUrl, hash);
+        // When
+        downloader.start();
+        // Then
+        waitDownloadFinish(downloader);
+        assertThat(downloader.isValidated(), is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotValidateDownloadWithUnsupportedAlgorithm() throws Exception {
+        // Given
+        String hash = "~NotHashAlg~:ce27cb141098feb00714e758646be3e99c185b71";
+        Downloader downloader = noProxyDownloader(downloadUrl, hash);
+        // When
+        downloader.start();
+        // Then
+        waitDownloadFinish(downloader);
+        assertThat(downloader.isValidated(), is(equalTo(false)));
+    }
+
+    private static Downloader noProxyDownloader(URL url, String hash) throws IOException {
+        return new Downloader(url, Proxy.NO_PROXY, tempDir.newFile(), hash);
+    }
+
+    private static void waitDownloadFinish(Downloader downloader) throws InterruptedException {
+        int i = 1;
+        while (downloader.getFinished() == null) {
+            Thread.sleep(50);
+            if (i == 200) {
+                break;
+            }
+            i++;
+        }
+    }
+}


### PR DESCRIPTION
Add tests to assert that the Downloader validates the hash of the
download properly, with supported/unsupported algorithms and with
equal/different hashes.