### PR TITLE
Encode anti-CSRF tokens in auth requests

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodType.java
@@ -404,7 +404,9 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
                 for (AntiCsrfToken antiCsrfToken : freshAcsrfTokens) {
                     oldAcsrfTokenValue = parameters.get(antiCsrfToken.getName());
                     replacedPostData =
-                            postRequestBody.replace(oldAcsrfTokenValue, antiCsrfToken.getValue());
+                            postRequestBody.replace(
+                                    oldAcsrfTokenValue,
+                                    paramEncoder.apply(antiCsrfToken.getValue()));
 
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug(


### PR DESCRIPTION
Change `PostBasedAuthenticationMethod` to encode the value of the
anti-CSRF token when replacing it in the POST data.

Fix #5490 - Anti-CSRF tokens not encoded in authentication requests