### PR TITLE
install zap python3 version of the library in containers

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2019-10-01
+ - Added Python3 and the pip3 version of ZAP in preparation for Python 2 EOL: https://www.python.org/dev/peps/pep-0373/
+
 ### 2019-09-05
  - Changed zap-full-scan.py to ignore example ascan rules
 

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	xterm \
 	net-tools \
 	python-pip \
+	python3-pip \
 	firefox \
 	vim \
 	xvfb \
@@ -27,6 +28,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*  && \
 	pip install --upgrade pip zapcli python-owasp-zap-v2.4 && \
+	pip3 install --upgrade pip zapcli python-owasp-zap-v2.4 && \
 	useradd -d /home/zap -m -s /bin/bash zap && \
 	echo zap:zap | chpasswd && \
 	mkdir /zap  && \

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	xterm \
 	net-tools \
 	python-pip \
+	python3-pip \
 	firefox \
 	xvfb \
 	x11vnc && \
@@ -26,6 +27,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	rm -rf /var/lib/apt/lists/*
 
 RUN pip install --upgrade pip zapcli python-owasp-zap-v2.4
+RUN pip3 install --upgrade pip zapcli python-owasp-zap-v2.4
 
 RUN useradd -d /home/zap -m -s /bin/bash zap
 RUN echo zap:zap | chpasswd

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	xterm \
 	net-tools \
 	python-pip \
+	python3-pip \
 	firefox \
 	xvfb \
 	x11vnc && \
@@ -26,6 +27,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	rm -rf /var/lib/apt/lists/*
 
 RUN pip install --upgrade pip zapcli python-owasp-zap-v2.4
+RUN pip3 install --upgrade pip zapcli python-owasp-zap-v2.4
 
 RUN useradd -d /home/zap -m -s /bin/bash zap
 RUN echo zap:zap | chpasswd


### PR DESCRIPTION
the containers are based off of ubuntu which still ships python2.7 (to be deprecated in January) as the default python interpreter.

This pull request installs python3 and fetches the python3 version of python-owasp-zap-v2.4
This change allows containers running python3 to be based off of the zap weekly container and the scripts still working.

It also makes it easier to move to python3 as the main interpreter in preparation for removing python2 when it gets deprecated