### PR TITLE
Ensure proxy auth credentials are set

### DIFF
--- a/zap/src/test/java/org/parosproxy/paros/network/HttpSenderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/network/HttpSenderUnitTest.java
@@ -1,0 +1,259 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.network;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.github.tomakehurst.wiremock.client.VerificationException;
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.matching.RequestPattern;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import com.github.tomakehurst.wiremock.verification.diff.Diff;
+import java.util.List;
+import org.apache.commons.httpclient.URI;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link HttpSender}. */
+public class HttpSenderUnitTest {
+
+    private static final String PROXY_RESPONSE = "Proxy Response";
+    private static final String SERVER_RESPONSE = "Server Response";
+
+    @Rule
+    public WireMockSequence proxy =
+            new WireMockSequence(defaultOptions().enableBrowserProxying(true));
+
+    @Rule public WireMockSequence server = new WireMockSequence(defaultOptions());
+
+    @Before
+    public void setup() {
+        server.stubFor(
+                any(anyUrl())
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withStatusMessage("OK")
+                                        .withBody(SERVER_RESPONSE)));
+    }
+
+    @Test
+    public void shouldProxyIfEnabled() throws Exception {
+        // Given
+        ConnectionParam options = createOptionsWithProxy("localhost", proxy.port());
+        options.setUseProxyChain(true);
+        HttpMessage message = createMessage("GET", "/");
+        HttpSender httpSender = new HttpSender(options, false, -1);
+        // When
+        httpSender.sendAndReceive(message);
+        // Then
+        proxy.verifyExactly(
+                getRequestedFor(urlMatching("/"))
+                        .withHeader("Host", matching("localhost:" + server.port())));
+        server.verifyExactly(
+                getRequestedFor(urlMatching("/"))
+                        .withHeader("Host", matching("localhost:" + server.port())));
+        assertThat(message.getResponseBody().toString(), is(equalTo(SERVER_RESPONSE)));
+    }
+
+    @Test
+    public void shouldNotProxyIfDisabled() throws Exception {
+        // Given
+        ConnectionParam options = createOptionsWithProxy("localhost", proxy.port());
+        options.setUseProxyChain(false);
+        HttpMessage message = createMessage("GET", "/");
+        HttpSender httpSender = new HttpSender(options, false, -1);
+        // When
+        httpSender.sendAndReceive(message);
+        // Then
+        proxy.verifyNoRequests();
+        server.verifyExactly(
+                getRequestedFor(urlMatching("/"))
+                        .withHeader("Host", matching("localhost:" + server.port())));
+        assertThat(message.getResponseBody().toString(), is(equalTo(SERVER_RESPONSE)));
+    }
+
+    @Test
+    public void shouldNotAuthenticateToProxyIfAuthDisabled() throws Exception {
+        // Given
+        proxy.stubFor(
+                get(urlMatching("/"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(407)
+                                        .withHeader("Proxy-Authenticate", "Basic realm=\"\"")
+                                        .withBody(PROXY_RESPONSE)));
+        ConnectionParam options = createOptionsWithProxy("localhost", proxy.port());
+        options.setUseProxyChain(true);
+        options.setUseProxyChainAuth(false);
+        HttpMessage message = createMessage("GET", "/");
+        HttpSender httpSender = new HttpSender(options, false, -1);
+        // When
+        httpSender.sendAndReceive(message);
+        // Then
+        proxy.verifyExactly(
+                getRequestedFor(urlMatching("/"))
+                        .withoutHeader("Proxy-Authorization")
+                        .withHeader("Host", matching("localhost:" + server.port())));
+        server.verifyNoRequests();
+        assertThat(message.getResponseBody().toString(), is(equalTo(PROXY_RESPONSE)));
+    }
+
+    @Test
+    public void shouldBasicAuthenticateToProxy() throws Exception {
+        // Given
+        String authRealm = "SomeRealm";
+        proxy.stubFor(
+                get(urlMatching("/"))
+                        .inScenario("Basic Proxy Auth")
+                        .whenScenarioStateIs(Scenario.STARTED)
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(407)
+                                        .withHeader(
+                                                "Proxy-Authenticate",
+                                                "Basic realm=\"" + authRealm + "\""))
+                        .willSetStateTo("Challenged"));
+
+        ConnectionParam options = createOptionsWithProxy("localhost", proxy.port());
+        options.setUseProxyChain(true);
+        options.setUseProxyChainAuth(true);
+        options.setProxyChainRealm(authRealm);
+        HttpMessage message = createMessage("GET", "/");
+        HttpSender httpSender = new HttpSender(options, false, -1);
+        // When
+        httpSender.sendAndReceive(message);
+        // Then
+        proxy.verifyExactly(
+                getRequestedFor(urlMatching("/"))
+                        .withoutHeader("Proxy-Authorization")
+                        .withHeader("Host", matching("localhost:" + server.port())),
+                getRequestedFor(urlMatching("/"))
+                        .withHeader(
+                                "Proxy-Authorization", matching("Basic dXNlcm5hbWU6cGFzc3dvcmQ="))
+                        .withHeader("Host", matching("localhost:" + server.port())));
+        server.verifyExactly(
+                getRequestedFor(urlMatching("/"))
+                        .withHeader("Host", matching("localhost:" + server.port())));
+        assertThat(message.getResponseBody().toString(), is(equalTo(SERVER_RESPONSE)));
+    }
+
+    @Test
+    public void shouldNotBasicAuthenticateToProxyIfRealmMismatch() throws Exception {
+        // Given
+        proxy.stubFor(
+                get(urlMatching("/"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(407)
+                                        .withHeader(
+                                                "Proxy-Authenticate", "Basic realm=\"SomeRealm\"")
+                                        .withBody(PROXY_RESPONSE)));
+        ConnectionParam options = createOptionsWithProxy("localhost", proxy.port());
+        options.setUseProxyChain(true);
+        options.setUseProxyChainAuth(true);
+        options.setProxyChainRealm("NotSomeRealm");
+        HttpMessage message = createMessage("GET", "/");
+        HttpSender httpSender = new HttpSender(options, false, -1);
+        // When
+        httpSender.sendAndReceive(message);
+        // Then
+        proxy.verifyExactly(
+                getRequestedFor(urlMatching("/"))
+                        .withoutHeader("Proxy-Authorization")
+                        .withHeader("Host", matching("localhost:" + server.port())));
+        server.verifyNoRequests();
+        assertThat(message.getResponseBody().toString(), is(equalTo(PROXY_RESPONSE)));
+    }
+
+    private HttpMessage createMessage(String method, String path) throws Exception {
+        URI uri = new URI("http://localhost:" + server.port() + path, true);
+        HttpRequestHeader requestHeader = new HttpRequestHeader(method, uri, "HTTP/1.1");
+        return new HttpMessage(requestHeader);
+    }
+
+    private static ConnectionParam createOptionsWithProxy(String address, int port) {
+        ConnectionParam options = createOptions();
+        options.setProxyChainName(address);
+        options.setProxyChainPort(port);
+        options.setProxyChainUserName("username");
+        options.setProxyChainPassword("password");
+        return options;
+    }
+
+    private static ConnectionParam createOptions() {
+        ConnectionParam options = new ConnectionParam();
+        options.load(new ZapXmlConfiguration());
+        return options;
+    }
+
+    private static WireMockConfiguration defaultOptions() {
+        return options()
+                .dynamicPort()
+                .useChunkedTransferEncoding(Options.ChunkedEncodingPolicy.NEVER);
+    }
+
+    private static class WireMockSequence extends WireMockRule {
+
+        public WireMockSequence(WireMockConfiguration options) {
+            super(options);
+        }
+
+        public void verifyNoRequests() {
+            List<LoggedRequest> requests =
+                    findRequestsMatching(RequestPattern.everything()).getRequests();
+            verifyRequestCount(requests, 0);
+        }
+
+        public void verifyExactly(RequestPatternBuilder... requestPatternBuilders) {
+            List<LoggedRequest> requests =
+                    findRequestsMatching(RequestPattern.everything()).getRequests();
+            verifyRequestCount(requests, requestPatternBuilders.length);
+            int i = 0;
+            for (LoggedRequest request : requests) {
+                RequestPattern requestPattern = requestPatternBuilders[i].build();
+                if (!requestPattern.match(request).isExactMatch()) {
+                    Diff diff = new Diff(requestPattern, request);
+                    throw VerificationException.forUnmatchedRequestPattern(diff);
+                }
+                i++;
+            }
+        }
+
+        private void verifyRequestCount(List<LoggedRequest> requests, int expected) {
+            if (requests.size() != expected) {
+                throw new VerificationException(
+                        String.format(
+                                "Expected %s request(s) but received %d",
+                                expected, requests.size()));
+            }
+        }
+    }
+}

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -77,9 +77,11 @@ dependencies {
         setTransitive(false)
     }
 
+    testImplementation("com.github.tomakehurst:wiremock-jre8:2.24.1")
     testImplementation("junit:junit:4.11")
     testImplementation("org.hamcrest:hamcrest-all:1.3")
     testImplementation("org.mockito:mockito-all:1.10.8")
+    testImplementation("org.slf4j:slf4j-log4j12:1.7.28")
 
     testRuntimeOnly(files(distDir))
 }


### PR DESCRIPTION
Change `HttpSender` to reinstate the proxy authentication credentials
when the HTTP state is changed to ensure they are available when
required.

Fix #5518 - ZAP might not use outgoing proxy authentication credentials