### PR TITLE
Do not remove resource bundle of other extensions

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/control/ExtensionFactory.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/ExtensionFactory.java
@@ -50,6 +50,7 @@ public class ExtensionFactory {
     private static Map<Class<? extends Extension>, Extension> mapClassExtension = new HashMap<>();
     private static TreeMap<Integer, Extension> mapOrderToExtension = new TreeMap<>();
     private static List<Extension> unorderedExtensions = new ArrayList<>();
+    private static Map<Extension, Boolean> extensionsWithMessages = new HashMap<>();
 
     private static AddOnLoader addOnLoader = null;
 
@@ -330,6 +331,7 @@ public class ExtensionFactory {
         ResourceBundle msg = getExtensionResourceBundle(ext);
         if (msg != null) {
             ext.setMessages(msg);
+            extensionsWithMessages.put(ext, Boolean.TRUE);
             Constant.messages.addMessageBundle(ext.getI18nPrefix(), ext.getMessages());
         } else if (addOn.getResourceBundle() != null) {
             ext.setMessages(addOn.getResourceBundle());
@@ -393,6 +395,10 @@ public class ExtensionFactory {
     }
 
     private static void unloadMessages(Extension extension) {
+        if (extensionsWithMessages.remove(extension) == null) {
+            return;
+        }
+
         ResourceBundle msg = extension.getMessages();
         if (msg != null) {
             Constant.messages.removeMessageBundle(extension.getI18nPrefix());


### PR DESCRIPTION
Change `ExtensionFactory` to only remove the resource bundle if the
extension has one, preventing an extension with same i18n prefix from
removing the resource bundle of another.