### PR TITLE
Add rule configuration for DOM XSS' browser

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/ruleconfig/RuleConfigParam.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ruleconfig/RuleConfigParam.java
@@ -79,6 +79,13 @@ public class RuleConfigParam extends AbstractParam {
     public static final String RULE_DOMAINS_TRUSTED = "rules.domains.trusted";
 
     /**
+     * The name of the rule to obtain the ID of the browser to use in DOM XSS scans.
+     *
+     * @since 2.8.0
+     */
+    public static final String RULE_DOMXSS_BROWSER_ID = "rules.domxss.browserid";
+
+    /**
      * The default time, in seconds, to use for time-based attacks
      *
      * @see #RULE_COMMON_SLEEP_TIME
@@ -103,6 +110,7 @@ public class RuleConfigParam extends AbstractParam {
         this.addRuleConfig(new RuleConfig(RULE_CSRF_IGNORE_ATT_VALUE, ""));
         this.addRuleConfig(new RuleConfig(RULE_COOKIE_IGNORE_LIST, ""));
         this.addRuleConfig(new RuleConfig(RULE_DOMAINS_TRUSTED, ""));
+        this.addRuleConfig(new RuleConfig(RULE_DOMXSS_BROWSER_ID, ""));
 
         Iterator<String> iter = this.getConfig().getKeys(RULES_BASE_KEY);
         RuleConfig rc;

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -2027,6 +2027,7 @@ Only use this feature to ignore FORMs that you know are safe, for example search
 rules.csrf.ignore.attname = The name of an HTML attribute that can be used to indicate that a form does not need an anti-CSRF Token. If 'rules.csrf.ignore.attvalue' is specified then this must also match the attribute's value. If found any related alerts will be raised at INFO level. 
 rules.csrf.ignore.attvalue = The value of an HTML attribute named by 'rules.csrf.ignore.attname' that can be used to indicate that a form does not need an anti-CSRF Token. If found any related alerts will be raised at INFO level.
 rules.domains.trusted = A comma separated list of URL regex patterns. Any URLs that match the patterns will be considered trusted domains and the issues ignored.
+rules.domxss.browserid = The ID of the browser to be used by DOM XSS scan rule. The IDs supported are documented in the help of DOM XSS add-on.
 
 scanner.category.browser = Client Browser
 scanner.category.info    = Information Gathering


### PR DESCRIPTION
Add rule `rules.domxss.browserid` to specify the ID of the browser to be
used by DOM XSS scan rule.

Related to #3866.