### PR TITLE
HttpSender use remove() instead of set(null) on IN_LISTENER.

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
@@ -80,6 +80,7 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/08/19 Reinstate proxy auth credentials when HTTP state is changed.
+// ZAP: 2019/09/17 Use remove() instead of set(null) on IN_LISTENER.
 package org.parosproxy.paros.network;
 
 import java.io.IOException;
@@ -506,7 +507,7 @@ public class HttpSender {
                 }
             }
         } finally {
-            IN_LISTENER.set(null);
+            IN_LISTENER.remove();
         }
     }
 
@@ -525,7 +526,7 @@ public class HttpSender {
                 }
             }
         } finally {
-            IN_LISTENER.set(null);
+            IN_LISTENER.remove();
         }
     }
 


### PR DESCRIPTION
Per sonarcloud:
https://sonarcloud.io/project/issues?id=zaproxy_zaproxy&open=AW06pHQSwvaFA2N5WdKx&resolved=false&types=BUG
https://sonarcloud.io/project/issues?id=zaproxy_zaproxy&open=AW06pHQSwvaFA2N5WdKy&resolved=false&types=BUG

( https://sonarcloud.io/project/issues?id=zaproxy_zaproxy&open=AW06pHQSwvaFA2N5WdKr&resolved=false&types=BUG )

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>