### PR TITLE
Add task to build the weekly release

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -23,11 +23,20 @@ The distributions are built into `zap/build/distributions/`.
 
 ### Daily
 A zip package with a day stamped version, does not target any specific OS, it bundles all add-ons present in the `plugin` directory always.
-This distribution is used for weekly releases.
 
 To build it run the task `:zap:distDaily`.
 
 (This distribution is built by default, it is a dependency of `assemble` task.)
+
+### Weekly
+A zip package with a day stamped version, does not target any specific OS, it bundles only [weekly add-ons] (built automatically from
+source when the distribution is built).
+This distribution is used for weekly releases.
+
+To build it run the task `:zap:distWeekly`.
+
+The build also provides the task `:zap:copyWeeklyAddOns` which builds and copies the weekly add-ons into the plugin directory,
+using existing repositories in the file system at the same level as zaproxy.
 
 ### Cross Platform
 A zip package, does not target any specific OS.
@@ -70,7 +79,8 @@ Once the build is finished the installers will be located in the directory `zap/
 [Gradle]: https://gradle.org/
 [Gradle Wrapper]: https://docs.gradle.org/current/userguide/gradle_wrapper.html
 [zap/src/main/dist/plugin/]: zap/src/main/dist/plugin/
-[predefined list of add-ons]: zap/src/main/dist/add-ons.txt
+[predefined list of add-ons]: zap/src/main/add-ons.txt
+[weekly add-ons]: zap/src/main/weekly-add-ons.json
 [install4j]: https://www.ej-technologies.com/products/install4j/overview.html
 [launch4j]: http://launch4j.sourceforge.net/
 [gradle-launch4j]: https://github.com/TheBoegl/gradle-launch4j

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,12 +3,16 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
+    jcenter()
     gradlePluginPortal()
 }
 
 dependencies {
     implementation("commons-codec:commons-codec:1.12")
+    implementation("com.google.code.gson:gson:2.8.5")
+    val jgitVersion = "5.3.1.201904271842-r"
+    implementation("org.eclipse.jgit:org.eclipse.jgit:$jgitVersion")
+    implementation("org.eclipse.jgit:org.eclipse.jgit.archive:$jgitVersion")
     // Gradle Plugins
     implementation("com.netflix.nebula:gradle-ospackage-plugin:6.2.0")
     implementation("de.undercouch:gradle-download-task:3.4.3")

--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/GradleBuildWithGitRepos.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/GradleBuildWithGitRepos.java
@@ -1,0 +1,238 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.tasks;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.tools.ant.taskdefs.condition.Os;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.gradle.api.Action;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Named;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.Project;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.TaskAction;
+import org.zaproxy.zap.internal.RepoData;
+
+/** A task that clones Git repositories and runs Gradle tasks contained in them. */
+public class GradleBuildWithGitRepos extends DefaultTask {
+
+    private final RegularFileProperty repositoriesDataFile;
+    private final DirectoryProperty repositoriesDirectory;
+    private final Property<Boolean> cloneRepositories;
+    private final Property<Boolean> updateRepositories;
+    private NamedDomainObjectContainer<Task> tasks;
+
+    public GradleBuildWithGitRepos() {
+        ObjectFactory objects = getProject().getObjects();
+        this.repositoriesDataFile = objects.fileProperty();
+        this.repositoriesDirectory = objects.directoryProperty();
+        this.cloneRepositories = objects.property(Boolean.class).value(true);
+        this.updateRepositories = objects.property(Boolean.class).value(true);
+        this.tasks = getProject().container(Task.class, name -> new Task(name, getProject()));
+    }
+
+    @InputFile
+    public RegularFileProperty getRepositoriesDataFile() {
+        return repositoriesDataFile;
+    }
+
+    @Input
+    public DirectoryProperty getRepositoriesDirectory() {
+        return repositoriesDirectory;
+    }
+
+    @Input
+    public Property<Boolean> getCloneRepositories() {
+        return cloneRepositories;
+    }
+
+    @Input
+    public Property<Boolean> getUpdateRepositories() {
+        return updateRepositories;
+    }
+
+    @Nested
+    public Iterable<Task> getTasks() {
+        return new ArrayList<>(tasks);
+    }
+
+    public void setTasks(NamedDomainObjectContainer<Task> tasks) {
+        this.tasks = tasks;
+    }
+
+    public void tasks(Action<? super NamedDomainObjectContainer<Task>> action) {
+        action.execute(tasks);
+    }
+
+    @TaskAction
+    public void buildWeeklyAddOns() throws GitAPIException, IOException {
+        Path reposDir = repositoriesDirectory.get().getAsFile().toPath();
+
+        List<RepoData> reposData = readRepoData();
+        for (RepoData repoData : reposData) {
+
+            String cloneUrl = repoData.getCloneUrl();
+            String repoName = extractRepoName(cloneUrl);
+            Path repoDir = reposDir.resolve(repoName);
+
+            if (Files.notExists(repoDir)) {
+                if (!cloneRepositories.get()) {
+                    getLogger()
+                            .warn(
+                                    "The directory {} does not exist, the {} add-on(s) will not be built.",
+                                    repoDir,
+                                    repoName);
+                    continue;
+                }
+
+                getProject().mkdir(reposDir);
+
+                // XXX Rely just on JGit once it supports depth arg:
+                // https://bugs.eclipse.org/bugs/show_bug.cgi?id=475615
+                getProject()
+                        .exec(
+                                spec -> {
+                                    spec.setWorkingDir(reposDir);
+                                    spec.setExecutable("git");
+                                    spec.setEnvironment(Collections.emptyMap());
+                                    spec.args(
+                                            "clone",
+                                            "--branch",
+                                            repoData.getBranch(),
+                                            "--depth",
+                                            "1",
+                                            cloneUrl,
+                                            repoName);
+                                })
+                        .assertNormalExitValue();
+                getLogger().debug("Cloned {} into {}", cloneUrl, repoDir);
+            } else if (updateRepositories.get()) {
+                FileRepositoryBuilder builder = new FileRepositoryBuilder();
+                Repository repository = builder.setGitDir(repoDir.resolve(".git").toFile()).build();
+                try (Git git = new Git(repository)) {
+                    git.pull().call();
+                    getLogger().debug("Pulled from {} into {}", cloneUrl, repoDir);
+                }
+            }
+
+            if (repoData.getProjects() == null || repoData.getProjects().isEmpty()) {
+                runTasks(repoDir, Arrays.asList(""));
+            } else {
+                runTasks(repoDir, repoData.getProjects());
+            }
+        }
+    }
+
+    private void runTasks(Path repoDir, List<String> projects) {
+        List<String> execArgs = new ArrayList<>();
+        for (String project : projects) {
+            String taskPrefix = project + ":";
+            for (Task task : tasks) {
+                execArgs.add(taskPrefix + task.getName());
+                execArgs.addAll(task.getArgs().get());
+            }
+        }
+        getProject()
+                .exec(
+                        spec -> {
+                            spec.setWorkingDir(repoDir);
+                            spec.setExecutable(gradleWrapper());
+                            spec.setEnvironment(Collections.emptyMap());
+                            spec.args(execArgs);
+                        })
+                .assertNormalExitValue();
+    }
+
+    private List<RepoData> readRepoData() throws IOException {
+        Gson gson = new Gson();
+        Type reposType = new TypeToken<List<RepoData>>() {}.getType();
+        File file = repositoriesDataFile.get().getAsFile();
+        try (Reader reader = Files.newBufferedReader(file.toPath())) {
+            return gson.fromJson(reader, reposType);
+        }
+    }
+
+    private static String extractRepoName(String cloneUrl) {
+        int slashIdx = cloneUrl.lastIndexOf('/');
+        if (slashIdx == -1) {
+            throw new InvalidUserDataException(
+                    "Unable to extract repository name, the clone URL does not have a slash: "
+                            + cloneUrl);
+        }
+        if (!cloneUrl.endsWith(".git")) {
+            throw new InvalidUserDataException(
+                    "Unable to extract repository name, the clone URL does not end with \".git\": "
+                            + cloneUrl);
+        }
+        return cloneUrl.substring(slashIdx + 1, cloneUrl.indexOf(".git"));
+    }
+
+    private static String gradleWrapper() {
+        if (Os.isFamily(Os.FAMILY_UNIX)) {
+            return "./gradlew";
+        }
+        return "gradlew.bat";
+    }
+
+    public static final class Task implements Named {
+
+        private final String name;
+        private final ListProperty<String> args;
+
+        public Task(String name, Project project) {
+            this.name = name;
+            this.args = project.getObjects().listProperty(String.class);
+        }
+
+        @Input
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Input
+        public ListProperty<String> getArgs() {
+            return args;
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/internal/BuildData.kt
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/internal/BuildData.kt
@@ -1,0 +1,22 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.internal
+
+data class RepoData(val cloneUrl: String, val branch: String, val projects: List<String>)

--- a/zap/src/main/weekly-add-ons.json
+++ b/zap/src/main/weekly-add-ons.json
@@ -1,0 +1,58 @@
+[
+  {
+    "cloneUrl": "https://github.com/zaproxy/zap-extensions.git",
+    "branch": "master",
+    "projects": [
+      ":addOns:accessControl",
+      ":addOns:alertFilters",
+      ":addOns:ascanrules",
+      ":addOns:ascanrulesBeta",
+      ":addOns:bruteforce",
+      ":addOns:coreLang",
+      ":addOns:diff",
+      ":addOns:directorylistv1",
+      ":addOns:formhandler",
+      ":addOns:fuzz",
+      ":addOns:gettingStarted",
+      ":addOns:importurls",
+      ":addOns:invoke",
+      ":addOns:jxbrowsers:jxbrowser",
+      ":addOns:jxbrowsers:jxbrowserlinux64",
+      ":addOns:jxbrowsers:jxbrowsermacos",
+      ":addOns:jxbrowsers:jxbrowserwindows",
+      ":addOns:jxbrowsers:jxbrowserwindows64",
+      ":addOns:onlineMenu",
+      ":addOns:openapi",
+      ":addOns:portscan",
+      ":addOns:plugnhack",
+      ":addOns:pscanrules",
+      ":addOns:pscanrulesBeta",
+      ":addOns:quickstart",
+      ":addOns:replacer",
+      ":addOns:reveal",
+      ":addOns:saverawmessage",
+      ":addOns:savexmlmessage",
+      ":addOns:sequence",
+      ":addOns:scripts",
+      ":addOns:selenium",
+      ":addOns:spiderAjax",
+      ":addOns:tips",
+      ":addOns:webdrivers:webdriverlinux",
+      ":addOns:webdrivers:webdrivermacos",
+      ":addOns:webdrivers:webdriverwindows",
+      ":addOns:websocket",
+      ":addOns:zest"
+    ]
+  },
+  {
+    "cloneUrl": "https://github.com/zaproxy/zap-core-help.git",
+    "branch": "master",
+    "projects": [
+        ":addOns:help"
+    ]
+  },
+  {
+    "cloneUrl": "https://github.com/zaproxy/zap-hud.git",
+    "branch": "develop"
+  }
+]

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -1,5 +1,6 @@
 import java.time.LocalDate
 import java.util.stream.Collectors
+import org.zaproxy.zap.tasks.GradleBuildWithGitRepos
 
 plugins {
     `java-library`
@@ -135,6 +136,23 @@ tasks.register<Copy>("copyLangPack") {
 
     from(langPack)
     into("$rootDir/../zap-extensions/addOns/coreLang/src/main/zapHomeFiles/lang/")
+}
+
+val copyWeeklyAddOns by tasks.registering(GradleBuildWithGitRepos::class) {
+    group = "ZAP Misc"
+    description = "Copies the weekly add-ons into plugin dir, built from local repos."
+
+    repositoriesDirectory.set(rootDir.parentFile)
+    repositoriesDataFile.set(file("src/main/weekly-add-ons.json"))
+    cloneRepositories.set(false)
+    updateRepositories.set(false)
+
+    val outputDir = file("src/main/dist/plugin/")
+    tasks {
+        register("copyZapAddOn") {
+            args.set(listOf("--into=$outputDir"))
+        }
+    }
 }
 
 val generateAllApiEndpoints by tasks.registering {


### PR DESCRIPTION
Add task `distWeekly` that creates the weekly release, automatically
building the required add-ons (the task will clone, or update if already
cloned, the required repositories).
Add task `copyWeeklyAddOns` to build and copy the weekly add-ons from
existing repositories, in the file system at the same level as zaproxy.
The add-ons are copied to the (dist) plugin directory.