### PR TITLE
Coverity Fixes

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderHtmlFormParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderHtmlFormParser.java
@@ -333,7 +333,7 @@ public class SpiderHtmlFormParser extends SpiderParser {
 
         // Get its value(s)
         List<String> values = field.getValues();
-        String defaultValue;
+        String defaultValue = null;
 
         // If the field has a value attribute present(Predefined value)
         // Should store the value being submitted to be passed to the ValueGenerator
@@ -347,25 +347,27 @@ public class SpiderHtmlFormParser extends SpiderParser {
 
         // If there are no values at all or only an empty value
         if (values.isEmpty() || (values.size() == 1 && values.get(0).isEmpty())) {
-            defaultValue = DEFAULT_EMPTY_VALUE;
 
             // Check if we can use predefined values
             Collection<String> predefValues = field.getPredefinedValues();
             if (!predefValues.isEmpty()) {
                 // Store those predefined values in a list for the DefaultValueGenerator
                 definedValues.addAll(predefValues);
-                // Try first elements
-                Iterator<String> iterator = predefValues.iterator();
-                defaultValue = iterator.next();
-
-                // If there are more values, don't use the first, as it usually is a "No select"
-                // item
-                if (iterator.hasNext()) {
+                if (defaultValue == null) {
+                    // Try first elements
+                    Iterator<String> iterator = predefValues.iterator();
                     defaultValue = iterator.next();
+
+                    // If there are more values, don't use the first, as it usually is a "No select"
+                    // item
+                    if (iterator.hasNext()) {
+                        defaultValue = iterator.next();
+                    }
                 }
             }
+            defaultValue = defaultValue == null ? DEFAULT_EMPTY_VALUE : defaultValue;
 
-        } else {
+        } else if (defaultValue == null) {
             defaultValue = values.get(0);
         }
 

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlFormParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlFormParserUnitTest.java
@@ -1083,7 +1083,7 @@ public class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
         boolean completelyParsed = htmlParser.parseResource(msg, source, BASE_DEPTH);
         // Then
         assertThat(completelyParsed, is(equalTo(false)));
-        assertThat(listener.getNumberOfResourcesFound(), is(equalTo(9)));
+        assertThat(listener.getNumberOfResourcesFound(), is(equalTo(8)));
         assertThat(
                 listener.getUrlsFound(),
                 contains(
@@ -1093,8 +1093,7 @@ public class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
                         "http://example.org/html5/misc?_color=%23ffffff&_email=foo-bar%40example.com&_tel=9999999999&_url=http%3A%2F%2Fwww.example.com&submit=Submit",
                         "http://example.org/unknown?_unknown&submit=Submit",
                         "http://example.org/selects?_select-one-option=first-option&_select-selected-option=selected-option&_select-two-options=last-option&submit=Submit",
-                        "http://example.org/radio?_radio=second-radio&submit=Submit",
-                        "http://example.org/checkbox?_checkbox=second-checkbox&submit=Submit",
+                        "http://example.org/checkbox?_checkbox=first-checkbox&submit=Submit",
                         "http://example.org/html5/date-time?"
                                 + params(
                                         param("_date", formattedDate("yyyy-MM-dd", date)),
@@ -1125,7 +1124,7 @@ public class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
         boolean completelyParsed = htmlParser.parseResource(msg, source, BASE_DEPTH);
         // Then
         assertThat(completelyParsed, is(equalTo(false)));
-        assertThat(listener.getNumberOfResourcesFound(), is(equalTo(9)));
+        assertThat(listener.getNumberOfResourcesFound(), is(equalTo(8)));
         assertThat(
                 listener.getResourcesFound(),
                 contains(
@@ -1159,13 +1158,8 @@ public class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
                         postResource(
                                 msg,
                                 1,
-                                "http://example.org/radio",
-                                "_radio=second-radio&submit=Submit"),
-                        postResource(
-                                msg,
-                                1,
                                 "http://example.org/checkbox",
-                                "_checkbox=second-checkbox&submit=Submit"),
+                                "_checkbox=first-checkbox&submit=Submit"),
                         postResource(
                                 msg,
                                 1,
@@ -1266,7 +1260,7 @@ public class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
                                         "http://example.com/",
                                         "http://example.org/post",
                                         "gender",
-                                        "f",
+                                        "m",
                                         list(("m,f")),
                                         attributes(
                                                 attribute("name", "gender"),

--- a/zap/src/test/resources/org/zaproxy/zap/spider/parser/htmlform/FormNoDefaultValues.html
+++ b/zap/src/test/resources/org/zaproxy/zap/spider/parser/htmlform/FormNoDefaultValues.html
@@ -60,12 +60,6 @@
 <input name="submit" type="submit" value="Submit" />
 </form>
 
-<form action="http://example.org/radio" method="%%METHOD%%">
-<input name="_radio" type="radio" value="first-radio" />
-<input name="_radio" type="radio" value="second-radio" />
-<input name="submit" type="submit" value="Submit" />
-</form>
-
 <form action="http://example.org/checkbox" method="%%METHOD%%">
 <input name="_checkbox" type="checkbox" value="first-checkbox" />
 <input name="_checkbox" type="checkbox" value="second-checkbox" />


### PR DESCRIPTION
* SpiderHtmlFormParser - CID 157242 Unused variable. Don't assign defaultValue in getDefaultTestValue` if it already has a value.
* SpiderHtmlFormParserUnitTest - Updated to account for new changes.
* FormNoDefaultValues.html - Removed radio buttons as one is always selected (representing a default value).

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>