### PR TITLE
PassiveScanner Default Methods

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanner.java
@@ -25,9 +25,9 @@ import org.parosproxy.paros.network.HttpMessage;
 
 public interface PassiveScanner {
 
-    void scanHttpRequestSend(HttpMessage msg, int id);
+    default void scanHttpRequestSend(HttpMessage msg, int id) {};
 
-    void scanHttpResponseReceive(HttpMessage msg, int id, Source source);
+    default void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {};
 
     void setParent(PassiveScanThread parent);
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
@@ -65,11 +65,6 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Ignore
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (this.getExtension() != null) {
             currentHRefId = id;

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/StatsPassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/StatsPassiveScanner.java
@@ -48,11 +48,6 @@ public class StatsPassiveScanner extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Ignore
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         try {
             String site = SessionStructure.getHostName(msg);


### PR DESCRIPTION
Create empty default methods for `scanHttpRequestSend(HttpMessage, int)` and  `scanHttpResponseReceive(HttpMessage, int)` so that scanners which often only scan request OR response, don't require an empty overridden method.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>