### PR TITLE
Address LGTM Items

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/encoder/Base64.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/encoder/Base64.java
@@ -5,6 +5,7 @@
  *  - base64.decode.badinput
  *  - base64.decode.invalidlenght
  * Changed to log the exception instead of print the exception stack trace.
+ * Minor formatting tweak and remove useless conditional (per LGTM issues)
  */
 package org.parosproxy.paros.extension.encoder;
 
@@ -1554,7 +1555,7 @@ public class Base64
         {
             // Set up some useful variables
             java.io.File file = new java.io.File( filename );
-            byte[] buffer = new byte[ Math.max((int)(file.length() * 1.4+1),40) ]; // Need max() for math on small files (v2.2.1); Need +1 for a few corner cases (v2.3.5)
+            byte[] buffer = new byte[Math.max((int)(file.length() * 1.4 + 1), 40)]; // Need max() for math on small files (v2.2.1); Need +1 for a few corner cases (v2.3.5)
             int length   = 0;
             int numBytes = 0;
             
@@ -1778,7 +1779,7 @@ public class Base64
             }   // end else: get data
             
             // Got data?
-            if( position >= 0 ) {
+            else {
                 // End of relevant data?
                 if( /*!encode &&*/ position >= numSigBytes ){
                     return -1;
@@ -1801,7 +1802,7 @@ public class Base64
                 return b & 0xFF; // This is how you "cast" a byte that's
                                  // intended to be unsigned.
                 
-            }   // end if: position >= 0
+            }   // end else (position >= 0)
             
             throw new java.io.IOException( "Error in Base64 code reading stream." );
         }   // end read

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpInputStream.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpInputStream.java
@@ -219,7 +219,7 @@ public class HttpInputStream extends BufferedInputStream {
     }
 
     @Override
