### PR TITLE
Update HTTP Protocol Version in Manual Request Editor

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/ManualHttpRequestEditorDialog.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/ManualHttpRequestEditorDialog.java
@@ -314,7 +314,7 @@ public class ManualHttpRequestEditorDialog extends ManualRequestEditorDialog
         try {
             URI uri = new URI("http://www.any_domain_name.org/path", true);
             msg.setRequestHeader(
-                    new HttpRequestHeader(HttpRequestHeader.GET, uri, HttpHeader.HTTP10));
+                    new HttpRequestHeader(HttpRequestHeader.GET, uri, HttpHeader.HTTP11));
             setMessage(msg);
         } catch (HttpMalformedHeaderException e) {
             logger.error(e.getMessage(), e);


### PR DESCRIPTION
Set protocol 1.1 instead of 1.0, since:
- It is 2019.
- The template request has a Host header.

<sub>Edit: Wasn't sure which label to use. It's minor but should probably hit the notes. It's sort of a bug fix, and not quite an enhancement.</sub>

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>