### PR TITLE
Docker: include response code in scan output

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2019-10-16
+ - Added response code after each URL reported on standard out:
+
+```
+WARN-NEW: Web Browser XSS Protection Not Enabled [10016] x 4 
+	https://www.example.com/ (200 OK)
+	https://www.example.com/robots.txt (404 Not Found)
+	https://www.example.com (200 OK)
+	https://www.example.com/sitemap.xml (404 Not Found)
+```
+
 ### 2019-10-01
  - Added Python3 and the pip3 version of ZAP in preparation for Python 2 EOL: https://www.python.org/dev/peps/pep-0373/
 

--- a/docker/zap-api-scan.py
+++ b/docker/zap-api-scan.py
@@ -492,19 +492,19 @@ def main(argv):
                         print('SKIP: ' + rule.get('name') + ' [' + plugin_id + ']')
 
             # print out the ignored rules
-            ignore_count, not_used = print_rules(alert_dict, 'IGNORE', config_dict, config_msg, min_level,
+            ignore_count, not_used = print_rules(zap, alert_dict, 'IGNORE', config_dict, config_msg, min_level,
                 inc_ignore_rules, True, detailed_output, {})
 
             # print out the info rules
-            info_count, not_used = print_rules(alert_dict, 'INFO', config_dict, config_msg, min_level,
+            info_count, not_used = print_rules(zap, alert_dict, 'INFO', config_dict, config_msg, min_level,
                 inc_info_rules, info_unspecified, detailed_output, in_progress_issues)
 
             # print out the warning rules
-            warn_count, warn_inprog_count = print_rules(alert_dict, 'WARN', config_dict, config_msg, min_level,
+            warn_count, warn_inprog_count = print_rules(zap, alert_dict, 'WARN', config_dict, config_msg, min_level,
                 inc_warn_rules, not info_unspecified, detailed_output, in_progress_issues)
 
             # print out the failing rules
-            fail_count, fail_inprog_count = print_rules(alert_dict, 'FAIL', config_dict, config_msg, min_level,
+            fail_count, fail_inprog_count = print_rules(zap, alert_dict, 'FAIL', config_dict, config_msg, min_level,
                 inc_fail_rules, True, detailed_output, in_progress_issues)
 
             if report_html:

--- a/docker/zap-baseline.py
+++ b/docker/zap-baseline.py
@@ -378,19 +378,19 @@ def main(argv):
             pass_count = len(pass_dict)
 
             # print out the ignored rules
-            ignore_count, not_used = print_rules(alert_dict, 'IGNORE', config_dict, config_msg, min_level,
+            ignore_count, not_used = print_rules(zap, alert_dict, 'IGNORE', config_dict, config_msg, min_level,
                 inc_ignore_rules, True, detailed_output, {})
 
             # print out the info rules
-            info_count, not_used = print_rules(alert_dict, 'INFO', config_dict, config_msg, min_level,
+            info_count, not_used = print_rules(zap, alert_dict, 'INFO', config_dict, config_msg, min_level,
                 inc_info_rules, info_unspecified, detailed_output, in_progress_issues)
 
             # print out the warning rules
-            warn_count, warn_inprog_count = print_rules(alert_dict, 'WARN', config_dict, config_msg, min_level,
+            warn_count, warn_inprog_count = print_rules(zap, alert_dict, 'WARN', config_dict, config_msg, min_level,
                 inc_warn_rules, not info_unspecified, detailed_output, in_progress_issues)
 
             # print out the failing rules
-            fail_count, fail_inprog_count = print_rules(alert_dict, 'FAIL', config_dict, config_msg, min_level,
+            fail_count, fail_inprog_count = print_rules(zap, alert_dict, 'FAIL', config_dict, config_msg, min_level,
                 inc_fail_rules, True, detailed_output, in_progress_issues)
 
             if report_html:

--- a/docker/zap-full-scan.py
+++ b/docker/zap-full-scan.py
@@ -420,19 +420,19 @@ def main(argv):
                         print('SKIP: ' + rule.get('name') + ' [' + plugin_id + ']')
 
             # print out the ignored rules
-            ignore_count, not_used = print_rules(alert_dict, 'IGNORE', config_dict, config_msg, min_level,
+            ignore_count, not_used = print_rules(zap, alert_dict, 'IGNORE', config_dict, config_msg, min_level,
                 inc_ignore_rules, True, detailed_output, {})
 
             # print out the info rules
-            info_count, not_used = print_rules(alert_dict, 'INFO', config_dict, config_msg, min_level,
+            info_count, not_used = print_rules(zap, alert_dict, 'INFO', config_dict, config_msg, min_level,
                 inc_info_rules, info_unspecified, detailed_output, in_progress_issues)
 
             # print out the warning rules
-            warn_count, warn_inprog_count = print_rules(alert_dict, 'WARN', config_dict, config_msg, min_level,
+            warn_count, warn_inprog_count = print_rules(zap, alert_dict, 'WARN', config_dict, config_msg, min_level,
                 inc_warn_rules, not info_unspecified, detailed_output, in_progress_issues)
 
             # print out the failing rules
-            fail_count, fail_inprog_count = print_rules(alert_dict, 'FAIL', config_dict, config_msg, min_level,
+            fail_count, fail_inprog_count = print_rules(zap, alert_dict, 'FAIL', config_dict, config_msg, min_level,
                 inc_fail_rules, True, detailed_output, in_progress_issues)
 
             if report_html:

--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -166,7 +166,7 @@ def is_in_scope(plugin_id, url, out_of_scope_dict):
     return True
 
 
-def print_rule(action, alert_list, detailed_output, user_msg, in_progress_issues):
+def print_rule(zap, action, alert_list, detailed_output, user_msg, in_progress_issues):
     id = alert_list[0].get('pluginId')
     if id in in_progress_issues:
         print (action + '-IN_PROGRESS: ' + alert_list[0].get('alert') + ' [' + id + '] x ' + str(len(alert_list)) + ' ' + user_msg)
@@ -175,13 +175,15 @@ def print_rule(action, alert_list, detailed_output, user_msg, in_progress_issues
     else:
         print (action + '-NEW: ' + alert_list[0].get('alert') + ' [' + id + '] x ' + str(len(alert_list)) + ' ' + user_msg)
     if detailed_output:
-        # Show (up to) first 5 urls
+        # Show (up to) first 5 urls, along with the response code (which we have to perform another request for)
         for alert in alert_list[0:5]:
-            print ('\t' + alert.get('url'))
+            msg = zap.core.message(alert.get('messageId'))
+            respHeader = msg['responseHeader']
+            code = respHeader[respHeader.index(' ') + 1 : respHeader.index('\r\n')]
+            print ('\t' + alert.get('url') + ' (' + code + ')')
 
 
-def print_rules(alert_dict, level, config_dict, config_msg, min_level, inc_rule, inc_extra, detailed_output, in_progress_issues):
-    # print out the ignored rules
+def print_rules(zap, alert_dict, level, config_dict, config_msg, min_level, inc_rule, inc_extra, detailed_output, in_progress_issues):
     count = 0
     inprog_count = 0
     for key, alert_list in sorted(alert_dict.items()):
@@ -191,7 +193,7 @@ def print_rules(alert_dict, level, config_dict, config_msg, min_level, inc_rule,
             if key in config_msg:
                 user_msg = config_msg[key]
             if min_level <= zap_conf_lvls.index(level):
-                print_rule(level, alert_list, detailed_output, user_msg, in_progress_issues)
+                print_rule(zap, level, alert_list, detailed_output, user_msg, in_progress_issues)
             if key in in_progress_issues:
                 inprog_count += 1
             else:


### PR DESCRIPTION
Added the response code and text after each url - this makes it easier to identify rules that are only failing for eg 404s

Example output
```
WARN-NEW: Incomplete or No Cache-control and Pragma HTTP Header Set [10015] x 2 
	https://www.example.com/ (200 OK)
	https://www.example.com (200 OK)
WARN-NEW: Web Browser XSS Protection Not Enabled [10016] x 4 
	https://www.example.com/ (200 OK)
	https://www.example.com/robots.txt (404 Not Found)
	https://www.example.com (200 OK)
	https://www.example.com/sitemap.xml (404 Not Found)
WARN-NEW: X-Frame-Options Header Not Set [10020] x 2 
	https://www.example.com/ (200 OK)
	https://www.example.com (200 OK)
WARN-NEW: X-Content-Type-Options Header Missing [10021] x 2 
	https://www.example.com/ (200 OK)
	https://www.example.com (200 OK)
```


Signed-off-by: Simon Bennetts <psiinon@gmail.com>