### PR TITLE
Update dependencies

### DIFF
--- a/LEGALNOTICE.md
+++ b/LEGALNOTICE.md
@@ -31,9 +31,9 @@ and subject to their respective licenses.
 
 | Library                             | License                   |
 |-------------------------------------|---------------------------|
-| bcmail-jdk15on-1.61.jar             | MIT                       |
-| bcpkix-jdk15on-1.61.jar             | MIT                       |
-| bcprov-jdk15on-1.61.jar             | MIT                       |
+| bcmail-jdk15on-1.64.jar             | MIT                       |
+| bcpkix-jdk15on-1.64.jar             | MIT                       |
+| bcprov-jdk15on-1.64.jar             | MIT                       |
 | commons-beanutils-1.9.3.jar         | Apache 2.0                |
 | commons-codec-1.12.jar              | Apache 2.0                |
 | commons-collections-3.2.2.jar       | Apache 2.0                |
@@ -52,7 +52,7 @@ and subject to their respective licenses.
 | delight-nashorn-sandbox-0.1.25.jar  | Apache 2.0                |
 | ezmorph-1.0.6.jar                   | Apache 2.0                |
 | harlib-1.1.2.jar                    | Apache 2.0                |
-| hsqldb-2.4.1.jar                    | BSD                       |
+| hsqldb-2.5.0.jar                    | BSD                       |
 | ice4j-1.0.jar                       | Apache 2.0                |
 | jackson-core-asl-1.8.5.jar          | Apache 2.0                |
 | javahelp-2.0.05.jar                 | GPL + classpath exception |
@@ -64,7 +64,7 @@ and subject to their respective licenses.
 | jgrapht-core-0.9.0.jar              | LGPL 2.1                  |
 | json-lib-2.4-jdk15.jar              | MIT + "Good, Not Evil"    |
 | log4j-1.2.17.jar                    | Apache 2.0                |
-| rsyntaxtextarea-3.0.3.jar           | BSD-3 clause              |
+| rsyntaxtextarea-3.0.4.jar           | BSD-3 clause              |
 | sqlite-jdbc-3.27.2.1.jar            | BSD-2 clause              |
 | - NestedVM                          | Apache 2.0                |
 | swingx-all-1.6.5-1.jar              | LGPL 2.1                  |

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -34,7 +34,7 @@ jacoco {
 }
 
 dependencies {
-    api("com.fifesoft:rsyntaxtextarea:3.0.3")
+    api("com.fifesoft:rsyntaxtextarea:3.0.4")
     api("com.github.zafarkhaja:java-semver:0.9.0")
     api("commons-beanutils:commons-beanutils:1.9.3")
     api("commons-codec:commons-codec:1.12")
@@ -51,10 +51,10 @@ dependencies {
     api("net.htmlparser.jericho:jericho-html:3.4")
     api("net.sf.json-lib:json-lib:2.4:jdk15")
     api("org.apache.commons:commons-csv:1.6")
-    api("org.bouncycastle:bcmail-jdk15on:1.61")
-    api("org.bouncycastle:bcprov-jdk15on:1.61")
-    api("org.bouncycastle:bcpkix-jdk15on:1.61")
-    api("org.hsqldb:hsqldb:2.4.1")
+    api("org.bouncycastle:bcmail-jdk15on:1.64")
+    api("org.bouncycastle:bcprov-jdk15on:1.64")
+    api("org.bouncycastle:bcpkix-jdk15on:1.64")
+    api("org.hsqldb:hsqldb:2.5.0")
     api("org.jfree:jfreechart:1.0.19")
     api("org.jgrapht:jgrapht-core:0.9.0")
     api("org.swinglabs.swingx:swingx-all:1.6.5-1")


### PR DESCRIPTION
Update the following dependencies:
 - Bouncy Castle, 1.61 → 1.64;
 - HSQLDB, 2.4.1 → 2.5.0;
 - RSyntaxTextArea, 3.0.3 → 3.0.4.

Update of HSQLDB and Bouncy Castle addresses "illegal reflective access"
warnings with Java 9+.
RSyntaxTextArea has performance improvements when word wrapping.

Fix #5442.