### PR TITLE
Do not run add-ons' tests for live Docker image

### DIFF
--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/distributions.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/distributions.gradle.kts
@@ -310,7 +310,9 @@ val buildWeeklyAddOns by tasks.registering(GradleBuildWithGitRepos::class) {
     clean.set(true)
 
     tasks {
-        register("test")
+        if (System.getenv("ZAP_WEEKLY_ADDONS_NO_TEST") != "true") {
+            register("test")
+        }
         register("copyZapAddOn") {
             args.set(listOf("--into=$weeklyAddOnsDir"))
         }

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -50,7 +50,7 @@ ENV PATH $JAVA_HOME/bin:/zap/:$PATH
 RUN git clone --depth 1 https://github.com/zaproxy/zaproxy.git && \
 	# Build ZAP with weekly add-ons
 	cd zaproxy && \
-	./gradlew :zap:prepareDistWeekly && \
+	ZAP_WEEKLY_ADDONS_NO_TEST=true ./gradlew :zap:prepareDistWeekly && \
 	cp -R /zap-src/zaproxy/zap/build/distFilesWeekly/* /zap/ && \
 	rm -rf /zap-src/* && \
 	cd /zap/ && \


### PR DESCRIPTION
Avoid flaky tests (e.g. #5349) from breaking the build of the live
image.