### PR TITLE
Fix deadlocks on check for updates

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -1387,7 +1387,11 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
         if (getView() != null) {
             // Initialise the dialogue so that it gets notifications of
             // possible add-on changes and is also shown when needed
-            getAddOnsDialog();
+            try {
+                EventQueue.invokeAndWait(() -> getAddOnsDialog());
+            } catch (InvocationTargetException | InterruptedException e) {
+                logger.error("Failed to initialise the Manage Add-ons dialogue:", e);
+            }
         }
         try {
             ZapRelease rel = aoc.getZapRelease();

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
@@ -1194,7 +1194,7 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
         logger.debug("gotLatestData(AddOnCollection " + aoc);
 
         if (aoc != null) {
-            setLatestVersionInfo(aoc);
+            EventQueue.invokeLater(() -> setLatestVersionInfo(aoc));
         } else {
             View.getSingleton()
                     .showWarningDialog(this, Constant.messages.getString("cfu.check.failed"));


### PR DESCRIPTION
Initialise/update the Manage Add-ons dialogue in the EDT to avoid
deadlocks between the check for updates thread and the EDT.