### PR TITLE
More LGTM Fixes

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Analyser.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Analyser.java
@@ -41,6 +41,7 @@
 // ZAP: 2017/12/29 Rely on HostProcess to validate the redirections.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2019/07/26 Remove null check in sendAndReceive(HttpMessage). (LGTM Issue)
 package org.parosproxy.paros.core.scanner;
 
 import java.io.IOException;
@@ -516,11 +517,7 @@ public class Analyser {
 
         httpSender.sendAndReceive(msg, parent.getRedirectRequestConfig());
         requestCount++;
-
-        // ZAP: Notify parent
-        if (parent != null) {
-            parent.notifyNewMessage(msg);
-        }
+        parent.notifyNewMessage(msg);
     }
 
     public int getDelayInMs() {

--- a/zap/src/main/java/org/parosproxy/paros/extension/ExtensionLoader.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/ExtensionLoader.java
@@ -83,6 +83,7 @@
 // ZAP: 2019/03/15 Issue 3578: Added Helper options for Import menu
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 019/07/25: Relocate null check to be earlier in hookScannerHook(scan) [LGTM issue].
 package org.parosproxy.paros.extension;
 
 import java.awt.Component;
@@ -495,13 +496,14 @@ public class ExtensionLoader {
         Iterator<ExtensionHook> iter = extensionHooks.values().iterator();
         while (iter.hasNext()) {
             ExtensionHook hook = iter.next();
+            if (hook == null) {
+                continue;
+            }
             List<ScannerHook> scannerHookList = hook.getScannerHookList();
 
             for (ScannerHook scannerHook : scannerHookList) {
                 try {
-                    if (hook != null) {
-                        scan.addScannerHook(scannerHook);
-                    }
+                    scan.addScannerHook(scannerHook);
 
                 } catch (Exception e) {
                     logger.error(e.getMessage(), e);

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/impl/http/HttpBreakpointMessage.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/impl/http/HttpBreakpointMessage.java
@@ -136,8 +136,9 @@ public class HttpBreakpointMessage extends AbstractBreakPointMessage {
                     }
                 }
 
-                String src = null;
+                String src;
                 switch (location) {
+                    default:
                     case url:
                         src = uri;
                         break;

--- a/zap/src/main/java/org/zaproxy/zap/view/StatusUI.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/StatusUI.java
@@ -45,7 +45,7 @@ public class StatusUI implements Comparable<StatusUI> {
         }
 
         if (stringRepresentation == null || stringRepresentation.isEmpty()) {
-            this.stringRepresentation = status.toString();
+            this.stringRepresentation = this.status.toString();
         } else {
             this.stringRepresentation = stringRepresentation;
         }


### PR DESCRIPTION
ExtensionLoader - Relocate hook null check earlier in hookScannerHook(Scanner). LGTM Rule: Dereferenced variable may be null. Specific finding: https://lgtm.com/projects/g/zaproxy/zaproxy/snapshot/6a2d4338c766f041ed0773d398eb609bc0319312/files/zap/src/main/java/org/parosproxy/paros/extension/ExtensionLoader.java?sort=name&dir=ASC&mode=heatmap#x89e8c7fad7ce7e45:1

Analyser - Remove parent null check in sendAndReceive(HttpMessage). LGTM Rule: Dereferenced variable may be null. Specific finding: https://lgtm.com/projects/g/zaproxy/zaproxy/snapshot/6a2d4338c766f041ed0773d398eb609bc0319312/files/zap/src/main/java/org/parosproxy/paros/core/scanner/Analyser.java?sort=name&dir=ASC&mode=heatmap#x4e1d1877edf3b8eb:1

HttpBreakpointMessage - Modify match(Message, boolean, boolean) remove null assignment on src and add default case which falls through to case url. LGTM Rule: Dereferenced variable may be null. Specific findings: https://lgtm.com/projects/g/zaproxy/zaproxy/snapshot/6a2d4338c766f041ed0773d398eb609bc0319312/files/zap/src/main/java/org/zaproxy/zap/extension/brk/impl/http/HttpBreakpointMessage.java?sort=name&dir=ASC&mode=heatmap#xf6c79c952cfcbf71:1 and https://lgtm.com/projects/g/zaproxy/zaproxy/snapshot/6a2d4338c766f041ed0773d398eb609bc0319312/files/zap/src/main/java/org/zaproxy/zap/extension/brk/impl/http/HttpBreakpointMessage.java?sort=name&dir=ASC&mode=heatmap#x31c7ce8d1a9199c6:1

StatusUI - Modify StatusUI(AddOn.Status, String) to use this.status which won't be null instead of the inbound status which might be null. LGTM Rule: Dereferenced variable may be null. Specific findings: https://lgtm.com/projects/g/zaproxy/zaproxy/snapshot/6a2d4338c766f041ed0773d398eb609bc0319312/files/zap/src/main/java/org/zaproxy/zap/view/StatusUI.java#xc78703fd791c978a:1

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>