### PR TITLE
Fix failing tests on Windows

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/utils/ByteBuilder.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/ByteBuilder.java
@@ -240,13 +240,21 @@ public class ByteBuilder {
     }
 
     public ByteBuilder append(String value) {
-        byte[] b = value.getBytes(Charset.defaultCharset());
+        return append(value, Charset.defaultCharset());
+    }
+
+    public ByteBuilder append(String value, Charset charset) {
+        byte[] b = value.getBytes(charset);
         testAddition(b.length + 4);
         return this.append(b.length).append(b);
     }
 
     public ByteBuilder append(StringBuffer value) {
-        byte[] b = value.toString().getBytes(Charset.defaultCharset());
+        return append(value, Charset.defaultCharset());
+    }
+
+    public ByteBuilder append(StringBuffer value, Charset charset) {
+        byte[] b = value.toString().getBytes(charset);
         testAddition(b.length + 4);
         return this.append(b.length).append(b);
     }

--- a/zap/src/test/java/org/parosproxy/paros/extension/report/ReportGeneratorUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/extension/report/ReportGeneratorUnitTest.java
@@ -38,6 +38,8 @@ import org.zaproxy.zap.testutils.TestUtils;
 /** Unit test for {@link ReportGenerator}. */
 public class ReportGeneratorUnitTest extends TestUtils {
 
+    private static final String NEWLINE = System.getProperty("line.separator");
+
     @ClassRule public static TemporaryFolder tempDir = new TemporaryFolder();
 
     @Test
@@ -53,7 +55,7 @@ public class ReportGeneratorUnitTest extends TestUtils {
     @Test
     public void shouldWriteReportWithWellformedXml() throws Exception {
         // Given
-        String data = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><data>J/ψ → VP</data>\n";
+        String data = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><data>J/ψ → VP</data>" + NEWLINE;
         Path report = tempDir.newFile().toPath();
         // When
         ReportGenerator.stringToHtml(data, identityXsl(), report.toString());

--- a/zap/src/test/java/org/zaproxy/zap/control/AddOnUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/AddOnUnitTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -31,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Arrays;
@@ -419,6 +421,9 @@ public class AddOnUnitTest extends TestUtils {
     public void shouldNotBeValidAddOnIfPathIsNotReadable() throws Exception {
         // Given
         Path file = createAddOnFile("addon.zap", "alpha", "1");
+        assumeTrue(
+                "Test requires support for POSIX file attributes.",
+                Files.getFileStore(file).supportsFileAttributeView(PosixFileAttributeView.class));
         Set<PosixFilePermission> perms =
                 Files.readAttributes(file, PosixFileAttributes.class).permissions();
         perms.remove(PosixFilePermission.OWNER_READ);

--- a/zap/src/test/java/org/zaproxy/zap/utils/ByteBuilderUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/ByteBuilderUnitTest.java
@@ -22,6 +22,8 @@ package org.zaproxy.zap.utils;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -315,11 +317,11 @@ public class ByteBuilderUnitTest {
     }
 
     @Test
-    public void shouldAppendStringValue() {
+    public void shouldAppendStringValueWithGivenCharset() {
         // given
         byteBuilder = new ByteBuilder(TEST_ARRAY);
         // when
-        byteBuilder.append("FooBarBaz£$%^&*");
+        byteBuilder.append("FooBarBaz£$%^&*", StandardCharsets.UTF_8);
         byte[] toByteArray = byteBuilder.toByteArray();
         // then
         assertThat(
@@ -332,11 +334,22 @@ public class ByteBuilderUnitTest {
     }
 
     @Test
-    public void shouldAppendStringBuffer() {
+    public void shouldAppendStringValueWithDefaultCharsetByDefault() {
+        // Given
+        byteBuilder = new ByteBuilder();
+        String value = "FooBarBaz£$%^&*";
+        // When
+        byteBuilder.append(value);
+        // Then
+        assertThat(byteBuilder.toByteArray(), is(lengthAndBytesOf(value)));
+    }
+
+    @Test
+    public void shouldAppendStringBufferWithGivenCharset() {
         // given
         byteBuilder = new ByteBuilder(TEST_ARRAY);
         // when
-        byteBuilder.append(new StringBuffer("FooBarBaz£$%^&*"));
+        byteBuilder.append(new StringBuffer("FooBarBaz£$%^&*"), StandardCharsets.UTF_8);
         byte[] toByteArray = byteBuilder.toByteArray();
         // then
         assertThat(
@@ -346,6 +359,17 @@ public class ByteBuilderUnitTest {
                             1, 2, 3, 0, 0, 0, 16, 70, 111, 111, 66, 97, 114, 66, 97, 122, -62, -93,
                             36, 37, 94, 38, 42
                         }));
+    }
+
+    @Test
+    public void shouldAppendStringBufferWithDefaultCharsetByDefault() {
+        // given
+        byteBuilder = new ByteBuilder();
+        String value = "FooBarBaz£$%^&*";
+        // when
+        byteBuilder.append(new StringBuffer(value));
+        // then
+        assertThat(byteBuilder.toByteArray(), is(lengthAndBytesOf(value)));
     }
 
     @Test
@@ -379,5 +403,13 @@ public class ByteBuilderUnitTest {
         byte[] toByteArray = byteBuilder.toByteArray();
         // then
         assertThat(toByteArray, is(new byte[] {1, 2, 3, -106, 126, -21}));
+    }
+
+    private static byte[] lengthAndBytesOf(String value) {
+        byte[] bytes = value.getBytes(Charset.defaultCharset());
+        byte[] result = new byte[4 + bytes.length];
+        result[3] = (byte) bytes.length;
+        System.arraycopy(bytes, 0, result, 4, bytes.length);
+        return result;
     }
 }


### PR DESCRIPTION
Change test in `AddOnUnitTest` to check that the system supports POSIX
attributes before making the file unreadable.
Change `ReportGeneratorUnitTest` to use the system's line separator
instead of hardcoded newline (LF vs CRLF).
Change `ByteBuilder` tests that append `String`/`StringBuffer` to check
the bytes with correct/expected charset and with a custom one (UTF-8
which was the one already being tested by default for non-Windows).