### PR TITLE
Update snap's README and Docker image

### DIFF
--- a/snap/.gitignore
+++ b/snap/.gitignore
@@ -2,4 +2,4 @@
 /prime/
 /snap/
 /stage/
-/zaproxy_2.7.0_amd64.snap
+/*.snap

--- a/snap/README.md
+++ b/snap/README.md
@@ -1,6 +1,6 @@
-This directory contains all of the files required to build a ZAP 2.7.0 https://snapcraft.io/ snap.
+This directory contains all of the files required to build a ZAP [snap].
 
-Docker is used to build the snap as snapcraft is only supported on a limited number of linux distros.
+Docker is used to build the snap as `snapcraft` is only supported on a limited number of Linux distros.
 
 In order to build the snap run:
 
@@ -8,9 +8,10 @@ In order to build the snap run:
 
 To install the snap you've built locally run:
 
-`snap install zaproxy_2.7.0_amd64.snap --dangerous --classic`
+`snap install zaproxy_<version>_amd64.snap --dangerous --classic`
 
-Note that the architecture component '_amd64' may be different on your system.
+Where `<version>` is the version of the snap, defined in [snapcraft.yaml].
+Note that the architecture component `_amd64` may be different on your system.
 
 You should then be able to run the ZAP snap using:
 
@@ -19,5 +20,10 @@ You should then be able to run the ZAP snap using:
 In order to publish the snap you will need appropriate permissions.
 Those people who have then can upload the snap using:
 
-`snapcraft login`
-`snapcraft push zaproxy_2.7.0_amd64.snap`
+```
+snapcraft login
+snapcraft push zaproxy_<version>_amd64.snap
+```
+
+[snap]: https://snapcraft.io/
+[snapcraft.yaml]: snapcraft.yaml

--- a/snap/build-snap.sh
+++ b/snap/build-snap.sh
@@ -1,3 +1,3 @@
-export DOCKER=snapcore/snapcraft:latest
+export DOCKER=snapcore/snapcraft:stable
 docker pull $DOCKER
 docker run -it -v "$PWD:$PWD" -w "$PWD" $DOCKER snapcraft


### PR DESCRIPTION
Change the README to not have the current ZAP version to not require
updating it after each release, also, do minor tweaks.
Ignore all snap packages instead of just the current version.
Update Docker image used to build the snap to stable.