### PR TITLE
Cope with missing token in auth POST data

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodType.java
@@ -400,11 +400,22 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
             Map<String, String> parameters = extractParametersFromPostData(postRequestBody);
             if (parameters != null) {
                 String oldAcsrfTokenValue = null;
-                String replacedPostData = null;
+                String replacedPostData = postRequestBody;
                 for (AntiCsrfToken antiCsrfToken : freshAcsrfTokens) {
                     oldAcsrfTokenValue = parameters.get(antiCsrfToken.getName());
+                    if (oldAcsrfTokenValue == null) {
+                        if (LOGGER.isDebugEnabled()) {
+                            LOGGER.debug(
+                                    "ACSRF token "
+                                            + antiCsrfToken.getName()
+                                            + " not found in the POST data: "
+                                            + postRequestBody);
+                        }
+                        continue;
+                    }
+
                     replacedPostData =
-                            postRequestBody.replace(
+                            replacedPostData.replace(
                                     oldAcsrfTokenValue,
                                     paramEncoder.apply(antiCsrfToken.getValue()));
 


### PR DESCRIPTION
Prevent a NPE if the anti-csrf token is not present in the POST data,
also, accumulate replacements in case there's more than one.