-    public int available() throws IOException {
+    public synchronized int available() throws IOException {
         int avail = 0;
         //		int oneByte = -1;
         int timeout = 0;

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpOutputStream.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpOutputStream.java
@@ -65,7 +65,7 @@ public class HttpOutputStream extends BufferedOutputStream {
     }
 
     @Override
-    public void write(byte[] buf, int off, int len) throws IOException {
+    public synchronized void write(byte[] buf, int off, int len) throws IOException {
         if (buf == null) return;
         // out.write(buf, off, len);
         super.write(buf, off, len);

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/API.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/API.java
@@ -482,6 +482,14 @@ public class API {
                     }
 
                     ApiResponse res;
+                    if (reqType == null) {
+                        throw new ApiException(
+                                ApiException.Type.BAD_TYPE, "Request Type was not provided.");
+                    }
+                    if (impl == null) {
+                        throw new ApiException(
+                                ApiException.Type.NO_IMPLEMENTOR, "Implementor was not provided.");
+                    }
                     switch (reqType) {
                         case action:
                             if (!getOptionsParamApi().isDisableKey()) {
@@ -537,21 +545,17 @@ public class API {
                             msg = impl.handleApiOther(msg, name, params);
                             break;
                         case pconn:
-                            if (impl != null) {
-                                ApiPersistentConnection pconn =
-                                        impl.getApiPersistentConnection(name);
-                                if (pconn != null) {
-                                    if (!getOptionsParamApi().isDisableKey()
-                                            && !getOptionsParamApi().isNoKeyForSafeOps()) {
-                                        if (!this.hasValidKey(requestHeader, params)) {
-                                            throw new ApiException(ApiException.Type.BAD_API_KEY);
-                                        }
+                            ApiPersistentConnection pconn = impl.getApiPersistentConnection(name);
+                            if (pconn != null) {
+                                if (!getOptionsParamApi().isDisableKey()
+                                        && !getOptionsParamApi().isNoKeyForSafeOps()) {
+                                    if (!this.hasValidKey(requestHeader, params)) {
+                                        throw new ApiException(ApiException.Type.BAD_API_KEY);
                                     }
-                                    validateMandatoryParams(params, pconn);
                                 }
-                                impl.handleApiPersistentConnection(
-                                        msg, httpIn, httpOut, name, params);
+                                validateMandatoryParams(params, pconn);
                             }
+                            impl.handleApiPersistentConnection(msg, httpIn, httpOut, name, params);
                             return new HttpMessage();
                     }
                 } else {

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanProgressDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanProgressDialog.java
@@ -173,7 +173,7 @@ public class ScanProgressDialog extends AbstractDialog {
             this.series500 =
                     new TimeSeries(Constant.messages.getString("ascan.progress.chart.5xx"));
 
-            long maxAge = mins * 60;
+            long maxAge = mins * 60L;
             this.seriesTotal.setMaximumItemAge(maxAge);
             this.series100.setMaximumItemAge(maxAge);
             this.series200.setMaximumItemAge(maxAge);

--- a/zap/src/main/java/org/zaproxy/zap/extension/dynssl/DynamicSSLPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/dynssl/DynamicSSLPanel.java
@@ -23,12 +23,12 @@ import java.awt.BorderLayout;
 import java.awt.Desktop;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
@@ -506,9 +506,9 @@ public class DynamicSSLPanel extends AbstractParamPanel {
     }
 
     private void writePubCertificateToFile(File file) throws IOException {
-        try (final OutputStreamWriter osw =
-                new OutputStreamWriter(new FileOutputStream(file), "ASCII")) {
-            osw.write(txt_PubCert.getText());
+        try (BufferedWriter bw =
+                Files.newBufferedWriter(file.toPath(), StandardCharsets.US_ASCII)) {
+            bw.write(txt_PubCert.getText());
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuExportURLs.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuExportURLs.java
@@ -134,7 +134,9 @@ public class PopupMenuExportURLs extends ExtensionPopupMenuItem {
                                     + file.getAbsolutePath());
         } finally {
             try {
-                fw.close();
+                if (fw != null) {
+                    fw.close();
+                }
             } catch (Exception e2) {
                 log.warn(e2.getStackTrace(), e2);
             }

--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderPanelTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderPanelTableModel.java
@@ -212,7 +212,7 @@ public class SpiderPanelTableModel extends AbstractTableModel {
         @Override
         public boolean equals(Object obj) {
             if (this == obj) return true;
-            if (obj == null) return false;
+            if (!(obj instanceof SpiderScanResult)) return false;
             // Removed some irrelevant checks, to speed up the method.
             SpiderScanResult other = (SpiderScanResult) obj;
             if (method == null) {

--- a/zap/src/main/java/org/zaproxy/zap/model/Tech.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/Tech.java
@@ -139,10 +139,9 @@ public class Tech implements Comparable<Tech> {
 
     @Override
     public boolean equals(Object tech) {
-        if (tech == null) {
+        if (!(tech instanceof Tech)) {
             return false;
         }
-
         return this.toString().equals(tech.toString());
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderSVNEntriesParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderSVNEntriesParser.java
@@ -195,6 +195,11 @@ public class SpiderSVNEntriesParser extends SpiderParser {
                                     break;
                             }
 
+                            if (rsNodes == null) {
+                                log.error(
+                                        "There was a problem parsing the resource. rsNodes should not be null.");
+                                return false;
+                            }
                             // now get the list of files stored in the SVN repo (or this folder of
                             // the repo, depending the SVN working copy format in use)
                             while (rsNodes.next()) {


### PR DESCRIPTION
I'm sure some of these are theoretical and actually never likely to cause an issue, however, hopefully fixing them doesn't either ;)

SpiderPanelTableModel.SpiderScanResult.equals - Check argument type, instanceof handles null case as well.
https://lgtm.com/projects/g/zaproxy/zaproxy/snapshot/65671ac39a63de448ea0e64229f1a70f25cd5268/files/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderPanelTableModel.java?sort=name&dir=ASC&mode=heatmap#x314d6388d6c6353a:1

Tech.equals - Check argument type, instanceof handles null case as well.
https://lgtm.com/projects/g/zaproxy/zaproxy/snapshot/65671ac39a63de448ea0e64229f1a70f25cd5268/files/zap/src/main/java/org/zaproxy/zap/model/Tech.java?sort=name&dir=ASC&mode=heatmap#x1724a4f7d3fadf5e:1

LGTM equals() rule: https://lgtm.com/rules/7850079/

ScanProgressDialog.initialize - maxAge variable was subject to a potential issue where int multiplication might overflow a long result. Addressed by casting one of the operands to long.
https://lgtm.com/projects/g/zaproxy/zaproxy/snapshot/65671ac39a63de448ea0e64229f1a70f25cd5268/files/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanProgressDialog.java?sort=name&dir=ASC&mode=heatmap#xb474c6b964c8a6a6:1

LGTM integer multiplication to long result rule: https://lgtm.com/rules/7900075/

Base64.encodeFromFile - Consistent use of spaces (formatting) to address "Whitespace around nested operators contradicts precedence."
https://lgtm.com/projects/g/zaproxy/zaproxy/snapshot/65671ac39a63de448ea0e64229f1a70f25cd5268/files/zap/src/main/java/org/parosproxy/paros/extension/encoder/Base64.java?sort=name&dir=ASC&mode=heatmap#x1dceda4e56e64fed:1

LGTM Whitespace contradicts operator precedence rule: https://lgtm.com/rules/11000068/

Base64.InputStream.read - Remove always true condition.
https://lgtm.com/projects/g/zaproxy/zaproxy/snapshot/65671ac39a63de448ea0e64229f1a70f25cd5268/files/zap/src/main/java/org/parosproxy/paros/extension/encoder/Base64.java?sort=name&dir=ASC&mode=heatmap#xac1058b2c8c37c3f:1

LGTM Useless comparison test rule: https://lgtm.com/rules/9990077/

HttpInputStream.available - Declare as synchronized as per super method.
https://lgtm.com/projects/g/zaproxy/zaproxy/snapshot/65671ac39a63de448ea0e64229f1a70f25cd5268/files/zap/src/main/java/org/parosproxy/paros/network/HttpInputStream.java?sort=name&dir=ASC&mode=heatmap#xadf099c7ccd3bb6:1

LGTM Synchronized method is overridden in subclass rule: https://lgtm.com/rules/5990064/

HttpOutputStream.write - Declare as synchronized as per super method.
https://lgtm.com/projects/g/zaproxy/zaproxy/snapshot/65671ac39a63de448ea0e64229f1a70f25cd5268/files/zap/src/main/java/org/parosproxy/paros/network/HttpOutputStream.java#x9cf12e712822774b:1

LGTM Synchronized method is overridden in subclass rule: https://lgtm.com/rules/5990064/

API.handleApiRequest - Add null checks.
https://lgtm.com/projects/g/zaproxy/zaproxy/snapshot/65671ac39a63de448ea0e64229f1a70f25cd5268/files/zap/src/main/java/org/zaproxy/zap/extension/api/API.java?sort=name&dir=ASC&mode=heatmap

LGTM Dereferenced variable may be null rule: https://lgtm.com/rules/1954750296/

SpiderSVNEntriesParser.parseResource - Add null check on rsNodes, log error and return false if null.
https://lgtm.com/projects/g/zaproxy/zaproxy/snapshot/65671ac39a63de448ea0e64229f1a70f25cd5268/files/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderSVNEntriesParser.java#x9122aa702b79a531:1

LGTM Dereferenced valiable may be null rule: https://lgtm.com/rules/1954750296/

DynamicSSLPanel.writePubCertificateToFile - Switch to using BufferedWriter and nio API.
https://lgtm.com/projects/g/zaproxy/zaproxy/snapshot/65671ac39a63de448ea0e64229f1a70f25cd5268/files/zap/src/main/java/org/zaproxy/zap/extension/dynssl/DynamicSSLPanel.java?sort=name&dir=ASC&mode=heatmap#x75d01e02973e1321:1

LGTM Potential output resource leak rule: https://lgtm.com/rules/2980072/

PopupMenuExportURLs.writeURLs - Add null check.
https://lgtm.com/projects/g/zaproxy/zaproxy/snapshot/65671ac39a63de448ea0e64229f1a70f25cd5268/files/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuExportURLs.java?sort=name&dir=ASC&mode=heatmap#xfb5651d878d7091b:1

LGTM Dereferenced variable may be null: https://lgtm.com/rules/1954750296/

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>