### PR TITLE
Genericize WritableFileChooser i18n Strings

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/view/widgets/WritableFileChooser.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/widgets/WritableFileChooser.java
@@ -54,9 +54,9 @@ public class WritableFileChooser extends JFileChooser {
                     JOptionPane.showConfirmDialog(
                             this,
                             Constant.messages.getString(
-                                    "report.write.diskspace.warning.dialog.message"),
+                                    "writable.file.chooser.write.diskspace.warning.dialog.message"),
                             Constant.messages.getString(
-                                    "report.write.diskspace.warning.dialog.title"),
+                                    "writable.file.chooser.write.diskspace.warning.dialog.title"),
                             JOptionPane.YES_NO_OPTION);
             if (result != JOptionPane.YES_OPTION) {
                 return;
@@ -64,7 +64,7 @@ public class WritableFileChooser extends JFileChooser {
         }
         if (!Files.isWritable(selectedFile.getParentFile().toPath())) {
             warnNotWritable(
-                    "report.write.permission.dir.dialog.message",
+                    "writable.file.chooser.write.permission.dir.dialog.message",
                     selectedFile.getParentFile().getAbsolutePath());
 
             return;
@@ -72,7 +72,7 @@ public class WritableFileChooser extends JFileChooser {
         if (fileExists) {
             if (!Files.isWritable(selectedFile.toPath())) {
                 warnNotWritable(
-                        "report.write.permission.file.dialog.message",
+                        "writable.file.chooser.write.permission.file.dialog.message",
                         selectedFile.getAbsolutePath());
                 return;
             }
@@ -80,8 +80,10 @@ public class WritableFileChooser extends JFileChooser {
             int result =
                     JOptionPane.showConfirmDialog(
                             this,
-                            Constant.messages.getString("report.write.overwrite.dialog.message"),
-                            Constant.messages.getString("report.write.overwrite.dialog.title"),
+                            Constant.messages.getString(
+                                    "writable.file.chooser.write.overwrite.dialog.message"),
+                            Constant.messages.getString(
+                                    "writable.file.chooser.write.overwrite.dialog.title"),
                             JOptionPane.YES_NO_OPTION);
             if (result == JOptionPane.NO_OPTION || result == JOptionPane.CLOSED_OPTION) {
                 return;
@@ -108,6 +110,6 @@ public class WritableFileChooser extends JFileChooser {
     private void warnNotWritable(String i18nKeyMessage, String path) {
         showErrorDialog(
                 Constant.messages.getString(i18nKeyMessage, path),
-                Constant.messages.getString("report.write.permission.dialog.title"));
+                Constant.messages.getString("writable.file.chooser.write.permission.dialog.title"));
     }
 }

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -1990,14 +1990,7 @@ report.complete.warning=Scanning report generated.\r\nPlease browse the file at:
 report.name = Report Extension
 report.unexpected.error=Failed to write to file, see log for detail
 report.unknown.error=Failed to write to file {0}, see log for detail
-report.write.overwrite.dialog.title=Existing File
-report.write.overwrite.dialog.message= The selected file already exists. Do you want to replace it?
-report.write.permission.dialog.title=Permissions Failure
-report.write.diskspace.warning.dialog.title=Low Disk Space
-report.write.diskspace.warning.dialog.message=There is less than 5MB available, would you like to continue the operation?
 report.write.dialog.message=File creation may have failed or is not complete.
-report.write.permission.dir.dialog.message=Directory not writable:\n{0}\nPlease select a different location.
-report.write.permission.file.dialog.message=File not writable:\n{0}\nPlease select a different location.
 
 ruleConfig.api.action.resetRuleConfigValue		= Reset the specified rule configuration, which must already exist
 ruleConfig.api.action.resetAllRuleConfigValues	= Reset all of the rule configurations
@@ -2543,6 +2536,14 @@ Safe mode: will not allow you to do anything potentially dangerous<br>\
 Protected mode: will only allow you to do potentially dangerous things on items in Scope<br>\
 Standard mode: will allow you to do potentially dangerous things on anything<br>\
 ATTACK mode: will active scan new nodes that are in scope as they are discovered</html>
+
+writable.file.chooser.write.diskspace.warning.dialog.message=There is less than 5MB available, would you like to continue the operation?
+writable.file.chooser.write.diskspace.warning.dialog.title=Low Disk Space
+writable.file.chooser.write.overwrite.dialog.message=The selected file already exists. Do you want to replace it?
+writable.file.chooser.write.overwrite.dialog.title=Existing File
+writable.file.chooser.write.permission.dialog.title=Permissions Failure
+writable.file.chooser.write.permission.dir.dialog.message=Directory not writable:\n{0}\nPlease select a different location.
+writable.file.chooser.write.permission.file.dialog.message=File not writable:\n{0}\nPlease select a different location.
 
 messagelocationspanel.add.location.warning.locations.overlap = Selected location not valid.\nThe selected location overlaps an already added location.
 messagelocationspanel.add.location.tooltip = To add a location you must select it first in the message.


### PR DESCRIPTION
Messages.properties > Tweak key/value pairs. (Ensured none of the removed content was used elsewhere in Zap repos).
WritableFileCHooser > Tweaked to align, and spotlessApply done.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>