### PR TITLE
Release related tweaks

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -18,7 +18,7 @@ action "Build and Release Main Version" {
   uses = "docker://openjdk:8"
   needs = ["Actor Filter Main Version"]
   runs = "./gradlew"
-  args = ["-Dorg.gradle.jvmargs=-XX:MaxMetaspaceSize=512m", ":zap:createMainReleaseFromGitHubRef"]
+  args = ["-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m", ":zap:createMainReleaseFromGitHubRef"]
   secrets = ["GITHUB_TOKEN", "INSTALL4J_LICENSE"]
 }
 
@@ -42,6 +42,6 @@ action "Build and Release Weekly" {
   uses = "docker://openjdk:8"
   needs = ["Actor Filter Weekly"]
   runs = "./gradlew"
-  args = ["-Dorg.gradle.jvmargs=-XX:MaxMetaspaceSize=512m", ":zap:createWeeklyReleaseFromGitHubRef"]
+  args = ["-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m", ":zap:createWeeklyReleaseFromGitHubRef"]
   secrets = ["GITHUB_TOKEN"]
 }


### PR DESCRIPTION
Give more memory to Gradle, it was failing to upload all distributions.
Make Gradle/git quiet by default to avoid creating unnecessary output
when building the add-ons.
Tweak logging levels to show the messages by default.