### PR TITLE
Remove null body checks

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/authentication/AuthenticationMethod.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/AuthenticationMethod.java
@@ -170,7 +170,7 @@ public abstract class AuthenticationMethod {
      * @return true, if is authenticated or no indicators have been set, and false otherwise
      */
     public boolean isAuthenticated(HttpMessage msg) {
-        if (msg == null || msg.getResponseBody() == null) {
+        if (msg == null) {
             return false;
         }
         // Assume logged in if nothing was set up

--- a/zap/src/main/java/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
@@ -338,7 +338,6 @@ public class ExtensionForcedUser extends ExtensionAdaptor
     @Override
     public void onHttpRequestSend(HttpMessage msg, int initiator, HttpSender sender) {
         if (!forcedUserModeEnabled
-                || msg.getResponseBody() == null
                 || msg.getRequestHeader().isImage()
                 || (initiator == HttpSender.AUTHENTICATION_INITIATOR
                         || initiator == HttpSender.CHECK_FOR_UPDATES_INITIATOR)) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/image/ResponseImageView.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/image/ResponseImageView.java
@@ -141,7 +141,7 @@ public class ResponseImageView implements HttpPanelView, HttpPanelViewModelListe
         if (aMessage instanceof HttpMessage) {
             HttpMessage httpMessage = (HttpMessage) aMessage;
 
-            if (httpMessage.getResponseBody() == null) {
+            if (httpMessage.getResponseBody().length() == 0) {
                 return false;
             }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/largeresponse/LargeResponseUtil.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/largeresponse/LargeResponseUtil.java
@@ -43,7 +43,7 @@ public class LargeResponseUtil {
     public static boolean isLargeResponse(Message aMessage) {
         if (aMessage instanceof HttpMessage) {
             HttpMessage httpMessage = (HttpMessage) aMessage;
-            if (httpMessage.getResponseBody() == null || minContentLength <= 0) {
+            if (minContentLength <= 0) {
                 return false;
             }
 


### PR DESCRIPTION
The HTTP request/response bodies are never null.