### PR TITLE
Fix weekly distribution

### DIFF
--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/distributions.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/distributions.gradle.kts
@@ -307,9 +307,9 @@ val buildWeeklyAddOns by tasks.registering(GradleBuildWithGitRepos::class) {
 
     repositoriesDirectory.set(temporaryDir)
     repositoriesDataFile.set(file("src/main/weekly-add-ons.json"))
+    clean.set(true)
 
     tasks {
-        register("clean")
         register("test")
         register("copyZapAddOn") {
             args.set(listOf("--into=$weeklyAddOnsDir"))


### PR DESCRIPTION
Run the clean task separately to avoid task ordering issues that would
clean required files, causing the add-ons to not have all the expected
files.