### PR TITLE
Add JaCoCo plugin

### DIFF
--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -4,6 +4,7 @@ import org.zaproxy.zap.tasks.GradleBuildWithGitRepos
 
 plugins {
     `java-library`
+    jacoco
     org.zaproxy.zap.distributions
     org.zaproxy.zap.installers
     org.zaproxy.zap.`github-releases`
@@ -21,6 +22,10 @@ val distDir = file("src/main/dist/")
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+jacoco {
+    toolVersion = "0.8.4"
 }
 
 dependencies {


### PR DESCRIPTION
Add JaCoCo plugin to generate code coverage report, with the task
`:zap:jacocoTestReport` (after running the tests `:zap:test`).