### PR TITLE
Handle shortcut only if API request

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/API.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/API.java
@@ -327,8 +327,7 @@ public class API {
             }
         }
 
-        if (shortcutImpl == null
-                && callbackImpl == null
+        if (callbackImpl == null
                 && !url.startsWith(API_URL)
                 && !url.startsWith(API_URL_S)
                 && !force) {


### PR DESCRIPTION
Change API to only handle the shortcut if the message is an API request.

Fix #5636 - script.js never served on localhost