### PR TITLE
Tweak description of add-on command line args

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -1882,7 +1882,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                         1,
                         null,
                         "",
-                        "-addoninstall <addon>    "
+                        "-addoninstall <addOnId>   "
                                 + Constant.messages.getString("cfu.cmdline.install.help"));
         arguments[ARG_CFU_INSTALL_ALL_IDX] =
                 new CommandLineArgument(
@@ -1890,7 +1890,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                         0,
                         null,
                         "",
-                        "-addoninstallall         "
+                        "-addoninstallall          "
                                 + Constant.messages.getString("cfu.cmdline.installall.help"));
         arguments[ARG_CFU_UNINSTALL_IDX] =
                 new CommandLineArgument(
@@ -1898,7 +1898,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                         1,
                         null,
                         "",
-                        "-addonuninstall <addon>  "
+                        "-addonuninstall <addOnId> "
                                 + Constant.messages.getString("cfu.cmdline.uninstall.help"));
         arguments[ARG_CFU_UPDATE_IDX] =
                 new CommandLineArgument(
@@ -1906,7 +1906,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                         0,
                         null,
                         "",
-                        "-addonupdate             "
+                        "-addonupdate              "
                                 + Constant.messages.getString("cfu.cmdline.update.help"));
         arguments[ARG_CFU_LIST_IDX] =
                 new CommandLineArgument(
@@ -1914,7 +1914,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                         0,
                         null,
                         "",
-                        "-addonlist               "
+                        "-addonlist                "
                                 + Constant.messages.getString("cfu.cmdline.list.help"));
         return arguments;
     }

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -910,7 +910,7 @@ cfu.cmdline.addonurl		= Downloading add-on from: {0}
 cfu.cmdline.addoninst.error = It's recommended to restart ZAP. Not all add-ons were successfully installed.
 cfu.cmdline.addoninst.uninstalls.required = Not installing add-on(s). The installation would require uninstalling the following add-ons: {0}
 cfu.cmdline.addonuninst.uninstalls.required = Not uninstalling add-on(s). The uninstallation would require uninstalling the following add-ons: {0}
-cfu.cmdline.install.help	= Install the specified add-on from the ZAP Marketplace
+cfu.cmdline.install.help	= Installs the add-on with specified ID from the ZAP Marketplace
 cfu.cmdline.installall.help	= Install all available add-ons from the ZAP Marketplace
 cfu.cmdline.list.help		= List all of the installed add-ons
 cfu.cmdline.update.help		= Update all changed add-ons from the ZAP Marketplace
@@ -918,7 +918,7 @@ cfu.cmdline.noaddon			= Failed to find add-on: {0}
 cfu.cmdline.nocfu			= Check for updates call failed
 cfu.cmdline.uninstallfail	= Failed to uninstall add-on {0}
 cfu.cmdline.uninstallok		= Uninstalled add-on {0}
-cfu.cmdline.uninstall.help	= Uninstall the specified add-on
+cfu.cmdline.uninstall.help	= Uninstalls the add-on with specified ID
 cfu.cmdline.updated			= Add-on update check complete
 
 cfu.confirm.launch     = The latest ZAP release: {0} has been downloaded to\n{1}\nLaunch this file and close ZAP?


### PR DESCRIPTION
Indicate that it's used the ID of the add-on in `-addoninstall`
and `-addonuninstall`.

---
From OWASP ZAP User Group: https://groups.google.com/d/topic/zaproxy-users/KwmSiOmnndM/discussion