### PR TITLE
Keep env vars for Gradle build

### DIFF
--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/GradleBuildWithGitRepos.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/GradleBuildWithGitRepos.java
@@ -177,7 +177,6 @@ public class GradleBuildWithGitRepos extends DefaultTask {
                         spec -> {
                             spec.setWorkingDir(repoDir);
                             spec.setExecutable(gradleWrapper());
-                            spec.setEnvironment(Collections.emptyMap());
                             spec.args(execArgs);
                         })
                 .assertNormalExitValue();


### PR DESCRIPTION
Otherwise it fails to find Java, when creating the releases.