### PR TITLE
Issue 5334 Suppress Stack Trace - Corrupt Addon(s)

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
@@ -453,7 +453,12 @@ public class AddOn {
         try {
             return Optional.of(new AddOn(file));
         } catch (AddOn.InvalidAddOnException e) {
-            logger.warn("Invalid add-on: " + file.toString(), e);
+            String logMessage = "Invalid add-on: " + file.toString() + ".";
+            if (logger.isDebugEnabled() || Constant.isDevMode()) {
+                logger.warn(logMessage, e);
+            } else {
+                logger.warn(logMessage + " " + e.getMessage());
+            }
         } catch (Exception e) {
             logger.error("Failed to create an add-on from: " + file.toString(), e);
         }


### PR DESCRIPTION
This doesn't address the un-install issue, however, it does address the stack trace. With this change the stack is only included in the log if debug is enabled or running in dev mode (in case one of the devs is
trying to troubleshoot something).

Related to zaproxy/zaproxy#5334

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>