### PR TITLE
Fix Coverity scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+install: if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then ./gradlew assemble ; fi
 
 jdk:
   - oraclejdk8


### PR DESCRIPTION
Don't assemble during installation phase when building for Coverity
scan, to compile the classes under Coverity watch.