### PR TITLE
Include file checksums in GitHub releases

### DIFF
--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/github-releases.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/github-releases.gradle.kts
@@ -20,6 +20,7 @@ System.getenv("GITHUB_REF")?.let { ref ->
 
         title.set("$targetTag")
         body.set("")
+        checksumAlgorithm.set("SHA-256")
         draft.set(true)
 
         val distDebian by tasks.existing(Deb::class)
@@ -78,6 +79,7 @@ System.getenv("GITHUB_REF")?.let { ref ->
 
         title.set("$targetTag")
         body.set("")
+        checksumAlgorithm.set("SHA-256")
         draft.set(true)
         prerelease.set(true)
 


### PR DESCRIPTION
Change `CreateGitHubRelease` to create a table with the checksums of the
files (enabled by default).
Set the checksum algorithm (SHA-256) to the release on tag tasks.