### PR TITLE
Remove usage of JDOM library

### DIFF
--- a/zap/src/main/resources/org/zaproxy/zap/resources/drivers.xml
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/drivers.xml
@@ -46,19 +46,19 @@
 		<name>CSPid - Windows (x64)</name>
 		<path>C:\Windows\SysWow64\cspid.dll</path>
 		<slot>1</slot>
-		<slotIndex>0</slotIndex>
+		<slotListIndex>0</slotListIndex>
 	</driver>
 	<driver>
 		<name>CSPid - Windows (x86)</name>
 		<path>C:\Windows\System32\cspid.dll</path>
 		<slot>1</slot>
-		<slotIndex>0</slotIndex>
+		<slotListIndex>0</slotListIndex>
 	</driver>
 	<driver>
 		<name>CSPid - Linux</name>
 		<path>/opt/cspid/libcspid.so</path>
 		<slot>1</slot>
-		<slotIndex>0</slotIndex>
+		<slotListIndex>0</slotListIndex>
 	</driver>
 	<driver>
 		<name>Portuguese Cartão de Cidadão - Windows (x86)</name>

--- a/zap/src/test/java/ch/csnc/extension/util/DriverConfigurationUnitTest.java
+++ b/zap/src/test/java/ch/csnc/extension/util/DriverConfigurationUnitTest.java
@@ -1,0 +1,82 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.csnc.extension.util;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Vector;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Unit test for {@link DriverConfiguration}. */
+public class DriverConfigurationUnitTest {
+
+    @ClassRule public static TemporaryFolder tempDir = new TemporaryFolder();
+
+    @Test
+    public void shouldCreateConfigurationFromFile() throws Exception {
+        // Given
+        File file = getDriversXmlFile();
+        // When
+        DriverConfiguration configuration = new DriverConfiguration(file);
+        // Then
+        assertThat(configuration.getNames(), contains("Name A", "Name B", "Name C"));
+        assertThat(configuration.getPaths(), contains("Path A", "Path B", "Path C"));
+        assertThat(configuration.getSlots(), contains(0, 2, 4));
+        assertThat(configuration.getSlotIndexes(), contains(1, 3, 5));
+    }
+
+    @Test
+    public void shouldWriteConfigurationToFile() throws Exception {
+        // Given
+        File file = tempDir.newFile();
+        DriverConfiguration configuration = new DriverConfiguration(file);
+        configuration.setNames(vector("Name A", "Name B", "Name C"));
+        configuration.setPaths(vector("Path A", "Path B", "Path C"));
+        configuration.setSlots(vector(0, 2, 4));
+        configuration.setSlotListIndexes(vector(1, 3, 5));
+        // When
+        configuration.write();
+        // Then
+        assertThat(contents(file), is(equalTo(contents(getDriversXmlFile()))));
+    }
+
+    private static <T> Vector<T> vector(T value1, T value2, T value3) {
+        return new Vector<T>(Arrays.asList(value1, value2, value3));
+    }
+
+    private File getDriversXmlFile() throws URISyntaxException {
+        return new File(getClass().getResource("drivers.xml").toURI());
+    }
+
+    private static List<String> contents(File file) throws IOException {
+        return Files.readAllLines(file.toPath());
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/utils/ContentMatcherUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/ContentMatcherUnitTest.java
@@ -1,0 +1,53 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.utils;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+/** Unit test for {@link ContentMatcher}. */
+public class ContentMatcherUnitTest {
+
+    @Test
+    public void shouldCreateContentMatcherFromFile() throws Exception {
+        // Given
+        String file = "content-matcher-patterns.xml";
+        // When
+        ContentMatcher matcher = ContentMatcher.getInstance(file);
+        // Then
+        assertThat(patternsOf(matcher), contains("Regex 1", "Regex 2"));
+        assertThat(stringsOf(matcher), contains("String 1", "String 2"));
+    }
+
+    private static List<String> patternsOf(ContentMatcher matcher) {
+        return matcher.getPatterns().stream().map(Pattern::pattern).collect(Collectors.toList());
+    }
+
+    private static List<String> stringsOf(ContentMatcher matcher) {
+        return matcher.getStrings().stream()
+                .map(BoyerMooreMatcher::getPattern)
+                .collect(Collectors.toList());
+    }
+}

--- a/zap/src/test/resources/ch/csnc/extension/util/drivers.xml
+++ b/zap/src/test/resources/ch/csnc/extension/util/drivers.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<driverConfiguration>
+    <driver>
+        <name>Name A</name>
+        <path>Path A</path>
+        <slot>0</slot>
+        <slotListIndex>1</slotListIndex>
+    </driver>
+    <driver>
+        <name>Name B</name>
+        <path>Path B</path>
+        <slot>2</slot>
+        <slotListIndex>3</slotListIndex>
+    </driver>
+    <driver>
+        <name>Name C</name>
+        <path>Path C</path>
+        <slot>4</slot>
+        <slotListIndex>5</slotListIndex>
+    </driver>
+</driverConfiguration>

--- a/zap/src/test/resources/org/zaproxy/zap/utils/content-matcher-patterns.xml
+++ b/zap/src/test/resources/org/zaproxy/zap/utils/content-matcher-patterns.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Patterns>
+    <Pattern type="string">String 1</Pattern>
+    <Pattern type="regex">Regex 1</Pattern>
+    <Pattern type="string">String 2</Pattern>
+    <Pattern type="regex">Regex 2</Pattern>
+</Patterns>
+

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -43,7 +43,6 @@ dependencies {
     api("org.bouncycastle:bcprov-jdk15on:1.52")
     api("org.bouncycastle:bcpkix-jdk15on:1.52")
     api("org.hsqldb:hsqldb:2.3.4")
-    api("org.jdom:jdom:1.1.3")
     api("org.jfree:jfreechart:1.0.19")
     api("org.jgrapht:jgrapht-core:0.9.0")
     api("org.swinglabs.swingx:swingx-all:1.6.4")
@@ -54,6 +53,11 @@ dependencies {
     implementation("org.jitsi:ice4j:1.0") {
         setTransitive(false)
     }
+
+    // The following is no longer used by core, remove once
+    // all (known) add-ons are updated accordingly.
+    runtimeOnly("org.jdom:jdom:1.1.3")
+    // -----------------------
 
     runtimeOnly("commons-jxpath:commons-jxpath:1.3")
     runtimeOnly("commons-logging:commons-logging:1.2")


### PR DESCRIPTION
Use Commons Configuration to read/write the XML files instead of JDOM,
the former is used in more places.
The library will still be made available to add-ons, until they are
changed to bundled it or use other library.
Add tests to assert that the corresponding XML files are correctly
handled.
Correct typos in XML elements of the drivers (no impact on functionality
the value of the element had the default value).

Part of #4780 - Tidy up dependencies