### PR TITLE
Default to author/URL of the add-on in Extension

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/Extension.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/Extension.java
@@ -44,6 +44,7 @@
 // ZAP: 2018/04/17 Deprecate getVersion().
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2019/09/12 Add defaults to getAuthor() and getURL().
 package org.parosproxy.paros.extension;
 
 import java.net.URL;
@@ -183,9 +184,39 @@ public interface Extension {
 
     boolean isCore();
 
-    String getAuthor();
+    /**
+     * Gets the author of the extension.
+     *
+     * <p>Since TODO add version defaults to the author of the add-on, if set, otherwise an empty
+     * string.
+     *
+     * @return the author of the extension, might be {@code null}.
+     * @since 1.4.0
+     */
+    default String getAuthor() {
+        AddOn addOn = getAddOn();
+        if (addOn != null) {
+            return addOn.getAuthor();
+        }
+        return "";
+    }
 
-    URL getURL();
+    /**
+     * Gets the URL to info about the extension.
+     *
+     * <p>Since TODO add version defaults to the info URL of the add-on, if set, otherwise {@code
+     * null}.
+     *
+     * @return the URL to info about the extension, might be {@code null}.
+     * @since 1.4.0
+     */
+    default URL getURL() {
+        AddOn addOn = getAddOn();
+        if (addOn != null) {
+            return addOn.getInfo();
+        }
+        return null;
+    }
 
     /**
      * Gets the resource bundle of the extension.

--- a/zap/src/main/java/org/parosproxy/paros/extension/ExtensionAdaptor.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/ExtensionAdaptor.java
@@ -45,9 +45,9 @@
 // ZAP: 2018/04/17 Deprecate ExtensionAdaptor(String, Version) and remove getVersion() override.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2019/09/12 Remove getURL().
 package org.parosproxy.paros.extension;
 
-import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.ResourceBundle;
@@ -224,11 +224,6 @@ public abstract class ExtensionAdaptor implements Extension {
     @Override
     public boolean isCore() {
         return false;
-    }
-
-    @Override
-    public URL getURL() {
-        return null;
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/ext/OptionsExtensionPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ext/OptionsExtensionPanel.java
@@ -159,11 +159,7 @@ public class OptionsExtensionPanel extends AbstractParamPanel {
                                         addOnName.setText(
                                                 addOnExtension ? ext.getAddOn().getName() : "");
                                         extDescription.setText(ext.getDescription());
-                                        if (ext.getAuthor() != null) {
-                                            extAuthor.setText(ext.getAuthor());
-                                        } else {
-                                            extAuthor.setText("");
-                                        }
+                                        extAuthor.setText(ext.getAuthor());
                                         if (ext.getURL() != null) {
                                             extURL.setText(ext.getURL().toString());
                                             getUrlLaunchButton().setEnabled(true);


### PR DESCRIPTION
Change `Extension` to default to author/URL of the add-on when set.
Remove override `ExtensionAdaptor#getURL()`, no longer needed.
Remove unnecessary null check when setting the author to the text
component, setting null or empty string has the same effect.

Avoids the need to override those methods for most extensions provided
by add-ons, since the author and URL (when set) are usually the same.