### PR TITLE
Fix ByteBuilder.toString()

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/utils/ByteBuilder.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/ByteBuilder.java
@@ -87,7 +87,7 @@ public class ByteBuilder {
 
     @Override
     public String toString() {
-        return new String(array);
+        return new String(array, 0, size);
     }
 
     // all append() methods return this so we can chain calls together, of course :)

--- a/zap/src/test/java/org/zaproxy/zap/utils/ByteBuilderUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/ByteBuilderUnitTest.java
@@ -102,15 +102,14 @@ public class ByteBuilderUnitTest {
     }
 
     @Test
-    public void shouldHaveALengthOfGivenArray() {
+    public void shouldProduceStringFromContents() {
         // given
-        byteBuilder = new ByteBuilder(TEST_ARRAY);
+        byteBuilder = new ByteBuilder(new byte[] {65, 45, 90});
+        byteBuilder.ensureCapacity(50);
         // when
-        String size = byteBuilder.toString();
+        String string = byteBuilder.toString();
         // then
-        assertThat(
-                size.substring(0, TEST_ARRAY.length),
-                is(new String(TEST_ARRAY, 0, TEST_ARRAY.length)));
+        assertThat(string, is("A-Z"));
     }
 
     @Test
@@ -350,7 +349,7 @@ public class ByteBuilderUnitTest {
     }
 
     @Test
-    public void shouldAppendByteBuffer() {
+    public void shouldAppendByteBuilder() {
         // given
         byteBuilder = new ByteBuilder(TEST_ARRAY);
         // when


### PR DESCRIPTION
Create the String up to the current size not the whole capacity of the
array.
Update test accordingly, also, correct existing method name (appending
ByteBuilder not ByteBuffer).

---
Addresses https://github.com/zaproxy/zaproxy/pull/5429#issuecomment-515537946.