### PR TITLE
Fix links to source files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ You can help translate the ZAP User Guide via the [Crowdin owasp-zap-help](https
 For information about the ZAP Evangelists and how to join up see the [ZAP Evangelists wiki page](https://github.com/zaproxy/zaproxy/wiki/ZapEvangelists)
 
 ## Help Improve the Documentation
-The source for the ZAP [User Guide](https://github.com/zaproxy/zap-core-help/wiki) is underneath the zap-core-tree repo [src/help/zaphelp/contents](https://github.com/zaproxy/zap-core-help/tree/master/src/help/zaphelp/contents) directory.
+The source for the ZAP [User Guide](https://github.com/zaproxy/zap-core-help/wiki) is underneath the zap-core-tree repo [addOns/help/src/main/javahelp/contents](https://github.com/zaproxy/zap-core-help/tree/master/addOns/help/src/main/javahelp/contents) directory.
 
 The Java Help included with ZAP and the online version are both generated from these HTML pages. Send Pull Requests to help us improve it.
 

--- a/zap/src/main/dist/scripts/templates/httpsender/AddZapHeader.js
+++ b/zap/src/main/dist/scripts/templates/httpsender/AddZapHeader.js
@@ -5,7 +5,7 @@
 // Right click the script in the Scripts tree and select "enable"  
 
 // For the latest list of 'initiator' values see the HttpSender class:
-// https://github.com/zaproxy/zaproxy/blob/master/src/org/parosproxy/paros/network/HttpSender.java
+// https://github.com/zaproxy/zaproxy/blob/master/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
 // 'helper' just has one method at the moment: helper.getHttpSender() which returns the HttpSender 
 // instance used to send the request.
 

--- a/zap/src/main/dist/scripts/templates/httpsender/HttpSender default template.js
+++ b/zap/src/main/dist/scripts/templates/httpsender/HttpSender default template.js
@@ -16,7 +16,7 @@
 // 		9	ACCESS_CONTROL_SCANNER_INITIATOR
 // 		10	AJAX_SPIDER_INITIATOR
 // For the latest list of values see the HttpSender class:
-// https://github.com/zaproxy/zaproxy/blob/master/src/org/parosproxy/paros/network/HttpSender.java
+// https://github.com/zaproxy/zaproxy/blob/master/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
 // 'helper' just has one method at the moment: helper.getHttpSender() which returns the HttpSender 
 // instance used to send the request.
 //

--- a/zap/src/main/dist/scripts/templates/variant/Input Vector default template.js
+++ b/zap/src/main/dist/scripts/templates/variant/Input Vector default template.js
@@ -6,7 +6,7 @@
 
 // The helper parameter leveraged within this variant provides access to the methods
 // in VariantCustom 
-// https://github.com/zaproxy/zaproxy/blob/develop/src/org/parosproxy/paros/core/scanner/VariantCustom.java
+// https://github.com/zaproxy/zaproxy/blob/master/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantCustom.java
 
 var B64STATE = 'b64';
 var paramStates = [];


### PR DESCRIPTION
Use the new dir path to source files in zaproxy and zap-core-help.

Related to #4949 and #5369.