### PR TITLE
Run tests with JUnit 5

### DIFF
--- a/zap/src/test/java/ch/csnc/extension/httpclient/AliasCertificateUnitTest.java
+++ b/zap/src/test/java/ch/csnc/extension/httpclient/AliasCertificateUnitTest.java
@@ -19,18 +19,18 @@
  */
 package ch.csnc.extension.httpclient;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 import static org.mockito.BDDMockito.given;
 
 import java.security.cert.Certificate;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AliasCertificateUnitTest {
 
     private AliasCertificate aliasCertificate;

--- a/zap/src/test/java/ch/csnc/extension/httpclient/AliasKeyManagerUnitTest.java
+++ b/zap/src/test/java/ch/csnc/extension/httpclient/AliasKeyManagerUnitTest.java
@@ -19,27 +19,38 @@
  */
 package ch.csnc.extension.httpclient;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 import java.net.Socket;
-import java.security.*;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.KeyStoreSpi;
+import java.security.NoSuchAlgorithmException;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Unit test for {@link ch.csnc.extension.httpclient.AliasKeyManager}
  *
  * @author bjoern.kimminich@gmx.de
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AliasKeyManagerUnitTest {
 
     private static final String ALIAS = "alias";
@@ -51,7 +62,7 @@ public class AliasKeyManagerUnitTest {
 
     @Mock private KeyStoreSpi keyStoreSpi;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         keyStore = new KeyStore(keyStoreSpi, null, null) {};
         keyStore.load(null);

--- a/zap/src/test/java/ch/csnc/extension/httpclient/PKCS11ConfigurationUnitTest.java
+++ b/zap/src/test/java/ch/csnc/extension/httpclient/PKCS11ConfigurationUnitTest.java
@@ -19,12 +19,18 @@
  */
 package ch.csnc.extension.httpclient;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import ch.csnc.extension.httpclient.PKCS11Configuration.PCKS11ConfigurationBuilder;
 import java.io.InputStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link ch.csnc.extension.httpclient.PKCS11Configuration} */
 public class PKCS11ConfigurationUnitTest {
@@ -33,54 +39,97 @@ public class PKCS11ConfigurationUnitTest {
     private static final String LIBRARY = "path/to/library";
 
     private PKCS11Configuration configuration;
-    private PCKS11ConfigurationBuilder configurationBuilder;
 
     private static PCKS11ConfigurationBuilder getConfigurationBuilderWithNameAndLibrarySet() {
         return PKCS11Configuration.builder().setName(NAME).setLibrary(LIBRARY);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowExceptionWhenBuildingAConfigurationWithoutNameAndLibrary() {
-        PKCS11Configuration.builder().build();
+        // Given
+        PCKS11ConfigurationBuilder builder = PKCS11Configuration.builder();
+        // When
+        IllegalStateException e = assertThrows(IllegalStateException.class, builder::build);
+        // Then
+        assertThat(e.getMessage(), containsString("name"));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowExceptionWhenBuildingAConfigurationWithoutName() {
-        PKCS11Configuration.builder().setLibrary(LIBRARY).build();
+        // Given
+        PCKS11ConfigurationBuilder builder = PKCS11Configuration.builder().setLibrary(LIBRARY);
+        // When
+        IllegalStateException e = assertThrows(IllegalStateException.class, builder::build);
+        // Then
+        assertThat(e.getMessage(), containsString("name"));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowExceptionWhenCreatingAConfigurationWithoutLibrary() {
-        PKCS11Configuration.builder().setName(NAME).build();
+        // Given
+        PCKS11ConfigurationBuilder builder = PKCS11Configuration.builder().setName(NAME);
+        // When
+        IllegalStateException e = assertThrows(IllegalStateException.class, builder::build);
+        // Then
+        assertThat(e.getMessage(), containsString("library"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionWhenSettingAnEmptyName() {
-        PKCS11Configuration.builder().setName("");
+        // Given
+        PCKS11ConfigurationBuilder builder = PKCS11Configuration.builder();
+        String name = "";
+        // When
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> builder.setName(name));
+        // Then
+        assertThat(e.getMessage(), containsString("name"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionWhenSettingANullName() {
-        PKCS11Configuration.builder().setName(null);
+        // Given
+        PCKS11ConfigurationBuilder builder = PKCS11Configuration.builder();
+        String name = null;
+        // When
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> builder.setName(name));
+        // Then
+        assertThat(e.getMessage(), containsString("name"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionWhenSettingAnEmptyLibrary() {
-        PKCS11Configuration.builder().setLibrary("");
+        // Given
+        PCKS11ConfigurationBuilder builder = PKCS11Configuration.builder();
+        String library = "";
+        // When
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> builder.setLibrary(library));
+        // Then
+        assertThat(e.getMessage(), containsString("library"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionWhenSettingANullLibrary() {
-        PKCS11Configuration.builder().setLibrary(null);
+        // Given
+        PCKS11ConfigurationBuilder builder = PKCS11Configuration.builder();
+        String library = null;
+        // When
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> builder.setLibrary(library));
+        // Then
+        assertThat(e.getMessage(), containsString("library"));
     }
 
     @Test
     public void shouldCreateConfigurationWithNonEmptyNameAndNonEmptyLibrary() {
         // Given
+        PCKS11ConfigurationBuilder builder = PKCS11Configuration.builder();
         String nonEmptyName = "ProviderName";
         String nonEmptyLibrary = "Library";
         // When / Then
-        PKCS11Configuration.builder().setName(nonEmptyName).setLibrary(nonEmptyLibrary).build();
+        assertDoesNotThrow(() -> builder.setName(nonEmptyName).setLibrary(nonEmptyLibrary).build());
     }
 
     @Test
@@ -135,13 +184,15 @@ public class PKCS11ConfigurationUnitTest {
         assertThat(retrievedStringRepresentation, containsString("slotListIndex = 0"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionWhenSettingNegativeSlotListIndex() {
         // Given
-        configurationBuilder = getConfigurationBuilderWithNameAndLibrarySet();
+        PCKS11ConfigurationBuilder builder = getConfigurationBuilderWithNameAndLibrarySet();
         // When
-        configurationBuilder.setSlotListIndex(-1);
-        // Then = IllegalArgumentException.class
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> builder.setSlotListIndex(-1));
+        // Then
+        assertThat(e.getMessage(), containsString("slotListIndex"));
     }
 
     @Test
@@ -234,13 +285,15 @@ public class PKCS11ConfigurationUnitTest {
         assertThat(retrievedSlotListIndexSet, is(equalTo(slotListIndexSet)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionWhenSettingNegativeSlotId() {
         // Given
-        configurationBuilder = getConfigurationBuilderWithNameAndLibrarySet();
+        PCKS11ConfigurationBuilder builder = getConfigurationBuilderWithNameAndLibrarySet();
         // When
-        configurationBuilder.setSlotId(-1);
-        // Then = IllegalArgumentException.class
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> builder.setSlotId(-1));
+        // Then
+        assertThat(e.getMessage(), containsString("slotId"));
     }
 
     @Test

--- a/zap/src/test/java/ch/csnc/extension/httpclient/SSLContextManagerUnitTest.java
+++ b/zap/src/test/java/ch/csnc/extension/httpclient/SSLContextManagerUnitTest.java
@@ -19,18 +19,18 @@
  */
 package ch.csnc.extension.httpclient;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SSLContextManagerUnitTest {
 
     private SSLContextManager sslContextManager;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         sslContextManager = new SSLContextManager();
     }

--- a/zap/src/test/java/ch/csnc/extension/util/DriverConfigurationUnitTest.java
+++ b/zap/src/test/java/ch/csnc/extension/util/DriverConfigurationUnitTest.java
@@ -19,26 +19,24 @@
  */
 package ch.csnc.extension.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Vector;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /** Unit test for {@link DriverConfiguration}. */
 public class DriverConfigurationUnitTest {
-
-    @ClassRule public static TemporaryFolder tempDir = new TemporaryFolder();
 
     @Test
     public void shouldCreateConfigurationFromFile() throws Exception {
@@ -54,9 +52,9 @@ public class DriverConfigurationUnitTest {
     }
 
     @Test
-    public void shouldWriteConfigurationToFile() throws Exception {
+    public void shouldWriteConfigurationToFile(@TempDir Path tempDir) throws Exception {
         // Given
-        File file = tempDir.newFile();
+        File file = Files.createTempFile(tempDir, "conf", "").toFile();
         DriverConfiguration configuration = new DriverConfiguration(file);
         configuration.setNames(vector("Name A", "Name B", "Name C"));
         configuration.setPaths(vector("Path A", "Path B", "Path C"));

--- a/zap/src/test/java/org/apache/commons/httpclient/HttpMethodBaseUnitTest.java
+++ b/zap/src/test/java/org/apache/commons/httpclient/HttpMethodBaseUnitTest.java
@@ -19,11 +19,11 @@
  */
 package org.apache.commons.httpclient;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class HttpMethodBaseUnitTest {
 

--- a/zap/src/test/java/org/apache/commons/httpclient/URIUnitTest.java
+++ b/zap/src/test/java/org/apache/commons/httpclient/URIUnitTest.java
@@ -19,11 +19,11 @@
  */
 package org.apache.commons.httpclient;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link URI}. */
 public class URIUnitTest {

--- a/zap/src/test/java/org/parosproxy/paros/CommandLineUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/CommandLineUnitTest.java
@@ -19,20 +19,24 @@
  */
 package org.parosproxy.paros;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
 import java.io.File;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,22 +46,19 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Vector;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.parosproxy.paros.extension.CommandLineArgument;
 import org.parosproxy.paros.extension.CommandLineListener;
 import org.zaproxy.zap.utils.I18N;
 
 /** Unit test for {@link CommandLine}. */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CommandLineUnitTest {
-
-    @Rule public TemporaryFolder folder = new TemporaryFolder();
 
     private static final Vector<CommandLineArgument[]> NO_EXTENSIONS_CUSTOM_ARGUMENTS =
             new Vector<>();
@@ -80,7 +81,7 @@ public class CommandLineUnitTest {
         {"aaa(1).ddd", "ggg"}
     };
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         given(i18n.getString(anyString())).willReturn("");
         given(i18n.getString(anyString(), any())).willReturn("");
@@ -91,9 +92,8 @@ public class CommandLineUnitTest {
     public void shouldAcceptNullArguments() throws Exception {
         // Given
         String[] args = null;
-        // When
-        cmdLine = new CommandLine(args);
-        // Then = No Exception.
+        // When / Then
+        assertDoesNotThrow(() -> new CommandLine(args));
     }
 
     @Test
@@ -101,9 +101,9 @@ public class CommandLineUnitTest {
         // Given
         String[] args = {null, null};
         cmdLine = new CommandLine(args);
-        // When
-        cmdLine.parse(NO_EXTENSIONS_CUSTOM_ARGUMENTS, NO_SUPPORTED_FILE_EXTENSIONS);
-        // Then = No Exception.
+        // When / Then
+        assertDoesNotThrow(
+                () -> cmdLine.parse(NO_EXTENSIONS_CUSTOM_ARGUMENTS, NO_SUPPORTED_FILE_EXTENSIONS));
     }
 
     @Test
@@ -133,18 +133,23 @@ public class CommandLineUnitTest {
         assertThat(cmdLine.isGUI(), is(equalTo(false)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailIfDaemonAndCommandLineArgumentsAreSet() throws Exception {
-        // Given / When
-        cmdLine = new CommandLine(new String[] {CommandLine.CMD, CommandLine.DAEMON});
-        // Then = IllegalArgumentException.class
+        // Given
+        String[] args = {CommandLine.CMD, CommandLine.DAEMON};
+        // When
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> new CommandLine(args));
+        // Then
+        assertThat(e.getMessage(), containsString("used at the same time"));
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldFailIfSessionArgumentDoesNotHaveValue() throws Exception {
-        // Given / When
-        cmdLine = new CommandLine(new String[] {CommandLine.SESSION});
-        // Then = Exception.class
+        // Given
+        String[] args = {CommandLine.SESSION};
+        // When / Then
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> new CommandLine(args));
     }
 
     @Test
@@ -157,11 +162,12 @@ public class CommandLineUnitTest {
         assertThat(cmdLine.getArgument(CommandLine.SESSION), is(equalTo(argumentValue)));
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldFailIfNewSessionArgumentDoesNotHaveValue() throws Exception {
-        // Given / When
-        cmdLine = new CommandLine(new String[] {CommandLine.NEW_SESSION});
-        // Then = Exception.class
+        // Given
+        String[] args = {CommandLine.NEW_SESSION};
+        // When / Then
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> new CommandLine(args));
     }
 
     @Test
@@ -174,18 +180,20 @@ public class CommandLineUnitTest {
         assertThat(cmdLine.getArgument(CommandLine.NEW_SESSION), is(equalTo(argumentValue)));
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldFailIfPortArgumentDoesNotHaveValue() throws Exception {
-        // Given / When
-        cmdLine = new CommandLine(new String[] {CommandLine.PORT});
-        // Then = Exception.class
+        // Given
+        String[] args = {CommandLine.PORT};
+        // When / Then
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> new CommandLine(args));
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldFailToParseInvalidPortArgument() throws Exception {
-        // Given / When
-        cmdLine = new CommandLine(new String[] {CommandLine.PORT, "InvalidPort"});
-        // Then = Exception.class
+        // Given
+        String[] args = {CommandLine.PORT, "InvalidPort"};
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> new CommandLine(args));
     }
 
     @Test
@@ -199,11 +207,12 @@ public class CommandLineUnitTest {
         assertThat(cmdLine.getArgument(CommandLine.PORT), is(equalTo("8080")));
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldFailIfHostArgumentDoesNotHaveValue() throws Exception {
-        // Given / When
-        cmdLine = new CommandLine(new String[] {CommandLine.HOST});
-        // Then = Exception.class
+        // Given
+        String[] args = {CommandLine.HOST};
+        // When / Then
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> new CommandLine(args));
     }
 
     @Test
@@ -255,13 +264,14 @@ public class CommandLineUnitTest {
         assertThat(cmdLine.getArgument(argName), is(equalTo(null)));
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldFailIfGivenUnsupportedArgument() throws Exception {
         // Given
         cmdLine = new CommandLine(new String[] {"-unsupported"});
-        // When
-        cmdLine.parse(NO_EXTENSIONS_CUSTOM_ARGUMENTS, NO_SUPPORTED_FILE_EXTENSIONS);
-        // Then = Exception.class
+        // When / Then
+        assertThrows(
+                Exception.class,
+                () -> cmdLine.parse(NO_EXTENSIONS_CUSTOM_ARGUMENTS, NO_SUPPORTED_FILE_EXTENSIONS));
     }
 
     @Test
@@ -317,12 +327,9 @@ public class CommandLineUnitTest {
                 new CommandLineArgument[] {new CommandLineArgument("-b", 2, null, null, null)});
         customArguments.add(
                 new CommandLineArgument[] {new CommandLineArgument("-c", 3, null, null, null)});
-        try {
-            cmdLine.parse(customArguments, NO_SUPPORTED_FILE_EXTENSIONS);
-            fail("Expected an exception");
-        } catch (Exception e) {
-            // Expected
-        }
+        assertThrows(
+                Exception.class,
+                () -> cmdLine.parse(customArguments, NO_SUPPORTED_FILE_EXTENSIONS));
     }
 
     @Test
@@ -338,50 +345,55 @@ public class CommandLineUnitTest {
         assertThat(customArguments.get(0)[0].getArguments().size(), is(equalTo(3)));
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldFailTheParseIfArgumentIsNotSupportedArgumentNorFile() throws Exception {
         // Given
         String notAFile = "NotAFile" + new Random().nextInt();
         cmdLine = new CommandLine(new String[] {notAFile});
-        // When
-        cmdLine.parse(NO_EXTENSIONS_CUSTOM_ARGUMENTS, NO_SUPPORTED_FILE_EXTENSIONS);
-        // Then = Exception.class
+        // When / Then
+        assertThrows(
+                Exception.class,
+                () -> cmdLine.parse(NO_EXTENSIONS_CUSTOM_ARGUMENTS, NO_SUPPORTED_FILE_EXTENSIONS));
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldFailTheParseIfArgumentIsNotSupportedArgumentNorSupportedFileWithExtension()
             throws Exception {
         // Given
         cmdLine = new CommandLine(new String[] {"notsupported.test"});
-        // When
-        cmdLine.parse(NO_EXTENSIONS_CUSTOM_ARGUMENTS, NO_SUPPORTED_FILE_EXTENSIONS);
-        // Then = Exception.class
+        // When / Then
+        assertThrows(
+                Exception.class,
+                () -> cmdLine.parse(NO_EXTENSIONS_CUSTOM_ARGUMENTS, NO_SUPPORTED_FILE_EXTENSIONS));
     }
 
     @Test
-    public void shouldAcceptFileArgumentIfHasSupportedFileExtension() throws Exception {
+    public void shouldAcceptFileArgumentIfHasSupportedFileExtension(@TempDir Path folder)
+            throws Exception {
         // Given
         String fileExtension = "test";
-        File testFile = folder.newFile("aaa." + fileExtension);
+        File testFile = Files.createFile(folder.resolve("aaa." + fileExtension)).toFile();
         Map<String, CommandLineListener> supportedExtensions = new HashMap<>();
         supportedExtensions.put(fileExtension, new AcceptAllFilesCommandLineListener());
         cmdLine = new CommandLine(new String[] {testFile.toString()});
-        // When
-        cmdLine.parse(NO_EXTENSIONS_CUSTOM_ARGUMENTS, supportedExtensions);
-        // Then = Accepted file argument
+        // When / Then = Accepted file argument
+        assertDoesNotThrow(
+                () -> cmdLine.parse(NO_EXTENSIONS_CUSTOM_ARGUMENTS, supportedExtensions));
     }
 
-    @Test(expected = Exception.class)
-    public void shouldNotAcceptFileArgumentIfRejectedBySupportedFileExtension() throws Exception {
+    @Test
+    public void shouldNotAcceptFileArgumentIfRejectedBySupportedFileExtension(@TempDir Path folder)
+            throws Exception {
         // Given
         String fileExtension = "test";
-        File testFile = folder.newFile("aaa." + fileExtension);
+        File testFile = Files.createFile(folder.resolve("aaa." + fileExtension)).toFile();
         Map<String, CommandLineListener> supportedExtensions = new HashMap<>();
         supportedExtensions.put(fileExtension, new RejectAllFilesCommandLineListener());
         cmdLine = new CommandLine(new String[] {testFile.toString()});
-        // When
-        cmdLine.parse(NO_EXTENSIONS_CUSTOM_ARGUMENTS, supportedExtensions);
-        // Then = Exception.class
+        // When / Then
+        assertThrows(
+                Exception.class,
+                () -> cmdLine.parse(NO_EXTENSIONS_CUSTOM_ARGUMENTS, supportedExtensions));
     }
 
     private static class AcceptAllFilesCommandLineListener implements CommandLineListener {
@@ -418,7 +430,7 @@ public class CommandLineUnitTest {
 
     @Test
     public void shouldMaintainConfigOrder() throws Exception {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         for (String[] kv : TEST_CONF_VALUES) {
             list.add("-config");
             list.add(kv[0] + "=" + kv[1]);
@@ -438,8 +450,8 @@ public class CommandLineUnitTest {
     }
 
     @Test
-    public void shouldMaintainConfigfileOrder() throws Exception {
-        File testFile = folder.newFile("text.conf");
+    public void shouldMaintainConfigfileOrder(@TempDir Path folder) throws Exception {
+        File testFile = Files.createFile(folder.resolve("text.conf")).toFile();
         PrintWriter pw = new PrintWriter(testFile);
         for (String[] kv : TEST_CONF_VALUES) {
             pw.println(kv[0] + "=" + kv[1]);

--- a/zap/src/test/java/org/parosproxy/paros/ConstantUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/ConstantUnitTest.java
@@ -19,9 +19,9 @@
  */
 package org.parosproxy.paros;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,21 +30,20 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /** Unit test for {@link Constant}. */
 public class ConstantUnitTest {
 
-    @ClassRule public static TemporaryFolder tempDir = new TemporaryFolder();
+    @TempDir static Path tempDir;
     private Path zapInstallDir;
     private Path zapHomeDir;
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
-        Path parentDir = tempDir.newFolder().toPath();
+        Path parentDir = Files.createTempDirectory(tempDir, "zap-");
         zapInstallDir = Files.createDirectories(parentDir.resolve("install"));
         zapHomeDir = Files.createDirectories(parentDir.resolve("home"));
     }

--- a/zap/src/test/java/org/parosproxy/paros/common/AbstractParamUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/common/AbstractParamUnitTest.java
@@ -19,16 +19,16 @@
  */
 package org.parosproxy.paros.common;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.configuration.FileConfiguration;
 import org.apache.commons.configuration.HierarchicalConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 /** Unit test for {@link AbstractParam}. */

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/AbstractPluginUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/AbstractPluginUnitTest.java
@@ -19,18 +19,20 @@
  */
 package org.parosproxy.paros.core.scanner;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.security.InvalidParameterException;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.httpclient.URI;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMessage;
@@ -43,13 +45,12 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
 /** Unit test for {@link AbstractPlugin}. */
 public class AbstractPluginUnitTest extends PluginTestUtils {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToSetNullTechSet() {
         // Given
         AbstractPlugin plugin = createAbstractPlugin();
-        // When
-        plugin.setTechSet(null);
-        // Then = IllegalArgumentException.class
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> plugin.setTechSet(null));
     }
 
     @Test
@@ -165,11 +166,12 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
         assertThat(plugin.isEnabled(), is(equalTo(Boolean.TRUE)));
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldFailWhenSettingEnabledStateWithoutConfig() {
-        // Given / When
-        createAbstractPlugin().setEnabled(false);
-        // Then = Exception.class
+        // Given
+        AbstractPlugin plugin = createAbstractPlugin();
+        // When / Then
+        assertThrows(NullPointerException.class, () -> plugin.setEnabled(false));
     }
 
     @Test
@@ -191,11 +193,14 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
         assertThat(plugin.getAttackStrength(), is(equalTo(Plugin.AttackStrength.MEDIUM)));
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldFailWhenSettingAttackStrengthWithoutConfig() {
-        // Given / When
-        createAbstractPlugin().setAttackStrength(Plugin.AttackStrength.INSANE);
-        // Then = Exception.class
+        // Given
+        AbstractPlugin plugin = createAbstractPlugin();
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> plugin.setAttackStrength(Plugin.AttackStrength.INSANE));
     }
 
     @Test
@@ -249,11 +254,14 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
         assertThat(plugin.getAlertThreshold(), is(equalTo(Plugin.AlertThreshold.MEDIUM)));
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldFailWhenSettingAlertThresholdWithoutConfig() {
-        // Given / When
-        createAbstractPlugin().setAlertThreshold(Plugin.AlertThreshold.DEFAULT);
-        // Then = Exception.class
+        // Given
+        AbstractPlugin plugin = createAbstractPlugin();
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> plugin.setAlertThreshold(Plugin.AlertThreshold.DEFAULT));
     }
 
     @Test
@@ -343,24 +351,22 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
         assertThat(plugin.getAlertThreshold(true), is(equalTo(anAlertThreshold)));
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldFailToCloneIntoNonAbstractPlugin() {
         // Given
         AbstractPlugin pluginA = createAbstractPluginWithConfig();
         Plugin pluginB = createNonAbstractPlugin();
-        // When
-        pluginA.cloneInto(pluginB);
-        // Then = Exception.class
+        // When / Then
+        assertThrows(InvalidParameterException.class, () -> pluginA.cloneInto(pluginB));
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldFailToCloneIntoPluginWithoutConfig() {
         // Given
         AbstractPlugin pluginA = createAbstractPluginWithConfig();
         AbstractPlugin pluginB = createAbstractPlugin();
-        // When
-        pluginA.cloneInto(pluginB);
-        // Then = Exception.class
+        // When / Then
+        assertThrows(NullPointerException.class, () -> pluginA.cloneInto(pluginB));
     }
 
     @Test
@@ -453,14 +459,13 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
         assertThat(comparisonResult, is(equalTo(1)));
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldFailToLoadFromConfigIfConfigNotSet() {
         // Given
         AbstractPlugin plugin = createAbstractPlugin();
         Configuration config = new ZapXmlConfiguration();
-        // When
-        plugin.loadFrom(config);
-        // Then = Exception.class
+        // When / Then
+        assertThrows(NullPointerException.class, () -> plugin.loadFrom(config));
     }
 
     @Test
@@ -1093,13 +1098,12 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
         assertThat(alert.getUri(), is(equalTo(messageUri)));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldFailToRaiseAlertWithNewAlertIfNoMessageProvided() {
         // Given
         AbstractPlugin plugin = createDefaultPlugin();
-        // When
-        plugin.newAlert().raise();
-        // Then = IllegalStateException
+        // When / Then
+        assertThrows(IllegalStateException.class, () -> plugin.newAlert().raise());
     }
 
     @Test
@@ -1187,14 +1191,13 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
         assertThat(alert.getMessage(), is(sameInstance(alertMessage)));
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldFailToSaveToConfigIfConfigNotSet() {
         // Given
         AbstractPlugin plugin = createAbstractPlugin();
         Configuration config = new ZapXmlConfiguration();
-        // When
-        plugin.saveTo(config);
-        // Then = Exception.class
+        // When / Then
+        assertThrows(NullPointerException.class, () -> plugin.saveTo(config));
     }
 
     @Test

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/KbUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/KbUnitTest.java
@@ -19,14 +19,18 @@
  */
 package org.parosproxy.paros.core.scanner;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Vector;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class KbUnitTest {
 
@@ -39,7 +43,7 @@ public class KbUnitTest {
 
     Kb knowledgeBase;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         knowledgeBase = new Kb();
     }
@@ -53,7 +57,7 @@ public class KbUnitTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void shouldStoreValueForGivenUriAndKey() {
         fail("Not yet implemented");
     }
@@ -70,7 +74,7 @@ public class KbUnitTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void shouldRetrieveStoredObjectsForGivenUriAndKey() {
         fail("Not yet implemented");
     }
@@ -84,7 +88,7 @@ public class KbUnitTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void shouldRetrieveStoredBooleanForGivenUriAndKey() {
         fail("Not yet implemented");
     }
@@ -98,7 +102,7 @@ public class KbUnitTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void shouldRetrieveStoredStringForGivenUriAndKey() {
         fail("Not yet implemented");
     }

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/NameValuePairUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/NameValuePairUnitTest.java
@@ -19,12 +19,12 @@
  */
 package org.parosproxy.paros.core.scanner;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link NameValuePair}. */
 public class NameValuePairUnitTest {

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/PluginFactoryUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/PluginFactoryUnitTest.java
@@ -19,13 +19,13 @@
  */
 package org.parosproxy.paros.core.scanner;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -33,19 +33,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
 
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.utils.I18N;
 
 /** Unit test for {@link PluginFactory}. */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PluginFactoryUnitTest extends PluginTestUtils {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         I18N i18n = mock(I18N.class, withSettings().lenient());
         given(i18n.getString(anyString())).willReturn("");

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/PluginTestUtils.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/PluginTestUtils.java
@@ -23,7 +23,7 @@ import java.util.Date;
 import org.apache.commons.configuration.Configuration;
 import org.apache.log4j.Logger;
 import org.apache.log4j.varia.NullAppender;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.control.AddOn.Status;
@@ -38,7 +38,7 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
  */
 public class PluginTestUtils {
 
-    @BeforeClass
+    @BeforeAll
     public static void suppressLogging() {
         Logger.getRootLogger().addAppender(new NullAppender());
     }

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/UtilUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/UtilUnitTest.java
@@ -19,11 +19,11 @@
  */
 package org.parosproxy.paros.core.scanner;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UtilUnitTest {
 

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantAbstractQueryUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantAbstractQueryUnitTest.java
@@ -19,18 +19,19 @@
  */
 package org.parosproxy.paros.core.scanner;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.commons.lang.mutable.MutableBoolean;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
@@ -49,23 +50,28 @@ public class VariantAbstractQueryUnitTest {
         assertThat(parameters, is(empty()));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldNotAllowToModifyReturnedParametersList() {
         // Given
         VariantAbstractQuery variantAbstractQuery = new VariantAbstractQueryImpl();
-        // When
-        variantAbstractQuery.getParamList().add(param("Name", "Value", 0));
-        // Then = UnsupportedOperationException
+        NameValuePair param = param("Name", "Value", 0);
+        // When / Then
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> variantAbstractQuery.getParamList().add(param));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToProcessUndefinedParameters() {
         // Given
         VariantAbstractQuery variantAbstractQuery = new VariantAbstractQueryImpl();
         List<org.zaproxy.zap.model.NameValuePair> undefinedParameters = null;
-        // When
-        variantAbstractQuery.setParameters(NAME_VALUE_PAIR_TYPE, undefinedParameters);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        variantAbstractQuery.setParameters(
+                                NAME_VALUE_PAIR_TYPE, undefinedParameters));
     }
 
     @Test

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantCookieUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantCookieUnitTest.java
@@ -19,18 +19,19 @@
  */
 package org.parosproxy.paros.core.scanner;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
@@ -48,23 +49,25 @@ public class VariantCookieUnitTest {
         assertThat(parameters, is(empty()));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldNotAllowToModifyReturnedParametersList() {
         // Given
         VariantCookie variantCookie = new VariantCookie();
-        // When
-        variantCookie.getParamList().add(cookie("Name", "Value", 0));
-        // Then = UnsupportedOperationException
+        NameValuePair cookie = cookie("Name", "Value", 0);
+        // When / Then
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> variantCookie.getParamList().add(cookie));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToExtractParametersFromUndefinedMessage() {
         // Given
         VariantCookie variantCookie = new VariantCookie();
         HttpMessage undefinedMessage = null;
-        // When
-        variantCookie.setMessage(undefinedMessage);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class, () -> variantCookie.setMessage(undefinedMessage));
     }
 
     @Test

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantHeaderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantHeaderUnitTest.java
@@ -19,17 +19,18 @@
  */
 package org.parosproxy.paros.core.scanner;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpHeaderField;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
@@ -48,23 +49,25 @@ public class VariantHeaderUnitTest {
         assertThat(parameters, is(empty()));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldNotAllowToModifyReturnedParametersList() {
         // Given
         VariantHeader variantHeader = new VariantHeader();
-        // When
-        variantHeader.getParamList().add(header("Name", "Value", 0));
-        // Then = UnsupportedOperationException
+        NameValuePair header = header("Name", "Value", 0);
+        // When / Then
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> variantHeader.getParamList().add(header));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToExtractParametersFromUndefinedMessage() {
         // Given
         VariantHeader variantHeader = new VariantHeader();
         HttpMessage undefinedMessage = null;
-        // When
-        variantHeader.setMessage(undefinedMessage);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class, () -> variantHeader.setMessage(undefinedMessage));
     }
 
     @Test

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantJSONQueryUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantJSONQueryUnitTest.java
@@ -19,12 +19,12 @@
  */
 package org.parosproxy.paros.core.scanner;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantMultipartFormParametersUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantMultipartFormParametersUnitTest.java
@@ -19,13 +19,14 @@
  */
 package org.parosproxy.paros.core.scanner;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
@@ -49,24 +50,24 @@ public class VariantMultipartFormParametersUnitTest {
         assertThat(parameters, is(empty()));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldNotAllowToModifyReturnedParametersList() {
         // Given
         VariantMultipartFormParameters variant = new VariantMultipartFormParameters();
-        // When
-        variant.getParamList()
-                .add(new NameValuePair(NameValuePair.TYPE_MULTIPART_DATA_PARAM, "name", "fred", 1));
-        // Then = UnsupportedOperationException
+        NameValuePair param =
+                new NameValuePair(NameValuePair.TYPE_MULTIPART_DATA_PARAM, "name", "fred", 1);
+        // When / Then
+        assertThrows(UnsupportedOperationException.class, () -> variant.getParamList().add(param));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToExtractParametersFromUndefinedMessage() {
         // Given
         VariantMultipartFormParameters variant = new VariantMultipartFormParameters();
         HttpMessage undefinedMessage = null;
-        // When
-        variant.setMessage(undefinedMessage);
         // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> variant.setMessage(undefinedMessage));
     }
 
     @Test

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantODataUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantODataUnitTest.java
@@ -19,12 +19,12 @@
  */
 package org.parosproxy.paros.core.scanner;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 

--- a/zap/src/test/java/org/parosproxy/paros/extension/report/ReportGeneratorUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/extension/report/ReportGeneratorUnitTest.java
@@ -19,10 +19,10 @@
  */
 package org.parosproxy.paros.extension.report;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -30,17 +30,14 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import javax.xml.transform.stream.StreamSource;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.zaproxy.zap.testutils.TestUtils;
 
 /** Unit test for {@link ReportGenerator}. */
 public class ReportGeneratorUnitTest extends TestUtils {
 
     private static final String NEWLINE = System.getProperty("line.separator");
-
-    @ClassRule public static TemporaryFolder tempDir = new TemporaryFolder();
 
     @Test
     public void shouldNotEntityEncodeHigherUnicodeChars() {
@@ -53,10 +50,10 @@ public class ReportGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void shouldWriteReportWithWellformedXml() throws Exception {
+    public void shouldWriteReportWithWellformedXml(@TempDir Path tempDir) throws Exception {
         // Given
         String data = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><data>J/ψ → VP</data>" + NEWLINE;
-        Path report = tempDir.newFile().toPath();
+        Path report = Files.createTempFile(tempDir, "", "");
         // When
         ReportGenerator.stringToHtml(data, identityXsl(), report.toString());
         // Then
@@ -64,10 +61,10 @@ public class ReportGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void shouldFailToWriteReportWithMalformedXml() throws Exception {
+    public void shouldFailToWriteReportWithMalformedXml(@TempDir Path tempDir) throws Exception {
         // Given
         String data = "J/ψ → VP</data>";
-        Path report = tempDir.newFile().toPath();
+        Path report = Files.createTempFile(tempDir, "", "");
         // When
         ReportGenerator.stringToHtml(data, identityXsl(), report.toString());
         // Then = nothing written.

--- a/zap/src/test/java/org/parosproxy/paros/model/FileCopierUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/model/FileCopierUnitTest.java
@@ -19,38 +19,38 @@
  */
 package org.parosproxy.paros.model;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 public class FileCopierUnitTest {
 
     private FileCopier fileCopier;
 
-    @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+    @TempDir Path tempFolder;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         fileCopier = new FileCopier();
-        tempFolder.create();
     }
 
     @Test
     public void shouldCopyFileViaPreJava7IO() throws Exception {
         // Given
-        File source = tempFolder.newFile();
+        File source = Files.createTempFile(tempFolder, "", "").toFile();
         FileUtils.writeStringToFile(source, "Test", StandardCharsets.UTF_8);
-        File target = tempFolder.newFile();
+        File target = newFile();
         // When
         fileCopier.copyLegacy(source, target);
         // Then
@@ -60,9 +60,9 @@ public class FileCopierUnitTest {
     @Test
     public void shouldCopyFileViaNIO() throws Exception {
         // Given
-        File source = tempFolder.newFile();
+        File source = newFile();
         FileUtils.writeStringToFile(source, "Test", StandardCharsets.UTF_8);
-        File target = tempFolder.newFile();
+        File target = newFile();
         // When
         fileCopier.copyNIO(source, target);
         // Then
@@ -74,12 +74,16 @@ public class FileCopierUnitTest {
         // Given
         FileCopier fileCopierStub = Mockito.spy(fileCopier);
         doThrow(IOException.class).when(fileCopierStub).copyNIO(any(File.class), any(File.class));
-        File source = tempFolder.newFile();
+        File source = newFile();
         FileUtils.writeStringToFile(source, "Test", StandardCharsets.UTF_8);
-        File target = tempFolder.newFile();
+        File target = newFile();
         // When
         fileCopierStub.copy(source, target);
         // Then
         assertTrue(FileUtils.contentEquals(source, target));
+    }
+
+    private File newFile() throws IOException {
+        return Files.createTempFile(tempFolder, "", "").toFile();
     }
 }

--- a/zap/src/test/java/org/parosproxy/paros/network/HtmlParameterUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/network/HtmlParameterUnitTest.java
@@ -19,12 +19,13 @@
  */
 package org.parosproxy.paros.network;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.network.HttpBodyTestUtils;
 
 /** Unit test for {@link HtmlParameter}. */
@@ -34,59 +35,66 @@ public class HtmlParameterUnitTest extends HttpBodyTestUtils {
     private static final String NON_NULL_NAME = "name";
     private static final String NON_NULL_VALUE = "value";
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToCreateHtmlParameterWithNullCookieLine() {
-        // Given / When
-        new HtmlParameter(null);
-        // Then = IllegalArgumentException
+        // Given
+        String cookieLine = null;
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> new HtmlParameter(cookieLine));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToCreateHtmlParameterWithNullType() {
-        // Given / When
-        new HtmlParameter(null, NON_NULL_NAME, NON_NULL_VALUE);
-        // Then = IllegalArgumentException
+        // Given
+        HtmlParameter.Type type = null;
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new HtmlParameter(type, NON_NULL_NAME, NON_NULL_VALUE));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToCreateHtmlParameterWithNullName() {
-        // Given / When
-        new HtmlParameter(NON_NULL_TYPE, null, NON_NULL_VALUE);
-        // Then = IllegalArgumentException
+        // Given
+        String name = null;
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new HtmlParameter(NON_NULL_TYPE, name, NON_NULL_VALUE));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToCreateHtmlParameterWithNullValue() {
-        // Given / When
-        new HtmlParameter(NON_NULL_TYPE, NON_NULL_NAME, null);
-        // Then = IllegalArgumentException
+        // Given
+        String value = null;
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new HtmlParameter(NON_NULL_TYPE, NON_NULL_NAME, value));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToSetNullType() {
         // Given
         HtmlParameter parameter = new HtmlParameter(NON_NULL_TYPE, NON_NULL_NAME, NON_NULL_VALUE);
-        // When
-        parameter.setType(null);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> parameter.setType(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToSetNullName() {
         // Given
         HtmlParameter parameter = new HtmlParameter(NON_NULL_TYPE, NON_NULL_NAME, NON_NULL_VALUE);
-        // When
-        parameter.setName(null);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> parameter.setName(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToSetNullValue() {
         // Given
         HtmlParameter parameter = new HtmlParameter(NON_NULL_TYPE, NON_NULL_NAME, NON_NULL_VALUE);
-        // When
-        parameter.setValue(null);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> parameter.setValue(null));
     }
 
     @Test

--- a/zap/src/test/java/org/parosproxy/paros/network/HttpBodyUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/network/HttpBodyUnitTest.java
@@ -19,16 +19,16 @@
  */
 package org.parosproxy.paros.network;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
 
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.network.HttpBodyTestUtils;
 
 /** Unit test for {@link HttpBody}. */

--- a/zap/src/test/java/org/parosproxy/paros/network/HttpMessageUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/network/HttpMessageUnitTest.java
@@ -19,15 +19,15 @@
  */
 package org.parosproxy.paros.network;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.model.HistoryReference;
 import org.zaproxy.zap.extension.httpsessions.HttpSession;
 import org.zaproxy.zap.network.HttpRequestBody;

--- a/zap/src/test/java/org/parosproxy/paros/network/HttpRequestHeaderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/network/HttpRequestHeaderUnitTest.java
@@ -19,15 +19,15 @@
  */
 package org.parosproxy.paros.network;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.TreeSet;
 import org.apache.commons.httpclient.URI;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link HttpRequestHeader}. */
 public class HttpRequestHeaderUnitTest {

--- a/zap/src/test/java/org/parosproxy/paros/network/HttpResponseHeaderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/network/HttpResponseHeaderUnitTest.java
@@ -19,11 +19,13 @@
  */
 package org.parosproxy.paros.network;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link HttpResponseHeader}. */
 public class HttpResponseHeaderUnitTest {
@@ -70,31 +72,37 @@ public class HttpResponseHeaderUnitTest {
         assertThat(header.getPrimeHeader(), is(equalTo("HTTP/1.1 100 OK")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToSetNegative3DigitStatusCode() throws Exception {
         // Given
         HttpResponseHeader header = new HttpResponseHeader("HTTP/1.1 200 OK\r\n\r\n");
         // When
-        header.setStatusCode(-200);
-        // Then = IllegalArgumentException
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> header.setStatusCode(-200));
+        // Then
+        assertThat(e.getMessage(), containsString("positive"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToSet2DigitStatusCode() throws Exception {
         // Given
         HttpResponseHeader header = new HttpResponseHeader("HTTP/1.1 200 OK\r\n\r\n");
         // When
-        header.setStatusCode(99);
-        // Then = IllegalArgumentException
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> header.setStatusCode(99));
+        // Then
+        assertThat(e.getMessage(), containsString("3 digit number"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToSet4DigitStatusCode() throws Exception {
         // Given
         HttpResponseHeader header = new HttpResponseHeader("HTTP/1.1 200 OK\r\n\r\n");
         // When
-        header.setStatusCode(1000);
-        // Then = IllegalArgumentException
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> header.setStatusCode(1000));
+        // Then
+        assertThat(e.getMessage(), containsString("3 digit number"));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/VerifyScriptTemplates.java
+++ b/zap/src/test/java/org/zaproxy/zap/VerifyScriptTemplates.java
@@ -19,11 +19,11 @@
  */
 package org.zaproxy.zap;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -39,7 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.script.Compilable;
 import javax.script.ScriptEngineManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Verifies that the script templates are parsed without errors. */
 public class VerifyScriptTemplates {

--- a/zap/src/test/java/org/zaproxy/zap/VersionUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/VersionUnitTest.java
@@ -19,62 +19,76 @@
  */
 package org.zaproxy.zap;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link org.zaproxy.zap.Version}. */
 public class VersionUnitTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionIfVersionIsNull() {
         // Given
         String version = null;
         // When
-        new Version(version);
-        // Then = Exception
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> new Version(version));
+        // Then
+        assertThat(e.getMessage(), containsString("null"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionIfVersionIsEmpty() {
         // Given
         String version = "";
         // When
-        new Version(version);
-        // Then = Exception
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> new Version(version));
+        // Then
+        assertThat(e.getMessage(), containsString("empty"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAcceptVersionWithOnlyMajorVersion() {
         // Given
         String versionWithOnlyMajorNumber = "1";
         // When
-        new Version(versionWithOnlyMajorNumber);
-        // Then = Exception
+        IllegalArgumentException e =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> new Version(versionWithOnlyMajorNumber));
+        // Then
+        assertThat(e.getMessage(), containsString("is not valid"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAcceptVersionWithOnlyMajorAndMinorVersion() {
         // Given
         String versionWithOnlyMajorAndMinorNumbers = "1.0";
         // When
-        new Version(versionWithOnlyMajorAndMinorNumbers);
-        // Then = Exception
+        IllegalArgumentException e =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> new Version(versionWithOnlyMajorAndMinorNumbers));
+        // Then
+        assertThat(e.getMessage(), containsString("is not valid"));
     }
 
     @Test
     public void shouldAcceptVersionWithMajorMinorAndPatchNumbers() {
         // Given
         String versionWithOnlyMajorMinorAndPatchNumbers = "1.0.0";
-        // When
-        new Version(versionWithOnlyMajorMinorAndPatchNumbers);
-        // Then = no exception
+        // When / Then
+        assertDoesNotThrow(() -> new Version(versionWithOnlyMajorMinorAndPatchNumbers));
     }
 
     @Test
@@ -82,8 +96,7 @@ public class VersionUnitTest {
         // Given
         String versionWithPreReleaseIdentifiers = "1.2.3-SNAPSHOT";
         // When
-        new Version(versionWithPreReleaseIdentifiers);
-        // Then = no exception
+        assertDoesNotThrow(() -> new Version(versionWithPreReleaseIdentifiers));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/WithConfigsTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/WithConfigsTest.java
@@ -24,14 +24,15 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.withSettings;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Locale;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.ExtensionLoader;
@@ -40,7 +41,7 @@ import org.zaproxy.zap.testutils.TestUtils;
 import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public abstract class WithConfigsTest extends TestUtils {
 
     /**
@@ -48,15 +49,16 @@ public abstract class WithConfigsTest extends TestUtils {
      *
      * <p>Can be used for other temporary files/dirs.
      */
-    @ClassRule public static TemporaryFolder tempDir = new TemporaryFolder();
+    @TempDir protected static Path tempDir;
 
     private static String zapInstallDir;
     private static String zapHomeDir;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() throws Exception {
-        zapInstallDir = tempDir.newFolder("install").getAbsolutePath();
-        zapHomeDir = tempDir.newFolder("home").getAbsolutePath();
+        zapInstallDir =
+                Files.createDirectories(tempDir.resolve("install")).toAbsolutePath().toString();
+        zapHomeDir = Files.createDirectories(tempDir.resolve("home")).toAbsolutePath().toString();
     }
 
     /**
@@ -65,7 +67,7 @@ public abstract class WithConfigsTest extends TestUtils {
      *
      * @throws Exception if an error occurred while setting up the dirs or core classes.
      */
-    @Before
+    @BeforeEach
     public void setUpZap() throws Exception {
         Constant.setZapInstall(zapInstallDir);
         Constant.setZapHome(zapHomeDir);

--- a/zap/src/test/java/org/zaproxy/zap/authentication/AuthenticationMethodIndicatorsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/authentication/AuthenticationMethodIndicatorsUnitTest.java
@@ -19,21 +19,21 @@
  */
 package org.zaproxy.zap.authentication;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.commons.httpclient.URI;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AuthenticationMethodIndicatorsUnitTest {
 
     private static final String LOGGED_OUT_COMPLEX_INDICATOR = "User [^\\s]* logged out";
@@ -57,7 +57,7 @@ public class AuthenticationMethodIndicatorsUnitTest {
     private HttpMessage loginMessage;
     private AuthenticationMethod method;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         loginMessage = new HttpMessage();
         HttpRequestHeader header = new HttpRequestHeader();

--- a/zap/src/test/java/org/zaproxy/zap/authentication/AuthenticationMethodUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/authentication/AuthenticationMethodUnitTest.java
@@ -19,11 +19,11 @@
  */
 package org.zaproxy.zap.authentication;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.extension.api.ApiResponse;
 import org.zaproxy.zap.session.SessionManagementMethod;
 import org.zaproxy.zap.session.WebSession;

--- a/zap/src/test/java/org/zaproxy/zap/authentication/UsernamePasswordAuthenticationCredentialsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/authentication/UsernamePasswordAuthenticationCredentialsUnitTest.java
@@ -26,12 +26,13 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
 import net.sf.json.JSON;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.extension.api.ApiResponse;
 
 /** @author Vahid Rafiei (@vahid_r) */
@@ -42,7 +43,7 @@ public class UsernamePasswordAuthenticationCredentialsUnitTest {
     private String username = "myUser";
     private String password = "myPass";
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.usernamePasswordAuthenticationCredentials =
                 new UsernamePasswordAuthenticationCredentials(username, password);
@@ -78,7 +79,7 @@ public class UsernamePasswordAuthenticationCredentialsUnitTest {
         assertThat(isConfigured, is(false));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionWhileEncodeWithFieldSeparator() {
         // Given
         String fieldSeparator = "~";
@@ -86,9 +87,13 @@ public class UsernamePasswordAuthenticationCredentialsUnitTest {
                 new UsernamePasswordAuthenticationCredentials(username, password);
 
         // When
-        usernamePasswordAuthenticationCredentials.encode(fieldSeparator);
+        IllegalArgumentException e =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> usernamePasswordAuthenticationCredentials.encode(fieldSeparator));
 
-        // Then throw IllegalArgumentException
+        // Then
+        assertThat(e.getMessage(), containsString("separator"));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/control/AddOnClassnamesUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/AddOnClassnamesUnitTest.java
@@ -19,34 +19,44 @@
  */
 package org.zaproxy.zap.control;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link AddOnClassnames}. */
 public class AddOnClassnamesUnitTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToCreateAddOnClassnamesWithNullAllowed() throws Exception {
         // Given
         List<String> allowed = null;
         // When
-        new AddOnClassnames(allowed, Collections.emptyList());
-        // Then = NullPointerException
+        IllegalArgumentException e =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> new AddOnClassnames(allowed, Collections.emptyList()));
+        // Then
+        assertThat(e.getMessage(), containsString("allowedClassnames"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToCreateAddOnClassnamesWithNullRestricted() throws Exception {
         // Given
         List<String> restricted = null;
         // When
-        new AddOnClassnames(Collections.emptyList(), restricted);
-        // Then = NullPointerException
+        IllegalArgumentException e =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> new AddOnClassnames(Collections.emptyList(), restricted));
+        // Then
+        assertThat(e.getMessage(), containsString("restrictedClassnames"));
     }
 
     @Test
@@ -105,12 +115,12 @@ public class AddOnClassnamesUnitTest {
         assertThat(addOnClassnames.isAllowed("org.example.y.Y"), is(equalTo(true)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailIfClassnameIsNull() throws Exception {
         // Given
         String classname = null;
-        // When
-        AddOnClassnames.ALL_ALLOWED.isAllowed(classname);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(
+                NullPointerException.class, () -> AddOnClassnames.ALL_ALLOWED.isAllowed(classname));
     }
 }

--- a/zap/src/test/java/org/zaproxy/zap/control/AddOnCollectionUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/AddOnCollectionUnitTest.java
@@ -19,16 +19,16 @@
  */
 package org.zaproxy.zap.control;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 import java.io.StringReader;
 import java.util.List;
 import org.apache.commons.configuration.ConfigurationException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.control.AddOnCollection.Platform;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
@@ -138,7 +138,7 @@ public class AddOnCollectionUnitTest {
                     + "	</addon_bbb>\n"
                     + "</ZAP>";
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         configA = new ZapXmlConfiguration();
         configA.setDelimiterParsingDisabled(true);

--- a/zap/src/test/java/org/zaproxy/zap/control/ExtensionFactoryUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/ExtensionFactoryUnitTest.java
@@ -19,9 +19,9 @@
  */
 package org.zaproxy.zap.control;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,15 +30,15 @@ import java.util.List;
 import java.util.Map;
 import org.apache.log4j.Logger;
 import org.apache.log4j.varia.NullAppender;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 
 /** Unit test for {@link ExtensionFactory}. */
 public class ExtensionFactoryUnitTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void suppressLogging() {
         Logger.getLogger(ExtensionFactory.class).addAppender(new NullAppender());
     }

--- a/zap/src/test/java/org/zaproxy/zap/control/ZapAddOnXmlFileUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/ZapAddOnXmlFileUnitTest.java
@@ -19,14 +19,16 @@
  */
 package org.zaproxy.zap.control;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -34,28 +36,26 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.Version;
 
 /** Unit test for {@link ZapAddOnXmlFile}. */
 public class ZapAddOnXmlFileUnitTest {
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldRequireInputStream() throws Exception {
         // Given
         InputStream manifestData = null;
-        // When
-        new ZapAddOnXmlFile(manifestData);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(NullPointerException.class, () -> new ZapAddOnXmlFile(manifestData));
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void shouldFailToLoadEmptyData() throws Exception {
         // Given
         InputStream manifestData = manifestData("");
-        // When
-        ZapAddOnXmlFile manifest = new ZapAddOnXmlFile(manifestData);
-        // Then = IOException
+        // When / Then
+        assertThrows(IOException.class, () -> new ZapAddOnXmlFile(manifestData));
     }
 
     @Test
@@ -148,15 +148,18 @@ public class ZapAddOnXmlFileUnitTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToLoadManifestWithUnrecognisedStatus() throws Exception {
         // Given
         String status = "unrecognised-status";
         InputStream manifestData =
                 manifestData("<zapaddon>", "<status>" + status + "</status>", "</zapaddon>");
         // When
-        ZapAddOnXmlFile manifest = new ZapAddOnXmlFile(manifestData);
-        // Then = IllegalArgumentException
+        IllegalArgumentException e =
+                assertThrows(
+                        IllegalArgumentException.class, () -> new ZapAddOnXmlFile(manifestData));
+        // Then
+        assertThat(e.getMessage(), containsString("status"));
     }
 
     @Test
@@ -316,7 +319,7 @@ public class ZapAddOnXmlFileUnitTest {
                 is(equalTo(" < 6.0.0")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToLoadManifestWithAddOnDepWithMissingId() throws Exception {
         // Given
         InputStream manifestData =
@@ -330,11 +333,15 @@ public class ZapAddOnXmlFileUnitTest {
                         "</dependencies>",
                         "</zapaddon>");
         // When
-        ZapAddOnXmlFile manifest = new ZapAddOnXmlFile(manifestData);
-        // Then = IllegalArgumentException
+        // When
+        IllegalArgumentException e =
+                assertThrows(
+                        IllegalArgumentException.class, () -> new ZapAddOnXmlFile(manifestData));
+        // Then
+        assertThat(e.getMessage(), containsString("id"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToLoadManifestWithAddOnDepWithEmptyId() throws Exception {
         // Given
         InputStream manifestData =
@@ -349,11 +356,14 @@ public class ZapAddOnXmlFileUnitTest {
                         "</dependencies>",
                         "</zapaddon>");
         // When
-        ZapAddOnXmlFile manifest = new ZapAddOnXmlFile(manifestData);
-        // Then = IllegalArgumentException
+        IllegalArgumentException e =
+                assertThrows(
+                        IllegalArgumentException.class, () -> new ZapAddOnXmlFile(manifestData));
+        // Then
+        assertThat(e.getMessage(), containsString("id"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToLoadManifestWithAddOnDepWithMalformedVersion() throws Exception {
         // Given
         InputStream manifestData =
@@ -369,11 +379,14 @@ public class ZapAddOnXmlFileUnitTest {
                         "</dependencies>",
                         "</zapaddon>");
         // When
-        ZapAddOnXmlFile manifest = new ZapAddOnXmlFile(manifestData);
-        // Then = IllegalArgumentException
+        IllegalArgumentException e =
+                assertThrows(
+                        IllegalArgumentException.class, () -> new ZapAddOnXmlFile(manifestData));
+        // Then
+        assertThat(e.getMessage(), containsString("version"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToLoadManifestWithAddOnDepWithMalformedSemVer() throws Exception {
         // Given
         InputStream manifestData =
@@ -389,11 +402,14 @@ public class ZapAddOnXmlFileUnitTest {
                         "</dependencies>",
                         "</zapaddon>");
         // When
-        ZapAddOnXmlFile manifest = new ZapAddOnXmlFile(manifestData);
-        // Then = IllegalArgumentException
+        IllegalArgumentException e =
+                assertThrows(
+                        IllegalArgumentException.class, () -> new ZapAddOnXmlFile(manifestData));
+        // Then
+        assertThat(e.getMessage(), containsString("version range"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToLoadManifestWithAddOnDepWithMalformedNotBeforeVersion()
             throws Exception {
         // Given
@@ -410,11 +426,14 @@ public class ZapAddOnXmlFileUnitTest {
                         "</dependencies>",
                         "</zapaddon>");
         // When
-        ZapAddOnXmlFile manifest = new ZapAddOnXmlFile(manifestData);
-        // Then = IllegalArgumentException
+        IllegalArgumentException e =
+                assertThrows(
+                        IllegalArgumentException.class, () -> new ZapAddOnXmlFile(manifestData));
+        // Then
+        assertThat(e.getMessage(), containsString("not-before-version"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToLoadManifestWithAddOnDepWithMalformedNotFromVersion() throws Exception {
         // Given
         InputStream manifestData =
@@ -430,8 +449,11 @@ public class ZapAddOnXmlFileUnitTest {
                         "</dependencies>",
                         "</zapaddon>");
         // When
-        ZapAddOnXmlFile manifest = new ZapAddOnXmlFile(manifestData);
-        // Then = IllegalArgumentException
+        IllegalArgumentException e =
+                assertThrows(
+                        IllegalArgumentException.class, () -> new ZapAddOnXmlFile(manifestData));
+        // Then
+        assertThat(e.getMessage(), containsString("not-from-version"));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/control/ZapReleaseComparitorUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/ZapReleaseComparitorUnitTest.java
@@ -19,10 +19,10 @@
  */
 package org.zaproxy.zap.control;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link ZapReleaseComparitor}. */
 public class ZapReleaseComparitorUnitTest {
@@ -72,17 +72,11 @@ public class ZapReleaseComparitorUnitTest {
         assertTrue(zrc.compare(new ZapRelease("2.0.1"), new ZapRelease("D-2013-01-07")) < 0);
 
         // Bad versions
-        try {
-            zrc.compare(new ZapRelease("1.4.1.theta"), new ZapRelease("1.4.1.alpha"));
-            fail("Should have thrown an exception");
-        } catch (IllegalArgumentException e) {
-            // worked
-        }
-        try {
-            zrc.compare(new ZapRelease("1.4.1.0"), new ZapRelease("1.4.1.theta"));
-            fail("Should have thrown an exception");
-        } catch (IllegalArgumentException e) {
-            // worked
-        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> zrc.compare(new ZapRelease("1.4.1.theta"), new ZapRelease("1.4.1.alpha")));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> zrc.compare(new ZapRelease("1.4.1.0"), new ZapRelease("1.4.1.theta")));
     }
 }

--- a/zap/src/test/java/org/zaproxy/zap/control/ZapReleaseUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/ZapReleaseUnitTest.java
@@ -19,10 +19,10 @@
  */
 package org.zaproxy.zap.control;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link ZapRelease}. */
 public class ZapReleaseUnitTest {

--- a/zap/src/test/java/org/zaproxy/zap/eventBus/SimpleEventBusUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/eventBus/SimpleEventBusUnitTest.java
@@ -19,22 +19,22 @@
  */
 package org.zaproxy.zap.eventBus;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link SimpleEventBus}. */
 public class SimpleEventBusUnitTest {
 
     SimpleEventBus seb;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         seb = new SimpleEventBus();
     }

--- a/zap/src/test/java/org/zaproxy/zap/extension/alert/ExtensionAlertUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/alert/ExtensionAlertUnitTest.java
@@ -19,10 +19,10 @@
  */
 package org.zaproxy.zap.extension.alert;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.Alert;
 
 public class ExtensionAlertUnitTest {
@@ -41,7 +41,7 @@ public class ExtensionAlertUnitTest {
 
     private ExtensionAlert extAlert;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         extAlert = new ExtensionAlert();
     }

--- a/zap/src/test/java/org/zaproxy/zap/extension/api/APIUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/api/APIUnitTest.java
@@ -21,12 +21,15 @@ package org.zaproxy.zap.extension.api;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import java.net.Inet4Address;
 import java.util.ArrayList;
@@ -37,11 +40,11 @@ import net.sf.json.JSONObject;
 import org.apache.commons.httpclient.URI;
 import org.apache.log4j.Logger;
 import org.apache.log4j.varia.NullAppender;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.parosproxy.paros.core.proxy.ProxyParam;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpInputStream;
@@ -55,12 +58,12 @@ import org.zaproxy.zap.network.DomainMatcher;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 /** Unit test for {@link API}. */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class APIUnitTest {
 
     private static final String CUSTOM_API_PATH = "/custom/api/";
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         Logger.getRootLogger().addAppender(new NullAppender());
     }
@@ -548,44 +551,52 @@ public class APIUnitTest {
         assertThat(apiImplementor.wasUsed(), is(equalTo(true)));
     }
 
-    @Test(expected = ApiException.class)
+    @Test
     public void shouldFailToGetXmlFromResponseWithNullEndpointName() throws ApiException {
         // Given
         String endpointName = null;
         ApiResponse response = ApiResponseTest.INSTANCE;
         // When
-        API.responseToXml(endpointName, response);
-        // Then = ApiException
+        ApiException e =
+                assertThrows(ApiException.class, () -> API.responseToXml(endpointName, response));
+        // Then
+        assertThat(e.getMessage(), containsString("internal_error"));
     }
 
-    @Test(expected = ApiException.class)
+    @Test
     public void shouldFailToGetXmlFromResponseWithEmptyEndpointName() throws ApiException {
         // Given
         String endpointName = "";
         ApiResponse response = ApiResponseTest.INSTANCE;
         // When
-        API.responseToXml(endpointName, response);
-        // Then = ApiException
+        ApiException e =
+                assertThrows(ApiException.class, () -> API.responseToXml(endpointName, response));
+        // Then
+        assertThat(e.getMessage(), containsString("internal_error"));
     }
 
-    @Test(expected = ApiException.class)
+    @Test
     public void shouldFailToGetXmlFromResponseWithInvalidXmlEndpointName() throws ApiException {
         // Given
         String endpointName = "<";
         ApiResponse response = ApiResponseTest.INSTANCE;
         // When
-        API.responseToXml(endpointName, response);
-        // Then = ApiException
+        ApiException e =
+                assertThrows(ApiException.class, () -> API.responseToXml(endpointName, response));
+        // Then
+        assertThat(e.getMessage(), containsString("internal_error"));
     }
 
-    @Test(expected = ApiException.class)
+    @Test
     public void shouldFailToGetXmlFromNullResponse() throws ApiException {
         // Given
         String endpointName = "Name";
         ApiResponse response = null;
         // When
-        API.responseToXml(endpointName, response);
-        // Then = ApiException
+        ApiException e =
+                assertThrows(ApiException.class, () -> API.responseToXml(endpointName, response));
+        // Then
+        assertThat(e.getMessage(), containsString("internal_error"));
     }
 
     @Test
@@ -668,7 +679,8 @@ public class APIUnitTest {
         try {
             URI requestUri = Mockito.mock(URI.class);
             when(requestUri.getPath()).thenReturn(requestPath);
-            HttpRequestHeader request = Mockito.mock(HttpRequestHeader.class);
+            HttpRequestHeader request =
+                    Mockito.mock(HttpRequestHeader.class, withSettings().lenient());
             when(request.getURI()).thenReturn(requestUri);
             when(request.getHeader(HttpHeader.X_ZAP_API_NONCE)).thenReturn(nonce);
             when(request.getSenderAddress())

--- a/zap/src/test/java/org/zaproxy/zap/extension/api/ApiGeneratorUtilsTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/api/ApiGeneratorUtilsTest.java
@@ -19,18 +19,18 @@
  */
 package org.zaproxy.zap.extension.api;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.ExtensionLoader;
@@ -46,7 +46,7 @@ public class ApiGeneratorUtilsTest extends WithConfigsTest {
 
     private Map<String, ApiImplementor> coreApis = new HashMap<>();
 
-    @Before
+    @BeforeEach
     public void loadCoreApis() throws Exception {
         ExtensionHook hook =
                 new ExtensionHook(Model.getSingleton(), null) {

--- a/zap/src/test/java/org/zaproxy/zap/extension/api/ApiResponseConversionUtilsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/api/ApiResponseConversionUtilsUnitTest.java
@@ -19,18 +19,18 @@
  */
 package org.zaproxy.zap.extension.api;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.BDDMockito.given;
 
 import java.io.ByteArrayOutputStream;
 import java.util.zip.GZIPOutputStream;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
@@ -38,7 +38,7 @@ import org.parosproxy.paros.network.HttpResponseHeader;
 import org.zaproxy.zap.network.HttpRequestBody;
 import org.zaproxy.zap.network.HttpResponseBody;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ApiResponseConversionUtilsUnitTest {
 
     @Mock HttpMessage message;
@@ -51,7 +51,7 @@ public class ApiResponseConversionUtilsUnitTest {
 
     @Mock HttpResponseBody responseBody;
 
-    @Before
+    @BeforeEach
     public void prepareMessage() {
         given(message.getRequestHeader()).willReturn(requestHeader);
         given(message.getRequestBody()).willReturn(requestBody);

--- a/zap/src/test/java/org/zaproxy/zap/extension/api/ApiResponseElementUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/api/ApiResponseElementUnitTest.java
@@ -19,15 +19,15 @@
  */
 package org.zaproxy.zap.extension.api;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
 import java.util.Map;
 import javax.xml.parsers.DocumentBuilderFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 

--- a/zap/src/test/java/org/zaproxy/zap/extension/api/ApiResponseListUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/api/ApiResponseListUnitTest.java
@@ -19,11 +19,11 @@
  */
 package org.zaproxy.zap.extension.api;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link ApiResponseList}. */
 public class ApiResponseListUnitTest {

--- a/zap/src/test/java/org/zaproxy/zap/extension/api/ApiResponseSetUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/api/ApiResponseSetUnitTest.java
@@ -19,11 +19,11 @@
  */
 package org.zaproxy.zap.extension.api;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link ApiResponseSet}. */
 public class ApiResponseSetUnitTest {

--- a/zap/src/test/java/org/zaproxy/zap/extension/api/OptionsParamApiUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/api/OptionsParamApiUnitTest.java
@@ -19,16 +19,17 @@
  */
 package org.zaproxy.zap.extension.api;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.FileConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 /** Unit test for {@link OptionsParamApi}. */
@@ -60,18 +61,17 @@ public class OptionsParamApiUnitTest {
         assertThat(param.isEnabled(), is(equalTo(true)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToSetEnabledStateWithoutConfig() {
-        // Given / When
+        // Given
         OptionsParamApi param = new OptionsParamApi();
-        // When
-        param.setEnabled(true);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(NullPointerException.class, () -> param.setEnabled(true));
     }
 
     @Test
     public void shouldSetEnabledStateWithConfig() {
-        // Given / When
+        // Given
         OptionsParamApi param = createOptionsParamApiWithConfig();
         // When
         param.setEnabled(false);
@@ -88,18 +88,17 @@ public class OptionsParamApiUnitTest {
         assertThat(param.isSecureOnly(), is(equalTo(false)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToSetSecureOnlyWithoutConfig() {
-        // Given / When
+        // Given
         OptionsParamApi param = new OptionsParamApi();
-        // When
-        param.setSecureOnly(true);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(NullPointerException.class, () -> param.setSecureOnly(true));
     }
 
     @Test
     public void shouldSetSecureOnlyWithConfig() {
-        // Given / When
+        // Given
         OptionsParamApi param = createOptionsParamApiWithConfig();
         // When
         param.setSecureOnly(true);
@@ -116,18 +115,17 @@ public class OptionsParamApiUnitTest {
         assertThat(param.isDisableKey(), is(equalTo(false)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToSetDisableKeyWithoutConfig() {
-        // Given / When
+        // Given
         OptionsParamApi param = new OptionsParamApi();
-        // When
-        param.setDisableKey(true);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(NullPointerException.class, () -> param.setDisableKey(true));
     }
 
     @Test
     public void shouldSetDisableKeyWithConfig() {
-        // Given / When
+        // Given
         OptionsParamApi param = createOptionsParamApiWithConfig();
         // When
         param.setDisableKey(true);
@@ -144,18 +142,17 @@ public class OptionsParamApiUnitTest {
         assertThat(param.isIncErrorDetails(), is(equalTo(false)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToSetIncErrorDetailsWithoutConfig() {
-        // Given / When
+        // Given
         OptionsParamApi param = new OptionsParamApi();
-        // When
-        param.setIncErrorDetails(true);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(NullPointerException.class, () -> param.setIncErrorDetails(true));
     }
 
     @Test
     public void shouldSetIncErrorDetailsWithConfig() {
-        // Given / When
+        // Given
         OptionsParamApi param = createOptionsParamApiWithConfig();
         // When
         param.setIncErrorDetails(true);
@@ -172,18 +169,17 @@ public class OptionsParamApiUnitTest {
         assertThat(param.isAutofillKey(), is(equalTo(false)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToSetAutofillKeyWithoutConfig() {
-        // Given / When
+        // Given
         OptionsParamApi param = new OptionsParamApi();
-        // When
-        param.setAutofillKey(true);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(NullPointerException.class, () -> param.setAutofillKey(true));
     }
 
     @Test
     public void shouldSetAutofillKeyWithConfig() {
-        // Given / When
+        // Given
         OptionsParamApi param = createOptionsParamApiWithConfig();
         // When
         param.setAutofillKey(true);
@@ -200,18 +196,17 @@ public class OptionsParamApiUnitTest {
         assertThat(param.isEnableJSONP(), is(equalTo(false)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToSetEnableJSONPWithoutConfig() {
-        // Given / When
+        // Given
         OptionsParamApi param = new OptionsParamApi();
-        // When
-        param.setEnableJSONP(true);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(NullPointerException.class, () -> param.setEnableJSONP(true));
     }
 
     @Test
     public void shouldSetEnableJSONPWithConfig() {
-        // Given / When
+        // Given
         OptionsParamApi param = createOptionsParamApiWithConfig();
         // When
         param.setEnableJSONP(true);
@@ -228,18 +223,17 @@ public class OptionsParamApiUnitTest {
         assertThat(param.isReportPermErrors(), is(equalTo(false)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToSetReportPermErrorsWithoutConfig() {
-        // Given / When
+        // Given
         OptionsParamApi param = new OptionsParamApi();
-        // When
-        param.setReportPermErrors(true);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(NullPointerException.class, () -> param.setReportPermErrors(true));
     }
 
     @Test
     public void shouldSetReportPermErrorsWithConfig() {
-        // Given / When
+        // Given
         OptionsParamApi param = createOptionsParamApiWithConfig();
         // When
         param.setReportPermErrors(true);
@@ -264,18 +258,17 @@ public class OptionsParamApiUnitTest {
         assertThat(param.isNoKeyForSafeOps(), is(equalTo(false)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToSetNoKeyForViewsOrSafeOthersWithoutConfig() {
-        // Given / When
+        // Given
         OptionsParamApi param = new OptionsParamApi();
-        // When
-        param.setNoKeyForSafeOps(true);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(NullPointerException.class, () -> param.setNoKeyForSafeOps(true));
     }
 
     @Test
     public void shouldSetNoKeyForViewsOrSafeOthersWithConfig() {
-        // Given / When
+        // Given
         OptionsParamApi param = createOptionsParamApiWithConfig();
         // When
         param.setNoKeyForSafeOps(true);
@@ -300,18 +293,17 @@ public class OptionsParamApiUnitTest {
         assertThat(param.getKey(), is(not(equalTo(""))));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToSetKeyWithoutConfig() {
-        // Given / When
+        // Given
         OptionsParamApi param = new OptionsParamApi();
-        // When
-        param.setKey("");
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(NullPointerException.class, () -> param.setKey(""));
     }
 
     @Test
     public void shouldSetKeyWithConfig() {
-        // Given / When
+        // Given
         OptionsParamApi param = createOptionsParamApiWithConfig();
         String apiKey = "Key";
         // When
@@ -323,7 +315,7 @@ public class OptionsParamApiUnitTest {
 
     @Test
     public void shouldSaveGeneratedKeyWithConfig() {
-        // Given / When
+        // Given
         OptionsParamApi param = new OptionsParamApi();
         Configuration conf = new Configuration();
         param.load(conf);

--- a/zap/src/test/java/org/zaproxy/zap/extension/api/VerifyApiImplementors.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/api/VerifyApiImplementors.java
@@ -19,17 +19,17 @@
  */
 package org.zaproxy.zap.extension.api;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.api.API.RequestType;
 import org.zaproxy.zap.utils.I18N;
@@ -43,7 +43,7 @@ public class VerifyApiImplementors {
     private static I18N i18n;
     private static List<String> missingKeys;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         i18n = new I18N(Locale.ENGLISH);
         Constant.messages = i18n;

--- a/zap/src/test/java/org/zaproxy/zap/extension/ascan/ScanPolicyUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/ascan/ScanPolicyUnitTest.java
@@ -19,12 +19,12 @@
  */
 package org.zaproxy.zap.extension.ascan;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.Plugin;
 import org.zaproxy.zap.WithConfigsTest;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
@@ -35,7 +35,7 @@ public class ScanPolicyUnitTest extends WithConfigsTest {
     private static final String DEFAULT_SCANNER_LEVEL_KEY = "scanner.level";
     private static final String DEFAULT_SCANNER_STRENGTH_KEY = "scanner.strength";
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         setUpZap();
     }

--- a/zap/src/test/java/org/zaproxy/zap/extension/ascan/filters/impl/GenericFilterUtilityTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/ascan/filters/impl/GenericFilterUtilityTest.java
@@ -19,13 +19,15 @@
  */
 package org.zaproxy.zap.extension.ascan.filters.impl;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.WithConfigsTest;
 import org.zaproxy.zap.extension.ascan.filters.FilterCriteria;
 import org.zaproxy.zap.extension.ascan.filters.FilterResult;
@@ -36,7 +38,7 @@ public class GenericFilterUtilityTest extends WithConfigsTest {
 
     private AbstractGenericScanFilter<String, String> abstractGenericScanFilter;
 
-    @Before
+    @BeforeEach
     public void init() {
         abstractGenericScanFilter =
                 new AbstractGenericScanFilter<String, String>() {
@@ -66,7 +68,7 @@ public class GenericFilterUtilityTest extends WithConfigsTest {
         FilterResult filterResult = abstractGenericScanFilter.isFiltered(values);
 
         // Then
-        Assert.assertEquals(filterResult.isFiltered(), false);
+        assertThat(filterResult.isFiltered(), is(false));
     }
 
     @Test
@@ -84,7 +86,7 @@ public class GenericFilterUtilityTest extends WithConfigsTest {
         FilterResult filterResult = abstractGenericScanFilter.isFiltered(values);
 
         // Then
-        Assert.assertEquals(filterResult.isFiltered(), false);
+        assertThat(filterResult.isFiltered(), is(false));
     }
 
     @Test
@@ -103,7 +105,7 @@ public class GenericFilterUtilityTest extends WithConfigsTest {
         FilterResult filterResult = abstractGenericScanFilter.isFiltered(values);
 
         // Then
-        Assert.assertEquals(filterResult.isFiltered(), false);
+        assertThat(filterResult.isFiltered(), is(false));
     }
 
     @Test
@@ -121,7 +123,7 @@ public class GenericFilterUtilityTest extends WithConfigsTest {
         FilterResult filterResult = abstractGenericScanFilter.isFiltered(values);
 
         // Then
-        Assert.assertEquals(filterResult.isFiltered(), false);
+        assertThat(filterResult.isFiltered(), is(false));
     }
 
     @Test
@@ -139,7 +141,7 @@ public class GenericFilterUtilityTest extends WithConfigsTest {
         FilterResult filterResult = abstractGenericScanFilter.isFiltered(values);
 
         // Then
-        Assert.assertEquals(filterResult.isFiltered(), true);
+        assertThat(filterResult.isFiltered(), is(true));
     }
 
     @Test
@@ -157,7 +159,7 @@ public class GenericFilterUtilityTest extends WithConfigsTest {
         FilterResult filterResult = abstractGenericScanFilter.isFiltered(values);
 
         // Then
-        Assert.assertEquals(filterResult.isFiltered(), false);
+        assertThat(filterResult.isFiltered(), is(false));
     }
 
     @Test
@@ -176,7 +178,7 @@ public class GenericFilterUtilityTest extends WithConfigsTest {
         FilterResult filterResult = abstractGenericScanFilter.isFiltered(values);
 
         // Then
-        Assert.assertEquals(filterResult.isFiltered(), true);
+        assertThat(filterResult.isFiltered(), is(true));
     }
 
     @Test
@@ -196,7 +198,7 @@ public class GenericFilterUtilityTest extends WithConfigsTest {
         FilterResult filterResult = abstractGenericScanFilter.isFiltered(values);
 
         // Then
-        Assert.assertEquals(filterResult.isFiltered(), true);
+        assertThat(filterResult.isFiltered(), is(true));
     }
 
     @Test
@@ -216,7 +218,7 @@ public class GenericFilterUtilityTest extends WithConfigsTest {
         FilterResult filterResult = abstractGenericScanFilter.isFiltered(values);
 
         // Then
-        Assert.assertEquals(filterResult.isFiltered(), true);
+        assertThat(filterResult.isFiltered(), is(true));
     }
 
     @Test
@@ -235,6 +237,6 @@ public class GenericFilterUtilityTest extends WithConfigsTest {
         FilterResult filterResult = abstractGenericScanFilter.isFiltered(values);
 
         // Then
-        Assert.assertEquals(filterResult.isFiltered(), false);
+        assertThat(filterResult.isFiltered(), is(false));
     }
 }

--- a/zap/src/test/java/org/zaproxy/zap/extension/authorization/BasicAuthorizationDetectionMethodUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/authorization/BasicAuthorizationDetectionMethodUnitTest.java
@@ -19,19 +19,20 @@
  */
 package org.zaproxy.zap.extension.authorization;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.withSettings;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.zaproxy.zap.extension.authorization.BasicAuthorizationDetectionMethod.LogicalOperator;
 import org.zaproxy.zap.network.HttpResponseBody;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class BasicAuthorizationDetectionMethodUnitTest {
 
     private static final String RESPONSE_TARGET_TEXT = "Unauthorized";
@@ -58,11 +59,13 @@ public class BasicAuthorizationDetectionMethodUnitTest {
     private HttpMessage message;
     private BasicAuthorizationDetectionMethod authorizationMethod;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
-        message = Mockito.mock(HttpMessage.class);
-        HttpResponseHeader mockedHeader = Mockito.mock(HttpResponseHeader.class);
-        HttpResponseBody mockedBody = Mockito.mock(HttpResponseBody.class);
+        message = Mockito.mock(HttpMessage.class, withSettings().lenient());
+        HttpResponseHeader mockedHeader =
+                Mockito.mock(HttpResponseHeader.class, withSettings().lenient());
+        HttpResponseBody mockedBody =
+                Mockito.mock(HttpResponseBody.class, withSettings().lenient());
         Mockito.when(message.getResponseHeader()).thenReturn(mockedHeader);
         Mockito.when(message.getResponseBody()).thenReturn(mockedBody);
         Mockito.when(mockedBody.toString()).thenReturn(RESPONSE_BODY);

--- a/zap/src/test/java/org/zaproxy/zap/extension/autoupdate/DownloaderUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/autoupdate/DownloaderUnitTest.java
@@ -19,35 +19,34 @@
  */
 package org.zaproxy.zap.extension.autoupdate;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.Proxy;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import org.apache.commons.io.FileUtils;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /** Unit test for {@link Downloader}. */
 public class DownloaderUnitTest {
 
     private static final String FILE_CONTENTS = "0123456789ABCDEF";
 
-    @ClassRule public static TemporaryFolder tempDir = new TemporaryFolder();
+    @TempDir static Path tempDir;
 
     private static URL downloadUrl;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws IOException {
-        File file = tempDir.newFile();
-        FileUtils.write(file, FILE_CONTENTS, StandardCharsets.UTF_8);
-        downloadUrl = file.toURI().toURL();
+        Path file = Files.createTempFile(tempDir, "file", "");
+        Files.write(file, FILE_CONTENTS.getBytes(StandardCharsets.UTF_8));
+        downloadUrl = file.toUri().toURL();
     }
 
     @Test
@@ -111,7 +110,8 @@ public class DownloaderUnitTest {
     }
 
     private static Downloader noProxyDownloader(URL url, String hash) throws IOException {
-        return new Downloader(url, Proxy.NO_PROXY, tempDir.newFile(), hash);
+        return new Downloader(
+                url, Proxy.NO_PROXY, Files.createTempFile(tempDir, "download", "").toFile(), hash);
     }
 
     private static void waitDownloadFinish(Downloader downloader) throws InterruptedException {

--- a/zap/src/test/java/org/zaproxy/zap/extension/autoupdate/OptionsParamCheckForUpdatesUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/autoupdate/OptionsParamCheckForUpdatesUnitTest.java
@@ -19,15 +19,15 @@
  */
 package org.zaproxy.zap.extension.autoupdate;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import org.apache.commons.configuration.FileConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 

--- a/zap/src/test/java/org/zaproxy/zap/extension/brk/impl/http/HttpBreakpointManagementDaemonImplUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/brk/impl/http/HttpBreakpointManagementDaemonImplUnitTest.java
@@ -19,11 +19,11 @@
  */
 package org.zaproxy.zap.extension.brk.impl.http;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
@@ -41,7 +41,7 @@ public class HttpBreakpointManagementDaemonImplUnitTest extends WithConfigsTest 
 
     private HttpBreakpointManagementDaemonImpl impl;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         impl = new HttpBreakpointManagementDaemonImpl();
     }

--- a/zap/src/test/java/org/zaproxy/zap/extension/dynssl/SslCertificateUtilsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/dynssl/SslCertificateUtilsUnitTest.java
@@ -19,10 +19,10 @@
  */
 package org.zaproxy.zap.extension.dynssl;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
@@ -30,7 +30,7 @@ import java.security.Provider;
 import java.security.Security;
 import java.util.Base64;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link SslCertificateUtils}. */
 public class SslCertificateUtilsUnitTest {

--- a/zap/src/test/java/org/zaproxy/zap/extension/ext/ExtensionParamUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/ext/ExtensionParamUnitTest.java
@@ -19,10 +19,11 @@
  */
 package org.zaproxy.zap.extension.ext;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,14 +31,14 @@ import java.util.Map;
 import org.apache.commons.configuration.FileConfiguration;
 import org.apache.log4j.Logger;
 import org.apache.log4j.varia.NullAppender;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 /** Unit test for {@link ExtensionParam}. */
 public class ExtensionParamUnitTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void suppressLogging() {
         Logger.getRootLogger().addAppender(new NullAppender());
     }
@@ -101,22 +102,22 @@ public class ExtensionParamUnitTest {
         assertThat(clone.isExtensionEnabled("Extension 3"), is(equalTo(false)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToPersistNullExtensionsState() {
         // Given
         ExtensionParam param = new ExtensionParam();
-        // When
-        param.setExtensionsState(null);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> param.setExtensionsState(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToPersistExtensionsStateWithoutConfigurationFile() {
         // Given
         ExtensionParam param = new ExtensionParam();
-        // When
-        param.setExtensionsState(Collections.<String, Boolean>emptyMap());
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> param.setExtensionsState(Collections.<String, Boolean>emptyMap()));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/hex/HttpPanelHexModelUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/hex/HttpPanelHexModelUnitTest.java
@@ -19,16 +19,18 @@
  */
 package org.zaproxy.zap.extension.httppanel.view.hex;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class HttpPanelHexModelUnitTest {
 
     private HttpPanelHexModel model;
 
-    @Before
+    @BeforeEach
     public void setup() {
         model = new HttpPanelHexModel();
     }
@@ -38,6 +40,6 @@ public class HttpPanelHexModelUnitTest {
         // setting value 'a0' in Hex view resulted in 'c2 a0'
         model.setData(new byte[] {(byte) 0xa0});
 
-        assertArrayEquals(new byte[] {(byte) 0xa0}, model.getData());
+        assertThat(new byte[] {(byte) 0xa0}, is(equalTo(model.getData())));
     }
 }

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/util/HttpTextViewUtilsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/util/HttpTextViewUtilsUnitTest.java
@@ -19,12 +19,13 @@
  */
 package org.zaproxy.zap.extension.httppanel.view.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import javax.swing.JTextArea;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link HttpTextViewUtils}. */
 public class HttpTextViewUtilsUnitTest {
@@ -39,29 +40,34 @@ public class HttpTextViewUtilsUnitTest {
     private static final JTextArea VIEW_WITH_BODY = new JTextArea(VIEW.getText() + BODY);
     private static final int VIEW_WITH_BODY_LENGTH = VIEW_WITH_BODY.getDocument().getLength();
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowUndefinedHeaderWhenGettingHeaderToViewPosition() {
         // Given
         String undefinedHeader = null;
-        // When
-        HttpTextViewUtils.getHeaderToViewPosition(VIEW, undefinedHeader, 0, 0);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> HttpTextViewUtils.getHeaderToViewPosition(VIEW, undefinedHeader, 0, 0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowUndefinedViewWhenGettingHeaderToViewPosition() {
         // Given
         JTextArea undefinedView = null;
-        // When
-        HttpTextViewUtils.getHeaderToViewPosition(undefinedView, HEADER, 0, 0);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> HttpTextViewUtils.getHeaderToViewPosition(undefinedView, HEADER, 0, 0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowNegativeStartWhenGettingHeaderToViewPosition() {
-        // Given / When
-        HttpTextViewUtils.getHeaderToViewPosition(VIEW, HEADER, -1, 0);
-        // Then = IllegalArgumentException
+        // Given
+        int start = -1;
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> HttpTextViewUtils.getHeaderToViewPosition(VIEW, HEADER, start, 0));
     }
 
     @Test
@@ -75,11 +81,14 @@ public class HttpTextViewUtilsUnitTest {
         assertThat(pos, is(equalTo(HttpTextViewUtils.INVALID_POSITION)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowNegativeEndWhenGettingHeaderToViewPosition() {
-        // Given / When
-        HttpTextViewUtils.getHeaderToViewPosition(VIEW, HEADER, 0, -1);
-        // Then = IllegalArgumentException
+        // Given
+        int end = -1;
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> HttpTextViewUtils.getHeaderToViewPosition(VIEW, HEADER, 0, end));
     }
 
     @Test
@@ -90,11 +99,15 @@ public class HttpTextViewUtilsUnitTest {
         assertThat(pos, is(equalTo(HttpTextViewUtils.INVALID_POSITION)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowStartGreaterThanEndWhenGettingHeaderToViewPosition() {
-        // Given / When
-        HttpTextViewUtils.getHeaderToViewPosition(VIEW, HEADER, 2, 1);
-        // Then = IllegalArgumentException
+        // Given
+        int start = 2;
+        int end = 1;
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> HttpTextViewUtils.getHeaderToViewPosition(VIEW, HEADER, start, end));
     }
 
     @Test
@@ -203,20 +216,24 @@ public class HttpTextViewUtilsUnitTest {
         assertThat(pos, is(equalTo(HttpTextViewUtils.INVALID_POSITION)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowUndefinedViewWhenGettingViewToHeaderPosition() {
         // Given
         JTextArea undefinedView = null;
-        // When
-        HttpTextViewUtils.getViewToHeaderPosition(undefinedView, 0, 0);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> HttpTextViewUtils.getViewToHeaderPosition(undefinedView, 0, 0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowNegativeStartWhenGettingViewToHeaderPosition() {
-        // Given / When
-        HttpTextViewUtils.getViewToHeaderPosition(VIEW, -1, 0);
-        // Then = IllegalArgumentException
+        // Given
+        int start = -1;
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> HttpTextViewUtils.getViewToHeaderPosition(VIEW, start, 0));
     }
 
     @Test
@@ -229,11 +246,14 @@ public class HttpTextViewUtilsUnitTest {
         assertThat(pos, is(equalTo(HttpTextViewUtils.INVALID_POSITION)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowNegativeEndWhenGettingViewToHeaderPosition() {
-        // Given / When
-        HttpTextViewUtils.getViewToHeaderPosition(VIEW, 0, -1);
-        // Then = IllegalArgumentException
+        // Given
+        int end = -1;
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> HttpTextViewUtils.getViewToHeaderPosition(VIEW, 0, end));
     }
 
     @Test
@@ -244,11 +264,15 @@ public class HttpTextViewUtilsUnitTest {
         assertThat(pos, is(equalTo(HttpTextViewUtils.INVALID_POSITION)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowStartGreaterThanEndWhenGettingViewToHeaderPosition() {
-        // Given / When
-        HttpTextViewUtils.getViewToHeaderPosition(VIEW, 2, 1);
-        // Then = IllegalArgumentException
+        // Given
+        int start = 2;
+        int end = 1;
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> HttpTextViewUtils.getViewToHeaderPosition(VIEW, start, end));
     }
 
     @Test
@@ -328,29 +352,36 @@ public class HttpTextViewUtilsUnitTest {
         assertThat(pos[1], is(equalTo(HEADER_LENGTH)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowUndefinedHeaderWhenGettingBodyToViewPosition() {
         // Given
         String undefinedHeader = null;
-        // When
-        HttpTextViewUtils.getBodyToViewPosition(VIEW_WITH_BODY, undefinedHeader, 0, 0);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        HttpTextViewUtils.getBodyToViewPosition(
+                                VIEW_WITH_BODY, undefinedHeader, 0, 0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowUndefinedViewWhenGettingBodyToViewPosition() {
         // Given
         JTextArea undefinedView = null;
-        // When
-        HttpTextViewUtils.getBodyToViewPosition(undefinedView, HEADER, 0, 0);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> HttpTextViewUtils.getBodyToViewPosition(undefinedView, HEADER, 0, 0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowNegativeStartWhenGettingBodyToViewPosition() {
-        // Given / When
-        HttpTextViewUtils.getBodyToViewPosition(VIEW_WITH_BODY, HEADER, -1, 0);
-        // Then = IllegalArgumentException
+        // Given
+        int start = -1;
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> HttpTextViewUtils.getBodyToViewPosition(VIEW_WITH_BODY, HEADER, start, 0));
     }
 
     @Test
@@ -366,11 +397,14 @@ public class HttpTextViewUtilsUnitTest {
         assertThat(pos, is(equalTo(HttpTextViewUtils.INVALID_POSITION)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowNegativeEndWhenGettingBodyToViewPosition() {
-        // Given / When
-        HttpTextViewUtils.getBodyToViewPosition(VIEW_WITH_BODY, HEADER, 0, -1);
-        // Then = IllegalArgumentException
+        // Given
+        int end = -1;
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> HttpTextViewUtils.getBodyToViewPosition(VIEW_WITH_BODY, HEADER, 0, end));
     }
 
     @Test
@@ -383,11 +417,15 @@ public class HttpTextViewUtilsUnitTest {
         assertThat(pos, is(equalTo(HttpTextViewUtils.INVALID_POSITION)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowStartGreaterThanEndWhenGettingBodyToViewPosition() {
-        // Given / When
-        HttpTextViewUtils.getBodyToViewPosition(VIEW_WITH_BODY, HEADER, 2, 1);
-        // Then = IllegalArgumentException
+        // Given
+        int start = 2;
+        int end = 1;
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> HttpTextViewUtils.getBodyToViewPosition(VIEW_WITH_BODY, HEADER, start, end));
     }
 
     @Test
@@ -441,29 +479,38 @@ public class HttpTextViewUtilsUnitTest {
         assertThat(pos, is(equalTo(HttpTextViewUtils.INVALID_POSITION)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowUndefinedHeaderWhenGettingViewToHeaderBodyPosition() {
         // Given
         String undefinedHeader = null;
-        // When
-        HttpTextViewUtils.getViewToHeaderBodyPosition(VIEW_WITH_BODY, undefinedHeader, 0, 0);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        HttpTextViewUtils.getViewToHeaderBodyPosition(
+                                VIEW_WITH_BODY, undefinedHeader, 0, 0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowUndefinedViewWhenGettingViewToHeaderBodyPosition() {
         // Given
         JTextArea undefinedView = null;
-        // When
-        HttpTextViewUtils.getViewToHeaderBodyPosition(undefinedView, HEADER, 0, 0);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> HttpTextViewUtils.getViewToHeaderBodyPosition(undefinedView, HEADER, 0, 0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowNegativeStartWhenGettingViewToHeaderBodyPosition() {
-        // Given / When
-        HttpTextViewUtils.getViewToHeaderBodyPosition(VIEW_WITH_BODY, HEADER, -1, 0);
-        // Then = IllegalArgumentException
+        // Given
+        int start = -1;
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        HttpTextViewUtils.getViewToHeaderBodyPosition(
+                                VIEW_WITH_BODY, HEADER, start, 0));
     }
 
     @Test
@@ -480,11 +527,16 @@ public class HttpTextViewUtilsUnitTest {
         assertThat(pos, is(equalTo(HttpTextViewUtils.INVALID_POSITION)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowNegativeEndWhenGettingViewToHeaderBodyPosition() {
-        // Given / When
-        HttpTextViewUtils.getViewToHeaderBodyPosition(VIEW_WITH_BODY, HEADER, 0, -1);
-        // Then = IllegalArgumentException
+        // Given
+        int end = -1;
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        HttpTextViewUtils.getViewToHeaderBodyPosition(
+                                VIEW_WITH_BODY, HEADER, 0, end));
     }
 
     @Test
@@ -498,11 +550,17 @@ public class HttpTextViewUtilsUnitTest {
         assertThat(pos, is(equalTo(HttpTextViewUtils.INVALID_POSITION)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowStartGreaterThanEndWhenGettingViewToHeaderBodyPosition() {
-        // Given / When
-        HttpTextViewUtils.getViewToHeaderBodyPosition(VIEW_WITH_BODY, HEADER, 2, 1);
-        // Then = IllegalArgumentException
+        // Given
+        int start = 2;
+        int end = 1;
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        HttpTextViewUtils.getViewToHeaderBodyPosition(
+                                VIEW_WITH_BODY, HEADER, start, end));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/extension/lang/LangImporterUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/lang/LangImporterUnitTest.java
@@ -19,12 +19,12 @@
  */
 package org.zaproxy.zap.extension.lang;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.regex.Pattern;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link LangImporter}. */
 public class LangImporterUnitTest {

--- a/zap/src/test/java/org/zaproxy/zap/extension/pscan/PassiveScannerListUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/pscan/PassiveScannerListUnitTest.java
@@ -19,20 +19,21 @@
  */
 package org.zaproxy.zap.extension.pscan;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
 
 /** Unit test for {@link PassiveScannerList}. */
@@ -40,7 +41,7 @@ public class PassiveScannerListUnitTest {
 
     private PassiveScannerList psl;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         psl = new PassiveScannerList();
     }
@@ -160,14 +161,15 @@ public class PassiveScannerListUnitTest {
         RegexAutoTagScanner scanner2 = mock(RegexAutoTagScanner.class);
         when(scanner2.getName()).thenReturn("RegexAutoTagScanner");
         psl.add(scanner2);
-        // When
-        psl.list()
-                .forEach(
-                        e -> {
-                            psl.removeScanner(e.getClass().getName());
-                            psl.add(e);
-                        });
-        // Then = No exception (but check the state is the expected).
+        // When / Then
+        assertDoesNotThrow(
+                () ->
+                        psl.list()
+                                .forEach(
+                                        e -> {
+                                            psl.removeScanner(e.getClass().getName());
+                                            psl.add(e);
+                                        }));
         assertThat(psl.list(), contains(scanner1, scanner2));
     }
 
@@ -181,14 +183,15 @@ public class PassiveScannerListUnitTest {
         List<RegexAutoTagScanner> autoTagScanners = new ArrayList<>();
         autoTagScanners.add(scanner2);
         psl.setAutoTagScanners(autoTagScanners);
-        // When
-        psl.list()
-                .forEach(
-                        e -> {
-                            psl.removeScanner(e.getClass().getName());
-                            psl.add(e);
-                        });
-        // Then = No exception (but check the state is the expected).
+        // When / Then
+        assertDoesNotThrow(
+                () ->
+                        psl.list()
+                                .forEach(
+                                        e -> {
+                                            psl.removeScanner(e.getClass().getName());
+                                            psl.add(e);
+                                        }));
         assertThat(psl.list(), contains(scanner1, scanner2));
     }
 

--- a/zap/src/test/java/org/zaproxy/zap/extension/pscan/PluginPassiveScannerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/pscan/PluginPassiveScannerUnitTest.java
@@ -19,15 +19,16 @@
  */
 package org.zaproxy.zap.extension.pscan;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import net.htmlparser.jericho.Source;
 import org.apache.commons.configuration.Configuration;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.control.AddOn;
@@ -38,7 +39,7 @@ public class PluginPassiveScannerUnitTest {
 
     private PluginPassiveScanner scanner;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         scanner = new TestPluginPassiveScanner();
     }
@@ -53,13 +54,12 @@ public class PluginPassiveScannerUnitTest {
         assertThat(scanner.getStatus(), is(equalTo(AddOn.Status.unknown)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToSetNullStatus() {
         // Given
         AddOn.Status status = null;
-        // When
-        scanner.setStatus(status);
-        // Then = IllegalArgumentException.
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> scanner.setStatus(status));
     }
 
     @Test
@@ -92,13 +92,13 @@ public class PluginPassiveScannerUnitTest {
         assertThat(scanner.getAlertThreshold(), is(equalTo(AlertThreshold.MEDIUM)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToSetNullAlertThreshold() {
         // Given
         AlertThreshold alertThreshold = null;
-        // When
-        scanner.setAlertThreshold(alertThreshold);
-        // Then = IllegalArgumentException.
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class, () -> scanner.setAlertThreshold(alertThreshold));
     }
 
     @Test
@@ -111,22 +111,24 @@ public class PluginPassiveScannerUnitTest {
         assertThat(scanner.getAlertThreshold(), is(equalTo(alertThreshold)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToSetNullDefaultAlertThreshold() {
         // Given
         AlertThreshold alertThreshold = null;
-        // When
-        scanner.setDefaultAlertThreshold(alertThreshold);
-        // Then = IllegalArgumentException.
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> scanner.setDefaultAlertThreshold(alertThreshold));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToSetDefaultToDefaultAlertThreshold() {
         // Given
         AlertThreshold alertThreshold = AlertThreshold.DEFAULT;
-        // When
-        scanner.setDefaultAlertThreshold(alertThreshold);
-        // Then = IllegalArgumentException.
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> scanner.setDefaultAlertThreshold(alertThreshold));
     }
 
     @Test
@@ -145,13 +147,12 @@ public class PluginPassiveScannerUnitTest {
         assertThat(scanner.getConfig(), is(nullValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToSetNullConfiguration() {
         // Given
         Configuration configuration = null;
-        // When
-        scanner.setConfig(configuration);
-        // Then = IllegalArgumentException.
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> scanner.setConfig(configuration));
     }
 
     @Test
@@ -271,11 +272,11 @@ public class PluginPassiveScannerUnitTest {
         assertThat(scanner.getAlertThreshold(), is(equalTo(AlertThreshold.MEDIUM)));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldFailToSaveByDefault() {
-        // Given / When
-        scanner.save();
-        // Then = IllegalStateException.
+        // Given scanner
+        // When / Then
+        assertThrows(IllegalStateException.class, () -> scanner.save());
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/extension/ruleconfig/RuleConfigParamUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/ruleconfig/RuleConfigParamUnitTest.java
@@ -19,12 +19,13 @@
  */
 package org.zaproxy.zap.extension.ruleconfig;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 /** Unit test for {@link RuleConfigParam}. */
@@ -34,7 +35,7 @@ public class RuleConfigParamUnitTest {
 
     RuleConfigParam rcp;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         rcp = new RuleConfigParam();
         configuration = new ZapXmlConfiguration();
@@ -65,16 +66,21 @@ public class RuleConfigParamUnitTest {
         assertThat(configuration.getString("key"), is(equalTo("new value")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToUpdateMissingKey() {
+        // Given
         rcp.addRuleConfig("key", "defaultValue", "value");
-        rcp.setRuleConfigValue("key2", "new value");
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class, () -> rcp.setRuleConfigValue("key2", "new value"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToResetMissingKey() {
+        // Given
         rcp.addRuleConfig("key", "defaultValue", "value");
-        rcp.resetRuleConfigValue("key2");
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> rcp.resetRuleConfigValue("key2"));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/extension/script/PacScriptUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/script/PacScriptUnitTest.java
@@ -19,10 +19,11 @@
  */
 package org.zaproxy.zap.extension.script;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.URL;
 import java.time.Clock;
@@ -38,7 +39,7 @@ import javax.script.ScriptException;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.extension.script.PacScript.Setting;
 import org.zaproxy.zap.extension.script.PacScript.Setting.Type;
 import org.zaproxy.zap.testutils.TestUtils;
@@ -70,34 +71,38 @@ public class PacScriptUnitTest extends TestUtils {
     private static final Clock FIXED_CLOCK_GMT = FIXED_CLOCK.withZone(ZoneId.of("GMT"));
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("uuuu-M-d");
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToCreatePacScriptWithEmptyString() throws Exception {
-        // Given / When
-        new PacScript("");
-        // Then = IllegalArgumentException
+        // Given
+        String script = "";
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> new PacScript(script));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToCreatePacScriptWithNullString() throws Exception {
-        // Given / When
-        new PacScript((String) null);
-        // Then = IllegalArgumentException
+        // Given
+        String script = null;
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> new PacScript(script));
     }
 
-    @Test(expected = ScriptException.class)
+    @Test
     public void shouldFailToCreatePacScriptWithMalformedStringScript() throws Exception {
-        // Given / When
-        new PacScript("not_a_function FindProxyForURL(url, host) { return \"DIRECT\" }");
-        // Then = ScriptException
+        // Given
+        String script = "not_a_function FindProxyForURL(url, host) { return \"DIRECT\" }";
+        // When / Then
+        assertThrows(ScriptException.class, () -> new PacScript(script));
     }
 
-    @Test(expected = ScriptException.class)
+    @Test
     public void shouldFailToEvaluateIfFindProxyForUrlIsMissing() throws Exception {
         // Given
         PacScript pacScript = new PacScript("function NotFindProxyForURL() { return 1; }");
-        // When
-        pacScript.evaluate("http://example.com/", "example.com");
-        // Then = ScriptException
+        // When / Then
+        assertThrows(
+                ScriptException.class,
+                () -> pacScript.evaluate("http://example.com/", "example.com"));
     }
 
     @Test
@@ -411,85 +416,94 @@ public class PacScriptUnitTest extends TestUtils {
         assertThat(settings.get(0), hasType(Type.DIRECT));
     }
 
-    @Test(expected = ScriptException.class)
+    @Test
     public void shouldFailIfSettingHasUnknownType() throws Exception {
         // Given
         PacScript pacScript = new PacScript(returns("NOTKNOWNTYPE example.com:80"));
-        // When
-        pacScript.findProxyForUrl("http://example.com/", "example.com");
-        // Then = ScriptException
+        // When / Then
+        assertThrows(
+                ScriptException.class,
+                () -> pacScript.findProxyForUrl("http://example.com/", "example.com"));
     }
 
-    @Test(expected = ScriptException.class)
+    @Test
     public void shouldFailIfNonDirectSettingHasNoHostPort() throws Exception {
         // Given
         PacScript pacScript = new PacScript(returns("PROXY "));
-        // When
-        pacScript.findProxyForUrl("http://example.com/", "example.com");
-        // Then = ScriptException
+        // When / Then
+        assertThrows(
+                ScriptException.class,
+                () -> pacScript.findProxyForUrl("http://example.com/", "example.com"));
     }
 
-    @Test(expected = ScriptException.class)
+    @Test
     public void shouldFailIfNonDirectSettingHasEmptyHost() throws Exception {
         // Given
         PacScript pacScript = new PacScript(returns("PROXY :80"));
-        // When
-        pacScript.findProxyForUrl("http://example.com/", "example.com");
-        // Then = ScriptException
+        // When / Then
+        assertThrows(
+                ScriptException.class,
+                () -> pacScript.findProxyForUrl("http://example.com/", "example.com"));
     }
 
-    @Test(expected = ScriptException.class)
+    @Test
     public void shouldFailIfNonDirectSettingHasNoPort() throws Exception {
         // Given
         PacScript pacScript = new PacScript(returns("PROXY host"));
-        // When
-        pacScript.findProxyForUrl("http://example.com/", "example.com");
-        // Then = ScriptException
+        // When / Then
+        assertThrows(
+                ScriptException.class,
+                () -> pacScript.findProxyForUrl("http://example.com/", "example.com"));
     }
 
-    @Test(expected = ScriptException.class)
+    @Test
     public void shouldFailIfNonDirectSettingHasEmptyPort() throws Exception {
         // Given
         PacScript pacScript = new PacScript(returns("PROXY host:"));
-        // When
-        pacScript.findProxyForUrl("http://example.com/", "example.com");
-        // Then = ScriptException
+        // When / Then
+        assertThrows(
+                ScriptException.class,
+                () -> pacScript.findProxyForUrl("http://example.com/", "example.com"));
     }
 
-    @Test(expected = ScriptException.class)
+    @Test
     public void shouldFailIfNonDirectSettingHasNonNumericPort() throws Exception {
         // Given
         PacScript pacScript = new PacScript(returns("PROXY host:a"));
-        // When
-        pacScript.findProxyForUrl("http://example.com/", "example.com");
-        // Then = ScriptException
+        // When / Then
+        assertThrows(
+                ScriptException.class,
+                () -> pacScript.findProxyForUrl("http://example.com/", "example.com"));
     }
 
-    @Test(expected = ScriptException.class)
+    @Test
     public void shouldFailIfNonDirectSettingHasPortLowerThanAllowed() throws Exception {
         // Given
         PacScript pacScript = new PacScript(returns("PROXY host:-1"));
-        // When
-        pacScript.findProxyForUrl("http://example.com/", "example.com");
-        // Then = ScriptException
+        // When / Then
+        assertThrows(
+                ScriptException.class,
+                () -> pacScript.findProxyForUrl("http://example.com/", "example.com"));
     }
 
-    @Test(expected = ScriptException.class)
+    @Test
     public void shouldFailIfNonDirectSettingHasPortHigherThanAllowed() throws Exception {
         // Given
         PacScript pacScript = new PacScript(returns("PROXY host:65536"));
-        // When
-        pacScript.findProxyForUrl("http://example.com/", "example.com");
-        // Then = ScriptException
+        // When / Then
+        assertThrows(
+                ScriptException.class,
+                () -> pacScript.findProxyForUrl("http://example.com/", "example.com"));
     }
 
-    @Test(expected = ScriptException.class)
+    @Test
     public void shouldFailIfDirectSettingHasOtherContents() throws Exception {
         // Given
         PacScript pacScript = new PacScript(returns("DIRECT example.com:80"));
-        // When
-        pacScript.findProxyForUrl("http://example.com/", "example.com");
-        // Then = ScriptException
+        // When / Then
+        assertThrows(
+                ScriptException.class,
+                () -> pacScript.findProxyForUrl("http://example.com/", "example.com"));
     }
 
     private static URL getFileUrl(String fileName) {

--- a/zap/src/test/java/org/zaproxy/zap/extension/script/ScriptVarsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/script/ScriptVarsUnitTest.java
@@ -19,37 +19,38 @@
  */
 package org.zaproxy.zap.extension.script;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Map;
 import javax.script.ScriptContext;
 import javax.script.SimpleScriptContext;
 import org.apache.commons.lang.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link ScriptVars}. */
 public class ScriptVarsUnitTest {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ScriptVars.clear();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldNotAllowToModifyReturnedGlobalVariables() {
         // Given
         Map<String, String> vars = ScriptVars.getGlobalVars();
-        // When
-        vars.put(createKey(), createValue());
-        // Then = UnsupportedOperationException
+        // When / Then
+        assertThrows(
+                UnsupportedOperationException.class, () -> vars.put(createKey(), createValue()));
     }
 
     @Test
@@ -77,24 +78,25 @@ public class ScriptVarsUnitTest {
         assertThat(ScriptVars.getGlobalVar(key), is(nullValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetGlobalVariableWithNullKey() {
         // Given
         String key = null;
-        // When
-        ScriptVars.setGlobalVar(key, createValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class, () -> ScriptVars.setGlobalVar(key, createValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetGlobalVariableIfMoreThanAllowed() {
         // Given
         for (int i = 0; i <= ScriptVars.MAX_GLOBAL_VARS; i++) {
             ScriptVars.setGlobalVar(createKey(), createValue());
         }
-        // When
-        ScriptVars.setGlobalVar(createKey(), createValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ScriptVars.setGlobalVar(createKey(), createValue()));
     }
 
     @Test
@@ -119,14 +121,14 @@ public class ScriptVarsUnitTest {
         assertThat(value, is(nullValue()));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldNotAllowToModifyReturnedScriptVariables() {
         // Given
         String scriptName = "ScriptName";
         Map<String, String> vars = ScriptVars.getScriptVars(scriptName);
-        // When
-        vars.put(createKey(), createValue());
-        // Then = UnsupportedOperationException
+        // When / Then
+        assertThrows(
+                UnsupportedOperationException.class, () -> vars.put(createKey(), createValue()));
     }
 
     @Test
@@ -158,70 +160,81 @@ public class ScriptVarsUnitTest {
         assertThat(ScriptVars.getScriptVar(scriptContext, key), is(nullValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptVariableUsingNullScriptContext() {
         // Given
         ScriptContext scriptContext = null;
-        // When
-        ScriptVars.setScriptVar(scriptContext, createKey(), createValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ScriptVars.setScriptVar(scriptContext, createKey(), createValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptVariableUsingNullScriptNameInScriptContext() {
         // Given
         ScriptContext scriptContext = createScriptContextWithName(null);
-        // When
-        ScriptVars.setScriptVar(scriptContext, createKey(), createValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ScriptVars.setScriptVar(scriptContext, createKey(), createValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptVariableUsingNonStringScriptNameInScriptContext() {
         // Given
         ScriptContext scriptContext = createScriptContextWithName(10);
-        // When
-        ScriptVars.setScriptVar(scriptContext, createKey(), createValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ScriptVars.setScriptVar(scriptContext, createKey(), createValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptVariableWithNullKeyUsingScriptContext() {
         // Given
         ScriptContext scriptContext = createScriptContextWithName("ScriptName");
-        // When
-        ScriptVars.setScriptVar(scriptContext, null, createValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ScriptVars.setScriptVar(scriptContext, null, createValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptVariableWithInvalidKeyLengthUsingScriptContext() {
         // Given
         ScriptContext scriptContext = createScriptContextWithName("ScriptName");
-        // When
-        ScriptVars.setScriptVar(scriptContext, createKeyWithInvalidLength(), createValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        ScriptVars.setScriptVar(
+                                scriptContext, createKeyWithInvalidLength(), createValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptVariableWithInvalidValueLengthUsingScriptContext() {
         // Given
         ScriptContext scriptContext = createScriptContextWithName("ScriptName");
-        // When
-        ScriptVars.setScriptVar(scriptContext, createKey(), createValueWithInvalidLength());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        ScriptVars.setScriptVar(
+                                scriptContext, createKey(), createValueWithInvalidLength()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptVariableIfMoreThanAllowedUsingScriptContext() {
         // Given
         ScriptContext scriptContext = createScriptContextWithName("ScriptName");
         for (int i = 0; i <= ScriptVars.MAX_SCRIPT_VARS; i++) {
             ScriptVars.setScriptVar(scriptContext, createKey(), createValue());
         }
-        // When
-        ScriptVars.setScriptVar(scriptContext, createKey(), createValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ScriptVars.setScriptVar(scriptContext, createKey(), createValue()));
     }
 
     @Test
@@ -263,63 +276,68 @@ public class ScriptVarsUnitTest {
         assertThat(ScriptVars.getScriptVar(scriptName, key), is(nullValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptVariableUsingNullScriptName() {
         // Given
         String scriptName = null;
-        // When
-        ScriptVars.setScriptVar(scriptName, createKey(), createValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ScriptVars.setScriptVar(scriptName, createKey(), createValue()));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldNotAllowToModifyReturnedScriptVariablesSet() {
         // Given
         String scriptName = "ScriptName";
         ScriptVars.setScriptVar(scriptName, createKey(), createValue());
         Map<String, String> vars = ScriptVars.getScriptVars(scriptName);
-        // When
-        vars.put(createKey(), createValue());
-        // Then = UnsupportedOperationException
+        // When / Then
+        assertThrows(
+                UnsupportedOperationException.class, () -> vars.put(createKey(), createValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptVariableWithNullKeyUsingScriptName() {
         // Given
         String key = null;
-        // When
-        ScriptVars.setScriptVar("ScriptName", key, createValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ScriptVars.setScriptVar("ScriptName", key, createValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptVariableWithInvalidKeyLengthUsingScriptName() {
         // Given
         String key = createKeyWithInvalidLength();
-        // When
-        ScriptVars.setScriptVar("ScriptName", key, createValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ScriptVars.setScriptVar("ScriptName", key, createValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptVariableWithInvalidValueLengthUsingScriptName() {
         // Given
         String value = createValueWithInvalidLength();
-        // When
-        ScriptVars.setScriptVar("ScriptName", createKey(), value);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ScriptVars.setScriptVar("ScriptName", createKey(), value));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptVariableIfMoreThanAllowedUsingScriptName() {
         // Given
         String scriptName = "ScriptName";
         for (int i = 0; i <= ScriptVars.MAX_SCRIPT_VARS; i++) {
             ScriptVars.setScriptVar(scriptName, createKey(), createValue());
         }
-        // When
-        ScriptVars.setScriptVar(scriptName, createKey(), createValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ScriptVars.setScriptVar(scriptName, createKey(), createValue()));
     }
 
     @Test
@@ -389,13 +407,14 @@ public class ScriptVarsUnitTest {
         assertThat(ScriptVars.getScriptCustomVars(scriptName2).size(), is(equalTo(1)));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldNotAllowToModifyReturnedGlobalCustomVariables() {
         // Given
         Map<String, Object> vars = ScriptVars.getGlobalCustomVars();
-        // When
-        vars.put(createKey(), createCustomValue());
-        // Then = UnsupportedOperationException
+        // When / Then
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> vars.put(createKey(), createCustomValue()));
     }
 
     @Test
@@ -423,24 +442,26 @@ public class ScriptVarsUnitTest {
         assertThat(ScriptVars.getGlobalCustomVar(key), is(nullValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetGlobalCustomVariableWithNullKey() {
         // Given
         String key = null;
-        // When
-        ScriptVars.setGlobalCustomVar(key, createCustomValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ScriptVars.setGlobalCustomVar(key, createCustomValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetGlobalCustomVariableIfMoreThanAllowed() {
         // Given
         for (int i = 0; i <= ScriptVars.MAX_GLOBAL_VARS; i++) {
             ScriptVars.setGlobalCustomVar(createKey(), createCustomValue());
         }
-        // When
-        ScriptVars.setGlobalCustomVar(createKey(), createCustomValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ScriptVars.setGlobalCustomVar(createKey(), createCustomValue()));
     }
 
     @Test
@@ -465,14 +486,15 @@ public class ScriptVarsUnitTest {
         assertThat(value, is(nullValue()));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldNotAllowToModifyReturnedScriptCustomVariables() {
         // Given
         String scriptName = "ScriptName";
         Map<String, Object> vars = ScriptVars.getScriptCustomVars(scriptName);
-        // When
-        vars.put(createKey(), createCustomValue());
-        // Then = UnsupportedOperationException
+        // When / Then
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> vars.put(createKey(), createCustomValue()));
     }
 
     @Test
@@ -504,62 +526,77 @@ public class ScriptVarsUnitTest {
         assertThat(ScriptVars.getScriptCustomVar(scriptContext, key), is(nullValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptCustomVariableUsingNullScriptContext() {
         // Given
         ScriptContext scriptContext = null;
-        // When
-        ScriptVars.setScriptCustomVar(scriptContext, createKey(), createCustomValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        ScriptVars.setScriptCustomVar(
+                                scriptContext, createKey(), createCustomValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptCustomVariableUsingNullScriptNameInScriptContext() {
         // Given
         ScriptContext scriptContext = createScriptContextWithName(null);
-        // When
-        ScriptVars.setScriptCustomVar(scriptContext, createKey(), createCustomValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        ScriptVars.setScriptCustomVar(
+                                scriptContext, createKey(), createCustomValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptCustomVariableUsingNonStringScriptNameInScriptContext() {
         // Given
         ScriptContext scriptContext = createScriptContextWithName(10);
-        // When
-        ScriptVars.setScriptCustomVar(scriptContext, createKey(), createCustomValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        ScriptVars.setScriptCustomVar(
+                                scriptContext, createKey(), createCustomValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptCustomVariableWithNullKeyUsingScriptContext() {
         // Given
         ScriptContext scriptContext = createScriptContextWithName("ScriptName");
-        // When
-        ScriptVars.setScriptCustomVar(scriptContext, null, createCustomValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ScriptVars.setScriptCustomVar(scriptContext, null, createCustomValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptCustomVariableWithInvalidKeyLengthUsingScriptContext() {
         // Given
         ScriptContext scriptContext = createScriptContextWithName("ScriptName");
-        // When
-        ScriptVars.setScriptCustomVar(
-                scriptContext, createKeyWithInvalidLength(), createCustomValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        ScriptVars.setScriptCustomVar(
+                                scriptContext, createKeyWithInvalidLength(), createCustomValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptCustomVariableIfMoreThanAllowedUsingScriptContext() {
         // Given
         ScriptContext scriptContext = createScriptContextWithName("ScriptName");
         for (int i = 0; i <= ScriptVars.MAX_SCRIPT_VARS; i++) {
             ScriptVars.setScriptCustomVar(scriptContext, createKey(), createCustomValue());
         }
-        // When
-        ScriptVars.setScriptCustomVar(scriptContext, createKey(), createCustomValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        ScriptVars.setScriptCustomVar(
+                                scriptContext, createKey(), createCustomValue()));
     }
 
     @Test
@@ -601,54 +638,59 @@ public class ScriptVarsUnitTest {
         assertThat(ScriptVars.getScriptCustomVar(scriptName, key), is(nullValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptCustomVariableUsingNullScriptName() {
         // Given
         String scriptName = null;
-        // When
-        ScriptVars.setScriptCustomVar(scriptName, createKey(), createCustomValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ScriptVars.setScriptCustomVar(scriptName, createKey(), createCustomValue()));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldNotAllowToModifyReturnedScriptCustomVariablesSet() {
         // Given
         String scriptName = "ScriptName";
         ScriptVars.setScriptCustomVar(scriptName, createKey(), createCustomValue());
         Map<String, Object> vars = ScriptVars.getScriptCustomVars(scriptName);
-        // When
-        vars.put(createKey(), createCustomValue());
-        // Then = UnsupportedOperationException
+        // When / Then
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> vars.put(createKey(), createCustomValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptCustomVariableWithNullKeyUsingScriptName() {
         // Given
         String key = null;
-        // When
-        ScriptVars.setScriptCustomVar("ScriptName", key, createCustomValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ScriptVars.setScriptCustomVar("ScriptName", key, createCustomValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptCustomVariableWithInvalidKeyLengthUsingScriptName() {
         // Given
         String key = createKeyWithInvalidLength();
-        // When
-        ScriptVars.setScriptCustomVar("ScriptName", key, createCustomValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ScriptVars.setScriptCustomVar("ScriptName", key, createCustomValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotSetScriptCustomVariableIfMoreThanAllowedUsingScriptName() {
         // Given
         String scriptName = "ScriptName";
         for (int i = 0; i <= ScriptVars.MAX_SCRIPT_VARS; i++) {
             ScriptVars.setScriptCustomVar(scriptName, createKey(), createCustomValue());
         }
-        // When
-        ScriptVars.setScriptCustomVar(scriptName, createKey(), createCustomValue());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ScriptVars.setScriptCustomVar(scriptName, createKey(), createCustomValue()));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/model/ContextUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/model/ContextUnitTest.java
@@ -19,26 +19,27 @@
  */
 package org.zaproxy.zap.model;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.parosproxy.paros.model.Session;
 
 /** Unit test for {@link Context}. */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ContextUnitTest {
 
     @Mock Session session;
 
     private Context context;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         context = new Context(session, 1);
     }
@@ -58,22 +59,20 @@ public class ContextUnitTest {
         assertThat(context.getName(), is(equalTo(String.valueOf(index))));
     }
 
-    @Test(expected = IllegalContextNameException.class)
+    @Test
     public void shouldNotAllowToSetNullName() {
         // Given
         String name = null;
-        // When
-        context.setName(name);
-        // Then = IllegalContextNameException.class
+        // When / Then
+        assertThrows(IllegalContextNameException.class, () -> context.setName(name));
     }
 
-    @Test(expected = IllegalContextNameException.class)
+    @Test
     public void shouldNotAllowToSetAnEmptyName() {
         // Given
         String name = "";
-        // When
-        context.setName(name);
-        // Then = IllegalContextNameException.class
+        // When / Then
+        assertThrows(IllegalContextNameException.class, () -> context.setName(name));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/model/SessionUtilsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/model/SessionUtilsUnitTest.java
@@ -21,25 +21,20 @@ package org.zaproxy.zap.model;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.parosproxy.paros.Constant;
 
 public class SessionUtilsUnitTest {
 
-    @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
-
-    @Before
-    public void setUp() throws Exception {
-        tempFolder.create();
-    }
+    @TempDir Path tempFolder;
 
     @Test
     public void shouldRetrieveExistingSessionFileFromAbsolutePath() throws Exception {
@@ -91,13 +86,13 @@ public class SessionUtilsUnitTest {
                 is(equalTo(pathWith(zapHome, Constant.FOLDER_SESSION_DEFAULT, "test.session"))));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailOnNullForSessionInput() throws Exception {
-        SessionUtils.getSessionPath(null);
+        assertThrows(NullPointerException.class, () -> SessionUtils.getSessionPath(null));
     }
 
     private Path newFile(String name) throws IOException {
-        return tempFolder.newFile(name).toPath();
+        return Files.createFile(tempFolder.resolve(name));
     }
 
     private static Path pathWith(String baseDir, String... paths) {
@@ -105,7 +100,7 @@ public class SessionUtilsUnitTest {
     }
 
     private String createZapHome() throws IOException {
-        String zapHome = tempFolder.newFolder("zap").toPath().toString();
+        String zapHome = Files.createDirectories(tempFolder.resolve("zap")).toString();
         Constant.setZapHome(zapHome);
         return zapHome;
     }

--- a/zap/src/test/java/org/zaproxy/zap/model/StandardParameterParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/model/StandardParameterParserUnitTest.java
@@ -19,7 +19,7 @@
  */
 package org.zaproxy.zap.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,15 +27,15 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link StandardParameterParser}. */
 public class StandardParameterParserUnitTest {
 
     private StandardParameterParser spp;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         spp = new StandardParameterParser();
     }

--- a/zap/src/test/java/org/zaproxy/zap/model/ValidateTranslatedVulnerabilitiesFilesUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/model/ValidateTranslatedVulnerabilitiesFilesUnitTest.java
@@ -19,10 +19,10 @@
  */
 package org.zaproxy.zap.model;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -30,8 +30,8 @@ import java.util.List;
 import java.util.Map;
 import org.apache.log4j.Logger;
 import org.apache.log4j.varia.NullAppender;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.testutils.TestUtils;
 
@@ -51,7 +51,7 @@ public class ValidateTranslatedVulnerabilitiesFilesUnitTest extends TestUtils {
     private VulnerabilitiesLoader loader =
             new VulnerabilitiesLoader(DIRECTORY, FILE_NAME, FILE_EXTENSION);
 
-    @BeforeClass
+    @BeforeAll
     public static void suppressLogging() {
         Logger.getRootLogger().addAppender(new NullAppender());
     }

--- a/zap/src/test/java/org/zaproxy/zap/model/VulnerabilitiesLoaderUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/model/VulnerabilitiesLoaderUnitTest.java
@@ -19,13 +19,17 @@
  */
 package org.zaproxy.zap.model;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.testutils.TestUtils;
 
 /** Unit test for {@link VulnerabilitiesLoader}. */
@@ -40,49 +44,54 @@ public class VulnerabilitiesLoaderUnitTest extends TestUtils {
 
     public VulnerabilitiesLoader loader;
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrownExceptionIfDirectoryIsNull() {
         // Given
         Path directory = null;
-        // When
-        loader = new VulnerabilitiesLoader(directory, FILE_NAME, FILE_EXTENSION);
-        // Then = Exception
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new VulnerabilitiesLoader(directory, FILE_NAME, FILE_EXTENSION));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrownExceptionIfFileNameIsNull() {
         // Given
         String fileName = null;
-        // When
-        loader = new VulnerabilitiesLoader(DIRECTORY, fileName, FILE_EXTENSION);
-        // Then = Exception
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new VulnerabilitiesLoader(DIRECTORY, fileName, FILE_EXTENSION));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrownExceptionIfFileNameIsEmpty() {
         // Given
         String fileName = "";
-        // When
-        loader = new VulnerabilitiesLoader(DIRECTORY, fileName, FILE_EXTENSION);
-        // Then = Exception
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new VulnerabilitiesLoader(DIRECTORY, fileName, FILE_EXTENSION));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrownExceptionIfFileExtensionIsNull() {
         // Given
         String fileExtension = null;
-        // When
-        loader = new VulnerabilitiesLoader(DIRECTORY, FILE_NAME, fileExtension);
-        // Then = Exception
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new VulnerabilitiesLoader(DIRECTORY, FILE_NAME, fileExtension));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrownExceptionIfFileExtensionIsEmpty() {
         // Given
         String fileExtension = "";
-        // When
-        loader = new VulnerabilitiesLoader(DIRECTORY, FILE_NAME, fileExtension);
-        // Then = Exception
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new VulnerabilitiesLoader(DIRECTORY, FILE_NAME, fileExtension));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/network/HttpBodyTestUtils.java
+++ b/zap/src/test/java/org/zaproxy/zap/network/HttpBodyTestUtils.java
@@ -26,7 +26,7 @@ import org.apache.log4j.varia.NullAppender;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 /**
  * Class with helper/utility methods to help testing classes involving {@code HttpBody} class and
@@ -76,7 +76,7 @@ public class HttpBodyTestUtils {
     protected static final String BODY_1_AND_2_STRING_UTF_8 =
             BODY_1_STRING_UTF_8 + BODY_2_STRING_UTF_8;
 
-    @BeforeClass
+    @BeforeAll
     public static void suppressLogging() {
         Logger.getRootLogger().addAppender(new NullAppender());
     }

--- a/zap/src/test/java/org/zaproxy/zap/network/HttpResponseBodyUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/network/HttpResponseBodyUnitTest.java
@@ -19,18 +19,18 @@
  */
 package org.zaproxy.zap.network;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
 
 import java.nio.charset.StandardCharsets;
 import org.apache.log4j.Logger;
 import org.apache.log4j.varia.NullAppender;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link HttpResponseBody}. */
 public class HttpResponseBodyUnitTest extends HttpBodyTestUtils {
@@ -38,7 +38,7 @@ public class HttpResponseBodyUnitTest extends HttpBodyTestUtils {
     private static final byte[] BODY_1_BYTES_UTF_16 =
             BODY_1_STRING.getBytes(StandardCharsets.UTF_16);
 
-    @BeforeClass
+    @BeforeAll
     public static void suppressLogging() {
         Logger.getRootLogger().addAppender(new NullAppender());
     }

--- a/zap/src/test/java/org/zaproxy/zap/network/ZapCookieSpecUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/network/ZapCookieSpecUnitTest.java
@@ -19,10 +19,13 @@
  */
 package org.zaproxy.zap.network;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.apache.commons.httpclient.Cookie;
 import org.apache.commons.httpclient.cookie.CookieSpec;
 import org.apache.commons.httpclient.cookie.MalformedCookieException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link ZapCookieSpec}. */
 public class ZapCookieSpecUnitTest {
@@ -32,76 +35,83 @@ public class ZapCookieSpecUnitTest {
     private static final String PATH = "/path/file";
     private static final boolean SECURE = true;
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowWhenValidatingWithNullHost() throws MalformedCookieException {
         // Given
         CookieSpec cookieSpec = createCookieSpec();
         String host = null;
-        // When
-        cookieSpec.validate(host, PORT, PATH, SECURE, new Cookie());
-        // Then = IllegalArgumentException.
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> cookieSpec.validate(host, PORT, PATH, SECURE, new Cookie()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowWhenValidatingWithEmptyHost() throws MalformedCookieException {
         // Given
         CookieSpec cookieSpec = createCookieSpec();
         String host = "";
-        // When
-        cookieSpec.validate(host, PORT, PATH, SECURE, new Cookie());
-        // Then = IllegalArgumentException.
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> cookieSpec.validate(host, PORT, PATH, SECURE, new Cookie()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowWhenValidatingWithNegativePort() throws MalformedCookieException {
         // Given
         CookieSpec cookieSpec = createCookieSpec();
         int port = -1;
-        // When
-        cookieSpec.validate(HOST, port, PATH, SECURE, new Cookie());
-        // Then = IllegalArgumentException.
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> cookieSpec.validate(HOST, port, PATH, SECURE, new Cookie()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowWhenValidatingWithNullPath() throws MalformedCookieException {
         // Given
         CookieSpec cookieSpec = createCookieSpec();
         String path = null;
-        // When
-        cookieSpec.validate(HOST, PORT, path, SECURE, new Cookie());
-        // Then = IllegalArgumentException.
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> cookieSpec.validate(HOST, PORT, path, SECURE, new Cookie()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowWhenValidatingWithNullCookie() throws MalformedCookieException {
         // Given
         CookieSpec cookieSpec = createCookieSpec();
         Cookie cookie = null;
-        // When
-        cookieSpec.validate(HOST, PORT, PATH, SECURE, cookie);
-        // Then = NullPointerException.
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> cookieSpec.validate(HOST, PORT, PATH, SECURE, cookie));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowWhenValidatingWithNullCookieDomain() throws MalformedCookieException {
         // Given
         CookieSpec cookieSpec = createCookieSpec();
         Cookie cookie = new Cookie(null, "name", "value");
-        // When
-        cookieSpec.validate(HOST, PORT, PATH, SECURE, cookie);
-        // Then = NullPointerException.
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> cookieSpec.validate(HOST, PORT, PATH, SECURE, cookie));
     }
 
-    @Test(expected = MalformedCookieException.class)
+    @Test
     public void shouldBeMalformedWhenValidatingWithNegativeCookieVersion()
             throws MalformedCookieException {
         // Given
         CookieSpec cookieSpec = createCookieSpec();
         Cookie cookie = new Cookie(HOST, "name", "value");
         cookie.setVersion(-1);
-        // When
-        cookieSpec.validate(HOST, PORT, PATH, SECURE, cookie);
-        // Then = MalformedCookieException.
+        // When / Then
+        assertThrows(
+                MalformedCookieException.class,
+                () -> cookieSpec.validate(HOST, PORT, PATH, SECURE, cookie));
     }
 
     @Test
@@ -111,9 +121,8 @@ public class ZapCookieSpecUnitTest {
         CookieSpec cookieSpec = createCookieSpec();
         Cookie cookie = new Cookie(HOST, "name", "value");
         cookie.setPath("/other/path/");
-        // When
-        cookieSpec.validate(HOST, PORT, PATH, SECURE, cookie);
-        // Then = No exception.
+        // When / Then
+        assertDoesNotThrow(() -> cookieSpec.validate(HOST, PORT, PATH, SECURE, cookie));
     }
 
     private static CookieSpec createCookieSpec() {

--- a/zap/src/test/java/org/zaproxy/zap/spider/URLCanonicalizerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/URLCanonicalizerUnitTest.java
@@ -19,16 +19,16 @@
  */
 package org.zaproxy.zap.spider;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
 import org.apache.log4j.varia.NullAppender;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.spider.SpiderParam.HandleParametersOption;
 
 /**
@@ -40,7 +40,7 @@ import org.zaproxy.zap.spider.SpiderParam.HandleParametersOption;
  */
 public class URLCanonicalizerUnitTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void suppressLogging() {
         Logger.getLogger(URLCanonicalizer.class).addAppender(new NullAppender());
     }

--- a/zap/src/test/java/org/zaproxy/zap/spider/URLResolverRfc1808ExamplesUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/URLResolverRfc1808ExamplesUnitTest.java
@@ -19,10 +19,10 @@
  */
 package org.zaproxy.zap.spider;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for RFC 1808 compliance of {@link org.zaproxy.zap.spider.URLResolver}. */
 public class URLResolverRfc1808ExamplesUnitTest {

--- a/zap/src/test/java/org/zaproxy/zap/spider/URLResolverUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/URLResolverUnitTest.java
@@ -19,10 +19,11 @@
  */
 package org.zaproxy.zap.spider;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test for {@link org.zaproxy.zap.spider.URLResolver}.
@@ -31,14 +32,23 @@ import org.junit.Test;
  */
 public class URLResolverUnitTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionOnMissingBaseUrl() {
-        URLResolver.resolveUrl(null, "notNull");
+        // Given
+        String baseUrl = null;
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class, () -> URLResolver.resolveUrl(baseUrl, "notNull"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionOnMissingRelativeUrl() {
-        URLResolver.resolveUrl("notNull", null);
+        // Given
+        String relativeUrl = null;
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> URLResolver.resolveUrl("notNull", relativeUrl));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/spider/filters/DefaultFetchFilterUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/filters/DefaultFetchFilterUnitTest.java
@@ -19,9 +19,9 @@
  */
 package org.zaproxy.zap.spider.filters;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
@@ -31,30 +31,30 @@ import java.util.List;
 import org.apache.commons.httpclient.URI;
 import org.apache.log4j.Logger;
 import org.apache.log4j.varia.NullAppender;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.spider.DomainAlwaysInScopeMatcher;
 import org.zaproxy.zap.spider.filters.FetchFilter.FetchStatus;
 
 /** Unit test for {@link DefaultFetchFilter}. */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class DefaultFetchFilterUnitTest {
 
     @Mock Context context;
 
     private DefaultFetchFilter filter;
 
-    @BeforeClass
+    @BeforeAll
     public static void suppressLogging() {
         Logger.getRootLogger().addAppender(new NullAppender());
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         filter = new DefaultFetchFilter();
     }

--- a/zap/src/test/java/org/zaproxy/zap/spider/filters/DefaultParseFilterUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/filters/DefaultParseFilterUnitTest.java
@@ -19,18 +19,20 @@
  */
 package org.zaproxy.zap.spider.filters;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.ResourceBundle;
 import org.apache.log4j.Logger;
 import org.apache.log4j.varia.NullAppender;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
@@ -46,12 +48,12 @@ public class DefaultParseFilterUnitTest {
 
     private ResourceBundle resourceBundle;
 
-    @BeforeClass
+    @BeforeAll
     public static void suppressLogging() {
         Logger.getRootLogger().addAppender(new NullAppender());
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         resourceBundle =
                 new ResourceBundle() {
@@ -77,42 +79,38 @@ public class DefaultParseFilterUnitTest {
     }
 
     @Test
-    @SuppressWarnings({"deprecation", "unused"})
+    @SuppressWarnings("deprecation")
     public void shouldCreateDefaultParseFilterWithDefaultConfigsAndResourceBundleIfNoneSet() {
-        // Given / When
-        new DefaultParseFilter();
-        // Then = No exception.
+        assertDoesNotThrow(() -> new DefaultParseFilter());
     }
 
     @Test
-    @SuppressWarnings("unused")
     public void shouldCreateDefaultParseFilterWithConfigsAndResourceBundleSet() {
         // Given
         SpiderParam configs = new SpiderParam();
-        // When
-        new DefaultParseFilter(configs, resourceBundle);
-        // Then = No exception.
+        // When / Then
+        assertDoesNotThrow(() -> new DefaultParseFilter(configs, resourceBundle));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    @SuppressWarnings("unused")
+    @Test
     public void shouldFailToCreateDefaultParseFilterWithNullConfigs() {
         // Given
         SpiderParam configs = null;
-        // When
-        new DefaultParseFilter(configs, resourceBundle);
-        // Then = IllegalArgumentException.
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new DefaultParseFilter(configs, resourceBundle));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    @SuppressWarnings("unused")
+    @Test
     public void shouldFailToCreateDefaultParseFilterWithNullResourceBundle() {
         // Given
         ResourceBundle resourceBundle = null;
         SpiderParam configs = new SpiderParam();
-        // When
-        new DefaultParseFilter(configs, resourceBundle);
-        // Then = IllegalArgumentException.
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new DefaultParseFilter(configs, resourceBundle));
     }
 
     @Test
@@ -156,9 +154,8 @@ public class DefaultParseFilterUnitTest {
         // Given
         DefaultParseFilter filter = createDefaultParseFilter();
         HttpMessage httpMessage = createHttpMessageWithRequestUri("http://example.com");
-        // When
-        filter.filtered(httpMessage);
-        // Then = No exception.
+        // When / Then
+        assertDoesNotThrow(() -> filter.filtered(httpMessage));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/spider/filters/HttpPrefixFetchFilterUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/filters/HttpPrefixFetchFilterUnitTest.java
@@ -19,66 +19,64 @@
  */
 package org.zaproxy.zap.spider.filters;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.log4j.Logger;
 import org.apache.log4j.varia.NullAppender;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.spider.filters.FetchFilter.FetchStatus;
 
 /** Unit test for {@link HttpPrefixFetchFilter}. */
 public class HttpPrefixFetchFilterUnitTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void suppressLogging() {
         Logger.getRootLogger().addAppender(new NullAppender());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToCreateFetchFilterWithUndefinedURI() {
-        // Given / When
-        new HttpPrefixFetchFilter(null);
-        // Then = IllegalArgumentException
+        // Given
+        URI undefinedUri = null;
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> new HttpPrefixFetchFilter(undefinedUri));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToCreateFetchFilterWithNoScheme() throws Exception {
         // Given
         URI prefixUri = new URI("example.org/", true);
-        // When
-        new HttpPrefixFetchFilter(prefixUri);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> new HttpPrefixFetchFilter(prefixUri));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToCreateFetchFilterWithNonHttpOrHttpsScheme() throws Exception {
         // Given
         URI prefixUri = new URI("ftp://example.org/", true);
-        // When
-        new HttpPrefixFetchFilter(prefixUri);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> new HttpPrefixFetchFilter(prefixUri));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToCreateFetchFilterWithNoHost() throws Exception {
         // Given
         URI prefixUri = new URI("http://", true);
-        // When
-        new HttpPrefixFetchFilter(prefixUri);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> new HttpPrefixFetchFilter(prefixUri));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToCreateFetchFilterWithMalformedHost() throws Exception {
         // Given
         URI prefixUri = new URI("http://a%0/", true);
-        // When
-        new HttpPrefixFetchFilter(prefixUri);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> new HttpPrefixFetchFilter(prefixUri));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlFormParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlFormParserUnitTest.java
@@ -19,11 +19,13 @@
  */
 package org.zaproxy.zap.spider.parser;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
@@ -37,8 +39,8 @@ import net.htmlparser.jericho.Source;
 import org.apache.commons.httpclient.URI;
 import org.apache.log4j.Logger;
 import org.apache.log4j.varia.NullAppender;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.model.DefaultValueGenerator;
 import org.zaproxy.zap.model.ValueGenerator;
@@ -58,28 +60,32 @@ public class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
     private static final Path BASE_DIR_HTML_FILES =
             getResourcePath("htmlform", SpiderHtmlFormParserUnitTest.class);
 
-    @BeforeClass
+    @BeforeAll
     public static void suppressLogging() {
         Logger.getRootLogger().addAppender(new NullAppender());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToCreateParserWithUndefinedSpiderOptions() {
         // Given
         SpiderParam undefinedSpiderOptions = null;
-        // When
-        new SpiderHtmlFormParser(undefinedSpiderOptions, new DefaultValueGenerator());
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        new SpiderHtmlFormParser(
+                                undefinedSpiderOptions, new DefaultValueGenerator()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToEvaluateAnUndefinedMessage() {
         // Given
         HttpMessage undefinedMessage = null;
         SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
-        // When
-        htmlParser.canParseResource(undefinedMessage, ROOT_PATH, false);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> htmlParser.canParseResource(undefinedMessage, ROOT_PATH, false));
     }
 
     @Test
@@ -140,15 +146,16 @@ public class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
         assertThat(canParse, is(equalTo(false)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToParseAnUndefinedMessage() {
         // Given
         HttpMessage undefinedMessage = null;
         SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
         Source source = createSource(createMessageWith("NoForms.html"));
-        // When
-        htmlParser.parseResource(undefinedMessage, source, BASE_DEPTH);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> htmlParser.parseResource(undefinedMessage, source, BASE_DEPTH));
     }
 
     @Test
@@ -176,9 +183,8 @@ public class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
         Source source = null;
         SpiderHtmlFormParser htmlParser = createSpiderHtmlFormParser();
         HttpMessage messageHtmlResponse = createMessageWith("NoForms.html");
-        // When
-        htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
-        // Then = No exception
+        // When / Then
+        assertDoesNotThrow(() -> htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlParserUnitTest.java
@@ -19,18 +19,20 @@
  */
 package org.zaproxy.zap.spider.parser;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.file.Path;
 import net.htmlparser.jericho.Source;
 import org.apache.log4j.Logger;
 import org.apache.log4j.varia.NullAppender;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.spider.SpiderParam;
 
@@ -43,28 +45,29 @@ public class SpiderHtmlParserUnitTest extends SpiderParserTestUtils {
     private static final Path BASE_DIR_HTML_FILES =
             getResourcePath("html", SpiderHtmlParserUnitTest.class);
 
-    @BeforeClass
+    @BeforeAll
     public static void suppressLogging() {
         Logger.getRootLogger().addAppender(new NullAppender());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToCreateParserWithUndefinedSpiderOptions() {
         // Given
         SpiderParam undefinedSpiderOptions = null;
-        // When
-        new SpiderHtmlParser(undefinedSpiderOptions);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class, () -> new SpiderHtmlParser(undefinedSpiderOptions));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToEvaluateAnUndefinedMessage() {
         // Given
         HttpMessage undefinedMessage = null;
         SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
-        // When
-        htmlParser.canParseResource(undefinedMessage, ROOT_PATH, false);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> htmlParser.canParseResource(undefinedMessage, ROOT_PATH, false));
     }
 
     @Test
@@ -103,15 +106,16 @@ public class SpiderHtmlParserUnitTest extends SpiderParserTestUtils {
         assertThat(canParse, is(equalTo(false)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToParseAnUndefinedMessage() {
         // Given
         HttpMessage undefinedMessage = null;
         SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
         Source source = createSource(createMessageWith("NoURLsSpiderHtmlParser.html"));
-        // When
-        htmlParser.parseResource(undefinedMessage, source, BASE_DEPTH);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> htmlParser.parseResource(undefinedMessage, source, BASE_DEPTH));
     }
 
     @Test
@@ -120,9 +124,8 @@ public class SpiderHtmlParserUnitTest extends SpiderParserTestUtils {
         Source source = null;
         SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
         HttpMessage messageHtmlResponse = createMessageWith("NoURLsSpiderHtmlParser.html");
-        // When
-        htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
-        // Then = No exception
+        // When / Then
+        assertDoesNotThrow(() -> htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderRedirectParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderRedirectParserUnitTest.java
@@ -19,19 +19,20 @@
  */
 package org.zaproxy.zap.spider.parser;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.log4j.Logger;
 import org.apache.log4j.varia.NullAppender;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
@@ -60,19 +61,20 @@ public class SpiderRedirectParserUnitTest extends SpiderParserTestUtils {
                         });
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void suppressLogging() {
         Logger.getRootLogger().addAppender(new NullAppender());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToEvaluateAnUndefinedMessage() {
         // Given
         HttpMessage undefinedMessage = null;
         SpiderRedirectParser redirectParser = new SpiderRedirectParser();
-        // When
-        redirectParser.canParseResource(undefinedMessage, ROOT_PATH, false);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> redirectParser.canParseResource(undefinedMessage, ROOT_PATH, false));
     }
 
     @Test
@@ -113,14 +115,15 @@ public class SpiderRedirectParserUnitTest extends SpiderParserTestUtils {
         assertThat(canParse, is(equalTo(true)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToParseAnUndefinedMessage() {
         // Given
         HttpMessage undefinedMessage = null;
         SpiderRedirectParser redirectParser = new SpiderRedirectParser();
-        // When
-        redirectParser.parseResource(undefinedMessage, null, BASE_DEPTH);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> redirectParser.parseResource(undefinedMessage, null, BASE_DEPTH));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderRobotstxtParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderRobotstxtParserUnitTest.java
@@ -19,16 +19,18 @@
  */
 package org.zaproxy.zap.spider.parser;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.log4j.Logger;
 import org.apache.log4j.varia.NullAppender;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.spider.SpiderParam;
 
@@ -39,18 +41,17 @@ public class SpiderRobotstxtParserUnitTest extends SpiderParserTestUtils {
     private static final String ROBOTS_TXT_PATH = "/robots.txt";
     private static final int BASE_DEPTH = 0;
 
-    @BeforeClass
+    @BeforeAll
     public static void suppressLogging() {
         Logger.getRootLogger().addAppender(new NullAppender());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldRequireNonNullSpiderParam() {
         // Given
         SpiderParam spiderParam = null;
-        // When
-        new SpiderRobotstxtParser(spiderParam);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(NullPointerException.class, () -> new SpiderRobotstxtParser(spiderParam));
     }
 
     @Test
@@ -58,9 +59,8 @@ public class SpiderRobotstxtParserUnitTest extends SpiderParserTestUtils {
         // Given
         String path = null;
         SpiderRobotstxtParser spiderParser = new SpiderRobotstxtParser(new SpiderParam());
-        // When
-        spiderParser.canParseResource(null, path, false);
-        // Then = No Exception.
+        // When / Then
+        assertDoesNotThrow(() -> spiderParser.canParseResource(null, path, false));
     }
 
     @Test
@@ -104,14 +104,15 @@ public class SpiderRobotstxtParserUnitTest extends SpiderParserTestUtils {
         assertThat(canParse, is(equalTo(false)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToParseAnUndefinedMessage() {
         // Given
         HttpMessage undefinedMessage = null;
         SpiderRobotstxtParser spiderParser = new SpiderRobotstxtParser(new SpiderParam());
-        // When
-        spiderParser.parseResource(undefinedMessage, null, BASE_DEPTH);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> spiderParser.parseResource(undefinedMessage, null, BASE_DEPTH));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderSitemapXMLParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderSitemapXMLParserUnitTest.java
@@ -19,17 +19,18 @@
  */
 package org.zaproxy.zap.spider.parser;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.file.Path;
 import net.htmlparser.jericho.Source;
 import org.apache.log4j.Logger;
 import org.apache.log4j.varia.NullAppender;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.spider.SpiderParam;
 
@@ -42,18 +43,19 @@ public class SpiderSitemapXMLParserUnitTest extends SpiderParserTestUtils {
     private static final Path BASE_DIR_TEST_FILES =
             getResourcePath("sitemapxml", SpiderSitemapXMLParserUnitTest.class);
 
-    @BeforeClass
+    @BeforeAll
     public static void suppressLogging() {
         Logger.getRootLogger().addAppender(new NullAppender());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailToCreateParserWithUndefinedSpiderOptions() {
         // Given
         SpiderParam undefinedSpiderOptions = null;
-        // When
-        new SpiderSitemapXMLParser(undefinedSpiderOptions);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new SpiderSitemapXMLParser(undefinedSpiderOptions));
     }
 
     @Test
@@ -67,14 +69,15 @@ public class SpiderSitemapXMLParserUnitTest extends SpiderParserTestUtils {
         assertThat(canParse, is(equalTo(false)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToEvaluateAnUndefinedPath() {
         // Given
         String undefinedPath = null;
         SpiderSitemapXMLParser spiderParser = createSpiderSitemapXMLParser();
-        // When
-        spiderParser.canParseResource(new HttpMessage(), undefinedPath, false);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> spiderParser.canParseResource(new HttpMessage(), undefinedPath, false));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderTextParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderTextParserUnitTest.java
@@ -19,17 +19,18 @@
  */
 package org.zaproxy.zap.spider.parser;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import net.htmlparser.jericho.Source;
 import org.apache.log4j.Logger;
 import org.apache.log4j.varia.NullAppender;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 
 /** Unit test for {@link SpiderTextParser}. */
@@ -39,19 +40,20 @@ public class SpiderTextParserUnitTest extends SpiderParserTestUtils {
     private static final String ROOT_PATH = "/";
     private static final int BASE_DEPTH = 0;
 
-    @BeforeClass
+    @BeforeAll
     public static void suppressLogging() {
         Logger.getRootLogger().addAppender(new NullAppender());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToEvaluateAnUndefinedMessage() {
         // Given
         HttpMessage undefinedMessage = null;
         SpiderTextParser spiderParser = new SpiderTextParser();
-        // When
-        spiderParser.canParseResource(undefinedMessage, ROOT_PATH, false);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> spiderParser.canParseResource(undefinedMessage, ROOT_PATH, false));
     }
 
     @Test
@@ -125,15 +127,16 @@ public class SpiderTextParserUnitTest extends SpiderParserTestUtils {
         assertThat(canParse, is(equalTo(false)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToParseAnUndefinedMessage() {
         // Given
         HttpMessage undefinedMessage = null;
         SpiderTextParser spiderParser = new SpiderTextParser();
         Source source = createSource(createMessageWith(EMPTY_BODY));
-        // When
-        spiderParser.parseResource(undefinedMessage, source, BASE_DEPTH);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> spiderParser.parseResource(undefinedMessage, source, BASE_DEPTH));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/users/UserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/users/UserUnitTest.java
@@ -24,9 +24,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -37,11 +37,11 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.authentication.AuthenticationCredentials;
 import org.zaproxy.zap.authentication.AuthenticationMethod;
@@ -51,7 +51,7 @@ import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.session.SessionManagementMethod;
 import org.zaproxy.zap.session.WebSession;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class UserUnitTest {
 
     private static final String USER_NAME = "username";
@@ -63,7 +63,7 @@ public class UserUnitTest {
     private static AuthenticationCredentials mockedCredentials;
     private static SessionManagementMethod mockedSessionManagementMethod;
 
-    @BeforeClass
+    @BeforeAll
     public static void classSetUp() {
         // Make sure something is returned for the encoder
         mockedCredentials = Mockito.mock(AuthenticationCredentials.class);

--- a/zap/src/test/java/org/zaproxy/zap/users/UsersTableModelUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/users/UsersTableModelUnitTest.java
@@ -19,14 +19,15 @@
  */
 package org.zaproxy.zap.users;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -36,20 +37,20 @@ import static org.mockito.Mockito.withSettings;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.event.TableModelListener;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.users.UsersTableModel;
 import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.view.TableModelTestUtils;
 
 /** Unit test for {@code UsersTableModel}. */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class UsersTableModelUnitTest extends TableModelTestUtils {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         I18N i18n = mock(I18N.class, withSettings().lenient());
         given(i18n.getString(anyString())).willReturn("");
@@ -57,13 +58,12 @@ public class UsersTableModelUnitTest extends TableModelTestUtils {
         Constant.messages = i18n;
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToCreateInstanceWithUndefinedUsersList() {
         // Given
         List<User> undefinedUsersList = null;
-        // When
-        UsersTableModel usersTableModel = new UsersTableModel(undefinedUsersList);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(NullPointerException.class, () -> new UsersTableModel(undefinedUsersList));
     }
 
     @Test
@@ -119,13 +119,12 @@ public class UsersTableModelUnitTest extends TableModelTestUtils {
         assertThat(usersTableModel.getElements(), is(empty()));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void shouldFailToGetValueOfNonExistingRow() {
         // Given
         UsersTableModel usersTableModel = new UsersTableModel();
-        // When
-        usersTableModel.getValueAt(0, 0);
-        // Then = IndexOutOfBoundsException
+        // When / Then
+        assertThrows(IndexOutOfBoundsException.class, () -> usersTableModel.getValueAt(0, 0));
     }
 
     @Test
@@ -290,13 +289,12 @@ public class UsersTableModelUnitTest extends TableModelTestUtils {
         assertThat(listener.getNumberOfEvents(), is(equalTo(0)));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void shouldFailToGetNonExistingElement() {
         // Given
         UsersTableModel usersTableModel = new UsersTableModel();
-        // When
-        usersTableModel.getElement(1);
-        // Then = IndexOutOfBoundsException
+        // When / Then
+        assertThrows(IndexOutOfBoundsException.class, () -> usersTableModel.getElement(1));
     }
 
     @Test
@@ -334,15 +332,16 @@ public class UsersTableModelUnitTest extends TableModelTestUtils {
         assertThat(listener.isRowInserted(0), is(equalTo(true)));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void shouldFailToModifyNonExistingElement() {
         // Given
         List<User> usersList = new ArrayList<>();
         usersList.add(createEnabledUser());
         UsersTableModel usersTableModel = new UsersTableModel(usersList);
-        // When
-        usersTableModel.modifyElement(1, createUser());
-        // Then = IndexOutOfBoundsException
+        // When / Then
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> usersTableModel.modifyElement(1, createUser()));
     }
 
     @Test
@@ -366,13 +365,12 @@ public class UsersTableModelUnitTest extends TableModelTestUtils {
         assertThat(listener.isRowUpdated(0), is(equalTo(true)));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void shouldFailToRemoveNonExistingElement() {
         // Given
         UsersTableModel usersTableModel = new UsersTableModel();
-        // When
-        usersTableModel.removeElement(1);
-        // Then = IndexOutOfBoundsException
+        // When / Then
+        assertThrows(IndexOutOfBoundsException.class, () -> usersTableModel.removeElement(1));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/utils/ApiUtilsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/ApiUtilsUnitTest.java
@@ -19,12 +19,13 @@
  */
 package org.zaproxy.zap.utils;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import net.sf.json.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.extension.api.ApiException;
 
 /** Unit test for {@link ApiUtils}. */
@@ -32,13 +33,12 @@ public class ApiUtilsUnitTest {
 
     private static final String HOST = "example.com";
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerExceptionWhenGettingIntFromNullParams() throws Exception {
         // Given
         JSONObject params = null;
-        // When
-        ApiUtils.getIntParam(params, "name");
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(NullPointerException.class, () -> ApiUtils.getIntParam(params, "name"));
     }
 
     @Test
@@ -83,13 +83,12 @@ public class ApiUtilsUnitTest {
         assertThat(obtainedValue, is(equalTo(value)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerExceptionWhenGettingBooleanFromNullParams() throws Exception {
         // Given
         JSONObject params = null;
-        // When
-        ApiUtils.getBooleanParam(params, "name");
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(NullPointerException.class, () -> ApiUtils.getBooleanParam(params, "name"));
     }
 
     @Test
@@ -134,13 +133,12 @@ public class ApiUtilsUnitTest {
         assertThat(obtainedValue, is(equalTo(value)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowExceptionWhenGettingAuthorityFromNullSite() {
         // Given
         String nullSite = null;
-        // When
-        ApiUtils.getAuthority(nullSite);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(NullPointerException.class, () -> ApiUtils.getAuthority(nullSite));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/utils/BoyerMooreMatcherUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/BoyerMooreMatcherUnitTest.java
@@ -19,31 +19,32 @@
  */
 package org.zaproxy.zap.utils;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link BoyerMooreMatcher} */
 public class BoyerMooreMatcherUnitTest {
 
     private static final String CONTENT = "The quick brown fox jumps over the lazy dog.";
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToCreateMatcherIfPatternIsNull() {
-        // Given / When
-        new BoyerMooreMatcher(null);
-        // Then = NullPointerException.class
+        // Given
+        String pattern = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> new BoyerMooreMatcher(pattern));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToFindInNullContent() {
         // Given
         BoyerMooreMatcher matcher = new BoyerMooreMatcher("");
-        // When
-        matcher.findInContent(null);
-        // Then = NullPointerException.class
+        // When / Then
+        assertThrows(NullPointerException.class, () -> matcher.findInContent(null));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/utils/ByteBuilderUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/ByteBuilderUnitTest.java
@@ -19,15 +19,14 @@
  */
 package org.zaproxy.zap.utils;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ByteBuilderUnitTest {
 
@@ -35,9 +34,7 @@ public class ByteBuilderUnitTest {
 
     private static final byte[] TEST_ARRAY = {(byte) 1, (byte) 2, (byte) 3};
 
-    @Rule public final ExpectedException thrown = ExpectedException.none();
-
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         byteBuilder = new ByteBuilder();
     }
@@ -173,10 +170,9 @@ public class ByteBuilderUnitTest {
     public void shouldThrowAnExceptionWhenAppendingValuesToEmptyByteArray() {
         // given
         byteBuilder = new ByteBuilder(TEST_ARRAY);
-        // when
-        thrown.expect(ArrayIndexOutOfBoundsException.class);
-        // then
-        byteBuilder.append(new byte[0], 2, 3);
+        // When / Then
+        assertThrows(
+                ArrayIndexOutOfBoundsException.class, () -> byteBuilder.append(new byte[0], 2, 3));
     }
 
     @Test
@@ -216,10 +212,9 @@ public class ByteBuilderUnitTest {
     public void shouldThrowAnExceptionWhenAppendingValuesToEmptyCharArray() {
         // given
         byteBuilder = new ByteBuilder(TEST_ARRAY);
-        // when
-        thrown.expect(ArrayIndexOutOfBoundsException.class);
-        // then
-        byteBuilder.append(new char[0], 2, 3);
+        // When / Then
+        assertThrows(
+                ArrayIndexOutOfBoundsException.class, () -> byteBuilder.append(new char[0], 2, 3));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/utils/ContentMatcherUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/ContentMatcherUnitTest.java
@@ -19,13 +19,13 @@
  */
 package org.zaproxy.zap.utils;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
 
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link ContentMatcher}. */
 public class ContentMatcherUnitTest {

--- a/zap/src/test/java/org/zaproxy/zap/utils/HirshbergMatcherUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/HirshbergMatcherUnitTest.java
@@ -19,12 +19,13 @@
  */
 package org.zaproxy.zap.utils;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link HirshbergMatcher} */
 public class HirshbergMatcherUnitTest {
@@ -32,22 +33,24 @@ public class HirshbergMatcherUnitTest {
     private static final String EMPTY_STRING = "";
     private static final String NON_EMPTY_STRING = "Non Empty String";
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToGetLCSIfStringAIsNull() {
         // Given
         HirshbergMatcher matcher = new HirshbergMatcher();
-        // When
-        matcher.getLCS(null, NON_EMPTY_STRING);
-        // Then = NullPointerException.class
+        String strA = null;
+        String strB = NON_EMPTY_STRING;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> matcher.getLCS(strA, strB));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToGetLCSIfStringBIsNull() {
         // Given
         HirshbergMatcher matcher = new HirshbergMatcher();
-        // When
-        matcher.getLCS(NON_EMPTY_STRING, null);
-        // Then = NullPointerException.class
+        String strA = NON_EMPTY_STRING;
+        String strB = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> matcher.getLCS(strA, strB));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/utils/JsonUtilUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/JsonUtilUnitTest.java
@@ -19,12 +19,12 @@
  */
 package org.zaproxy.zap.utils;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import net.sf.json.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link JsonUtil}. */
 public class JsonUtilUnitTest {

--- a/zap/src/test/java/org/zaproxy/zap/utils/LocaleUtilsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/LocaleUtilsUnitTest.java
@@ -19,12 +19,14 @@
  */
 package org.zaproxy.zap.utils;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -36,7 +38,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.regex.Pattern;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link LocaleUtils}. */
 public class LocaleUtilsUnitTest {
@@ -49,22 +51,24 @@ public class LocaleUtilsUnitTest {
     private static final String FILE_NAME = "FileName";
     private static final String FILE_EXTENSION = ".extension";
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionWhenGettingResourceFilesRegexWithNullFileName() {
         // Given
         String nullFileName = null;
-        // When
-        LocaleUtils.createResourceFilesRegex(nullFileName, FILE_EXTENSION);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> LocaleUtils.createResourceFilesRegex(nullFileName, FILE_EXTENSION));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionWhenGettingResourceFilesRegexWithNullFileExtension() {
         // Given
         String nullFileExtension = null;
-        // When
-        LocaleUtils.createResourceFilesRegex(FILE_NAME, nullFileExtension);
-        // Then = IllegalArgumentException
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> LocaleUtils.createResourceFilesRegex(FILE_NAME, nullFileExtension));
     }
 
     @Test
@@ -72,31 +76,32 @@ public class LocaleUtilsUnitTest {
             shouldReturnValidRegexWhenGettingResourceFilesRegexWithNonNullFileNameAndFileExtension() {
         // Given
         String regex = LocaleUtils.createResourceFilesRegex(FILE_NAME, FILE_EXTENSION);
-        // When
-        Pattern.compile(regex);
-        // Then = valid regex
+        // When / Then = valid regex
+        assertDoesNotThrow(() -> Pattern.compile(regex));
     }
 
     @Test
     public void shouldAcceptFileNameWithSpecialRegexCharsWhenGettingResourceFilesRegex() {
         // Given
         String fileNameWithSpecialRegexChars = "?]|*-)(^[:.";
-        // When
-        Pattern.compile(
-                LocaleUtils.createResourceFilesRegex(
-                        fileNameWithSpecialRegexChars, FILE_EXTENSION));
-        // Then = valid regex
+        // When / Then = valid regex
+        assertDoesNotThrow(
+                () ->
+                        Pattern.compile(
+                                LocaleUtils.createResourceFilesRegex(
+                                        fileNameWithSpecialRegexChars, FILE_EXTENSION)));
     }
 
     @Test
     public void shouldAcceptFileExtensionWithSpecialRegexCharsWhenGettingResourceFilesRegex() {
         // Given
         String fileExtensionWithSpecialRegexChars = "?]|*-)(^[:.";
-        // When
-        Pattern.compile(
-                LocaleUtils.createResourceFilesRegex(
-                        FILE_NAME, fileExtensionWithSpecialRegexChars));
-        // Then = valid regex
+        // When / Then = valid regex
+        assertDoesNotThrow(
+                () ->
+                        Pattern.compile(
+                                LocaleUtils.createResourceFilesRegex(
+                                        FILE_NAME, fileExtensionWithSpecialRegexChars)));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/utils/MessagesLocaleUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/MessagesLocaleUnitTest.java
@@ -19,8 +19,8 @@
  */
 package org.zaproxy.zap.utils;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.net.URL;
@@ -38,8 +38,8 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 import org.apache.log4j.Logger;
 import org.apache.log4j.varia.NullAppender;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.testutils.TestUtils;
 
@@ -55,7 +55,7 @@ public class MessagesLocaleUnitTest extends TestUtils {
     private static final String FILE_NAME = BASE_NAME + "_";
     private static final String FILE_EXTENSION = ".properties";
 
-    @BeforeClass
+    @BeforeAll
     public static void suppressLogging() {
         Logger.getRootLogger().addAppender(new NullAppender());
     }

--- a/zap/src/test/java/org/zaproxy/zap/utils/StatisticsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/StatisticsUnitTest.java
@@ -19,16 +19,16 @@
  */
 package org.zaproxy.zap.utils;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link Statistics}. */
 public class StatisticsUnitTest {

--- a/zap/src/test/java/org/zaproxy/zap/utils/TimeStampLocaleUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/TimeStampLocaleUnitTest.java
@@ -19,8 +19,8 @@
  */
 package org.zaproxy.zap.utils;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.net.URL;
@@ -37,7 +37,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.testutils.TestUtils;
 

--- a/zap/src/test/java/org/zaproxy/zap/utils/XMLStringUtilUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/XMLStringUtilUnitTest.java
@@ -19,10 +19,10 @@
  */
 package org.zaproxy.zap.utils;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class XMLStringUtilUnitTest {
 

--- a/zap/src/test/java/org/zaproxy/zap/utils/ZapXmlConfigurationUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/ZapXmlConfigurationUnitTest.java
@@ -19,15 +19,15 @@
  */
 package org.zaproxy.zap.utils;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link ZapXmlConfiguration}. */
 public class ZapXmlConfigurationUnitTest {

--- a/zap/src/test/java/org/zaproxy/zap/view/AbstractMultipleOptionsBaseTableModelUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/view/AbstractMultipleOptionsBaseTableModelUnitTest.java
@@ -19,26 +19,26 @@
  */
 package org.zaproxy.zap.view;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@code AbstractMultipleOptionsBaseTableModel}. */
 public class AbstractMultipleOptionsBaseTableModelUnitTest extends TableModelTestUtils {
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldFailToGetNonExistingElement() {
         // Given
         AbstractMultipleOptionsBaseTableModel<Object> tableModel =
                 new MultipleOptionsBaseTableModelImpl();
-        // When
-        tableModel.getElement(1);
-        // Then = Exception
+        // When / Then
+        assertThrows(IndexOutOfBoundsException.class, () -> tableModel.getElement(1));
     }
 
     @Test
@@ -59,14 +59,14 @@ public class AbstractMultipleOptionsBaseTableModelUnitTest extends TableModelTes
         assertThat(listener.isRowInserted(0), is(equalTo(true)));
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldFailToModifyNonExistingElement() {
         // Given
         AbstractMultipleOptionsBaseTableModel<Object> tableModel =
                 new MultipleOptionsBaseTableModelImpl();
-        // When
-        tableModel.modifyElement(1, new Object());
-        // Then = Exception
+        // When / Then
+        assertThrows(
+                IndexOutOfBoundsException.class, () -> tableModel.modifyElement(1, new Object()));
     }
 
     @Test
@@ -89,14 +89,13 @@ public class AbstractMultipleOptionsBaseTableModelUnitTest extends TableModelTes
         assertThat(listener.isRowUpdated(0), is(equalTo(true)));
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void shouldFailToRemoveNonExistingElement() {
         // Given
         AbstractMultipleOptionsBaseTableModel<Object> tableModel =
                 new MultipleOptionsBaseTableModelImpl();
-        // When
-        tableModel.removeElement(1);
-        // Then = Exception
+        // When / Then
+        assertThrows(IndexOutOfBoundsException.class, () -> tableModel.removeElement(1));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/view/JCheckBoxTreeUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/view/JCheckBoxTreeUnitTest.java
@@ -19,12 +19,14 @@
  */
 package org.zaproxy.zap.view;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -35,7 +37,7 @@ import javax.swing.tree.MutableTreeNode;
 import javax.swing.tree.TreeModel;
 import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link JCheckBoxTree}. */
 public class JCheckBoxTreeUnitTest {
@@ -45,31 +47,28 @@ public class JCheckBoxTreeUnitTest {
         // Given
         TreeModel undefinedTreeModel = null;
         JCheckBoxTree checkBoxTree = new JCheckBoxTree();
-        // When
-        checkBoxTree.setModel(undefinedTreeModel);
-        // Then = No exception.
+        // When / Then
+        assertDoesNotThrow(() -> checkBoxTree.setModel(undefinedTreeModel));
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test
     public void shouldFailToSetATreeModelWithRootNonDefaultMutableTreeNode() {
         // Given
         TreeModel treeModel = new DefaultTreeModel(new TreeNodeImpl());
         JCheckBoxTree checkBoxTree = new JCheckBoxTree();
-        // When
-        checkBoxTree.setModel(treeModel);
-        // Then = ClassCastException
+        // When / Then
+        assertThrows(ClassCastException.class, () -> checkBoxTree.setModel(treeModel));
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test
     public void shouldFailToSetATreeModelWithChildNonDefaultMutableTreeNodes() {
         // Given
         DefaultMutableTreeNode rootNode = new DefaultMutableTreeNode();
         rootNode.add(new MutableTreeNodeImpl());
         TreeModel treeModel = new DefaultTreeModel(rootNode);
         JCheckBoxTree checkBoxTree = new JCheckBoxTree();
-        // When
-        checkBoxTree.setModel(treeModel);
-        // Then = ClassCastException
+        // When / Then
+        assertThrows(ClassCastException.class, () -> checkBoxTree.setModel(treeModel));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/view/LayoutHelperUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/view/LayoutHelperUnitTest.java
@@ -19,11 +19,12 @@
  */
 package org.zaproxy.zap.view;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
-import java.awt.*;
-import org.junit.Test;
+import java.awt.GridBagConstraints;
+import java.awt.Insets;
+import org.junit.jupiter.api.Test;
 
 public class LayoutHelperUnitTest {
 

--- a/zap/src/test/java/org/zaproxy/zap/view/panelsearch/SearchUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/view/panelsearch/SearchUnitTest.java
@@ -19,13 +19,13 @@
  */
 package org.zaproxy.zap.view.panelsearch;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import javax.swing.JButton;
 import javax.swing.JPanel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SearchUnitTest {
 

--- a/zap/src/test/java/org/zaproxy/zap/view/widgets/UsersListModelUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/view/widgets/UsersListModelUnitTest.java
@@ -19,13 +19,14 @@
  */
 package org.zaproxy.zap.view.widgets;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -35,10 +36,10 @@ import static org.mockito.Mockito.withSettings;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.event.ListDataListener;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.users.UsersTableModel;
 import org.zaproxy.zap.users.User;
@@ -46,10 +47,10 @@ import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.view.ListModelTestUtils;
 
 /** Unit test for {@code UsersListModel}. */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class UsersListModelUnitTest extends ListModelTestUtils {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         I18N i18n = mock(I18N.class, withSettings().lenient());
         given(i18n.getString(anyString())).willReturn("");
@@ -57,13 +58,12 @@ public class UsersListModelUnitTest extends ListModelTestUtils {
         Constant.messages = i18n;
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldFailToCreateInstanceWithUndefinedUsersTableModel() {
         // Given
         UsersTableModel undefinedTableModel = null;
-        // When
-        UsersListModel usersListModel = new UsersListModel(undefinedTableModel);
-        // Then = NullPointerException
+        // When / Then
+        assertThrows(NullPointerException.class, () -> new UsersListModel(undefinedTableModel));
     }
 
     @Test
@@ -99,14 +99,13 @@ public class UsersListModelUnitTest extends ListModelTestUtils {
         assertThat(user, is(nullValue()));
     }
 
-    @Test(expected = ArrayIndexOutOfBoundsException.class)
+    @Test
     public void shouldFailToGetCustomUserIfIndexIsMoreThanAvailableCustomUsers() {
         // Given
         UsersListModel usersListModel = new UsersListModel(createUsersTableModel(0));
         usersListModel.setCustomUsers(new User[] {createUser(), createUser()});
-        // When
-        usersListModel.getElementAt(2);
-        // Then = ArrayIndexOutOfBoundsException
+        // When / Then
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> usersListModel.getElementAt(2));
     }
 
     @Test

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -73,13 +73,23 @@ dependencies {
         setTransitive(false)
     }
 
-    testImplementation("com.github.tomakehurst:wiremock-jre8:2.25.1")
-    testImplementation("junit:junit:4.11")
+    testImplementation("com.github.tomakehurst:wiremock-jre8:2.25.1") {
+        // Not needed.
+        exclude(group = "org.junit")
+    }
     testImplementation("org.hamcrest:hamcrest-all:1.3")
-    testImplementation("org.mockito:mockito-core:3.1.0")
+    val jupiterVersion = "5.5.2"
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$jupiterVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:$jupiterVersion")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$jupiterVersion")
+    testImplementation("org.mockito:mockito-junit-jupiter:3.1.0")
     testImplementation("org.slf4j:slf4j-log4j12:1.7.28")
 
     testRuntimeOnly(files(distDir))
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
 }
 
 tasks.register<JavaExec>("run") {


### PR DESCRIPTION
Add dependency on JUnit 5 and remove JUnit 4.
Use Mockito library for JUnit 5.

Change tests to:
 - Use new annotations/imports;
 - Inline temporary directories when just needed in few tests;
 - Assert exceptions with `assertThrows`;
 - Explicitly assert that no exception is thrown (in tests that had no
  assertion and where no exception is expected);
 - Make more mocks lenient where needed.