### PR TITLE
Update Jericho HTML Parser

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/Constant.java
+++ b/zap/src/main/java/org/parosproxy/paros/Constant.java
@@ -86,6 +86,7 @@
 //                 Fix exceptions during config update.
 // ZAP: 2019/05/14 Added silent option
 // ZAP: 2019/05/17 Update cert option to boolean.
+// ZAP: 2019/05/29 Update Jericho log configuration.
 
 package org.parosproxy.paros;
 
@@ -95,6 +96,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -656,14 +658,47 @@ public final class Constant {
         messages = new I18N(locale);
     }
 
-    private static void setUpLogging() throws IOException {
+    private void setUpLogging() throws IOException {
         String fileName = "log4j.properties";
         File logFile = new File(zapHome, fileName);
         if (!logFile.exists()) {
             copyFileToHome(logFile.toPath(), "xml/" + fileName, "/org/zaproxy/zap/resources/" + fileName);
+        } else {
+            updateLog4jProperties();
         }
         System.setProperty("log4j.configuration", logFile.getAbsolutePath());
         PropertyConfigurator.configure(logFile.getAbsolutePath());
+    }
+
+    private void updateLog4jProperties() {
+        // Update only if config version <= 2.7.0
+        if (Files.notExists(Paths.get(FILE_CONFIG))) {
+            return;
+        }
+
+        try {
+            XMLConfiguration config = new ZapXmlConfiguration(FILE_CONFIG);
+            if (config.getLong("version") > V_2_7_0_TAG) {
+                return;
+            }
+        } catch (Exception ignore) {
+            // Version unknown, don't update.
+            return;
+        }
+
+        try {
+            Path log4jProperties = Paths.get(zapHome, "log4j.properties");
+            String fileContents =
+                    new String(Files.readAllBytes(log4jProperties), StandardCharsets.UTF_8);
+            fileContents =
+                    fileContents.replace(
+                            "log4j.logger.net.htmlparser.jericho=ERROR",
+                            "# Disable Jericho log, it logs HTML parsing issues as errors.\n"
+                                    + "log4j.logger.net.htmlparser.jericho=OFF");
+            Files.write(log4jProperties, fileContents.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            System.err.println("An error occured while updating the log4j.properties: " + e.getMessage());
+        }
     }
     
     private void handleMalformedConfigFile(Exception e) throws IOException {

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
@@ -27,7 +27,7 @@ import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.utils.Stats;
 
 import net.htmlparser.jericho.MasonTagTypes;
-import net.htmlparser.jericho.MicrosoftTagTypes;
+import net.htmlparser.jericho.MicrosoftConditionalCommentTagTypes;
 import net.htmlparser.jericho.PHPTagTypes;
 import net.htmlparser.jericho.Source;
 
@@ -97,7 +97,7 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
 		
 		this.scannerList = passiveScannerList;
 		
-		MicrosoftTagTypes.register();
+		MicrosoftConditionalCommentTagTypes.register();
 		PHPTagTypes.register();
 		PHPTagTypes.PHP_SHORT.deregister(); // remove PHP short tags otherwise they override processing instructions
 		MasonTagTypes.register();

--- a/zap/src/main/resources/org/zaproxy/zap/resources/log4j.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/log4j.properties
@@ -16,7 +16,8 @@ log4j.appender.R.layout.ConversionPattern=%d [%-5t] %-5p %c{1} - %m%n
 log4j.logger.org.parosproxy.paros=INFO
 log4j.logger.org.zaproxy.zap=INFO
 log4j.logger.org.apache.commons.httpclient=ERROR
-log4j.logger.net.htmlparser.jericho=ERROR
+# Disable Jericho log, it logs HTML parsing issues as errors.
+log4j.logger.net.htmlparser.jericho=OFF
 
 # Prevent Crawljax from logging too many, not so useful, INFO messages.
 # For example:

--- a/zap/src/test/java/org/zaproxy/zap/testutils/TestUtils.java
+++ b/zap/src/test/java/org/zaproxy/zap/testutils/TestUtils.java
@@ -24,10 +24,19 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.zaproxy.zap.ZAP;
+
+import net.htmlparser.jericho.Config;
+
 /**
  * Class with utility/helper methods for general tests.
  */
 public class TestUtils {
+
+    static {
+        // Initialise this earlier as possible.
+        Config.LoggerProvider = ZAP.JERICHO_LOGGER_PROVIDER;
+    }
 
     /**
      * Gets the (file system) path to the given resource.

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     api("edu.umass.cs.benchlab:harlib:1.1.2")
     api("javax.help:javahelp:2.0.05")
     api("log4j:log4j:1.2.17")
-    api("net.htmlparser.jericho:jericho-html:3.1")
+    api("net.htmlparser.jericho:jericho-html:3.4")
     api("net.sf.json-lib:json-lib:2.4:jdk15")
     api("org.apache.commons:commons-csv:1.6")
     api("org.bouncycastle:bcmail-jdk15on:1.61")


### PR DESCRIPTION
Update from 3.1 to 3.4.
Set up Jericho's logging to redirect to log4j.
Disable the logging by default and on update from older ZAP versions to
avoid logging errors when parsing the HTML (it was changed from INFO
level to ERROR).
Change `TestUtils` to also set up Jericho's logging.
Address deprecation warnings.

Part of #4780 - Tidy up dependencies