### PR TITLE
Prefer instance view usage

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/control/Control.java
+++ b/zap/src/main/java/org/parosproxy/paros/control/Control.java
@@ -77,6 +77,7 @@
 // ZAP: 2019/03/14 Improve error handling on shutdown
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2019/09/30 Reduce View singleton usage and replace null checks with hasView().
 package org.parosproxy.paros.control;
 
 import java.awt.Desktop;
@@ -139,7 +140,7 @@ public class Control extends AbstractControl implements SessionListener {
         getExtensionLoader().hookPersistentConnectionListener(proxy);
         getExtensionLoader().hookConnectRequestProxyListeners(proxy);
 
-        if (view != null) {
+        if (hasView()) {
             // ZAP: Add site map listeners
             getExtensionLoader().hookSiteMapListener(view.getSiteTreePanel());
         }
@@ -150,6 +151,10 @@ public class Control extends AbstractControl implements SessionListener {
             return proxy.startServer();
         }
         return false;
+    }
+
+    private boolean hasView() {
+        return view != null;
     }
 
     public Proxy getProxy() {
@@ -188,7 +193,7 @@ public class Control extends AbstractControl implements SessionListener {
     @Override
     public void shutdown(boolean compact) {
         try {
-            if (view != null) {
+            if (hasView()) {
                 view.getRequestPanel().saveConfig(model.getOptionsParam().getConfig());
                 view.getResponsePanel().saveConfig(model.getOptionsParam().getConfig());
             }
@@ -219,7 +224,7 @@ public class Control extends AbstractControl implements SessionListener {
                             .getChildCount(model.getSession().getSiteTree().getRoot());
         }
         boolean askOnExit =
-                view != null
+                hasView()
                         && Model.getSingleton()
                                         .getOptionsParam()
                                         .getViewParam()
@@ -302,7 +307,7 @@ public class Control extends AbstractControl implements SessionListener {
                         },
                         "ZAP-Shutdown");
 
-        if (view != null) {
+        if (hasView()) {
             WaitMessageDialog dialog =
                     view.getWaitMessageDialog(
                             Constant.messages.getString("menu.file.shuttingDown")); // ZAP: i18n
@@ -378,7 +383,7 @@ public class Control extends AbstractControl implements SessionListener {
         final Session session = createNewSession();
         model.saveSession(fileName);
 
-        if (View.isInitialised()) {
+        if (hasView()) {
             SwingUtilities.invokeLater(
                     new Runnable() {
 
@@ -448,7 +453,7 @@ public class Control extends AbstractControl implements SessionListener {
         getExtensionLoader().databaseOpen(model.getDb());
         getExtensionLoader().sessionChangedAllPlugin(session);
 
-        if (View.isInitialised()) {
+        if (hasView()) {
             SwingUtilities.invokeLater(
                     new Runnable() {
                         @Override

--- a/zap/src/main/java/org/parosproxy/paros/extension/ExtensionAdaptor.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/ExtensionAdaptor.java
@@ -46,6 +46,7 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/09/12 Remove getURL().
+// ZAP: 2019/09/30 Add hasView().
 package org.parosproxy.paros.extension;
 
 import java.util.Collections;
@@ -167,6 +168,17 @@ public abstract class ExtensionAdaptor implements Extension {
     @Override
     public ViewDelegate getView() {
         return view;
+    }
+
+    /**
+     * Convenience method that tells whether or not the extension has a view.
+     *
+     * @return {@code true} if the extension has a view, {@code false} otherwise.
+     * @since TODO add version
+     * @see #getView()
+     */
+    protected boolean hasView() {
+        return view != null;
     }
 
     @Override

--- a/zap/src/main/java/org/parosproxy/paros/extension/ExtensionLoader.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/ExtensionLoader.java
@@ -85,6 +85,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/07/25 Relocate null check to be earlier in hookScannerHook(scan) [LGTM issue].
 // ZAP: 2019/08/19 Validate menu and main frame in EDT.
+// ZAP: 2019/09/30 Use instance variable for view checks.
 package org.parosproxy.paros.extension;
 
 import java.awt.Component;
@@ -477,20 +478,26 @@ public class ExtensionLoader {
     }
 
     private void removeSiteMapListener(ExtensionHook hook) {
-        if (view != null) {
-            SiteMapPanel siteMapPanel = view.getSiteTreePanel();
-            List<SiteMapListener> listenerList = hook.getSiteMapListenerList();
-            for (SiteMapListener listener : listenerList) {
-                try {
-                    if (listener != null) {
-                        siteMapPanel.removeSiteMapListener(listener);
-                    }
+        if (!hasView()) {
+            return;
+        }
 
-                } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
+        SiteMapPanel siteMapPanel = view.getSiteTreePanel();
+        List<SiteMapListener> listenerList = hook.getSiteMapListenerList();
+        for (SiteMapListener listener : listenerList) {
+            try {
+                if (listener != null) {
+                    siteMapPanel.removeSiteMapListener(listener);
                 }
+
+            } catch (Exception e) {
+                logger.error(e.getMessage(), e);
             }
         }
+    }
+
+    private boolean hasView() {
+        return view != null;
     }
 
     // ZAP: method called by the scanner to load all scanner hooks.
@@ -753,7 +760,7 @@ public class ExtensionLoader {
             Extension extension = getExtension(i);
             try {
                 extension.start();
-                if (view != null) {
+                if (hasView()) {
                     view.addSplashScreenLoadingCompletion(factorPerc);
                 }
 
@@ -770,7 +777,7 @@ public class ExtensionLoader {
     public void startLifeCycle() {
 
         // Percentages are passed into the calls as doubles
-        if (view != null) {
+        if (hasView()) {
             view.setSplashScreenLoadingCompletion(0.0);
         }
 
@@ -811,7 +818,7 @@ public class ExtensionLoader {
             hookContextDataFactories(ext, extHook);
             hookApiImplementors(ext, extHook);
 
-            if (view != null) {
+            if (hasView()) {
                 // no need to hook view if no GUI
                 hookView(ext, view, extHook);
                 hookMenu(view, extHook);
@@ -833,7 +840,7 @@ public class ExtensionLoader {
         hookPersistentConnectionListeners(proxy, extHook.getPersistentConnectionListener());
         hookConnectRequestProxyListeners(proxy, extHook.getConnectRequestProxyListeners());
 
-        if (view != null) {
+        if (hasView()) {
             hookSiteMapListeners(view.getSiteTreePanel(), extHook.getSiteMapListenerList());
         }
     }
@@ -889,7 +896,7 @@ public class ExtensionLoader {
                 hookApiImplementors(ext, extHook);
                 hookHttpSenderListeners(ext, extHook);
 
-                if (view != null) {
+                if (hasView()) {
                     EventQueue.invokeAndWait(
                             new Runnable() {
 
@@ -923,7 +930,7 @@ public class ExtensionLoader {
             }
         }
 
-        if (view != null) {
+        if (hasView()) {
             try {
                 EventQueue.invokeAndWait(
                         () -> {
@@ -1020,7 +1027,7 @@ public class ExtensionLoader {
     }
 
     private void hookMenu(View view, ExtensionHook hook) {
-        if (view == null) {
+        if (!hasView()) {
             return;
         }
 
@@ -1084,7 +1091,7 @@ public class ExtensionLoader {
     }
 
     private void removeMenu(View view, ExtensionHook hook) {
-        if (view == null) {
+        if (!hasView()) {
             return;
         }
 
@@ -1166,7 +1173,7 @@ public class ExtensionLoader {
     }
 
     private void hookView(Extension extension, View view, ExtensionHook hook) {
-        if (view == null) {
+        if (!hasView()) {
             return;
         }
 
@@ -1217,7 +1224,7 @@ public class ExtensionLoader {
     }
 
     private void removeView(Extension extension, View view, ExtensionHook hook) {
-        if (view == null) {
+        if (!hasView()) {
             return;
         }
 
@@ -1268,19 +1275,19 @@ public class ExtensionLoader {
     }
 
     public void removeStatusPanel(AbstractPanel panel) {
-        if (!View.isInitialised()) {
+        if (!hasView()) {
             return;
         }
 
-        View.getSingleton().getWorkbench().removePanel(panel, WorkbenchPanel.PanelType.STATUS);
+        view.getWorkbench().removePanel(panel, WorkbenchPanel.PanelType.STATUS);
     }
 
     public void removeOptionsPanel(AbstractParamPanel panel) {
-        if (!View.isInitialised()) {
+        if (!hasView()) {
             return;
         }
 
-        View.getSingleton().getOptionsDialog("").removeParamPanel(panel);
+        view.getOptionsDialog("").removeParamPanel(panel);
     }
 
     public void removeOptionsParamSet(AbstractParam params) {
@@ -1288,67 +1295,67 @@ public class ExtensionLoader {
     }
 
     public void removeWorkPanel(AbstractPanel panel) {
-        if (!View.isInitialised()) {
+        if (!hasView()) {
             return;
         }
 
-        View.getSingleton().getWorkbench().removePanel(panel, WorkbenchPanel.PanelType.WORK);
+        view.getWorkbench().removePanel(panel, WorkbenchPanel.PanelType.WORK);
     }
 
     public void removePopupMenuItem(ExtensionPopupMenuItem popupMenuItem) {
-        if (!View.isInitialised()) {
+        if (!hasView()) {
             return;
         }
 
-        View.getSingleton().getPopupList().remove(popupMenuItem);
+        view.getPopupList().remove(popupMenuItem);
     }
 
     public void removeFileMenuItem(JMenuItem menuItem) {
-        if (!View.isInitialised()) {
+        if (!hasView()) {
             return;
         }
 
-        View.getSingleton().getMainFrame().getMainMenuBar().getMenuFile().remove(menuItem);
+        view.getMainFrame().getMainMenuBar().getMenuFile().remove(menuItem);
     }
 
     public void removeEditMenuItem(JMenuItem menuItem) {
-        if (!View.isInitialised()) {
+        if (!hasView()) {
             return;
         }
 
-        View.getSingleton().getMainFrame().getMainMenuBar().getMenuEdit().remove(menuItem);
+        view.getMainFrame().getMainMenuBar().getMenuEdit().remove(menuItem);
     }
 
     public void removeViewMenuItem(JMenuItem menuItem) {
-        if (!View.isInitialised()) {
+        if (!hasView()) {
             return;
         }
 
-        View.getSingleton().getMainFrame().getMainMenuBar().getMenuView().remove(menuItem);
+        view.getMainFrame().getMainMenuBar().getMenuView().remove(menuItem);
     }
 
     public void removeToolsMenuItem(JMenuItem menuItem) {
-        if (!View.isInitialised()) {
+        if (!hasView()) {
             return;
         }
 
-        View.getSingleton().getMainFrame().getMainMenuBar().getMenuTools().remove(menuItem);
+        view.getMainFrame().getMainMenuBar().getMenuTools().remove(menuItem);
     }
 
     public void removeHelpMenuItem(JMenuItem menuItem) {
-        if (!View.isInitialised()) {
+        if (!hasView()) {
             return;
         }
 
-        View.getSingleton().getMainFrame().getMainMenuBar().getMenuHelp().remove(menuItem);
+        view.getMainFrame().getMainMenuBar().getMenuHelp().remove(menuItem);
     }
 
     public void removeReportMenuItem(JMenuItem menuItem) {
-        if (!View.isInitialised()) {
+        if (!hasView()) {
             return;
         }
 
-        View.getSingleton().getMainFrame().getMainMenuBar().getMenuReport().remove(menuItem);
+        view.getMainFrame().getMainMenuBar().getMenuReport().remove(menuItem);
     }
 
     /** Init all extensions */
@@ -1360,7 +1367,7 @@ public class ExtensionLoader {
             try {
                 extension.init();
                 extension.databaseOpen(Model.getSingleton().getDb());
-                if (view != null) {
+                if (hasView()) {
                     view.addSplashScreenLoadingCompletion(factorPerc);
                 }
 
@@ -1382,7 +1389,7 @@ public class ExtensionLoader {
             Extension extension = getExtension(i);
             try {
                 extension.initModel(model);
-                if (view != null) {
+                if (hasView()) {
                     view.addSplashScreenLoadingCompletion(factorPerc);
                 }
 
@@ -1398,7 +1405,7 @@ public class ExtensionLoader {
      * @param view the View that need to be applied
      */
     private void initViewAllExtension(final View view, double progressFactor) {
-        if (view == null) {
+        if (!hasView()) {
             return;
         }
 
@@ -1430,7 +1437,7 @@ public class ExtensionLoader {
             Extension extension = getExtension(i);
             try {
                 extension.initXML(session, options);
-                if (view != null) {
+                if (hasView()) {
                     view.addSplashScreenLoadingCompletion(factorPerc);
                 }
 
@@ -1509,7 +1516,7 @@ public class ExtensionLoader {
     }
 
     private void removeViewInEDT(final Extension extension, final ExtensionHook hook) {
-        if (view == null) {
+        if (!hasView()) {
             return;
         }
 

--- a/zap/src/main/java/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -90,6 +90,7 @@
 // ZAP: 2018/03/12 Use the same help page in request editors.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2019/09/30 Use hasView().
 package org.parosproxy.paros.extension.history;
 
 import java.awt.EventQueue;
@@ -256,7 +257,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
         extensionHook.addProxyListener(getProxyListenerLog());
         extensionHook.addConnectionRequestProxyListener(getProxyListenerLog());
 
-        if (getView() != null) {
+        if (hasView()) {
             ExtensionHookView pv = extensionHook.getHookView();
             pv.addStatusPanel(getLogPanel());
 
@@ -312,7 +313,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
     }
 
     public void removeFromHistoryList(final HistoryReference href) {
-        if (!View.isInitialised() || EventQueue.isDispatchThread()) {
+        if (!hasView() || EventQueue.isDispatchThread()) {
             this.historyTableModel.removeEntry(href.getHistoryId());
             historyIdToRef.remove(href.getHistoryId());
         } else {
@@ -332,7 +333,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
     }
 
     private void notifyHistoryItemChanged(final int historyId) {
-        if (!View.isInitialised() || EventQueue.isDispatchThread()) {
+        if (!hasView() || EventQueue.isDispatchThread()) {
             this.historyTableModel.refreshEntryRow(historyId);
         } else {
             EventQueue.invokeLater(
@@ -347,7 +348,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
     }
 
     private void notifyHistoryItemsChanged() {
-        if (!View.isInitialised() || EventQueue.isDispatchThread()) {
+        if (!hasView() || EventQueue.isDispatchThread()) {
             this.historyTableModel.refreshEntryRows();
         } else {
             EventQueue.invokeLater(
@@ -422,7 +423,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
                         addToMap(historyRef);
                         return;
                     }
-                    if (getView() != null) {
+                    if (hasView()) {
                         // Dont do this in daemon mode
                         HistoryFilterPlusDialog dialog = getFilterPlusDialog();
                         HistoryFilter historyFilter = dialog.getFilter();
@@ -456,7 +457,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
     }
 
     private void addHistoryInEventQueue(final HistoryReference ref) {
-        if (!View.isInitialised() || EventQueue.isDispatchThread()) {
+        if (!hasView() || EventQueue.isDispatchThread()) {
             historyTableModel.addHistoryReference(ref);
         } else {
             EventQueue.invokeLater(
@@ -495,7 +496,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
     private void buildHistory(List<Integer> dbList, HistoryFilter historyFilter) {
         HistoryReference historyRef = null;
         synchronized (historyTableModel) {
-            if (getView() != null) {
+            if (hasView()) {
                 getLogPanel().setModel(EMPTY_MODEL);
             }
             historyTableModel.clear();
@@ -536,7 +537,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
                     logger.error(e.getMessage(), e);
                 }
             }
-            if (getView() != null) {
+            if (hasView()) {
                 getLogPanel().setModel(historyTableModel);
             }
         }
@@ -769,11 +770,11 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
     public void sessionAboutToChange(final Session session) {
         sessionChanging = true;
 
-        if (getView() == null || EventQueue.isDispatchThread()) {
+        if (!hasView() || EventQueue.isDispatchThread()) {
             historyTableModel.clear();
             historyIdToRef.clear();
 
-            if (getView() != null) {
+            if (hasView()) {
                 getView().displayMessage(null);
             }
         } else {
@@ -884,7 +885,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
     }
 
     private void sessionChanged() {
-        if (getView() != null) {
+        if (hasView()) {
             searchHistory(getFilterPlusDialog().getFilter());
         } else {
             searchHistory(null);
@@ -953,7 +954,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
      * @since 2.7.0
      */
     public void purgeHistory(List<HistoryReference> hrefs) {
-        if (getView() != null && hrefs.size() > 1) {
+        if (hasView() && hrefs.size() > 1) {
             int result =
                     getView()
                             .showConfirmDialog(

--- a/zap/src/main/java/org/parosproxy/paros/extension/history/ProxyListenerLog.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/ProxyListenerLog.java
@@ -34,6 +34,7 @@
 // being persisted.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2019/09/30 Use instance variable for view checks.
 package org.parosproxy.paros.extension.history;
 
 import java.awt.EventQueue;
@@ -50,7 +51,6 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpStatusCode;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.model.SessionStructure;
 import org.zaproxy.zap.model.StructuralNode;
 
@@ -185,7 +185,7 @@ public class ProxyListenerLog implements ProxyListener, ConnectRequestProxyListe
     }
 
     private void addToSiteMap(final HistoryReference ref, final HttpMessage msg) {
-        if (View.isInitialised() && !EventQueue.isDispatchThread()) {
+        if (hasView() && !EventQueue.isDispatchThread()) {
             try {
                 EventQueue.invokeAndWait(
                         new Runnable() {
@@ -204,10 +204,14 @@ public class ProxyListenerLog implements ProxyListener, ConnectRequestProxyListe
         SessionStructure.addPath(model.getSession(), ref, msg);
         if (isFirstAccess && !Constant.isLowMemoryOptionSet()) {
             isFirstAccess = false;
-            if (View.isInitialised()) {
+            if (hasView()) {
                 view.getSiteTreePanel().expandRoot();
             }
         }
+    }
+
+    private boolean hasView() {
+        return view != null;
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -340,7 +340,7 @@ public class ExtensionAlert extends ExtensionAdaptor
             return;
         }
 
-        if (!View.isInitialised() || EventQueue.isDispatchThread()) {
+        if (!hasView() || EventQueue.isDispatchThread()) {
             addAlertToTreeEventHandler(alert);
 
         } else {
@@ -510,7 +510,7 @@ public class ExtensionAlert extends ExtensionAdaptor
         }
         this.recalcAlerts();
 
-        if (View.isInitialised()) {
+        if (hasView()) {
             JTree alertTree = this.getAlertPanel().getTreeAlert();
             TreePath alertPath = new TreePath(getTreeModel().getAlertNode(alert).getPath());
             alertTree.setSelectionPath(alertPath);
@@ -779,7 +779,7 @@ public class ExtensionAlert extends ExtensionAdaptor
      * @see View#isInitialised()
      */
     void recalcAlerts() {
-        if (!View.isInitialised()) {
+        if (!hasView()) {
             return;
         }
         // Must only be called when View is initialised
@@ -808,7 +808,7 @@ public class ExtensionAlert extends ExtensionAdaptor
                 }
             }
         }
-        MainFooterPanel footer = View.getSingleton().getMainFrame().getMainFooterPanel();
+        MainFooterPanel footer = getView().getMainFrame().getMainFooterPanel();
         footer.setAlertInfo(totalInfo);
         footer.setAlertLow(totalLow);
         footer.setAlertMedium(totalMedium);

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ExtensionAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ExtensionAPI.java
@@ -28,7 +28,6 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.model.Model;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.DesktopUtils;
 import org.zaproxy.zap.view.ZapMenuItem;
 
@@ -108,7 +107,7 @@ public class ExtensionAPI extends ExtensionAdaptor {
 
                                 int option =
                                         JOptionPane.showOptionDialog(
-                                                View.getSingleton().getMainFrame(),
+                                                getView().getMainFrame(),
                                                 message,
                                                 title,
                                                 JOptionPane.YES_NO_OPTION,

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -51,7 +51,6 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.AbstractParamPanel;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
 import org.zaproxy.zap.extension.script.ExtensionScript;
@@ -126,9 +125,9 @@ public class ExtensionActiveScan extends ExtensionAdaptor
         policyManager.init();
 
         if (Control.getSingleton().getMode().equals(Mode.attack)) {
-            if (View.isInitialised() && !this.getScannerParam().isAllowAttackOnStart()) {
+            if (hasView() && !this.getScannerParam().isAllowAttackOnStart()) {
                 // Disable attack mode for safeties sake (when running with the UI)
-                View.getSingleton().getMainFrame().getMainToolbarPanel().setMode(Mode.standard);
+                getView().getMainFrame().getMainToolbarPanel().setMode(Mode.standard);
             } else {
                 // Needed to make sure the attackModeScanner starts up
                 this.attackModeScanner.sessionModeChanged(Control.getSingleton().getMode());
@@ -153,7 +152,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor
             extensionHook.getHookView().addOptionPanel(getOptionsVariantPanel());
 
             extensionHook.getHookView().addMainToolBarComponent(this.getPolicyButton());
-            View.getSingleton()
+            getView()
                     .getMainFrame()
                     .getMainFooterPanel()
                     .addFooterToolbarRightLabel(attackModeScanner.getScanStatus().getCountLabel());
@@ -286,7 +285,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor
         }
 
         int id = this.ascanController.startScan(name, target, user, contextSpecificObjects);
-        if (View.isInitialised()) {
+        if (hasView()) {
             ActiveScan scanner = this.ascanController.getScan(id);
             scanner.addScannerListener(getActiveScanPanel()); // So the UI get updated
             this.getActiveScanPanel().scannerStarted(scanner);
@@ -416,7 +415,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor
 
     private void sessionChangedEventHandler(Session session) {
         // The scans are stopped in sessionAboutToChange(..)
-        if (View.isInitialised()) {
+        if (hasView()) {
             this.getActiveScanPanel().reset();
         }
 
@@ -541,7 +540,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor
         this.ascanController.reset();
         this.attackModeScanner.stop();
 
-        if (View.isInitialised()) {
+        if (hasView()) {
             this.getActiveScanPanel().reset();
             if (customScanDialog != null) {
                 customScanDialog.reset();
@@ -571,7 +570,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor
 
     @Override
     public void sessionScopeChanged(Session session) {
-        if (View.isInitialised()) {
+        if (hasView()) {
             this.getActiveScanPanel().sessionScopeChanged(session);
         }
         this.attackModeScanner.sessionScopeChanged(session);
@@ -582,7 +581,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor
         if (Mode.safe.equals(mode)) {
             this.ascanController.stopAllScans();
         }
-        if (View.isInitialised()) {
+        if (hasView()) {
             getMenuItemCustomScan().setEnabled(!Mode.safe.equals(mode));
             this.getActiveScanPanel().sessionModeChanged(mode);
         }
@@ -593,7 +592,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor
     public void destroy() {
         this.ascanController.stopAllScans();
 
-        if (View.isInitialised()) {
+        if (hasView()) {
             this.getActiveScanPanel().reset();
         }
     }
@@ -628,7 +627,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor
                             this,
                             tabs,
                             this.customScanPanels,
-                            View.getSingleton().getMainFrame(),
+                            getView().getMainFrame(),
                             new Dimension(700, 500));
         }
         if (customScanDialog.isVisible()) {
@@ -659,7 +658,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor
 
     public void showPolicyManagerDialog() {
         if (policyManagerDialog == null) {
-            policyManagerDialog = new PolicyManagerDialog(View.getSingleton().getMainFrame());
+            policyManagerDialog = new PolicyManagerDialog(getView().getMainFrame());
             policyManagerDialog.init(this);
         }
         // The policy names _may_ have changed, eg via the api
@@ -703,7 +702,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor
     @Override
     public void pauseScan(int id) {
         ascanController.pauseScan(id);
-        if (View.isInitialised()) {
+        if (hasView()) {
             // Update the UI in case this was initiated from the API
             this.getActiveScanPanel().updateScannerUI();
         }
@@ -712,7 +711,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor
     @Override
     public void resumeScan(int id) {
         ascanController.resumeScan(id);
-        if (View.isInitialised()) {
+        if (hasView()) {
             // Update the UI in case this was initiated from the API
             this.getActiveScanPanel().updateScannerUI();
         }
@@ -727,7 +726,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor
     @Override
     public void pauseAllScans() {
         ascanController.pauseAllScans();
-        if (View.isInitialised()) {
+        if (hasView()) {
             // Update the UI in case this was initiated from the API
             this.getActiveScanPanel().updateScannerUI();
         }
@@ -736,7 +735,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor
     @Override
     public void resumeAllScans() {
         ascanController.removeAllScans();
-        if (View.isInitialised()) {
+        if (hasView()) {
             // Update the UI in case this was initiated from the API
             this.getActiveScanPanel().updateScannerUI();
         }
@@ -764,7 +763,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor
 
     public int registerScan(ActiveScan scanner) {
         int id = ascanController.registerScan(scanner);
-        if (View.isInitialised()) {
+        if (hasView()) {
             // Update the UI in case this was initiated from the API
             scanner.addScannerListener(getActiveScanPanel()); // So the UI get updated
             this.getActiveScanPanel().scannerStarted(scanner);

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -252,7 +252,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                                                         "file.format.zap.addon");
                                             }
                                         });
-                                int rc = chooser.showOpenDialog(View.getSingleton().getMainFrame());
+                                int rc = chooser.showOpenDialog(getView().getMainFrame());
                                 if (rc == JFileChooser.APPROVE_OPTION) {
                                     file = chooser.getSelectedFile();
                                     if (file == null) {
@@ -383,7 +383,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                 int reinstall =
                         View.getSingleton()
                                 .showYesNoDialog(
-                                        View.getSingleton().getMainFrame(),
+                                        getView().getMainFrame(),
                                         new Object[] {
                                             Constant.messages.getString(
                                                     "cfu.warn.addOnSameVersion",
@@ -401,7 +401,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                 }
                 uninstallBeforeAddOnCopy = true;
             } else if (!ao.isUpdateTo(installedAddOn)) {
-                View.getSingleton()
+                getView()
                         .showWarningDialog(
                                 Constant.messages.getString(
                                         "cfu.warn.addOnOlderVersion",
@@ -482,15 +482,14 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
     }
 
     private void showWarningMessageInvalidAddOnFile(String reason) {
-        View.getSingleton()
-                .showWarningDialog(Constant.messages.getString("cfu.warn.invalidAddOn", reason));
+        getView().showWarningDialog(Constant.messages.getString("cfu.warn.invalidAddOn", reason));
     }
 
     private void showWarningMessageCantLoadAddOn(AddOn ao) {
         String message =
                 Constant.messages.getString(
                         "cfu.warn.cantload", ao.getNotBeforeVersion(), ao.getNotFromVersion());
-        View.getSingleton().showWarningDialog(message);
+        getView().showWarningDialog(message);
     }
 
     private static File copyAddOnFileToLocalPluginFolder(AddOn addOn) throws IOException {
@@ -546,9 +545,9 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
     }
 
     private void downloadFile(URL url, File targetFile, long size, String hash) {
-        if (View.isInitialised()) {
+        if (hasView()) {
             // Report info to the Output tab
-            View.getSingleton()
+            getView()
                     .getOutputPanel()
                     .append(
                             Constant.messages.getString(
@@ -558,7 +557,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                                     + "\n");
         }
         this.downloadFiles.add(this.downloadManager.downloadFile(url, targetFile, size, hash));
-        if (View.isInitialised()) {
+        if (hasView()) {
             // Means we do have a UI
             if (this.downloadProgressThread != null && !this.downloadProgressThread.isAlive()) {
                 this.downloadProgressThread = null;
@@ -717,7 +716,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
             extensionHook.getHookView().addMainToolBarComponent(getAddonsButton());
             extensionHook.getHookView().addMainToolBarComponent(getCheckForUpdatesButton());
 
-            View.getSingleton()
+            getView()
                     .getMainFrame()
                     .getMainFooterPanel()
                     .addFooterToolbarRightLabel(getScanStatus().getCountLabel());
@@ -834,7 +833,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
         final OptionsParamCheckForUpdates options =
                 getModel().getOptionsParam().getCheckForUpdatesParam();
 
-        if (View.isInitialised()) {
+        if (hasView()) {
             if (!options.isCheckOnStart()) {
                 alertIfOutOfDate(false);
                 return;
@@ -849,7 +848,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
 
         if (!options.checkOnStart()) {
             // Top level option not set, dont do anything, unless already downloaded last release
-            if (View.isInitialised() && this.getPreviousVersionInfo() != null) {
+            if (hasView() && this.getPreviousVersionInfo() != null) {
                 ZapRelease rel = this.getPreviousVersionInfo().getZapRelease();
                 if (rel != null && rel.isNewerThan(this.getCurrentVersion())) {
                     File f = new File(Constant.FOLDER_LOCAL_PLUGIN, rel.getFileName());
@@ -928,7 +927,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                     result =
                             View.getSingleton()
                                     .showYesNoDialog(
-                                            View.getSingleton().getMainFrame(),
+                                            getView().getMainFrame(),
                                             new Object[] {msg, cfuOnStart});
                     setCfuOnStart = cfuOnStart.isSelected();
                 }
@@ -956,7 +955,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                                 }
                             });
 
-                    View.getSingleton()
+                    getView()
                             .getMainFrame()
                             .getMainFooterPanel()
                             .addFooterToolbarLeftComponent(button);
@@ -986,8 +985,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                 result =
                         View.getSingleton()
                                 .showYesNoDialog(
-                                        View.getSingleton().getMainFrame(),
-                                        new Object[] {msg, cfuOnStart});
+                                        getView().getMainFrame(), new Object[] {msg, cfuOnStart});
                 setCfuOnStart = cfuOnStart.isSelected();
             }
             options.setDayLastUpdateWarned();
@@ -999,14 +997,14 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                 getAddOnsDialog().setVisible(true);
                 getAddOnsDialog().checkForUpdates();
                 if (noCfuAlertAdded) {
-                    View.getSingleton()
+                    getView()
                             .getMainFrame()
                             .getMainFooterPanel()
                             .removeFooterToolbarLeftComponent(getOutOfDateButton());
                 }
 
             } else if (!noCfuAlertAdded) {
-                View.getSingleton()
+                getView()
                         .getMainFrame()
                         .getMainFooterPanel()
                         .addFooterToolbarLeftComponent(getOutOfDateButton());
@@ -1090,7 +1088,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
 
     protected boolean downloadLatestRelease() {
         if (Constant.isKali()) {
-            if (View.isInitialised()) {
+            if (hasView()) {
                 // Just tell the user to use one of the Kali options
                 View.getSingleton()
                         .showMessageDialog(
@@ -1279,7 +1277,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
 
     protected void promptToLaunchReleaseAndClose(String version, File f) {
         int ans =
-                View.getSingleton()
+                getView()
                         .showConfirmDialog(
                                 Constant.messages.getString(
                                         "cfu.confirm.launch", version, f.getAbsolutePath()));
@@ -1309,9 +1307,9 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
             }
         }
         logger.info("Installing new addon " + ao.getId() + " v" + ao.getVersion());
-        if (View.isInitialised()) {
+        if (hasView()) {
             // Report info to the Output tab
-            View.getSingleton()
+            getView()
                     .getOutputPanel()
                     .append(
                             Constant.messages.getString(
@@ -1322,9 +1320,9 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
         ExtensionFactory.getAddOnLoader().addAddon(ao);
 
         logger.info("Finished installing new addon " + ao.getId() + " v" + ao.getVersion());
-        if (View.isInitialised()) {
+        if (hasView()) {
             // Report info to the Output tab
-            View.getSingleton()
+            getView()
                     .getOutputPanel()
                     .append(
                             Constant.messages.getString(
@@ -1374,8 +1372,8 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
     @Override
     public void insecureUrl(String url, Exception cause) {
         logger.error("Failed to get check for updates on " + url, cause);
-        if (View.isInitialised()) {
-            View.getSingleton().showWarningDialog(Constant.messages.getString("cfu.warn.badurl"));
+        if (hasView()) {
+            getView().showWarningDialog(Constant.messages.getString("cfu.warn.badurl"));
         }
     }
 
@@ -1404,7 +1402,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                 // New ZAP release
                 if (Constant.isKali()) {
                     // Kali has its own package management system
-                    if (View.isInitialised()) {
+                    if (hasView()) {
                         getAddOnsDialog().setVisible(true);
                     }
                     return;

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/ExtensionBreak.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/ExtensionBreak.java
@@ -45,7 +45,6 @@ import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteNode;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.brk.impl.http.HttpBreakpointManagementDaemonImpl;
 import org.zaproxy.zap.extension.brk.impl.http.HttpBreakpointMessage;
 import org.zaproxy.zap.extension.brk.impl.http.HttpBreakpointMessage.Location;
@@ -487,7 +486,7 @@ public class ExtensionBreak extends ExtensionAdaptor
                         public void actionPerformed(java.awt.event.ActionEvent e) {
                             // Check to see if anything is selected in the main tabs
                             String url = "";
-                            Component c = View.getSingleton().getMainFrame().getFocusOwner();
+                            Component c = getView().getMainFrame().getFocusOwner();
                             if (c != null) {
                                 if (c instanceof JList) {
                                     // Handles the history list and similar

--- a/zap/src/main/java/org/zaproxy/zap/extension/callback/ExtensionCallback.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/callback/ExtensionCallback.java
@@ -43,7 +43,6 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpStatusCode;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.callback.ui.CallbackPanel;
 import org.zaproxy.zap.extension.callback.ui.CallbackRequest;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
@@ -87,7 +86,7 @@ public class ExtensionCallback extends ExtensionAdaptor
         extensionHook.addOptionsParamSet(getCallbackParam());
         extensionHook.addOptionsChangedListener(this);
         extensionHook.addSessionListener(this);
-        if (View.isInitialised()) {
+        if (hasView()) {
             extensionHook.getHookView().addStatusPanel(getCallbackPanel());
             extensionHook.getHookView().addOptionPanel(getOptionsCallbackPanel());
             ExtensionHelp.enableHelpKey(getCallbackPanel(), "ui.tabs.callbacks");
@@ -266,7 +265,7 @@ public class ExtensionCallback extends ExtensionAdaptor
     }
 
     private void invokeIfRequiredAndViewIsInitialised(Runnable runnable) {
-        if (View.isInitialised()) {
+        if (hasView()) {
             if (!EventQueue.isDispatchThread()) {
                 try {
                     EventQueue.invokeAndWait(runnable);
@@ -317,8 +316,8 @@ public class ExtensionCallback extends ExtensionAdaptor
                                     "callback.test.msg",
                                     url,
                                     msg.getRequestHeader().getSenderAddress().toString());
-                    if (View.isInitialised()) {
-                        View.getSingleton().getOutputPanel().appendAsync(str + "\n");
+                    if (hasView()) {
+                        getView().getOutputPanel().appendAsync(str + "\n");
                     }
                     LOGGER.info(str);
                     callbackReceived(

--- a/zap/src/main/java/org/zaproxy/zap/extension/compare/ExtensionCompare.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/compare/ExtensionCompare.java
@@ -55,7 +55,6 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SessionListener;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.DesktopUtils;
 
 public class ExtensionCompare extends ExtensionAdaptor
@@ -195,7 +194,7 @@ public class ExtensionCompare extends ExtensionAdaptor
                         return Constant.messages.getString("file.format.zap.session");
                     }
                 });
-        int rc = chooser.showOpenDialog(View.getSingleton().getMainFrame());
+        int rc = chooser.showOpenDialog(getView().getMainFrame());
         if (rc == JFileChooser.APPROVE_OPTION) {
             try {
                 file = chooser.getSelectedFile();
@@ -207,8 +206,7 @@ public class ExtensionCompare extends ExtensionAdaptor
 
                 // log.info("opening session file " + file.getAbsolutePath());
                 // WaitMessageDialog waitMessageDialog =
-                // View.getSingleton().getWaitMessageDialog("Loading session file.  Please wait
-                // ...");
+                // getView().getWaitMessageDialog("Loading session file.  Please wait...");
                 cmpModel.openSession(file, this);
 
                 // TODO support other implementations in the future
@@ -325,7 +323,7 @@ public class ExtensionCompare extends ExtensionAdaptor
                             DesktopUtils.openUrlInBrowser(outputFile.toURI());
                         } catch (Exception e) {
                             log.error(e.getMessage(), e);
-                            View.getSingleton()
+                            getView()
                                     .showMessageDialog(
                                             Constant.messages.getString(
                                                     "report.complete.warning",

--- a/zap/src/main/java/org/zaproxy/zap/extension/dynssl/ExtensionDynSSL.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/dynssl/ExtensionDynSSL.java
@@ -51,7 +51,6 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.security.CachedSslCertifificateServiceImpl;
 import org.parosproxy.paros.security.SslCertificateService;
-import org.parosproxy.paros.view.View;
 
 /**
  * Extension enables configuration for Root CA certificate
@@ -360,7 +359,7 @@ public class ExtensionDynSSL extends ExtensionAdaptor implements CommandLineList
                         "dynssl.warn.cert.expired",
                         cert.getNotAfter().toString(),
                         new Date().toString());
-        if (View.isInitialised()) {
+        if (hasView()) {
             getView().showWarningDialog(warnMsg);
         }
         logger.warn(warnMsg);

--- a/zap/src/main/java/org/zaproxy/zap/extension/keyboard/ExtensionKeyboard.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/keyboard/ExtensionKeyboard.java
@@ -35,7 +35,6 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.view.MainMenuBar;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.DesktopUtils;
 import org.zaproxy.zap.view.ZapMenuItem;
 
@@ -91,7 +90,7 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
 
     @Override
     public void postInit() {
-        if (View.isInitialised()) {
+        if (hasView()) {
             logger.info("Initializing keyboard shortcuts");
             processMainMenuBarMenus(this::initAllMenuItems);
         }
@@ -229,7 +228,7 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
     }
 
     public List<KeyboardShortcut> getShortcuts(boolean reset) {
-        if (View.isInitialised()) {
+        if (hasView()) {
             List<KeyboardShortcut> kss = new ArrayList<KeyboardShortcut>();
             processMainMenuBarMenus(menu -> addAllMenuItems(kss, menu, reset));
             return kss;

--- a/zap/src/main/java/org/zaproxy/zap/extension/log4j/ExtensionLog4j.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/log4j/ExtensionLog4j.java
@@ -30,7 +30,6 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.SessionChangedListener;
 import org.parosproxy.paros.model.Session;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.ScanStatus;
 import org.zaproxy.zap.view.ZapMenuItem;
 
@@ -52,7 +51,7 @@ public class ExtensionLog4j extends ExtensionAdaptor {
         super(NAME);
         this.setOrder(56);
 
-        if (Constant.isDevMode() && View.isInitialised()) {
+        if (Constant.isDevMode() && hasView()) {
             // Only enable if this is a developer build, ie build from source, or explicitly enabled
 
             scanStatus =
@@ -64,7 +63,7 @@ public class ExtensionLog4j extends ExtensionAdaptor {
 
             Logger.getRootLogger().addAppender(new ZapOutputWriter(scanStatus));
 
-            View.getSingleton()
+            getView()
                     .getMainFrame()
                     .getMainFooterPanel()
                     .addFooterToolbarRightLabel(scanStatus.getCountLabel());

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -40,7 +40,6 @@ import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.extension.SessionChangedListener;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.Session;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.control.CoreFunctionality;
 import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
@@ -108,7 +107,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
                     .getHookView()
                     .addOptionPanel(getOptionsPassiveScan(getPassiveScanThread()));
             extensionHook.getHookView().addOptionPanel(getPolicyPanel());
-            View.getSingleton()
+            getView()
                     .getMainFrame()
                     .getMainFooterPanel()
                     .addFooterToolbarRightLabel(getScanStatus().getCountLabel());
@@ -176,7 +175,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
 
         PassiveScanner scanner = getPassiveScannerList().removeScanner(className);
 
-        if (scanner != null && View.isInitialised() && scanner instanceof PluginPassiveScanner) {
+        if (scanner != null && hasView() && scanner instanceof PluginPassiveScanner) {
             getPolicyPanel()
                     .getPassiveScanTableModel()
                     .removeScanner((PluginPassiveScanner) scanner);
@@ -284,7 +283,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
 
             added = addPassiveScannerImpl(scanner);
 
-            if (View.isInitialised()) {
+            if (hasView()) {
                 getPolicyPanel().getPassiveScanTableModel().addScanner(scanner);
             }
 
@@ -500,7 +499,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
     @Override
     public void sessionChanged(Session session) {
         startPassiveScanThread();
-        if (View.isInitialised()) {
+        if (hasView()) {
             getScanStatus().setScanCount(0);
         }
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -216,7 +216,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 
         extensionHook.addCommandLine(getCommandLineArguments());
 
-        if (View.isInitialised()) {
+        if (hasView()) {
             extensionHook.getHookView().addOptionPanel(getOptionsScriptPanel());
         } else {
             // No GUI so add stdout as a writer
@@ -897,8 +897,8 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
                 .collect(ArrayList::new, (c, e) -> c.add(e.getName()), ArrayList::addAll);
     }
 
-    private static void informScriptsNotAdded(final List<String[]> scriptsNotAdded) {
-        if (!View.isInitialised() || scriptsNotAdded.isEmpty()) {
+    private void informScriptsNotAdded(final List<String[]> scriptsNotAdded) {
+        if (!hasView() || scriptsNotAdded.isEmpty()) {
             return;
         }
 
@@ -951,7 +951,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
                     @Override
                     public void run() {
                         JOptionPane.showMessageDialog(
-                                View.getSingleton().getMainFrame(),
+                                getView().getMainFrame(),
                                 optionPaneContents.toArray(),
                                 Constant.PROGRAM_NAME,
                                 JOptionPane.INFORMATION_MESSAGE);
@@ -2032,7 +2032,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 
         this.loadScript(sw);
         this.addScript(sw);
-        if (!View.isInitialised()) {
+        if (!hasView()) {
             // Only invoke if run from the command line
             // if the GUI is present then its up to the user to invoke it
             this.invokeScript(sw);

--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/ExtensionSpider.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/ExtensionSpider.java
@@ -42,7 +42,6 @@ import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.SessionChangedListener;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteNode;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.DefaultValueGenerator;
@@ -220,7 +219,7 @@ public class ExtensionSpider extends ExtensionAdaptor
     public void sessionAboutToChange(Session session) {
         // Shut all of the scans down and remove them
         this.scanController.reset();
-        if (View.isInitialised()) {
+        if (hasView()) {
             this.getSpiderPanel().reset();
             if (spiderDialog != null) {
                 spiderDialog.reset();
@@ -254,7 +253,7 @@ public class ExtensionSpider extends ExtensionAdaptor
      */
     private void sessionChangedEventHandler(Session session) {
         // Clear all scans
-        if (View.isInitialised()) {
+        if (hasView()) {
             this.getSpiderPanel().reset();
         }
         if (session == null) {
@@ -319,7 +318,7 @@ public class ExtensionSpider extends ExtensionAdaptor
 
     @Override
     public void sessionScopeChanged(Session session) {
-        if (View.isInitialised()) {
+        if (hasView()) {
             this.getSpiderPanel().sessionScopeChanged(session);
         }
     }
@@ -330,7 +329,7 @@ public class ExtensionSpider extends ExtensionAdaptor
             this.scanController.stopAllScans();
         }
 
-        if (View.isInitialised()) {
+        if (hasView()) {
             this.getSpiderPanel().sessionModeChanged(mode);
             getMenuItemCustomScan().setEnabled(!Mode.safe.equals(mode));
         }
@@ -387,7 +386,7 @@ public class ExtensionSpider extends ExtensionAdaptor
     public void destroy() {
         // Shut all of the scans down
         this.stopAllScans();
-        if (View.isInitialised()) {
+        if (hasView()) {
             this.getSpiderPanel().reset();
         }
     }
@@ -634,7 +633,7 @@ public class ExtensionSpider extends ExtensionAdaptor
         }
 
         int id = this.scanController.startScan(displayName, target, user, customConfigurations);
-        if (View.isInitialised()) {
+        if (hasView()) {
             addScanToUi(this.scanController.getScan(id));
         }
         return id;
@@ -757,7 +756,7 @@ public class ExtensionSpider extends ExtensionAdaptor
     @Override
     public void pauseScan(int id) {
         this.scanController.pauseScan(id);
-        if (View.isInitialised()) {
+        if (hasView()) {
             // Update the UI in case this was initiated from the API
             this.getSpiderPanel().updateScannerUI();
         }
@@ -766,7 +765,7 @@ public class ExtensionSpider extends ExtensionAdaptor
     @Override
     public void pauseAllScans() {
         this.scanController.pauseAllScans();
-        if (View.isInitialised()) {
+        if (hasView()) {
             // Update the UI in case this was initiated from the API
             this.getSpiderPanel().updateScannerUI();
         }
@@ -775,7 +774,7 @@ public class ExtensionSpider extends ExtensionAdaptor
     @Override
     public void resumeScan(int id) {
         this.scanController.resumeScan(id);
-        if (View.isInitialised()) {
+        if (hasView()) {
             // Update the UI in case this was initiated from the API
             this.getSpiderPanel().updateScannerUI();
         }
@@ -784,7 +783,7 @@ public class ExtensionSpider extends ExtensionAdaptor
     @Override
     public void resumeAllScans() {
         this.scanController.resumeAllScans();
-        if (View.isInitialised()) {
+        if (hasView()) {
             // Update the UI in case this was initiated from the API
             this.getSpiderPanel().updateScannerUI();
         }
@@ -839,8 +838,7 @@ public class ExtensionSpider extends ExtensionAdaptor
     public void showSpiderDialog(Target target) {
         if (spiderDialog == null) {
             spiderDialog =
-                    new SpiderDialog(
-                            this, View.getSingleton().getMainFrame(), new Dimension(700, 430));
+                    new SpiderDialog(this, getView().getMainFrame(), new Dimension(700, 430));
         }
         if (spiderDialog.isVisible()) {
             // Its behind you! Actually not needed no the window is alwaysOnTop, but keeping in case

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
@@ -40,7 +40,6 @@ import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.Model;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.history.PopupMenuExportContextURLs;
 import org.zaproxy.zap.model.Context;
@@ -267,7 +266,7 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
                                             .getSession()
                                             .getContext(popupContextTreeMenuExport.getContextId());
                             ContextExportDialog exportDialog =
-                                    new ContextExportDialog(View.getSingleton().getMainFrame());
+                                    new ContextExportDialog(getView().getMainFrame());
                             exportDialog.setSelectedContext(context);
                             exportDialog.setVisible(true);
                         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
@@ -29,7 +29,7 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.SessionChangedListener;
 import org.parosproxy.paros.model.Session;
-import org.parosproxy.paros.view.View;
+import org.parosproxy.paros.view.MainFrame;
 
 /**
  * This extension was introduced so that the session persist and snapshot menu item and buttons can
@@ -84,9 +84,10 @@ public class ExtensionUiUtils extends ExtensionAdaptor implements SessionChanged
     }
 
     private void sessionChangedEventHandler(Session session) {
-        View.getSingleton().getMainFrame().getMainMenuBar().sessionChanged(session);
-        View.getSingleton().getMainFrame().getMainToolbarPanel().sessionChanged(session);
-        View.getSingleton().getMainFrame().setTitle(session);
+        MainFrame mainFrame = getView().getMainFrame();
+        mainFrame.getMainMenuBar().sessionChanged(session);
+        mainFrame.getMainToolbarPanel().sessionChanged(session);
+        mainFrame.setTitle(session);
     }
 
     @Override
@@ -98,7 +99,7 @@ public class ExtensionUiUtils extends ExtensionAdaptor implements SessionChanged
     @Override
     public void sessionPropertiesChanged(Session session) {
         if (EventQueue.isDispatchThread()) {
-            View.getSingleton().getMainFrame().setTitle(session);
+            getView().getMainFrame().setTitle(session);
             return;
         }
 


### PR DESCRIPTION
Prefer instance variable instead of singleton (for example, `getView()`
instead of `View.getSingleton()`).
Add convenience method `ExtensionAdaptor#hasView()` and change
extensions to use it (more readable than a null check).