### PR TITLE
Improve error handling when creating scan policies

### DIFF
--- a/zap/src/test/java/org/zaproxy/zap/WithConfigsTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/WithConfigsTest.java
@@ -37,6 +37,7 @@ import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.testutils.TestUtils;
 import org.zaproxy.zap.utils.I18N;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 @RunWith(MockitoJUnitRunner.class)
 public abstract class WithConfigsTest extends TestUtils {
@@ -80,5 +81,6 @@ public abstract class WithConfigsTest extends TestUtils {
         given(i18n.getLocal()).willReturn(Locale.getDefault());
         Constant.messages = i18n;
         Control.initSingletonForTesting(Model.getSingleton());
+        Model.getSingleton().getOptionsParam().load(new ZapXmlConfiguration());
     }
 }

--- a/zap/src/test/java/org/zaproxy/zap/extension/ascan/ScanPolicyUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/ascan/ScanPolicyUnitTest.java
@@ -1,0 +1,86 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascan;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.parosproxy.paros.core.scanner.Plugin;
+import org.zaproxy.zap.WithConfigsTest;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link ScanPolicy}. */
+public class ScanPolicyUnitTest extends WithConfigsTest {
+
+    private static final String DEFAULT_SCANNER_LEVEL_KEY = "scanner.level";
+    private static final String DEFAULT_SCANNER_STRENGTH_KEY = "scanner.strength";
+
+    @Before
+    public void setup() throws Exception {
+        setUpZap();
+    }
+
+    @Test
+    public void shouldUseValidDefaultScannerLevelFromConfig() throws Exception {
+        // Given
+        ZapXmlConfiguration conf = new ZapXmlConfiguration();
+        conf.setProperty(DEFAULT_SCANNER_LEVEL_KEY, Plugin.AlertThreshold.HIGH.name());
+        // When
+        ScanPolicy scanPolicy = new ScanPolicy(conf);
+        // Then
+        assertThat(scanPolicy.getDefaultThreshold(), is(equalTo(Plugin.AlertThreshold.HIGH)));
+    }
+
+    @Test
+    public void shouldUseMediumIfInvalidDefaultScannerLevelFromConfig() throws Exception {
+        // Given
+        ZapXmlConfiguration conf = new ZapXmlConfiguration();
+        conf.setProperty(DEFAULT_SCANNER_LEVEL_KEY, "NotValid");
+        // When
+        ScanPolicy scanPolicy = new ScanPolicy(conf);
+        // Then
+        assertThat(scanPolicy.getDefaultThreshold(), is(equalTo(Plugin.AlertThreshold.MEDIUM)));
+    }
+
+    @Test
+    public void shouldUseValidDefaultScannerStrengthFromConfig() throws Exception {
+        // Given
+        ZapXmlConfiguration conf = new ZapXmlConfiguration();
+        conf.setProperty(DEFAULT_SCANNER_STRENGTH_KEY, Plugin.AttackStrength.LOW.name());
+        // When
+        ScanPolicy scanPolicy = new ScanPolicy(conf);
+        // Then
+        assertThat(scanPolicy.getDefaultStrength(), is(equalTo(Plugin.AttackStrength.LOW)));
+    }
+
+    @Test
+    public void shouldUseMediumIfInvalidDefaultScannerStrengthFromConfig() throws Exception {
+        // Given
+        ZapXmlConfiguration conf = new ZapXmlConfiguration();
+        conf.setProperty(DEFAULT_SCANNER_STRENGTH_KEY, "NotValid");
+        // When
+        ScanPolicy scanPolicy = new ScanPolicy(conf);
+        // Then
+        assertThat(scanPolicy.getDefaultStrength(), is(equalTo(Plugin.AttackStrength.MEDIUM)));
+    }
+}


### PR DESCRIPTION
Take into account possible errors when reading the attack strength and
alert threshold from the configuration file, which could prevent showing
the active scan dialogue or the edition of the scan policy.

---
From OWASP ZAP User Group: https://groups.google.com/d/topic/zaproxy-users/LaNtsIhOk-8/discussion