### PR TITLE
Exclude methods moved to interface

### DIFF
--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -123,6 +123,11 @@ val japicmp by tasks.registering(JapicmpTask::class) {
     oldClasspath = files(zapJar(versionBC))
     newClasspath = files(tasks.named<Jar>(JavaPlugin.JAR_TASK_NAME).map { it.archivePath })
     ignoreMissingClasses = true
+    methodExcludes = listOf(
+        // Implementation moved to interface
+        "org.parosproxy.paros.extension.ExtensionAdaptor#getURL()",
+        "org.parosproxy.paros.extension.ExtensionAdaptor#getAuthor()"
+    )
 
     richReport {
         destinationDir = file("$buildDir/reports/japicmp/")


### PR DESCRIPTION
Exclude `ExtensionAdaptor#getURL()` and `getAuthor()` both moved to the
interface `Extension`.
Ensures that the binary compatibility check doesn't fail because of those
methods (i.e. `METHOD_REMOVED_IN_SUPERCLASS`).