### PR TITLE
Allow add-ons to provide repo location

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
@@ -248,6 +248,7 @@ public class AddOn {
     private File file = null;
     private URL url = null;
     private URL info = null;
+    private URL repo;
     private long size = 0;
     private boolean hasZapAddOnEntry = false;
 
@@ -562,7 +563,8 @@ public class AddOn {
         this.notBeforeVersion = zapAddOnXml.getNotBeforeVersion();
         this.notFromVersion = zapAddOnXml.getNotFromVersion();
         this.dependencies = zapAddOnXml.getDependencies();
-        this.info = createInfoUrl(zapAddOnXml.getUrl());
+        this.info = createUrl(zapAddOnXml.getUrl());
+        this.repo = createUrl(zapAddOnXml.getRepo());
 
         this.ascanrules = zapAddOnXml.getAscanrules();
         this.extensions = zapAddOnXml.getExtensions();
@@ -621,18 +623,19 @@ public class AddOn {
         this.size = addOnData.getSize();
         this.notBeforeVersion = addOnData.getNotBeforeVersion();
         this.notFromVersion = addOnData.getNotFromVersion();
-        this.info = createInfoUrl(addOnData.getInfo());
+        this.info = createUrl(addOnData.getInfo());
+        this.repo = createUrl(addOnData.getRepo());
         this.hash = addOnData.getHash();
 
         loadManifestFile();
     }
 
-    private URL createInfoUrl(String url) {
+    private URL createUrl(String url) {
         if (url != null && !url.isEmpty()) {
             try {
                 return new URL(url);
             } catch (Exception e) {
-                logger.warn("Invalid info URL for add-on \"" + id + "\":", e);
+                logger.warn("Invalid URL for add-on \"" + id + "\": " + url, e);
             }
         }
         return null;
@@ -1607,6 +1610,16 @@ public class AddOn {
 
     public void setInfo(URL info) {
         this.info = info;
+    }
+
+    /**
+     * Gets the URL to the browsable repo.
+     *
+     * @return the URL to the repo, might be {@code null}.
+     * @since TODO add version
+     */
+    public URL getRepo() {
+        return repo;
     }
 
     public String getHash() {

--- a/zap/src/main/java/org/zaproxy/zap/control/BaseZapAddOnXmlData.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/BaseZapAddOnXmlData.java
@@ -48,6 +48,7 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
  *   <li>description;
  *   <li>author;
  *   <li>url;
+ *   <li>repo (URL of browsable repository);
  *   <li>changes;
  *   <li>not-before-version;
  *   <li>not-from-version;
@@ -103,6 +104,7 @@ public abstract class BaseZapAddOnXmlData {
     private static final String AUTHOR_ELEMENT = "author";
     private static final String URL_ELEMENT = "url";
     private static final String CHANGES_ELEMENT = "changes";
+    private static final String REPO_ELEMENT = "repo";
     private static final String NOT_BEFORE_VERSION_ELEMENT = "not-before-version";
     private static final String NOT_FROM_VERSION_ELEMENT = "not-from-version";
 
@@ -142,6 +144,7 @@ public abstract class BaseZapAddOnXmlData {
     private String author;
     private String url;
     private String changes;
+    private String repo;
 
     private Dependencies dependencies;
 
@@ -224,6 +227,7 @@ public abstract class BaseZapAddOnXmlData {
         author = zapAddOnXml.getString(AUTHOR_ELEMENT, "");
         url = zapAddOnXml.getString(URL_ELEMENT, "");
         changes = zapAddOnXml.getString(CHANGES_ELEMENT, "");
+        repo = zapAddOnXml.getString(REPO_ELEMENT, "");
 
         dependencies = readDependencies(zapAddOnXml, "zapaddon");
 
@@ -297,6 +301,16 @@ public abstract class BaseZapAddOnXmlData {
 
     public String getChanges() {
         return changes;
+    }
+
+    /**
+     * Gets the URL to the browsable repo.
+     *
+     * @return the URL to the repo, might be {@code null}.
+     * @since TODO add version
+     */
+    public String getRepo() {
+        return repo;
     }
 
     public String getUrl() {

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/AutoUpdateAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/AutoUpdateAPI.java
@@ -186,6 +186,7 @@ public class AutoUpdateAPI extends ApiImplementor {
         map.put("description", ao.getDescription());
         map.put("hash", ObjectUtils.toString(ao.getHash()));
         map.put("infoUrl", ObjectUtils.toString(ao.getInfo()));
+        map.put("repoUrl", ObjectUtils.toString(ao.getRepo()));
         map.put("sizeInBytes", String.valueOf(ao.getSize()));
         map.put("status", ao.getStatus().toString());
         map.put("url", ObjectUtils.toString(ao.getUrl()));

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
@@ -1223,6 +1223,8 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
         private final JEditorPane changesField;
         private final JLabel infoLabel;
         private final JXHyperlink infoField;
+        private final JLabel repoLabel;
+        private final JXHyperlink repoField;
         private final ZapLabel idField;
         private final JLabel authorLabel;
         private final ZapLabel authorField;
@@ -1287,6 +1289,10 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
             infoField = new JXHyperlink();
             infoLabel.setLabelFor(infoField);
 
+            repoLabel = new JLabel(Constant.messages.getString("cfu.table.header.repo"));
+            repoField = new JXHyperlink();
+            repoLabel.setLabelFor(repoField);
+
             JLabel idLabel = new JLabel(Constant.messages.getString("cfu.table.header.id"));
             idField = createZapLabelField(idLabel);
 
@@ -1318,6 +1324,7 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
                                             .addComponent(descLabel)
                                             .addComponent(changesLabel)
                                             .addComponent(infoLabel)
+                                            .addComponent(repoLabel)
                                             .addComponent(idLabel)
                                             .addComponent(authorLabel)
                                             .addComponent(dependenciesLabel)
@@ -1353,6 +1360,11 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
                                                     Short.MAX_VALUE)
                                             .addComponent(
                                                     infoField,
+                                                    0,
+                                                    GroupLayout.DEFAULT_SIZE,
+                                                    Short.MAX_VALUE)
+                                            .addComponent(
+                                                    repoField,
                                                     0,
                                                     GroupLayout.DEFAULT_SIZE,
                                                     Short.MAX_VALUE)
@@ -1415,6 +1427,10 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
                                             .addComponent(infoField))
                             .addGroup(
                                     layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                            .addComponent(repoLabel)
+                                            .addComponent(repoField))
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
                                             .addComponent(idLabel)
                                             .addComponent(idField))
                             .addGroup(
@@ -1461,15 +1477,8 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
             versionField.setText(addOn.getVersion().toString());
             setTextOrHide(descLabel, descField, addOn.getDescription());
             setTextOrHide(changesLabel, changesField, addOn.getChanges());
-            if (addOn.getInfo() != null) {
-                infoLabel.setVisible(true);
-                infoField.setURI(URI.create(addOn.getInfo().toString()));
-                infoField.setVisible(true);
-            } else {
-                infoLabel.setVisible(false);
-                infoField.setURI(null);
-                infoField.setVisible(false);
-            }
+            setUriOrHide(infoLabel, infoField, addOn.getInfo());
+            setUriOrHide(repoLabel, repoField, addOn.getRepo());
             idField.setText(addOn.getId());
             setTextOrHide(authorLabel, authorField, addOn.getAuthor());
             setTextOrHide(
@@ -1509,6 +1518,7 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
             descField.setText("");
             changesField.setText("");
             infoField.setText("");
+            repoField.setText("");
             idField.setText("");
             authorField.setText("");
             dependenciesField.setText("");
@@ -1531,6 +1541,13 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
         label.setVisible(visible);
         textComponent.setVisible(visible);
         textComponent.setText(text);
+    }
+
+    private static void setUriOrHide(JLabel label, JXHyperlink hyperlink, URL url) {
+        boolean visible = url != null;
+        label.setVisible(visible);
+        hyperlink.setVisible(visible);
+        hyperlink.setURI(visible ? URI.create(url.toString()) : null);
     }
 
     private static class DisableSelectionHighlighter extends AbstractHighlighter {

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -1010,6 +1010,7 @@ cfu.table.header.download = Download
 cfu.table.header.file = File
 cfu.table.header.id    = Id
 cfu.table.header.info = Info
+cfu.table.header.repo = Repo
 cfu.table.header.select  = Select
 cfu.table.header.name  = Name
 cfu.table.header.notbefore = Not Before Version

--- a/zap/src/test/java/org/zaproxy/zap/control/ZapAddOnXmlFileUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/ZapAddOnXmlFileUnitTest.java
@@ -72,6 +72,7 @@ public class ZapAddOnXmlFileUnitTest {
         assertThat(manifest.getAuthor(), isEmptyString());
         assertThat(manifest.getUrl(), isEmptyString());
         assertThat(manifest.getChanges(), isEmptyString());
+        assertThat(manifest.getRepo(), isEmptyString());
         assertThat(manifest.getNotBeforeVersion(), isEmptyString());
         assertThat(manifest.getNotFromVersion(), isEmptyString());
         assertThat(manifest.getBundleBaseName(), isEmptyString());
@@ -98,6 +99,7 @@ public class ZapAddOnXmlFileUnitTest {
         String author = "Author";
         String url = "http://example.org";
         String changes = "Changes";
+        String repo = "http://example.org/repo/";
         String notBeforeVersion = "1.2.3";
         String notFromVersion = "3.2.1";
         InputStream manifestData =
@@ -111,6 +113,7 @@ public class ZapAddOnXmlFileUnitTest {
                         "<author>" + author + "</author>",
                         "<url>" + url + "</url>",
                         "<changes>" + changes + "</changes>",
+                        "<repo>" + repo + "</repo>",
                         "<not-before-version>" + notBeforeVersion + "</not-before-version>",
                         "<not-from-version>" + notFromVersion + "</not-from-version>",
                         "</zapaddon>");
@@ -125,6 +128,7 @@ public class ZapAddOnXmlFileUnitTest {
         assertThat(manifest.getAuthor(), is(equalTo(author)));
         assertThat(manifest.getUrl(), is(equalTo(url)));
         assertThat(manifest.getChanges(), is(equalTo(changes)));
+        assertThat(manifest.getRepo(), is(equalTo(repo)));
         assertThat(manifest.getNotBeforeVersion(), is(equalTo(notBeforeVersion)));
         assertThat(manifest.getNotFromVersion(), is(equalTo(notFromVersion)));
     }


### PR DESCRIPTION
Read a new field, `repo`, from the add-on manifest and ZapVersions.xml
which should contain the URL to the browsable repo.
Expose the repo URL in the Manage Add-ons dialogue and the API.

Per comment in #3588 - Marketplace/Extension UI Ideas