### PR TITLE
Deprecate Context.getIndex and implement Context.getId

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/view/SessionDialog.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/SessionDialog.java
@@ -25,6 +25,7 @@
 // ZAP: 2016/10/26 Initialise the panels when added to the dialogue, if shown
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2019/07/10 Update to use Context.getId following deprecation of Context.getIndex
 package org.parosproxy.paros.view;
 
 import java.awt.Frame;
@@ -117,7 +118,7 @@ public class SessionDialog extends AbstractParamDialog {
      * @see AbstractContextPropertiesPanel#initContextData(Session, Context)
      */
     private void initContextPanel(AbstractContextPropertiesPanel contextPanel) {
-        Context ctx = uiContexts.get(contextPanel.getContextIndex());
+        Context ctx = uiContexts.get(contextPanel.getContextId());
         if (ctx != null) {
             contextPanel.initContextData(session, ctx);
         }
@@ -149,7 +150,7 @@ public class SessionDialog extends AbstractParamDialog {
         uiContexts.clear();
         for (Context context : session.getContexts()) {
             Context uiContext = context.duplicate();
-            uiContexts.put(context.getIndex(), uiContext);
+            uiContexts.put(context.getId(), uiContext);
         }
     }
 
@@ -163,7 +164,7 @@ public class SessionDialog extends AbstractParamDialog {
      */
     public void createUISharedContext(Context context) {
         if (session != null) {
-            uiContexts.put(context.getIndex(), context.duplicate());
+            uiContexts.put(context.getId(), context.duplicate());
         }
     }
 

--- a/zap/src/main/java/org/parosproxy/paros/view/SiteMapPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/SiteMapPanel.java
@@ -50,6 +50,7 @@
 // ZAP: 2018/07/17 Use ViewDelegate.getMenuShortcutKeyStroke.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2019/07/10 Update to use Context.getId following deprecation of Context.getIndex
 package org.parosproxy.paros.view;
 
 import java.awt.Component;
@@ -626,7 +627,7 @@ public class SiteMapPanel extends AbstractPanel {
         for (int i = 0; i < root.getChildCount(); i++) {
             SiteNode node = (SiteNode) root.getChildAt(i);
             Target target = (Target) node.getUserObject();
-            if (c.getIndex() == target.getContext().getIndex()) {
+            if (c.getId() == target.getContext().getId()) {
                 target.setContext(c);
                 if (node.getNodeName().equals(c.getName())) {
                     this.contextTree.nodeChanged(node);

--- a/zap/src/main/java/org/parosproxy/paros/view/View.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/View.java
@@ -86,6 +86,7 @@
 // ZAP: 2019/01/04 Keep Show Tab menu item in the position it was added.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2019/07/10 Update to use Context.getId following deprecation of Context.getIndex
 package org.parosproxy.paros.view;
 
 import java.awt.Component;
@@ -757,7 +758,7 @@ public class View implements ViewDelegate {
         getSessionDialog().createUISharedContext(c);
 
         String contextsNodeName = Constant.messages.getString("context.list");
-        ContextGeneralPanel contextGenPanel = new ContextGeneralPanel(c.getName(), c.getIndex());
+        ContextGeneralPanel contextGenPanel = new ContextGeneralPanel(c.getName(), c.getId());
         contextGenPanel.setSessionDialog(getSessionDialog());
         getSessionDialog().addParamPanel(new String[] {contextsNodeName}, contextGenPanel, false);
         this.contextPanels.add(contextGenPanel);
@@ -821,7 +822,7 @@ public class View implements ViewDelegate {
     public void renameContext(Context c) {
         ContextGeneralPanel ctxPanel = getContextGeneralPanel(c);
         if (ctxPanel != null) {
-            getSessionDialog().renamePanel(ctxPanel, c.getIndex() + ":" + c.getName());
+            getSessionDialog().renamePanel(ctxPanel, c.getId() + ":" + c.getName());
         }
         this.getSiteTreePanel().reloadContextTree();
     }
@@ -836,7 +837,7 @@ public class View implements ViewDelegate {
         for (AbstractParamPanel panel : contextPanels) {
             if (panel instanceof ContextGeneralPanel) {
                 ContextGeneralPanel contextGeneralPanel = (ContextGeneralPanel) panel;
-                if (contextGeneralPanel.getContextIndex() == context.getIndex()) {
+                if (contextGeneralPanel.getContextId() == context.getId()) {
                     return contextGeneralPanel;
                 }
             }
@@ -894,7 +895,7 @@ public class View implements ViewDelegate {
         for (Iterator<AbstractContextPropertiesPanel> it = contextPanels.iterator();
                 it.hasNext(); ) {
             AbstractContextPropertiesPanel panel = it.next();
-            if (panel.getContextIndex() == c.getIndex()) {
+            if (panel.getContextId() == c.getId()) {
                 getSessionDialog().removeParamPanel(panel);
                 it.remove();
                 removedPanels.add(panel);

--- a/zap/src/main/java/org/zaproxy/zap/authentication/GenericAuthenticationCredentials.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/GenericAuthenticationCredentials.java
@@ -161,7 +161,7 @@ public class GenericAuthenticationCredentials implements AuthenticationCredentia
                                 .getExtension(ExtensionUserManagement.class);
                 User user =
                         extensionUserManagement
-                                .getContextUserAuthManager(context.getIndex())
+                                .getContextUserAuthManager(context.getId())
                                 .getUserById(userId);
                 if (user == null)
                     throw new ApiException(

--- a/zap/src/main/java/org/zaproxy/zap/authentication/HttpAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/HttpAuthenticationMethodType.java
@@ -377,7 +377,7 @@ public class HttpAuthenticationMethodType extends AuthenticationMethodType {
             public void handleAction(JSONObject params) throws ApiException {
                 Context context =
                         ApiUtils.getContextByParamId(params, AuthenticationAPI.PARAM_CONTEXT_ID);
-                HttpAuthenticationMethod method = createAuthenticationMethod(context.getIndex());
+                HttpAuthenticationMethod method = createAuthenticationMethod(context.getId());
 
                 method.hostname = ApiUtils.getNonEmptyStringParam(params, PARAM_HOSTNAME);
                 try {

--- a/zap/src/main/java/org/zaproxy/zap/authentication/ManualAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/ManualAuthenticationMethodType.java
@@ -412,7 +412,7 @@ public class ManualAuthenticationMethodType extends AuthenticationMethodType {
             public void handleAction(JSONObject params) throws ApiException {
                 Context context =
                         ApiUtils.getContextByParamId(params, AuthenticationAPI.PARAM_CONTEXT_ID);
-                ManualAuthenticationMethod method = createAuthenticationMethod(context.getIndex());
+                ManualAuthenticationMethod method = createAuthenticationMethod(context.getId());
                 context.setAuthenticationMethod(method);
             }
         };
@@ -444,7 +444,7 @@ public class ManualAuthenticationMethodType extends AuthenticationMethodType {
                                 .getExtension(ExtensionUserManagement.class);
                 User user =
                         extensionUserManagement
-                                .getContextUserAuthManager(context.getIndex())
+                                .getContextUserAuthManager(context.getId())
                                 .getUserById(userId);
                 if (user == null) {
                     throw new ApiException(Type.USER_NOT_FOUND, UsersAPI.PARAM_USER_ID);

--- a/zap/src/main/java/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodType.java
@@ -801,7 +801,7 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
 
                     ExtensionUserManagement userExt = getUserExt();
                     if (userExt != null
-                            && userExt.getUIConfiguredUsers(context.getIndex()).size() == 0) {
+                            && userExt.getUIConfiguredUsers(context.getId()).size() == 0) {
                         String username = userParam.getValue();
                         String password = passwdParam.getValue();
                         if (!username.isEmpty()
@@ -813,13 +813,13 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
                             String userStr = paramDecoder.apply(username);
                             String passwdStr = paramDecoder.apply(password);
                             if (!userStr.isEmpty() && !passwdStr.isEmpty()) {
-                                User user = new User(context.getIndex(), userStr);
+                                User user = new User(context.getId(), userStr);
                                 UsernamePasswordAuthenticationCredentials upac =
                                         new UsernamePasswordAuthenticationCredentials(
                                                 userStr, passwdStr);
                                 user.setAuthenticationCredentials(upac);
                                 getUserExt()
-                                        .getContextUserAuthManager(context.getIndex())
+                                        .getContextUserAuthManager(context.getId())
                                         .addUser(user);
                             }
                         }
@@ -1022,8 +1022,7 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
                                 sessionDialog.recreateUISharedContexts(
                                         Model.getSingleton().getSession());
                                 uiSharedContext =
-                                        sessionDialog.getUISharedContext(
-                                                this.getContext().getIndex());
+                                        sessionDialog.getUISharedContext(this.getContext().getId());
 
                                 // Do the work/changes on the UI shared context
                                 if (isTypeForMethod(this.getContext().getAuthenticationMethod())) {
@@ -1031,7 +1030,7 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
                                             "Selected new login request via PopupMenu. Changing existing "
                                                     + methodName
                                                     + " instance for Context "
-                                                    + getContext().getIndex());
+                                                    + getContext().getId());
                                     PostBasedAuthenticationMethod method =
                                             (PostBasedAuthenticationMethod)
                                                     uiSharedContext.getAuthenticationMethod();
@@ -1050,16 +1049,16 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
                                             .showSessionDialog(
                                                     Model.getSingleton().getSession(),
                                                     ContextAuthenticationPanel.buildName(
-                                                            this.getContext().getIndex()),
+                                                            this.getContext().getId()),
                                                     false);
                                 } else {
                                     LOGGER.info(
                                             "Selected new login request via PopupMenu. Creating new "
                                                     + methodName
                                                     + " instance for Context "
-                                                    + getContext().getIndex());
+                                                    + getContext().getId());
                                     PostBasedAuthenticationMethod method =
-                                            createAuthenticationMethod(getContext().getIndex());
+                                            createAuthenticationMethod(getContext().getId());
 
                                     try {
                                         method.setLoginRequest(sn);
@@ -1086,7 +1085,7 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
                                             .showSessionDialog(
                                                     Model.getSingleton().getSession(),
                                                     ContextAuthenticationPanel.buildName(
-                                                            this.getContext().getIndex()),
+                                                            this.getContext().getId()),
                                                     false,
                                                     new Runnable() {
 
@@ -1207,8 +1206,7 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
                 }
 
                 // Set the method
-                PostBasedAuthenticationMethod method =
-                        createAuthenticationMethod(context.getIndex());
+                PostBasedAuthenticationMethod method = createAuthenticationMethod(context.getId());
                 try {
                     method.setLoginRequest(loginUrl, postData);
                 } catch (Exception e) {

--- a/zap/src/main/java/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
@@ -837,7 +837,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
 
                 // Prepare the method
                 ScriptBasedAuthenticationMethod method =
-                        createAuthenticationMethod(context.getIndex());
+                        createAuthenticationMethod(context.getId());
 
                 // Load the script and make sure it exists and follows the required interface
                 ScriptWrapper script = getScriptsExtension().getScript(scriptName);

--- a/zap/src/main/java/org/zaproxy/zap/authentication/UsernamePasswordAuthenticationCredentials.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/UsernamePasswordAuthenticationCredentials.java
@@ -250,7 +250,7 @@ public class UsernamePasswordAuthenticationCredentials implements Authentication
                                 .getExtension(ExtensionUserManagement.class);
                 User user =
                         extensionUserManagement
-                                .getContextUserAuthManager(context.getIndex())
+                                .getContextUserAuthManager(context.getId())
                                 .getUserById(userId);
                 if (user == null)
                     throw new ApiException(

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ContextAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ContextAPI.java
@@ -180,7 +180,7 @@ public class ContextAPI extends ApiImplementor {
                     throw new ApiException(ApiException.Type.ALREADY_EXISTS, contextName, e);
                 }
                 Model.getSingleton().getSession().saveContext(context);
-                return new ApiResponseElement(CONTEXT_ID, String.valueOf(context.getIndex()));
+                return new ApiResponseElement(CONTEXT_ID, String.valueOf(context.getId()));
             case ACTION_REMOVE_CONTEXT:
                 context = getContext(params);
                 Model.getSingleton().getSession().deleteContext(context);
@@ -209,7 +209,7 @@ public class ContextAPI extends ApiImplementor {
                         throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
                     }
                 }
-                return new ApiResponseElement(CONTEXT_ID, String.valueOf(context.getIndex()));
+                return new ApiResponseElement(CONTEXT_ID, String.valueOf(context.getId()));
             case ACTION_EXPORT_CONTEXT:
                 filename = params.getString(CONTEXT_FILE_PARAM);
                 context = getContext(params);
@@ -385,7 +385,7 @@ public class ContextAPI extends ApiImplementor {
     private ApiResponse buildResponseFromContext(Context c) {
         Map<String, String> fields = new HashMap<>();
         fields.put("name", c.getName());
-        fields.put("id", Integer.toString(c.getIndex()));
+        fields.put("id", Integer.toString(c.getId()));
         fields.put("description", c.getDescription());
         fields.put("inScope", Boolean.toString(c.isInScope()));
         fields.put("excludeRegexs", jsonEncodeList(c.getExcludeFromContextRegexs()));

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
@@ -317,7 +317,7 @@ public class ActiveScanAPI extends ApiImplementor {
                     context = ApiUtils.getContextByParamId(params, PARAM_CONTEXT_ID);
                     user =
                             usersExtension
-                                    .getContextUserAuthManager(context.getIndex())
+                                    .getContextUserAuthManager(context.getId())
                                     .getUserById(userID);
                     if (user == null) {
                         throw new ApiException(Type.USER_NOT_FOUND, PARAM_USER_ID);

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
@@ -404,7 +404,7 @@ public class CustomScanDialog extends StandardFieldsDialog {
         if (context != null) {
             String userName = this.getStringValue(FIELD_USER);
             List<User> users =
-                    this.extUserMgmt.getContextUserAuthManager(context.getIndex()).getUsers();
+                    this.extUserMgmt.getContextUserAuthManager(context.getId()).getUsers();
             for (User user : users) {
                 if (userName.equals(user.getName())) {
                     return user;
@@ -419,7 +419,7 @@ public class CustomScanDialog extends StandardFieldsDialog {
         List<String> userNames = new ArrayList<>();
         if (context != null) {
             List<User> users =
-                    this.extUserMgmt.getContextUserAuthManager(context.getIndex()).getUsers();
+                    this.extUserMgmt.getContextUserAuthManager(context.getId()).getUsers();
             userNames.add(""); // The default should always be 'not specified'
             for (User user : users) {
                 userNames.add(user.getName());

--- a/zap/src/main/java/org/zaproxy/zap/extension/authentication/AuthenticationAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authentication/AuthenticationAPI.java
@@ -177,13 +177,13 @@ public class AuthenticationAPI extends ApiImplementor {
                     actionParams = API.getParams(params.getString(PARAM_METHOD_CONFIG_PARAMS));
                 else actionParams = new JSONObject();
                 context = getContext(params);
-                actionParams.put(PARAM_CONTEXT_ID, context.getIndex());
+                actionParams.put(PARAM_CONTEXT_ID, context.getId());
 
                 AuthenticationMethodType oldMethodType =
                         context.getAuthenticationMethod().getType();
                 AuthMethodEntry authEntry = getSetMethodActionImplementor(params);
                 authEntry.getApi().handleAction(actionParams);
-                resetUsersCredentials(context.getIndex(), oldMethodType, authEntry.getMethodType());
+                resetUsersCredentials(context.getId(), oldMethodType, authEntry.getMethodType());
                 context.save();
                 return ApiResponseElement.OK;
             default:

--- a/zap/src/main/java/org/zaproxy/zap/extension/authentication/ContextAuthenticationPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authentication/ContextAuthenticationPanel.java
@@ -106,7 +106,7 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
      * @param context the context
      */
     public ContextAuthenticationPanel(ExtensionAuthentication extension, Context context) {
-        super(context.getIndex());
+        super(context.getId());
         this.extension = extension;
         initialize();
     }
@@ -118,7 +118,7 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
     /** Initialize the panel. */
     private void initialize() {
         this.setLayout(new CardLayout());
-        this.setName(buildName(getContextIndex()));
+        this.setName(buildName(getContextId()));
         this.setLayout(new GridBagLayout());
         this.setBorder(new EmptyBorder(2, 2, 2, 2));
 
@@ -232,7 +232,7 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
                                 if (selectedAuthenticationMethod == null
                                         || !type.isTypeForMethod(selectedAuthenticationMethod)) {
                                     selectedAuthenticationMethod =
-                                            type.createAuthenticationMethod(getContextIndex());
+                                            type.createAuthenticationMethod(getContextId());
                                 }
 
                                 // Show the configuration panel
@@ -431,7 +431,7 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
     public void saveContextData(Session session) throws Exception {
         saveMethod();
 
-        Context context = session.getContext(getContextIndex());
+        Context context = session.getContext(getContextId());
         // Notify the previously saved method that it's being discarded so the changes can be
         // reflected in the UI
         if (context.getAuthenticationMethod() != null)

--- a/zap/src/main/java/org/zaproxy/zap/extension/authentication/ExtensionAuthentication.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authentication/ExtensionAuthentication.java
@@ -121,10 +121,10 @@ public class ExtensionAuthentication extends ExtensionAdaptor
 
     @Override
     public AbstractContextPropertiesPanel getContextPanel(Context context) {
-        ContextAuthenticationPanel panel = this.contextPanelsMap.get(context.getIndex());
+        ContextAuthenticationPanel panel = this.contextPanelsMap.get(context.getId());
         if (panel == null) {
             panel = new ContextAuthenticationPanel(this, context);
-            this.contextPanelsMap.put(context.getIndex(), panel);
+            this.contextPanelsMap.put(context.getId(), panel);
         }
         return panel;
     }
@@ -256,17 +256,17 @@ public class ExtensionAuthentication extends ExtensionAdaptor
         try {
             List<String> typeL =
                     session.getContextDataStrings(
-                            context.getIndex(), RecordContext.TYPE_AUTH_METHOD_TYPE);
+                            context.getId(), RecordContext.TYPE_AUTH_METHOD_TYPE);
             if (typeL != null && typeL.size() > 0) {
                 AuthenticationMethodType t =
                         getAuthenticationMethodTypeForIdentifier(Integer.parseInt(typeL.get(0)));
                 if (t != null) {
                     context.setAuthenticationMethod(
-                            t.loadMethodFromSession(session, context.getIndex()));
+                            t.loadMethodFromSession(session, context.getId()));
 
                     List<String> loginIndicatorL =
                             session.getContextDataStrings(
-                                    context.getIndex(),
+                                    context.getId(),
                                     RecordContext.TYPE_AUTH_METHOD_LOGGEDIN_INDICATOR);
                     if (loginIndicatorL != null && loginIndicatorL.size() > 0)
                         context.getAuthenticationMethod()
@@ -274,7 +274,7 @@ public class ExtensionAuthentication extends ExtensionAdaptor
 
                     List<String> logoutIndicatorL =
                             session.getContextDataStrings(
-                                    context.getIndex(),
+                                    context.getId(),
                                     RecordContext.TYPE_AUTH_METHOD_LOGGEDOUT_INDICATOR);
                     if (logoutIndicatorL != null && logoutIndicatorL.size() > 0)
                         context.getAuthenticationMethod()
@@ -290,7 +290,7 @@ public class ExtensionAuthentication extends ExtensionAdaptor
     @Override
     public void persistContextData(Session session, Context context) {
         try {
-            int contextIdx = context.getIndex();
+            int contextIdx = context.getId();
             AuthenticationMethodType t = context.getAuthenticationMethod().getType();
             session.setContextData(
                     contextIdx,
@@ -332,7 +332,7 @@ public class ExtensionAuthentication extends ExtensionAdaptor
 
     @Override
     public void discardContext(Context ctx) {
-        contextPanelsMap.remove(ctx.getIndex());
+        contextPanelsMap.remove(ctx.getId());
     }
 
     @Override
@@ -358,7 +358,7 @@ public class ExtensionAuthentication extends ExtensionAdaptor
         ctx.setAuthenticationMethod(
                 getAuthenticationMethodTypeForIdentifier(
                                 config.getInt(AuthenticationMethod.CONTEXT_CONFIG_AUTH_TYPE))
-                        .createAuthenticationMethod(ctx.getIndex()));
+                        .createAuthenticationMethod(ctx.getId()));
         String str = config.getString(AuthenticationMethod.CONTEXT_CONFIG_AUTH_LOGGEDIN, "");
         if (str.length() > 0) {
             ctx.getAuthenticationMethod().setLoggedInIndicatorPattern(str);

--- a/zap/src/main/java/org/zaproxy/zap/extension/authentication/PopupFlagLoggedInIndicatorMenu.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authentication/PopupFlagLoggedInIndicatorMenu.java
@@ -39,7 +39,7 @@ public class PopupFlagLoggedInIndicatorMenu extends ExtensionPopupMenuItem {
     private int contextId;
 
     public PopupFlagLoggedInIndicatorMenu(Context ctx) {
-        this.contextId = ctx.getIndex();
+        this.contextId = ctx.getId();
 
         this.setText(
                 Constant.messages.getString(

--- a/zap/src/main/java/org/zaproxy/zap/extension/authentication/PopupFlagLoggedOutIndicatorMenu.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authentication/PopupFlagLoggedOutIndicatorMenu.java
@@ -39,7 +39,7 @@ public class PopupFlagLoggedOutIndicatorMenu extends ExtensionPopupMenuItem {
     private int contextId;
 
     public PopupFlagLoggedOutIndicatorMenu(Context ctx) {
-        this.contextId = ctx.getIndex();
+        this.contextId = ctx.getId();
 
         this.setText(
                 Constant.messages.getString(

--- a/zap/src/main/java/org/zaproxy/zap/extension/authorization/ContextAuthorizationPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authorization/ContextAuthorizationPanel.java
@@ -101,7 +101,7 @@ public class ContextAuthorizationPanel extends AbstractContextPropertiesPanel {
     /** Initialize the panel. */
     private void initialize() {
         this.setLayout(new CardLayout());
-        this.setName(getContextIndex() + ": " + PANEL_NAME);
+        this.setName(getContextId() + ": " + PANEL_NAME);
         this.setLayout(new GridBagLayout());
         this.setBorder(new EmptyBorder(2, 2, 2, 2));
 
@@ -225,7 +225,7 @@ public class ContextAuthorizationPanel extends AbstractContextPropertiesPanel {
     @Override
     public void saveContextData(Session session) throws Exception {
         saveMethod();
-        session.getContext(getContextIndex()).setAuthorizationDetectionMethod(authorizationMethod);
+        session.getContext(getContextId()).setAuthorizationDetectionMethod(authorizationMethod);
         log.debug("Saving authorization method: " + authorizationMethod);
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/authorization/ExtensionAuthorization.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authorization/ExtensionAuthorization.java
@@ -93,10 +93,10 @@ public class ExtensionAuthorization extends ExtensionAdaptor
 
     @Override
     public AbstractContextPropertiesPanel getContextPanel(Context context) {
-        ContextAuthorizationPanel panel = this.contextPanelsMap.get(context.getIndex());
+        ContextAuthorizationPanel panel = this.contextPanelsMap.get(context.getId());
         if (panel == null) {
-            panel = new ContextAuthorizationPanel(this, context.getIndex());
-            this.contextPanelsMap.put(context.getIndex(), panel);
+            panel = new ContextAuthorizationPanel(this, context.getId());
+            this.contextPanelsMap.put(context.getId(), panel);
         }
         return panel;
     }
@@ -108,7 +108,7 @@ public class ExtensionAuthorization extends ExtensionAdaptor
 
     @Override
     public void discardContext(Context ctx) {
-        this.contextPanelsMap.remove(ctx.getIndex());
+        this.contextPanelsMap.remove(ctx.getId());
     }
 
     @Override
@@ -116,7 +116,7 @@ public class ExtensionAuthorization extends ExtensionAdaptor
         try {
             List<String> loadedData =
                     session.getContextDataStrings(
-                            context.getIndex(), RecordContext.TYPE_AUTHORIZATION_METHOD_TYPE);
+                            context.getId(), RecordContext.TYPE_AUTHORIZATION_METHOD_TYPE);
             if (loadedData != null && loadedData.size() > 0) {
                 int type = Integer.parseInt(loadedData.get(0));
                 // Based on the type, call the appropriate method loader
@@ -124,7 +124,7 @@ public class ExtensionAuthorization extends ExtensionAdaptor
                     case BasicAuthorizationDetectionMethod.METHOD_UNIQUE_ID:
                         context.setAuthorizationDetectionMethod(
                                 BasicAuthorizationDetectionMethod.loadMethodFromSession(
-                                        session, context.getIndex()));
+                                        session, context.getId()));
                         break;
                 }
             }
@@ -139,11 +139,11 @@ public class ExtensionAuthorization extends ExtensionAdaptor
             // Persist the method type first and then the method data itself
             int type = context.getAuthorizationDetectionMethod().getMethodUniqueIdentifier();
             session.setContextData(
-                    context.getIndex(),
+                    context.getId(),
                     RecordContext.TYPE_AUTHORIZATION_METHOD_TYPE,
                     Integer.toString(type));
             context.getAuthorizationDetectionMethod()
-                    .persistMethodToSession(session, context.getIndex());
+                    .persistMethodToSession(session, context.getId());
         } catch (DatabaseException e) {
             log.error("Unable to persist Authorization Detection method.", e);
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/forceduser/ContextForcedUserPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/forceduser/ContextForcedUserPanel.java
@@ -52,7 +52,7 @@ public class ContextForcedUserPanel extends AbstractContextPropertiesPanel {
     /** Initialize the panel. */
     private void initialize() {
         this.setLayout(new CardLayout());
-        this.setName(getContextIndex() + ": " + PANEL_NAME);
+        this.setName(getContextId() + ": " + PANEL_NAME);
         this.setLayout(new GridBagLayout());
         this.setBorder(new EmptyBorder(2, 2, 2, 2));
 
@@ -72,14 +72,14 @@ public class ContextForcedUserPanel extends AbstractContextPropertiesPanel {
 
     private ContextPanelUsersSelectComboBox getUsersComboBox() {
         if (usersComboBox == null) {
-            usersComboBox = new ContextPanelUsersSelectComboBox(getContextIndex());
+            usersComboBox = new ContextPanelUsersSelectComboBox(getContextId());
         }
         return usersComboBox;
     }
 
     @Override
     public void initContextData(Session session, Context uiSharedContext) {
-        usersComboBox.setSelectedInternalItem(extension.getForcedUser(getContextIndex()));
+        usersComboBox.setSelectedInternalItem(extension.getForcedUser(getContextId()));
     }
 
     @Override
@@ -94,7 +94,7 @@ public class ContextForcedUserPanel extends AbstractContextPropertiesPanel {
 
     @Override
     public void saveContextData(Session session) throws Exception {
-        extension.setForcedUser(getContextIndex(), (User) getUsersComboBox().getSelectedItem());
+        extension.setForcedUser(getContextId(), (User) getUsersComboBox().getSelectedItem());
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
@@ -282,10 +282,10 @@ public class ExtensionForcedUser extends ExtensionAdaptor
 
     @Override
     public AbstractContextPropertiesPanel getContextPanel(Context context) {
-        ContextForcedUserPanel panel = this.contextPanelsMap.get(context.getIndex());
+        ContextForcedUserPanel panel = this.contextPanelsMap.get(context.getId());
         if (panel == null) {
-            panel = new ContextForcedUserPanel(this, context.getIndex());
-            this.contextPanelsMap.put(context.getIndex(), panel);
+            panel = new ContextForcedUserPanel(this, context.getId());
+            this.contextPanelsMap.put(context.getId(), panel);
         }
         return panel;
     }
@@ -323,8 +323,8 @@ public class ExtensionForcedUser extends ExtensionAdaptor
 
     @Override
     public void discardContext(Context ctx) {
-        this.contextForcedUsersMap.remove(ctx.getIndex());
-        this.contextPanelsMap.remove(ctx.getIndex());
+        this.contextForcedUsersMap.remove(ctx.getId());
+        this.contextPanelsMap.remove(ctx.getId());
         // Make sure the status of the toggle button is properly updated when changing the session
         updateForcedUserModeToggleButtonState();
     }
@@ -355,8 +355,8 @@ public class ExtensionForcedUser extends ExtensionAdaptor
         for (Context context : contexts) {
             if (context.isInContext(msg.getRequestHeader().getURI().toString())) {
                 // Is there enough info
-                if (contextForcedUsersMap.containsKey(context.getIndex())) {
-                    requestingUser = contextForcedUsersMap.get(context.getIndex());
+                if (contextForcedUsersMap.containsKey(context.getId())) {
+                    requestingUser = contextForcedUsersMap.get(context.getId());
                     break;
                 }
             }
@@ -385,10 +385,10 @@ public class ExtensionForcedUser extends ExtensionAdaptor
             // Load the forced user id for this context
             List<String> forcedUserS =
                     session.getContextDataStrings(
-                            context.getIndex(), RecordContext.TYPE_FORCED_USER_ID);
+                            context.getId(), RecordContext.TYPE_FORCED_USER_ID);
             if (forcedUserS != null && forcedUserS.size() > 0) {
                 int forcedUserId = Integer.parseInt(forcedUserS.get(0));
-                setForcedUser(context.getIndex(), forcedUserId);
+                setForcedUser(context.getId(), forcedUserId);
             }
         } catch (Exception e) {
             log.error("Unable to load forced user.", e);
@@ -399,17 +399,16 @@ public class ExtensionForcedUser extends ExtensionAdaptor
     public void persistContextData(Session session, Context context) {
         try {
             // Save only if we have anything to save
-            if (getForcedUser(context.getIndex()) != null) {
+            if (getForcedUser(context.getId()) != null) {
                 session.setContextData(
-                        context.getIndex(),
+                        context.getId(),
                         RecordContext.TYPE_FORCED_USER_ID,
-                        Integer.toString(getForcedUser(context.getIndex()).getId()));
+                        Integer.toString(getForcedUser(context.getId()).getId()));
                 // Note: Do not persist whether the 'Forced User Mode' is enabled as there's no need
                 // for this and the mode can be easily enabled/disabled directly
             } else {
                 // If we don't have a forced user, force deletion of any previous values
-                session.clearContextDataForType(
-                        context.getIndex(), RecordContext.TYPE_FORCED_USER_ID);
+                session.clearContextDataForType(context.getId(), RecordContext.TYPE_FORCED_USER_ID);
             }
         } catch (Exception e) {
             log.error("Unable to persist forced user.", e);
@@ -418,7 +417,7 @@ public class ExtensionForcedUser extends ExtensionAdaptor
 
     @Override
     public void exportContextData(Context ctx, Configuration config) {
-        User user = getForcedUser(ctx.getIndex());
+        User user = getForcedUser(ctx.getId());
         if (user != null) {
             config.setProperty("context.forceduser", user.getId());
         } else {
@@ -430,7 +429,7 @@ public class ExtensionForcedUser extends ExtensionAdaptor
     public void importContextData(Context ctx, Configuration config) {
         int id = config.getInt("context.forceduser");
         if (id >= 0) {
-            this.setForcedUser(ctx.getIndex(), id);
+            this.setForcedUser(ctx.getId(), id);
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/forceduser/ForcedUserAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/forceduser/ForcedUserAPI.java
@@ -75,7 +75,7 @@ public class ForcedUserAPI extends ApiImplementor {
         switch (name) {
             case VIEW_GET_FORCED_USER:
                 Context context = ApiUtils.getContextByParamId(params, PARAM_CONTEXT_ID);
-                User forcedUser = extension.getForcedUser(context.getIndex());
+                User forcedUser = extension.getForcedUser(context.getId());
                 if (forcedUser != null)
                     return new ApiResponseElement(
                             "forcedUserId", Integer.toString(forcedUser.getId()));
@@ -97,7 +97,7 @@ public class ForcedUserAPI extends ApiImplementor {
                 context = ApiUtils.getContextByParamId(params, PARAM_CONTEXT_ID);
                 int userId = ApiUtils.getIntParam(params, PARAM_USER_ID);
                 try {
-                    extension.setForcedUser(context.getIndex(), userId);
+                    extension.setForcedUser(context.getId(), userId);
                 } catch (IllegalStateException ex) {
                     throw new ApiException(Type.USER_NOT_FOUND);
                 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/PopupMenuFactoryAddUserFromSession.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/PopupMenuFactoryAddUserFromSession.java
@@ -245,8 +245,7 @@ public class PopupMenuFactoryAddUserFromSession extends PopupContextMenuItemFact
             // on an UI shared Context, so changes can be undone by pressing Cancel
             SessionDialog sessionDialog = View.getSingleton().getSessionDialog();
             sessionDialog.recreateUISharedContexts(Model.getSingleton().getSession());
-            final Context uiSharedContext =
-                    sessionDialog.getUISharedContext(this.context.getIndex());
+            final Context uiSharedContext = sessionDialog.getUISharedContext(this.context.getId());
 
             HttpSessionsPanel panel = extension.getHttpSessionsPanel();
             HttpSession session = panel.getSelectedSession();
@@ -267,7 +266,7 @@ public class PopupMenuFactoryAddUserFromSession extends PopupContextMenuItemFact
                                 + uiSharedContext.getName());
                 ManualAuthenticationMethod method =
                         new ManualAuthenticationMethodType()
-                                .createAuthenticationMethod(context.getIndex());
+                                .createAuthenticationMethod(context.getId());
 
                 if (!confirmUsersDeletion(uiSharedContext)) {
                     log.debug("Cancelled change of authentication type.");
@@ -295,7 +294,7 @@ public class PopupMenuFactoryAddUserFromSession extends PopupContextMenuItemFact
             View.getSingleton()
                     .showSessionDialog(
                             Model.getSingleton().getSession(),
-                            ContextUsersPanel.getPanelName(context.getIndex()),
+                            ContextUsersPanel.getPanelName(context.getId()),
                             false,
                             new Runnable() {
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/sessions/ContextSessionManagementPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/sessions/ContextSessionManagementPanel.java
@@ -81,7 +81,7 @@ public class ContextSessionManagementPanel extends AbstractContextPropertiesPane
      * @param context the context
      */
     public ContextSessionManagementPanel(ExtensionSessionManagement extension, Context context) {
-        super(context.getIndex());
+        super(context.getId());
         this.extension = extension;
         initialize();
     }
@@ -89,7 +89,7 @@ public class ContextSessionManagementPanel extends AbstractContextPropertiesPane
     /** Initialize the panel. */
     private void initialize() {
         this.setLayout(new CardLayout());
-        this.setName(getContextIndex() + ": " + PANEL_NAME);
+        this.setName(getContextId() + ": " + PANEL_NAME);
         this.setLayout(new GridBagLayout());
         this.setBorder(new EmptyBorder(2, 2, 2, 2));
 
@@ -187,7 +187,7 @@ public class ContextSessionManagementPanel extends AbstractContextPropertiesPane
                                         || !type.isTypeForMethod(selectedMethod)) {
                                     // Create the new session management method
                                     selectedMethod =
-                                            type.createSessionManagementMethod(getContextIndex());
+                                            type.createSessionManagementMethod(getContextId());
                                 }
 
                                 // Show the status panel and configuration button, if needed
@@ -267,7 +267,7 @@ public class ContextSessionManagementPanel extends AbstractContextPropertiesPane
     @Override
     public void saveContextData(Session session) throws Exception {
         if (shownConfigPanel != null) shownConfigPanel.saveMethod();
-        session.getContext(getContextIndex()).setSessionManagementMethod(selectedMethod);
+        session.getContext(getContextId()).setSessionManagementMethod(selectedMethod);
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/sessions/ExtensionSessionManagement.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/sessions/ExtensionSessionManagement.java
@@ -106,10 +106,10 @@ public class ExtensionSessionManagement extends ExtensionAdaptor
 
     @Override
     public AbstractContextPropertiesPanel getContextPanel(Context context) {
-        ContextSessionManagementPanel panel = this.contextPanelsMap.get(context.getIndex());
+        ContextSessionManagementPanel panel = this.contextPanelsMap.get(context.getId());
         if (panel == null) {
             panel = new ContextSessionManagementPanel(this, context);
-            this.contextPanelsMap.put(context.getIndex(), panel);
+            this.contextPanelsMap.put(context.getId(), panel);
         }
         return panel;
     }
@@ -158,7 +158,7 @@ public class ExtensionSessionManagement extends ExtensionAdaptor
 
     @Override
     public void discardContext(Context c) {
-        this.contextPanelsMap.remove(c.getIndex());
+        this.contextPanelsMap.remove(c.getId());
     }
 
     /**
@@ -178,13 +178,13 @@ public class ExtensionSessionManagement extends ExtensionAdaptor
         try {
             List<String> typeL =
                     session.getContextDataStrings(
-                            context.getIndex(), RecordContext.TYPE_SESSION_MANAGEMENT_TYPE);
+                            context.getId(), RecordContext.TYPE_SESSION_MANAGEMENT_TYPE);
             if (typeL != null && typeL.size() > 0) {
                 SessionManagementMethodType t =
                         getSessionManagementMethodTypeForIdentifier(Integer.parseInt(typeL.get(0)));
                 if (t != null) {
                     context.setSessionManagementMethod(
-                            t.loadMethodFromSession(session, context.getIndex()));
+                            t.loadMethodFromSession(session, context.getId()));
                 }
             }
         } catch (DatabaseException e) {
@@ -197,11 +197,11 @@ public class ExtensionSessionManagement extends ExtensionAdaptor
         try {
             SessionManagementMethodType t = context.getSessionManagementMethod().getType();
             session.setContextData(
-                    context.getIndex(),
+                    context.getId(),
                     RecordContext.TYPE_SESSION_MANAGEMENT_TYPE,
                     Integer.toString(t.getUniqueIdentifier()));
             t.persistMethodToSession(
-                    session, context.getIndex(), context.getSessionManagementMethod());
+                    session, context.getId(), context.getSessionManagementMethod());
         } catch (DatabaseException e) {
             log.error("Unable to persist Session Management method.", e);
         }
@@ -220,7 +220,7 @@ public class ExtensionSessionManagement extends ExtensionAdaptor
                 getSessionManagementMethodTypeForIdentifier(
                         config.getInt(CONTEXT_CONFIG_SESSION_TYPE));
         if (t != null) {
-            SessionManagementMethod method = t.createSessionManagementMethod(ctx.getIndex());
+            SessionManagementMethod method = t.createSessionManagementMethod(ctx.getId());
             t.importData(config, method);
             ctx.setSessionManagementMethod(method);
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/sessions/SessionManagementAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/sessions/SessionManagementAPI.java
@@ -133,7 +133,7 @@ public class SessionManagementAPI extends ApiImplementor {
                     actionParams = API.getParams(params.getString(PARAM_METHOD_CONFIG_PARAMS));
                 else actionParams = new JSONObject();
                 Context context = getContext(params);
-                actionParams.put(PARAM_CONTEXT_ID, context.getIndex());
+                actionParams.put(PARAM_CONTEXT_ID, context.getId());
                 // Run the method
                 getSetMethodActionImplementor(params).handleAction(actionParams);
                 context.save();

--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderAPI.java
@@ -264,7 +264,7 @@ public class SpiderAPI extends ApiImplementor {
                 context = ApiUtils.getContextByParamId(params, PARAM_CONTEXT_ID);
                 User user =
                         usersExtension
-                                .getContextUserAuthManager(context.getIndex())
+                                .getContextUserAuthManager(context.getId())
                                 .getUserById(userID);
                 if (user == null) {
                     throw new ApiException(Type.USER_NOT_FOUND, PARAM_USER_ID);

--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderDialog.java
@@ -250,7 +250,7 @@ public class SpiderDialog extends StandardFieldsDialog {
         if (context != null) {
             String userName = this.getStringValue(FIELD_USER);
             List<User> users =
-                    this.extUserMgmt.getContextUserAuthManager(context.getIndex()).getUsers();
+                    this.extUserMgmt.getContextUserAuthManager(context.getId()).getUsers();
             for (User user : users) {
                 if (userName.equals(user.getName())) {
                     return user;
@@ -265,7 +265,7 @@ public class SpiderDialog extends StandardFieldsDialog {
         List<String> userNames = new ArrayList<String>();
         if (context != null) {
             List<User> users =
-                    this.extUserMgmt.getContextUserAuthManager(context.getIndex()).getUsers();
+                    this.extUserMgmt.getContextUserAuthManager(context.getId()).getUsers();
             userNames.add(""); // The default should always be 'not specified'
             for (User user : users) {
                 userNames.add(user.getName());

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupContextTreeMenu.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupContextTreeMenu.java
@@ -46,7 +46,7 @@ public class PopupContextTreeMenu extends ExtensionPopupMenuItem {
             if (node == null || node.isRoot()) {
                 return false;
             }
-            contextId = ((Target) node.getUserObject()).getContext().getIndex();
+            contextId = ((Target) node.getUserObject()).getContext().getId();
             return isEnabledForContext(contextId);
         }
         return false;

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupUserMenuItemHolder.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupUserMenuItemHolder.java
@@ -151,7 +151,7 @@ public abstract class PopupUserMenuItemHolder extends ExtensionPopupMenuMessageC
         List<Context> contexts = session.getContexts();
         for (Context context : contexts) {
             ContextUserAuthManager manager =
-                    extensionUserAuth.getContextUserAuthManager(context.getIndex());
+                    extensionUserAuth.getContextUserAuthManager(context.getId());
 
             for (User user : manager.getUsers()) {
                 ExtensionPopupMenuItem piicm;

--- a/zap/src/main/java/org/zaproxy/zap/extension/users/ContextUsersPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/users/ContextUsersPanel.java
@@ -60,7 +60,7 @@ public class ContextUsersPanel extends AbstractContextPropertiesPanel {
 
     private void initialize() {
         this.setLayout(new CardLayout());
-        this.setName(getPanelName(getContextIndex()));
+        this.setName(getPanelName(getContextId()));
         this.setLayout(new GridBagLayout());
 
         this.add(
@@ -69,7 +69,7 @@ public class ContextUsersPanel extends AbstractContextPropertiesPanel {
 
         usersTableModel = new UsersTableModel();
         usersOptionsPanel =
-                new UsersMultipleOptionsPanel(this.extension, usersTableModel, getContextIndex());
+                new UsersMultipleOptionsPanel(this.extension, usersTableModel, getContextId());
         this.add(usersOptionsPanel, LayoutHelper.getGBC(0, 1, 1, 1.0d, 1.0d));
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/users/DialogAddUser.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/users/DialogAddUser.java
@@ -136,10 +136,10 @@ public class DialogAddUser extends AbstractFormDialog {
         if (this.user != null)
             this.user =
                     new User(
-                            workingContext.getIndex(),
+                            workingContext.getId(),
                             getNameTextField().getText(),
                             this.user.getId());
-        else this.user = new User(workingContext.getIndex(), getNameTextField().getText());
+        else this.user = new User(workingContext.getId(), getNameTextField().getText());
         this.user.setEnabled(getEnabledCheckBox().isSelected());
         // Make sure the credentials panel saves its changes first
         credentialsPanel.saveCredentials();

--- a/zap/src/main/java/org/zaproxy/zap/extension/users/ExtensionUserManagement.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/users/ExtensionUserManagement.java
@@ -170,7 +170,7 @@ public class ExtensionUserManagement extends ExtensionAdaptor
 
     @Override
     public AbstractContextPropertiesPanel getContextPanel(Context ctx) {
-        return getContextPanel(ctx.getIndex());
+        return getContextPanel(ctx.getId());
     }
 
     /**
@@ -239,18 +239,18 @@ public class ExtensionUserManagement extends ExtensionAdaptor
 
     @Override
     public void discardContext(Context ctx) {
-        this.contextManagers.remove(ctx.getIndex());
-        this.userPanelsMap.remove(ctx.getIndex());
+        this.contextManagers.remove(ctx.getId());
+        this.userPanelsMap.remove(ctx.getId());
     }
 
     @Override
     public void loadContextData(Session session, Context context) {
         try {
             List<String> encodedUsers =
-                    session.getContextDataStrings(context.getIndex(), RecordContext.TYPE_USER);
-            ContextUserAuthManager usersManager = getContextUserAuthManager(context.getIndex());
+                    session.getContextDataStrings(context.getId(), RecordContext.TYPE_USER);
+            ContextUserAuthManager usersManager = getContextUserAuthManager(context.getId());
             for (String e : encodedUsers) {
-                User u = User.decode(context.getIndex(), e);
+                User u = User.decode(context.getId(), e);
                 usersManager.addUser(u);
             }
         } catch (Exception ex) {
@@ -262,12 +262,12 @@ public class ExtensionUserManagement extends ExtensionAdaptor
     public void persistContextData(Session session, Context context) {
         try {
             List<String> encodedUsers = new ArrayList<>();
-            ContextUserAuthManager m = contextManagers.get(context.getIndex());
+            ContextUserAuthManager m = contextManagers.get(context.getId());
             if (m != null) {
                 for (User u : m.getUsers()) {
                     encodedUsers.add(User.encode(u));
                 }
-                session.setContextData(context.getIndex(), RecordContext.TYPE_USER, encodedUsers);
+                session.setContextData(context.getId(), RecordContext.TYPE_USER, encodedUsers);
             }
         } catch (Exception ex) {
             log.error("Unable to persist Users.", ex);
@@ -281,7 +281,7 @@ public class ExtensionUserManagement extends ExtensionAdaptor
      * @param sharedContext the shared context
      */
     public void removeSharedContextUsers(Context sharedContext) {
-        this.getContextPanel(sharedContext.getIndex()).getUsersTableModel().removeAllUsers();
+        this.getContextPanel(sharedContext.getId()).getUsersTableModel().removeAllUsers();
     }
 
     /**
@@ -292,11 +292,11 @@ public class ExtensionUserManagement extends ExtensionAdaptor
      * @param user the user
      */
     public void addSharedContextUser(Context sharedContext, User user) {
-        this.getContextPanel(sharedContext.getIndex()).getUsersTableModel().addUser(user);
+        this.getContextPanel(sharedContext.getId()).getUsersTableModel().addUser(user);
     }
 
     public List<User> getSharedContextUsers(Context sharedContext) {
-        return getContextPanel(sharedContext.getIndex()).getUsersTableModel().getUsers();
+        return getContextPanel(sharedContext.getId()).getUsersTableModel().getUsers();
     }
 
     /**
@@ -310,7 +310,7 @@ public class ExtensionUserManagement extends ExtensionAdaptor
 
     @Override
     public void exportContextData(Context ctx, Configuration config) {
-        ContextUserAuthManager m = contextManagers.get(ctx.getIndex());
+        ContextUserAuthManager m = contextManagers.get(ctx.getId());
         if (m != null) {
             for (User u : m.getUsers()) {
                 config.addProperty(CONTEXT_CONFIG_USERS_USER, User.encode(u));
@@ -321,9 +321,9 @@ public class ExtensionUserManagement extends ExtensionAdaptor
     @Override
     public void importContextData(Context ctx, Configuration config) {
         List<Object> list = config.getList(CONTEXT_CONFIG_USERS_USER);
-        ContextUserAuthManager m = getContextUserAuthManager(ctx.getIndex());
+        ContextUserAuthManager m = getContextUserAuthManager(ctx.getId());
         for (Object o : list) {
-            User usersManager = User.decode(ctx.getIndex(), o.toString());
+            User usersManager = User.decode(ctx.getId(), o.toString());
             m.addUser(usersManager);
         }
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/users/UsersAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/users/UsersAPI.java
@@ -144,7 +144,7 @@ public class UsersAPI extends ApiImplementor {
                 else {
                     users = new ArrayList<>();
                     for (Context c : Model.getSingleton().getSession().getContexts())
-                        users.addAll(extension.getContextUserAuthManager(c.getIndex()).getUsers());
+                        users.addAll(extension.getContextUserAuthManager(c.getId()).getUsers());
                 }
 
                 // Prepare the response
@@ -182,19 +182,17 @@ public class UsersAPI extends ApiImplementor {
             case ACTION_NEW_USER:
                 context = ApiUtils.getContextByParamId(params, PARAM_CONTEXT_ID);
                 String userName = ApiUtils.getNonEmptyStringParam(params, PARAM_USER_NAME);
-                user = new User(context.getIndex(), userName);
+                user = new User(context.getId(), userName);
                 user.setAuthenticationCredentials(
                         context.getAuthenticationMethod().createAuthenticationCredentials());
-                extension.getContextUserAuthManager(context.getIndex()).addUser(user);
+                extension.getContextUserAuthManager(context.getId()).addUser(user);
                 context.save();
                 return new ApiResponseElement(PARAM_USER_ID, String.valueOf(user.getId()));
             case ACTION_REMOVE_USER:
                 context = ApiUtils.getContextByParamId(params, PARAM_CONTEXT_ID);
                 int userId = ApiUtils.getIntParam(params, PARAM_USER_ID);
                 boolean deleted =
-                        extension
-                                .getContextUserAuthManager(context.getIndex())
-                                .removeUserById(userId);
+                        extension.getContextUserAuthManager(context.getId()).removeUserById(userId);
                 if (deleted) {
                     context.save();
                     return ApiResponseElement.OK;
@@ -226,7 +224,7 @@ public class UsersAPI extends ApiImplementor {
                     actionParams = API.getParams(params.getString(PARAM_CREDENTIALS_CONFIG_PARAMS));
                 else actionParams = new JSONObject();
                 context = ApiUtils.getContextByParamId(params, PARAM_CONTEXT_ID);
-                actionParams.put(PARAM_CONTEXT_ID, context.getIndex());
+                actionParams.put(PARAM_CONTEXT_ID, context.getId());
                 actionParams.put(PARAM_USER_ID, getUserId(params));
                 // Run the method
                 ApiDynamicActionImplementor a =

--- a/zap/src/main/java/org/zaproxy/zap/model/Context.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/Context.java
@@ -69,7 +69,7 @@ public class Context {
     private static Logger log = Logger.getLogger(Context.class);
 
     private Session session;
-    private int index;
+    private int id;
     private String name;
     private String description = "";
 
@@ -93,12 +93,12 @@ public class Context {
     private ParameterParser urlParamParser = new StandardParameterParser();
     private ParameterParser postParamParser = new StandardParameterParser();
 
-    public Context(Session session, int index) {
+    public Context(Session session, int id) {
         this.session = session;
-        this.index = index;
-        this.name = String.valueOf(index);
-        this.sessionManagementMethod = new CookieBasedSessionManagementMethod(index);
-        this.authenticationMethod = new ManualAuthenticationMethod(index);
+        this.id = id;
+        this.name = String.valueOf(id);
+        this.sessionManagementMethod = new CookieBasedSessionManagementMethod(id);
+        this.authenticationMethod = new ManualAuthenticationMethod(id);
         this.authorizationDetectionMethod =
                 new BasicAuthorizationDetectionMethod(null, null, null, LogicalOperator.AND);
         this.urlParamParser.setContext(this);
@@ -496,8 +496,23 @@ public class Context {
         this.description = description;
     }
 
+    /**
+     * Returns the ID of the {@code Context}
+     *
+     * @deprecated (TODO Add version) Use {@link #getId()} instead.
+     */
+    @Deprecated
     public int getIndex() {
-        return this.index;
+        return getId();
+    }
+
+    /**
+     * Returns the ID of the {@code Context}
+     *
+     * @since TODO add version
+     */
+    public int getId() {
+        return this.id;
     }
 
     public boolean isInScope() {
@@ -740,7 +755,7 @@ public class Context {
      * @return the context
      */
     public Context duplicate() {
-        Context newContext = new Context(session, getIndex());
+        Context newContext = new Context(session, getId());
         newContext.description = this.description;
         newContext.name = this.name;
         newContext.includeInRegexs = new ArrayList<>(this.includeInRegexs);
@@ -762,7 +777,7 @@ public class Context {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + index;
+        result = prime * result + id;
         return result;
     }
 
@@ -772,7 +787,7 @@ public class Context {
         if (obj == null) return false;
         if (getClass() != obj.getClass()) return false;
         Context other = (Context) obj;
-        if (index != other.index) return false;
+        if (id != other.id) return false;
         return true;
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/session/CookieBasedSessionManagementMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/session/CookieBasedSessionManagementMethodType.java
@@ -301,8 +301,7 @@ public class CookieBasedSessionManagementMethodType extends SessionManagementMet
             public void handleAction(JSONObject params) throws ApiException {
                 Context context =
                         ApiUtils.getContextByParamId(params, SessionManagementAPI.PARAM_CONTEXT_ID);
-                context.setSessionManagementMethod(
-                        createSessionManagementMethod(context.getIndex()));
+                context.setSessionManagementMethod(createSessionManagementMethod(context.getId()));
             }
         };
     }

--- a/zap/src/main/java/org/zaproxy/zap/session/HttpAuthSessionManagementMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/session/HttpAuthSessionManagementMethodType.java
@@ -193,8 +193,7 @@ public class HttpAuthSessionManagementMethodType extends SessionManagementMethod
             public void handleAction(JSONObject params) throws ApiException {
                 Context context =
                         ApiUtils.getContextByParamId(params, SessionManagementAPI.PARAM_CONTEXT_ID);
-                context.setSessionManagementMethod(
-                        createSessionManagementMethod(context.getIndex()));
+                context.setSessionManagementMethod(createSessionManagementMethod(context.getId()));
             }
         };
     }

--- a/zap/src/main/java/org/zaproxy/zap/view/AbstractContextPropertiesPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/AbstractContextPropertiesPanel.java
@@ -144,8 +144,20 @@ public abstract class AbstractContextPropertiesPanel extends AbstractParamPanel 
      * Gets the index of the context to which this panel corresponds.
      *
      * @return the context index
+     * @deprecated (TODO Add version) Use {@link #getContextId()} instead
      */
+    @Deprecated
     public int getContextIndex() {
+        return getContextId();
+    }
+
+    /**
+     * Gets the ID of the context to which this panel corresponds.
+     *
+     * @return the context ID
+     * @since TODO Add version
+     */
+    public int getContextId() {
         return contextId;
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/view/ContextExcludePanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ContextExcludePanel.java
@@ -39,16 +39,16 @@ public class ContextExcludePanel extends AbstractContextPropertiesPanel {
     private MultipleRegexesOptionsPanel regexesPanel;
 
     /**
-     * Returns the name of the panel "Exclude from context" for the given {@code contextIndex}.
+     * Returns the name of the panel "Exclude from context" for the given {@code contextId}.
      *
-     * @param contextIndex the context index that will be used to create the name of the panel
-     * @return the name of the panel "Exclude from context" for the given {@code contextIndex}
+     * @param contextId the context ID that will be used to create the name of the panel
+     * @return the name of the panel "Exclude from context" for the given {@code contextId}
      * @since 2.2.0
-     * @see Context#getIndex()
+     * @see Context#getId()
      */
-    public static String getPanelName(int contextIndex) {
+    public static String getPanelName(int contextId) {
         // Panel names have to be unique, so precede with the context index
-        return contextIndex + ": " + PANEL_NAME;
+        return contextId + ": " + PANEL_NAME;
     }
 
     /**
@@ -61,7 +61,7 @@ public class ContextExcludePanel extends AbstractContextPropertiesPanel {
      */
     @Deprecated
     public static String getPanelName(Context context) {
-        return getPanelName(context.getIndex());
+        return getPanelName(context.getId());
     }
 
     /**
@@ -70,12 +70,12 @@ public class ContextExcludePanel extends AbstractContextPropertiesPanel {
      * @param context the target context, must not be {@code null}.
      */
     public ContextExcludePanel(Context context) {
-        super(context.getIndex());
+        super(context.getId());
 
         regexesPanel = new MultipleRegexesOptionsPanel(View.getSingleton().getSessionDialog());
 
         this.setLayout(new CardLayout());
-        this.setName(getPanelName(getContextIndex()));
+        this.setName(getPanelName(getContextId()));
         this.add(getPanelSession(), getPanelSession().getName());
     }
     /**
@@ -136,7 +136,7 @@ public class ContextExcludePanel extends AbstractContextPropertiesPanel {
 
     @Override
     public void saveContextData(Session session) throws Exception {
-        Context context = session.getContext(getContextIndex());
+        Context context = session.getContext(getContextId());
         context.setExcludeFromContextRegexs(regexesPanel.getRegexes());
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/view/ContextGeneralPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ContextGeneralPanel.java
@@ -43,7 +43,7 @@ public class ContextGeneralPanel extends AbstractContextPropertiesPanel {
     private JCheckBox chkInScope = null;
 
     public static String getPanelName(Context ctx) {
-        return getPanelName(ctx.getIndex(), ctx.getName());
+        return getPanelName(ctx.getId(), ctx.getName());
     }
 
     public static String getPanelName(int index, String name) {
@@ -70,10 +70,10 @@ public class ContextGeneralPanel extends AbstractContextPropertiesPanel {
             super.setName(name);
             return;
         }
-        if (name.startsWith(this.getContextIndex() + ":")) {
+        if (name.startsWith(this.getContextId() + ":")) {
             name = name.substring(name.indexOf(":") + 1);
         }
-        super.setName(getPanelName(this.getContextIndex(), name));
+        super.setName(getPanelName(this.getContextId(), name));
     }
 
     /**
@@ -153,7 +153,7 @@ public class ContextGeneralPanel extends AbstractContextPropertiesPanel {
         getTxtDescription().discardAllEdits();
         getChkInScope().setSelected(uiSharedContext.isInScope());
 
-        if (uiSharedContext.getName().equals(Integer.toString(uiSharedContext.getIndex()))
+        if (uiSharedContext.getName().equals(Integer.toString(uiSharedContext.getId()))
                 && uiSharedContext.getIncludeInContextRegexs().size() == 1) {
             // Default to the host name in the first and only regex
             String firstRegex = uiSharedContext.getIncludeInContextRegexs().get(0);
@@ -183,7 +183,7 @@ public class ContextGeneralPanel extends AbstractContextPropertiesPanel {
                     Constant.messages.getString("context.error.name.empty"));
         }
 
-        if (!this.getName().equals(getPanelName(this.getContextIndex(), name))
+        if (!this.getName().equals(getPanelName(this.getContextId(), name))
                 && session.getContext(name) != null) {
             throw new IllegalContextNameException(
                     IllegalContextNameException.Reason.DUPLICATED_NAME,
@@ -193,10 +193,10 @@ public class ContextGeneralPanel extends AbstractContextPropertiesPanel {
 
     @Override
     public void saveContextData(Session session) {
-        Context context = session.getContext(this.getContextIndex());
+        Context context = session.getContext(this.getContextId());
         saveDataInContext(context);
         String name = getTxtName().getText();
-        if (!this.getName().equals(getPanelName(this.getContextIndex(), name))
+        if (!this.getName().equals(getPanelName(this.getContextId(), name))
                 && View.isInitialised()) {
             View.getSingleton().renameContext(context);
         }

--- a/zap/src/main/java/org/zaproxy/zap/view/ContextIncludePanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ContextIncludePanel.java
@@ -39,16 +39,16 @@ public class ContextIncludePanel extends AbstractContextPropertiesPanel {
     private MultipleRegexesOptionsPanel regexesPanel;
 
     /**
-     * Returns the name of the panel "Include in context" for the given {@code contextIndex}.
+     * Returns the name of the panel "Include in context" for the given {@code contextId}.
      *
-     * @param contextIndex the context index that will be used to create the name of the panel
-     * @return the name of the panel "Include in context" for the given {@code contextIndex}
+     * @param contextId the context index that will be used to create the name of the panel
+     * @return the name of the panel "Include in context" for the given {@code contextId}
      * @since 2.2.0
-     * @see Context#getIndex()
+     * @see Context#getId()
      */
-    public static String getPanelName(int contextIndex) {
+    public static String getPanelName(int contextId) {
         // Panel names have to be unique, so precede with the context index
-        return contextIndex + ": " + PANEL_NAME;
+        return contextId + ": " + PANEL_NAME;
     }
 
     /**
@@ -61,7 +61,7 @@ public class ContextIncludePanel extends AbstractContextPropertiesPanel {
      */
     @Deprecated
     public static String getPanelName(Context context) {
-        return getPanelName(context.getIndex());
+        return getPanelName(context.getId());
     }
 
     /**
@@ -70,12 +70,12 @@ public class ContextIncludePanel extends AbstractContextPropertiesPanel {
      * @param context the target context, must not be {@code null}.
      */
     public ContextIncludePanel(Context context) {
-        super(context.getIndex());
+        super(context.getId());
 
         regexesPanel = new MultipleRegexesOptionsPanel(View.getSingleton().getSessionDialog());
 
         this.setLayout(new CardLayout());
-        this.setName(getPanelName(getContextIndex()));
+        this.setName(getPanelName(getContextId()));
         this.add(getPanelSession(), getPanelSession().getName());
     }
 
@@ -137,7 +137,7 @@ public class ContextIncludePanel extends AbstractContextPropertiesPanel {
 
     @Override
     public void saveContextData(Session session) throws Exception {
-        Context context = session.getContext(getContextIndex());
+        Context context = session.getContext(getContextId());
         context.setIncludeInContextRegexs(regexesPanel.getRegexes());
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/view/ContextListPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ContextListPanel.java
@@ -151,7 +151,7 @@ public class ContextListPanel extends AbstractParamPanel {
         List<Object[]> values = new ArrayList<>();
         List<Context> contexts = session.getContexts();
         for (Context context : contexts) {
-            values.add(new Object[] {context.getIndex(), context.getName(), context.isInScope()});
+            values.add(new Object[] {context.getId(), context.getName(), context.isInScope()});
         }
         this.model.setValues(values);
     }

--- a/zap/src/main/java/org/zaproxy/zap/view/ContextStructurePanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ContextStructurePanel.java
@@ -62,7 +62,7 @@ public class ContextStructurePanel extends AbstractContextPropertiesPanel {
      * @param contextId the context index that will be used to create the name of the panel
      * @return the name of the panel "Include in context" for the given context index
      * @since 2.2.0
-     * @see Context#getIndex()
+     * @see Context#getId()
      */
     public static String getPanelName(int contextId) {
         // Panel names hav to be unique, so prefix with the context id
@@ -75,10 +75,10 @@ public class ContextStructurePanel extends AbstractContextPropertiesPanel {
      * @param context the target context, must not be {@code null}.
      */
     public ContextStructurePanel(Context context) {
-        super(context.getIndex());
+        super(context.getId());
 
         this.setLayout(new CardLayout());
-        this.setName(getPanelName(this.getContextIndex()));
+        this.setName(getPanelName(this.getContextId()));
         this.add(getPanel(), getPanel().getName());
     }
 
@@ -282,7 +282,7 @@ public class ContextStructurePanel extends AbstractContextPropertiesPanel {
 
     @Override
     public void saveContextData(Session session) throws Exception {
-        Context context = session.getContext(getContextIndex());
+        Context context = session.getContext(getContextId());
         saveToContext(context, true);
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/view/ContextTechnologyPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ContextTechnologyPanel.java
@@ -41,14 +41,14 @@ public class ContextTechnologyPanel extends AbstractContextPropertiesPanel {
     }
 
     public ContextTechnologyPanel(Context context) {
-        super(context.getIndex());
+        super(context.getId());
         initialize();
     }
 
     /** This method initializes this */
     private void initialize() {
         this.setLayout(new CardLayout());
-        this.setName(getPanelName(getContextIndex()));
+        this.setName(getPanelName(getContextId()));
         this.add(getPanelSession(), getPanelSession().getName());
     }
 
@@ -97,7 +97,7 @@ public class ContextTechnologyPanel extends AbstractContextPropertiesPanel {
     @Override
     public void saveContextData(Session session) throws Exception {
 
-        session.getContext(getContextIndex()).setTechSet(getTechTree().getTechSet());
+        session.getContext(getContextId()).setTechSet(getTechTree().getTechSet());
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/view/panels/AbstractScanToolbarStatusPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/panels/AbstractScanToolbarStatusPanel.java
@@ -312,7 +312,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
      */
     protected void pauseScan(Context context) {
         log.debug("Access Control pause on Context: " + context);
-        threadManager.getScannerThread(context.getIndex()).pauseScan();
+        threadManager.getScannerThread(context.getId()).pauseScan();
     }
 
     /**
@@ -324,7 +324,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
      */
     protected void resumeScan(Context context) {
         log.debug("Access Control resume on Context: " + context);
-        threadManager.getScannerThread(context.getIndex()).resumeScan();
+        threadManager.getScannerThread(context.getId()).resumeScan();
     }
 
     /**
@@ -336,7 +336,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
      */
     protected void stopScan(Context context) {
         log.debug("Access Control stop on Context: " + context);
-        threadManager.getScannerThread(context.getIndex()).stopScan();
+        threadManager.getScannerThread(context.getId()).stopScan();
     }
 
     /**
@@ -348,7 +348,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
      * @return {@code true} if the scan is paused, {@code false} otherwise.
      */
     protected boolean isScanStarted(Context context) {
-        return threadManager.getScannerThread(context.getIndex()).isRunning();
+        return threadManager.getScannerThread(context.getId()).isRunning();
     }
 
     /**
@@ -360,7 +360,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
      * @return {@code true} if the scan is paused, {@code false} otherwise.
      */
     protected boolean isScanPaused(Context context) {
-        return threadManager.getScannerThread(context.getIndex()).isPaused();
+        return threadManager.getScannerThread(context.getId()).isPaused();
     }
 
     /**
@@ -372,7 +372,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
      * @return the progress
      */
     protected int getScanProgress(Context context) {
-        return threadManager.getScannerThread(context.getIndex()).getScanProgress();
+        return threadManager.getScannerThread(context.getId()).getScanProgress();
     }
 
     /**
@@ -384,7 +384,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
      * @return the maximum value of the progress
      */
     protected int getScanMaximumProgress(Context context) {
-        return threadManager.getScannerThread(context.getIndex()).getScanMaximumProgress();
+        return threadManager.getScannerThread(context.getId()).getScanMaximumProgress();
     }
 
     @Override
@@ -395,7 +395,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
                     public void run() {
                         log.debug("ScanStarted " + panelPrefix + " on context" + contextId);
                         if (getSelectedContext() != null
-                                && contextId == getSelectedContext().getIndex()) {
+                                && contextId == getSelectedContext().getId()) {
                             setScanButtonsAndProgressBarStates(true, false, false);
                             getProgressBar().setValue(0);
                         }
@@ -417,7 +417,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
                     public void run() {
                         log.debug("ScanFinished " + panelPrefix + " on context" + contextId);
                         if (getSelectedContext() != null
-                                && contextId == getSelectedContext().getIndex()) {
+                                && contextId == getSelectedContext().getId()) {
                             setScanButtonsAndProgressBarStates(false, false, true);
                         }
                     }
@@ -444,7 +444,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
                                         + " "
                                         + progress);
                         if (getSelectedContext() != null
-                                && contextId == getSelectedContext().getIndex()) {
+                                && contextId == getSelectedContext().getId()) {
                             getProgressBar().setValue(progress);
                             getProgressBar().setMaximum(maximum);
                         }

--- a/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemContextDataDrivenNode.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemContextDataDrivenNode.java
@@ -58,7 +58,7 @@ public class PopupMenuItemContextDataDrivenNode extends PopupMenuItemSiteNodeCon
 
         SessionDialog sessionDialog = View.getSingleton().getSessionDialog();
         sessionDialog.recreateUISharedContexts(session);
-        Context uiSharedContext = sessionDialog.getUISharedContext(context.getIndex());
+        Context uiSharedContext = sessionDialog.getUISharedContext(context.getId());
 
         // We want to form a regex expression like:
         // https://www.example.com/(aa/bb/cc/)(.+?)(/.*)
@@ -91,7 +91,7 @@ public class PopupMenuItemContextDataDrivenNode extends PopupMenuItemSiteNodeCon
         // Show the session dialog without recreating UI Shared contexts
         View.getSingleton()
                 .showSessionDialog(
-                        session, ContextStructurePanel.getPanelName(context.getIndex()), false);
+                        session, ContextStructurePanel.getPanelName(context.getId()), false);
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemExcludeFromContext.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemExcludeFromContext.java
@@ -57,7 +57,7 @@ public class PopupMenuItemExcludeFromContext extends PopupMenuItemSiteNodeContai
     @Override
     public void performAction(SiteNode sn) {
         Context uiSharedContext =
-                View.getSingleton().getSessionDialog().getUISharedContext(context.getIndex());
+                View.getSingleton().getSessionDialog().getUISharedContext(context.getId());
 
         try {
             uiSharedContext.excludeFromContext(sn, !sn.isLeaf());
@@ -78,7 +78,7 @@ public class PopupMenuItemExcludeFromContext extends PopupMenuItemSiteNodeContai
         // Show the session dialog without recreating UI Shared contexts
         View.getSingleton()
                 .showSessionDialog(
-                        session, ContextExcludePanel.getPanelName(context.getIndex()), false);
+                        session, ContextExcludePanel.getPanelName(context.getId()), false);
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemIncludeInContext.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemIncludeInContext.java
@@ -77,7 +77,7 @@ public class PopupMenuItemIncludeInContext extends PopupMenuItemSiteNodeContaine
         }
 
         Context uiSharedContext =
-                View.getSingleton().getSessionDialog().getUISharedContext(context.getIndex());
+                View.getSingleton().getSessionDialog().getUISharedContext(context.getId());
         uiSharedContext.addIncludeInContextRegex(url);
     }
 
@@ -94,7 +94,7 @@ public class PopupMenuItemIncludeInContext extends PopupMenuItemSiteNodeContaine
         // Show the session dialog without recreating UI Shared contexts
         View.getSingleton()
                 .showSessionDialog(
-                        session, ContextIncludePanel.getPanelName(context.getIndex()), false);
+                        session, ContextIncludePanel.getPanelName(context.getId()), false);
     }
 
     private void recreateUISharedContexts(Session session) {


### PR DESCRIPTION
Also deprecate AbstractContextPropertiesPanel.getContextIndex() and implement AbstractContextPropertiesPanel.getContextId()

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>