### PR TITLE
Remove Dialog Icon on Manual Request Editor

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/ManualRequestEditorDialog.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/ManualRequestEditorDialog.java
@@ -37,7 +37,6 @@
 // ZAP: 2017/02/20 Issue 2699: Make SSLException handling more user friendly
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
-// ZAP: 2019/10/04 Add dialog icon.
 package org.parosproxy.paros.extension.manualrequest;
 
 import java.awt.BorderLayout;
@@ -98,7 +97,6 @@ public abstract class ManualRequestEditorDialog extends AbstractFrame implements
     }
 
     protected void initialize() {
-        this.setIconImage(ExtensionManualRequestEditor.getIcon().getImage());
         addWindowListener(
                 new WindowAdapter() {
                     @Override


### PR DESCRIPTION
Revert change setting the titlebar icon on the Manual Request Editor.
(https://github.com/zaproxy/zaproxy/pull/5614) [Also drop the no-longer necessary ZAP comment in the Paros file].

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>