### PR TITLE
Restore error counter

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/log4j/ExtensionLog4j.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/log4j/ExtensionLog4j.java
@@ -30,6 +30,7 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.SessionChangedListener;
 import org.parosproxy.paros.model.Session;
+import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.ScanStatus;
 import org.zaproxy.zap.view.ZapMenuItem;
 
@@ -51,7 +52,7 @@ public class ExtensionLog4j extends ExtensionAdaptor {
         super(NAME);
         this.setOrder(56);
 
-        if (Constant.isDevMode() && hasView()) {
+        if (Constant.isDevMode() && View.isInitialised()) {
             // Only enable if this is a developer build, ie build from source, or explicitly enabled
 
             scanStatus =
@@ -63,7 +64,7 @@ public class ExtensionLog4j extends ExtensionAdaptor {
 
             Logger.getRootLogger().addAppender(new ZapOutputWriter(scanStatus));
 
-            getView()
+            View.getSingleton()
                     .getMainFrame()
                     .getMainFooterPanel()
                     .addFooterToolbarRightLabel(scanStatus.getCountLabel());


### PR DESCRIPTION
Previous change (#5603) prevented the counter from being initialised and
added because the instance view is not yet set.