### PR TITLE
Remove homepage URL from ZAP extensions

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/Constant.java
+++ b/zap/src/main/java/org/parosproxy/paros/Constant.java
@@ -98,6 +98,7 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/06/07 Update current version.
+// ZAP: 2019/09/16 Deprecate ZAP_HOMEPAGE and ZAP_EXTENSIONS_PAGE.
 package org.parosproxy.paros;
 
 import java.io.File;
@@ -146,8 +147,12 @@ public final class Constant {
     // ZAP: rebrand
     public static final String PROGRAM_NAME = "OWASP ZAP";
     public static final String PROGRAM_NAME_SHORT = "ZAP";
-    public static final String ZAP_HOMEPAGE = "http://www.owasp.org/index.php/ZAP";
+    /** @deprecated (TODO add version) Do not use, it will be removed. */
+    @Deprecated public static final String ZAP_HOMEPAGE = "http://www.owasp.org/index.php/ZAP";
+    /** @deprecated (TODO add version) Do not use, it will be removed. */
+    @Deprecated
     public static final String ZAP_EXTENSIONS_PAGE = "https://github.com/zaproxy/zap-extensions";
+
     public static final String ZAP_TEAM = "ZAP Dev Team";
     public static final String PAROS_TEAM = "Chinotec Technologies";
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -23,8 +23,6 @@ import java.awt.EventQueue;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -911,15 +909,6 @@ public class ExtensionAlert extends ExtensionAdaptor
     @Override
     public String getDescription() {
         return Constant.messages.getString("alerts.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRF.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRF.java
@@ -20,8 +20,6 @@
 package org.zaproxy.zap.extension.anticsrf;
 
 import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -456,15 +454,6 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
     @Override
     public String getDescription() {
         return Constant.messages.getString("anticsrf.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ExtensionAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ExtensionAPI.java
@@ -20,8 +20,6 @@
 package org.zaproxy.zap.extension.api;
 
 import java.math.BigInteger;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.security.SecureRandom;
 import javax.swing.JOptionPane;
 import org.parosproxy.paros.Constant;
@@ -142,15 +140,6 @@ public class ExtensionAPI extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString("api.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     public CoreAPI getCoreAPI() {

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -24,8 +24,6 @@ import java.awt.EventQueue;
 import java.awt.event.KeyEvent;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.security.InvalidParameterException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -556,16 +554,6 @@ public class ExtensionActiveScan extends ExtensionAdaptor
     @Override
     public String getDescription() {
         return Constant.messages.getString("ascan.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/authentication/ExtensionAuthentication.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authentication/ExtensionAuthentication.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.authentication;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -127,15 +125,6 @@ public class ExtensionAuthentication extends ExtensionAdaptor
             this.contextPanelsMap.put(context.getId(), panel);
         }
         return panel;
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/authorization/ExtensionAuthorization.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authorization/ExtensionAuthorization.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.authorization;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -146,15 +144,6 @@ public class ExtensionAuthorization extends ExtensionAdaptor
                     .persistMethodToSession(session, context.getId());
         } catch (DatabaseException e) {
             log.error("Unable to persist Authorization Detection method.", e);
-        }
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -28,7 +28,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.lang.reflect.InvocationTargetException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -793,15 +792,6 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
     @Override
     public String getDescription() {
         return Constant.messages.getString("autoupdate.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/ExtensionBreak.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/ExtensionBreak.java
@@ -22,8 +22,6 @@ package org.zaproxy.zap.extension.brk;
 import java.awt.Component;
 import java.awt.EventQueue;
 import java.awt.event.KeyEvent;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -564,15 +562,6 @@ public class ExtensionBreak extends ExtensionAdaptor
     @Override
     public String getDescription() {
         return Constant.messages.getString("brk.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/compare/ExtensionCompare.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/compare/ExtensionCompare.java
@@ -22,8 +22,6 @@ package org.zaproxy.zap.extension.compare;
 import java.awt.EventQueue;
 import java.io.File;
 import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -384,15 +382,6 @@ public class ExtensionCompare extends ExtensionAdaptor
     @Override
     public String getDescription() {
         return Constant.messages.getString("cmp.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/dynssl/ExtensionDynSSL.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/dynssl/ExtensionDynSSL.java
@@ -22,8 +22,6 @@ package org.zaproxy.zap.extension.dynssl;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -145,15 +143,6 @@ public class ExtensionDynSSL extends ExtensionAdaptor implements CommandLineList
     @Override
     public String getDescription() {
         return Constant.messages.getString("dynssl.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     public void setRootCa(KeyStore rootca)

--- a/zap/src/main/java/org/zaproxy/zap/extension/encoder2/ExtensionEncoder2.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/encoder2/ExtensionEncoder2.java
@@ -21,8 +21,6 @@ package org.zaproxy.zap.extension.encoder2;
 
 import java.awt.Frame;
 import java.awt.event.KeyEvent;
-import java.net.MalformedURLException;
-import java.net.URL;
 import javax.swing.text.JTextComponent;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
@@ -139,15 +137,6 @@ public class ExtensionEncoder2 extends ExtensionAdaptor implements OptionsChange
     @Override
     public String getDescription() {
         return Constant.messages.getString("enc2.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     private EncodeDecodeParamPanel getOptionsPanel() {

--- a/zap/src/main/java/org/zaproxy/zap/extension/ext/ExtensionExtension.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ext/ExtensionExtension.java
@@ -20,8 +20,6 @@
 package org.zaproxy.zap.extension.ext;
 
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -92,15 +90,6 @@ public class ExtensionExtension extends ExtensionAdaptor implements CommandLineL
     @Override
     public String getDescription() {
         return Constant.messages.getString("ext.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
@@ -20,8 +20,6 @@
 package org.zaproxy.zap.extension.forceduser;
 
 import java.awt.event.ActionEvent;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -288,15 +286,6 @@ public class ExtensionForcedUser extends ExtensionAdaptor
             this.contextPanelsMap.put(context.getId(), panel);
         }
         return panel;
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/help/ExtensionHelp.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/help/ExtensionHelp.java
@@ -23,7 +23,6 @@ import java.awt.Component;
 import java.awt.EventQueue;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -487,15 +486,6 @@ public class ExtensionHelp extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString("help.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     /** No database tables used, so all supported */

--- a/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
@@ -20,8 +20,6 @@
 package org.zaproxy.zap.extension.httpsessions;
 
 import java.net.HttpCookie;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -141,15 +139,6 @@ public class ExtensionHttpSessions extends ExtensionAdaptor
     @Override
     public String getDescription() {
         return Constant.messages.getString("httpsessions.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/keyboard/ExtensionKeyboard.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/keyboard/ExtensionKeyboard.java
@@ -20,8 +20,6 @@
 package org.zaproxy.zap.extension.keyboard;
 
 import java.awt.Component;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -325,15 +323,6 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString("keyboard.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     /** No database tables used, so all supported */

--- a/zap/src/main/java/org/zaproxy/zap/extension/log4j/ExtensionLog4j.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/log4j/ExtensionLog4j.java
@@ -20,8 +20,6 @@
 package org.zaproxy.zap.extension.log4j;
 
 import java.awt.EventQueue;
-import java.net.MalformedURLException;
-import java.net.URL;
 import javax.swing.ImageIcon;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -112,15 +110,6 @@ public class ExtensionLog4j extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString("log4j.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     /** No database tables used, so all supported */

--- a/zap/src/main/java/org/zaproxy/zap/extension/params/ExtensionParams.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/params/ExtensionParams.java
@@ -20,8 +20,6 @@
 package org.zaproxy.zap.extension.params;
 
 import java.awt.EventQueue;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -638,15 +636,6 @@ public class ExtensionParams extends ExtensionAdaptor
     @Override
     public String getDescription() {
         return Constant.messages.getString("params.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/proxies/ExtensionProxies.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/proxies/ExtensionProxies.java
@@ -21,9 +21,7 @@ package org.zaproxy.zap.extension.proxies;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.net.MalformedURLException;
 import java.net.ServerSocket;
-import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.List;
@@ -279,15 +277,6 @@ public class ExtensionProxies extends ExtensionAdaptor implements OptionsChanged
     @Override
     public String getDescription() {
         return Constant.messages.getString("proxies.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     static boolean isSameAddress(String address, String otherAddress) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.pscan;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -546,15 +544,6 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
     @Override
     public String getDescription() {
         return Constant.messages.getString("pscan.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/ruleconfig/ExtensionRuleConfig.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ruleconfig/ExtensionRuleConfig.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.ruleconfig;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
@@ -102,15 +100,6 @@ public class ExtensionRuleConfig extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString("ruleconfig.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     /** No database tables used, so all supported */

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -24,8 +24,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.MalformedInputException;
 import java.nio.charset.StandardCharsets;
@@ -624,15 +622,6 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
     @Override
     public String getDescription() {
         return Constant.messages.getString("script.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     private void refreshScript(ScriptWrapper script) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/search/ExtensionSearch.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/search/ExtensionSearch.java
@@ -21,8 +21,6 @@ package org.zaproxy.zap.extension.search;
 
 import java.awt.EventQueue;
 import java.awt.event.KeyEvent;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.log4j.Logger;
@@ -355,15 +353,6 @@ public class ExtensionSearch extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString("search.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     public void setSearchJustInScope(boolean searchJustInScope) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/sessions/ExtensionSessionManagement.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/sessions/ExtensionSessionManagement.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.sessions;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -112,15 +110,6 @@ public class ExtensionSessionManagement extends ExtensionAdaptor
             this.contextPanelsMap.put(context.getId(), panel);
         }
         return panel;
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/siterefresh/ExtensionSitesRefresh.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/siterefresh/ExtensionSitesRefresh.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.siterefresh;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
@@ -64,15 +62,6 @@ public class ExtensionSitesRefresh extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString("siterefresh.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     /** No database tables used, so all supported */

--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/ExtensionSpider.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/ExtensionSpider.java
@@ -22,8 +22,6 @@ package org.zaproxy.zap.extension.spider;
 import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.event.KeyEvent;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -305,15 +303,6 @@ public class ExtensionSpider extends ExtensionAdaptor
     @Override
     public String getDescription() {
         return Constant.messages.getString("spider.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/stats/ExtensionStats.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stats/ExtensionStats.java
@@ -20,8 +20,6 @@
 package org.zaproxy.zap.extension.stats;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.net.UnknownHostException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -105,15 +103,6 @@ public class ExtensionStats extends ExtensionAdaptor implements OptionsChangedLi
     @Override
     public String getDescription() {
         return Constant.messages.getString("stats.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     /** No database tables used, so all supported */

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
@@ -27,8 +27,6 @@ import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.ImageIcon;
@@ -463,15 +461,6 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
     @Override
     public String getDescription() {
         return Constant.messages.getString("stdexts.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     /** No database tables used, so all supported */

--- a/zap/src/main/java/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
@@ -20,8 +20,6 @@
 package org.zaproxy.zap.extension.uiutils;
 
 import java.awt.EventQueue;
-import java.net.MalformedURLException;
-import java.net.URL;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control.Mode;
@@ -119,15 +117,6 @@ public class ExtensionUiUtils extends ExtensionAdaptor implements SessionChanged
     @Override
     public String getDescription() {
         return Constant.messages.getString("uiutils.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/users/ExtensionUserManagement.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/users/ExtensionUserManagement.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.users;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -157,15 +155,6 @@ public class ExtensionUserManagement extends ExtensionAdaptor
     @Override
     public List<Class<? extends Extension>> getDependencies() {
         return EXTENSION_DEPENDENCIES;
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override


### PR DESCRIPTION
The URL is redundant (already provided through the Online menu item,
added by Online Menus add-on) and does not provide any specific info
about the extensions.
Deprecate `Constant#ZAP_HOMEPAGE` and `ZAP_EXTENSIONS_PAGE`, not in use
by any core class.