### PR TITLE
Fix typo in API endpoint description

### DIFF
--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -546,7 +546,7 @@ autoupdate.api.view.marketplaceAddons = Return a list of all of the add-ons on t
 autoupdate.desc = Allows ZAP to check for updates
 autoupdate.name = Auto-update Extension
 
-break.api.action.addHttpBreakpoint = Adds a custom HTTP breakpont. The string is the string to match. Location may be one of: url, request_header, request_body, response_header or response_body. Match may be: contains or regex. Inverse (match) may be true or false. Lastly, ignorecase (when matching the string) may be true or false.  
+break.api.action.addHttpBreakpoint = Adds a custom HTTP breakpoint. The string is the string to match. Location may be one of: url, request_header, request_body, response_header or response_body. Match may be: contains or regex. Inverse (match) may be true or false. Lastly, ignorecase (when matching the string) may be true or false.  
 break.api.action.break = Controls the global break functionality. The type may be one of: http-all, http-request or http-response. The state may be true (for turning break on for the specified type) or false (for turning break off). Scope is not currently used.
 break.api.action.continue = Submits the currently intercepted message and unsets the global request/response break points
 break.api.action.drop = Drops the currently intercepted message


### PR DESCRIPTION
Fix typo in break API endpoint description.