### PR TITLE
Allow to raise alerts more easily

### DIFF
--- a/zap/src/main/dist/scripts/templates/active/Active default template.js
+++ b/zap/src/main/dist/scripts/templates/active/Active default template.js
@@ -68,14 +68,23 @@ function scan(as, msg, param, value) {
 	
 	// Test the response here, and make other requests as required
 	if (true) {	// Change to a test which detects the vulnerability
-		// raiseAlert(risk, int confidence, String name, String description, String uri, 
-		//		String param, String attack, String otherInfo, String solution, String evidence, 
-		//		int cweId, int wascId, HttpMessage msg)
 		// risk: 0: info, 1: low, 2: medium, 3: high
 		// confidence: 0: falsePositive, 1: low, 2: medium, 3: high, 4: confirmed
-		as.raiseAlert(1, 1, 'Active Vulnerability title', 'Full description', 
-		msg.getRequestHeader().getURI().toString(), 
-			param, 'Your attack', 'Any other info', 'The solution ', '', 'References', 0, 0, msg);
+		as.newAlert()
+			.setRisk(1)
+			.setConfidence(1)
+			.setName('Active Vulnerability title')
+			.setDescription('Full description')
+			.setParam(param)
+			.setAttack('Your attack')
+			.setEvidence('Evidence')
+			.setOtherInfo('Any other info')
+			.setSolution('The solution')
+			.setReference('References')
+			.setCweId(0)
+			.setWascId(0)
+			.setMessage(msg)
+			.raise();
 	}
 }
 

--- a/zap/src/main/dist/scripts/templates/passive/Passive default template.js
+++ b/zap/src/main/dist/scripts/templates/passive/Passive default template.js
@@ -19,14 +19,21 @@ var PluginPassiveScanner = Java.type("org.zaproxy.zap.extension.pscan.PluginPass
 function scan(ps, msg, src) {
 	// Test the request and/or response here
 	if (true) {	// Change to a test which detects the vulnerability
-		// raiseAlert(risk, int confidence, String name, String description, String uri, 
-		//		String param, String attack, String otherInfo, String solution, String evidence, 
-		//		int cweId, int wascId, HttpMessage msg)
 		// risk: 0: info, 1: low, 2: medium, 3: high
 		// confidence: 0: falsePositive, 1: low, 2: medium, 3: high, 4: confirmed
-		ps.raiseAlert(1, 1, 'Passive Vulnerability title', 'Full description', 
-			msg.getRequestHeader().getURI().toString(), 
-			'The param', 'Your attack', 'Any other info', 'The solution', '', 'References', 0, 0, msg);
+		ps.newAlert()
+			.setRisk(1)
+			.setConfidence(1)
+			.setName('Passive Vulnerability title')
+			.setDescription('Full description')
+			.setParam('The param')
+			.setEvidence('Evidence')
+			.setOtherInfo('Any other info')
+			.setSolution('The solution')
+			.setReference('References')
+			.setCweId(0)
+			.setWascId(0)
+			.raise();
 		
 		//addTag(String tag)
 		ps.addTag('tag')			

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -63,6 +63,7 @@
 // ZAP: 2019/03/22 Add bingo with references.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2019/10/21 Use and expose Alert builder.
 package org.parosproxy.paros.core.scanner;
 
 import java.io.IOException;
@@ -79,7 +80,9 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.httpclient.HttpException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.Alert.Source;
 import org.parosproxy.paros.extension.encoder.Encoder;
+import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.control.AddOn;
@@ -391,7 +394,10 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
      * @param attack the attack that shows the issue
      * @param otherInfo other information about the issue
      * @param msg the message that shows the issue
+     * @deprecated (TODO add version) Use {@link #newAlert()} to build and {@link
+     *     AlertBuilder#raise() raise} the alert.
      */
+    @Deprecated
     protected void bingo(
             int risk,
             int confidence,
@@ -428,7 +434,10 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
      * @param otherInfo other information about the issue
      * @param solution the solution for the issue
      * @param msg the message that shows the issue
+     * @deprecated (TODO add version) Use {@link #newAlert()} to build and {@link
+     *     AlertBuilder#raise() raise} the alert.
      */
+    @Deprecated
     protected void bingo(
             int risk,
             int confidence,
@@ -441,27 +450,18 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
             String solution,
             HttpMessage msg) {
 
-        log.debug("New alert pluginid=" + +this.getId() + " " + name + " uri=" + uri);
-
-        Alert alert = new Alert(this.getId(), risk, confidence, name);
-        if (uri == null || uri.equals("")) {
-            uri = msg.getRequestHeader().getURI().toString();
-        }
-
-        alert.setDetail(
-                description,
-                uri,
-                param,
-                attack,
-                otherInfo,
-                solution,
-                this.getReference(),
-                "",
-                this.getCweId(),
-                this.getWascId(),
-                msg);
-
-        parent.alertFound(alert);
+        newAlert()
+                .setRisk(risk)
+                .setConfidence(confidence)
+                .setName(name)
+                .setDescription(description)
+                .setUri(uri)
+                .setParam(param)
+                .setAttack(attack)
+                .setOtherInfo(otherInfo)
+                .setSolution(solution)
+                .setMessage(msg)
+                .raise();
     }
 
     /**
@@ -476,7 +476,10 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
      * @param otherInfo other information about the issue
      * @param evidence the evidence (in the response) that shows the issue
      * @param msg the message that shows the issue
+     * @deprecated (TODO add version) Use {@link #newAlert()} to build and {@link
+     *     AlertBuilder#raise() raise} the alert.
      */
+    @Deprecated
     protected void bingo(
             int risk,
             int confidence,
@@ -516,7 +519,10 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
      * @param solution the solution for the issue
      * @param evidence the evidence (in the response) that shows the issue
      * @param msg the message that shows the issue
+     * @deprecated (TODO add version) Use {@link #newAlert()} to build and {@link
+     *     AlertBuilder#raise() raise} the alert.
      */
+    @Deprecated
     protected void bingo(
             int risk,
             int confidence,
@@ -530,28 +536,26 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
             String evidence,
             HttpMessage msg) {
 
-        log.debug("New alert pluginid=" + +this.getId() + " " + name + " uri=" + uri);
-        Alert alert = new Alert(this.getId(), risk, confidence, name);
-        if (uri == null || uri.equals("")) {
-            uri = msg.getRequestHeader().getURI().toString();
-        }
-
-        alert.setDetail(
-                description,
-                uri,
-                param,
-                attack,
-                otherInfo,
-                solution,
-                this.getReference(),
-                evidence,
-                this.getCweId(),
-                this.getWascId(),
-                msg);
-
-        parent.alertFound(alert);
+        newAlert()
+                .setRisk(risk)
+                .setConfidence(confidence)
+                .setName(name)
+                .setDescription(description)
+                .setUri(uri)
+                .setParam(param)
+                .setAttack(attack)
+                .setOtherInfo(otherInfo)
+                .setSolution(solution)
+                .setEvidence(evidence)
+                .setMessage(msg)
+                .raise();
     }
 
+    /**
+     * @deprecated (TODO add version) Use {@link #newAlert()} to build and {@link
+     *     AlertBuilder#raise() raise} the alert.
+     */
+    @Deprecated
     protected void bingo(
             int risk,
             int confidence,
@@ -583,6 +587,11 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
                 msg);
     }
 
+    /**
+     * @deprecated (TODO add version) Use {@link #newAlert()} to build and {@link
+     *     AlertBuilder#raise() raise} the alert.
+     */
+    @Deprecated
     protected void bingo(
             int risk,
             int confidence,
@@ -599,27 +608,22 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
             int wascId,
             HttpMessage msg) {
 
-        log.debug("New alert pluginid=" + +this.getId() + " " + name + " uri=" + uri);
-        Alert alert = new Alert(this.getId(), risk, confidence, name);
-
-        if (uri == null || uri.equals("")) {
-            uri = msg.getRequestHeader().getURI().toString();
-        }
-
-        alert.setDetail(
-                description,
-                uri,
-                param,
-                attack,
-                otherInfo,
-                solution,
-                reference,
-                evidence,
-                cweId,
-                wascId,
-                msg);
-
-        parent.alertFound(alert);
+        newAlert()
+                .setRisk(risk)
+                .setConfidence(confidence)
+                .setName(name)
+                .setDescription(description)
+                .setUri(uri)
+                .setParam(param)
+                .setAttack(attack)
+                .setOtherInfo(otherInfo)
+                .setSolution(solution)
+                .setEvidence(evidence)
+                .setReference(reference)
+                .setCweId(cweId)
+                .setWascId(wascId)
+                .setMessage(msg)
+                .raise();
     }
 
     /**
@@ -1141,5 +1145,192 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
 
     public void setStatus(AddOn.Status status) {
         this.status = status;
+    }
+
+    /**
+     * Returns a new alert builder.
+     *
+     * <p>By default the alert builder sets the following fields of the alert:
+     *
+     * <ul>
+     *   <li>Plugin ID - using {@link #getId()}
+     *   <li>Name - using {@link #getName()}
+     *   <li>Risk - using {@link #getRisk()}
+     *   <li>Description - using {@link #getDescription()}
+     *   <li>Solution - using {@link #getSolution()}
+     *   <li>Reference - using {@link #getReference()}
+     *   <li>CWE ID - using {@link #getCweId()}
+     *   <li>WASC ID - using {@link #getWascId()}
+     *   <li>URI - from the alert message
+     * </ul>
+     *
+     * @return the alert builder.
+     * @since TODO add version
+     */
+    protected AlertBuilder newAlert() {
+        return new AlertBuilder(this);
+    }
+
+    /**
+     * An alert builder to fluently build and {@link #raise() raise alerts}.
+     *
+     * @since TODO add version
+     */
+    public static final class AlertBuilder extends Alert.Builder {
+
+        private final AbstractPlugin plugin;
+        private boolean messageSet;
+
+        private AlertBuilder(AbstractPlugin plugin) {
+            this.plugin = plugin;
+
+            setPluginId(plugin.getId());
+            setName(plugin.getName());
+            setRisk(plugin.getRisk());
+            setDescription(plugin.getDescription());
+            setSolution(plugin.getSolution());
+            setReference(plugin.getReference());
+            setCweId(plugin.getCweId());
+            setWascId(plugin.getWascId());
+        }
+
+        @Override
+        public AlertBuilder setAlertId(int alertId) {
+            super.setAlertId(alertId);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setPluginId(int pluginId) {
+            super.setPluginId(pluginId);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setName(String name) {
+            super.setName(name);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setRisk(int risk) {
+            super.setRisk(risk);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setConfidence(int confidence) {
+            super.setConfidence(confidence);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setDescription(String description) {
+            super.setDescription(description);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setUri(String uri) {
+            super.setUri(uri);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setParam(String param) {
+            super.setParam(param);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setAttack(String attack) {
+            super.setAttack(attack);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setOtherInfo(String otherInfo) {
+            super.setOtherInfo(otherInfo);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setSolution(String solution) {
+            super.setSolution(solution);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setReference(String reference) {
+            super.setReference(reference);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setEvidence(String evidence) {
+            super.setEvidence(evidence);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setCweId(int cweId) {
+            super.setCweId(cweId);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setWascId(int wascId) {
+            super.setWascId(wascId);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setMessage(HttpMessage message) {
+            super.setMessage(message);
+            messageSet = message != null;
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setSourceHistoryId(int sourceHistoryId) {
+            super.setSourceHistoryId(sourceHistoryId);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setHistoryRef(HistoryReference historyRef) {
+            super.setHistoryRef(historyRef);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setSource(Source source) {
+            super.setSource(source);
+            return this;
+        }
+
+        /**
+         * Raises the alert with specified data.
+         *
+         * @throws IllegalStateException if the HTTP message was not set.
+         */
+        public void raise() {
+            if (!messageSet) {
+                throw new IllegalStateException(
+                        "A HTTP message must be set before raising the alert.");
+            }
+
+            Alert alert = build();
+            if (plugin.log.isDebugEnabled()) {
+                plugin.log.debug(
+                        "New alert pluginid="
+                                + alert.getPluginId()
+                                + " "
+                                + alert.getName()
+                                + " uri="
+                                + alert.getUri());
+            }
+            plugin.parent.alertFound(alert);
+        }
     }
 }

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Alert.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Alert.java
@@ -55,6 +55,7 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/07/10 Add utility methods isValidRisk(int) and isValidConfidence(int)
+// ZAP: 2019/10/21 Add Alert builder.
 package org.parosproxy.paros.core.scanner;
 
 import java.net.URL;
@@ -289,9 +290,30 @@ public class Alert implements Comparable<Alert> {
     }
 
     public void setRiskConfidence(int risk, int confidence) {
+        setRisk(risk);
+        setConfidence(confidence);
+    }
+
+    /**
+     * Sets the risk of the alert.
+     *
+     * @param risk the new risk.
+     * @since TODO Add version
+     */
+    public void setRisk(int risk) {
         this.risk = risk;
+    }
+
+    /**
+     * Sets the confidence of the alert.
+     *
+     * @param confidence the new confidence.
+     * @since TODO add version
+     */
+    public void setConfidence(int confidence) {
         this.confidence = confidence;
     }
+
     /**
      * @deprecated (2.5.0) Replaced by {@link #setName}. Use of alert has been deprecated in favour
      *     of using name.
@@ -324,6 +346,7 @@ public class Alert implements Comparable<Alert> {
      * @param msg the HTTP message that triggers/triggered the issue
      * @deprecated (2.2.0) Replaced by {@link #setDetail(String, String, String, String, String,
      *     String, String, String, int, int, HttpMessage)}. It will be removed in a future release.
+     * @see Builder
      */
     @Deprecated
     public void setDetail(
@@ -353,6 +376,7 @@ public class Alert implements Comparable<Alert> {
      * @param wascId the WASC ID of the issue
      * @param msg the HTTP message that triggers/triggered the issue
      * @since 2.2.0
+     * @see Builder
      */
     public void setDetail(
             String description,
@@ -892,6 +916,183 @@ public class Alert implements Comparable<Alert> {
             throw new IllegalArgumentException("Parameter source must not be null.");
         }
         this.source = source;
+    }
+
+    /**
+     * Returns a new alert builder.
+     *
+     * @return the alert builder.
+     * @since TODO add version
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder of alerts.
+     *
+     * @since TODO add version
+     * @see #build()
+     */
+    public static class Builder {
+
+        private int alertId = -1;
+        private int pluginId;
+        private String name;
+        private int risk = RISK_INFO;
+        private int confidence = CONFIDENCE_MEDIUM;
+        private String description;
+        private String uri;
+        private String param;
+        private String attack;
+        private String otherInfo;
+        private String solution;
+        private String reference;
+        private String evidence;
+        private int cweId = -1;
+        private int wascId = -1;
+        private HttpMessage message;
+        private int sourceHistoryId;
+        private HistoryReference historyRef;
+        private Source source = Source.UNKNOWN;
+
+        protected Builder() {}
+
+        public Builder setAlertId(int alertId) {
+            this.alertId = alertId;
+            return this;
+        }
+
+        public Builder setPluginId(int pluginId) {
+            this.pluginId = pluginId;
+            return this;
+        }
+
+        public Builder setName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder setRisk(int risk) {
+            this.risk = risk;
+            return this;
+        }
+
+        public Builder setConfidence(int confidence) {
+            this.confidence = confidence;
+            return this;
+        }
+
+        public Builder setDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder setUri(String uri) {
+            this.uri = uri;
+            return this;
+        }
+
+        public Builder setParam(String param) {
+            this.param = param;
+            return this;
+        }
+
+        public Builder setAttack(String attack) {
+            this.attack = attack;
+            return this;
+        }
+
+        public Builder setOtherInfo(String otherInfo) {
+            this.otherInfo = otherInfo;
+            return this;
+        }
+
+        public Builder setSolution(String solution) {
+            this.solution = solution;
+            return this;
+        }
+
+        public Builder setReference(String reference) {
+            this.reference = reference;
+            return this;
+        }
+
+        public Builder setEvidence(String evidence) {
+            this.evidence = evidence;
+            return this;
+        }
+
+        public Builder setCweId(int cweId) {
+            this.cweId = cweId;
+            return this;
+        }
+
+        public Builder setWascId(int wascId) {
+            this.wascId = wascId;
+            return this;
+        }
+
+        public Builder setMessage(HttpMessage message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder setSourceHistoryId(int sourceHistoryId) {
+            this.sourceHistoryId = sourceHistoryId;
+            return this;
+        }
+
+        public Builder setHistoryRef(HistoryReference historyRef) {
+            this.historyRef = historyRef;
+            return this;
+        }
+
+        public Builder setSource(Source source) {
+            this.source = source;
+            return this;
+        }
+
+        /**
+         * Builds the alert from the specified data.
+         *
+         * <p>The alert URI defaults to the one from the {@code HistoryReference} or {@code
+         * HttpMessage} if set.
+         *
+         * @return the alert with specified data.
+         */
+        public final Alert build() {
+            String alertUri = uri;
+            if (alertUri == null || alertUri.isEmpty()) {
+                if (historyRef != null) {
+                    alertUri = historyRef.getURI().toString();
+                } else if (message != null) {
+                    alertUri = message.getRequestHeader().getURI().toString();
+                }
+            }
+
+            Alert alert = new Alert(pluginId);
+            alert.setAlertId(alertId);
+            alert.setName(name);
+            alert.setRisk(risk);
+            alert.setConfidence(confidence);
+            alert.setDescription(description);
+            alert.setUri(alertUri);
+            alert.setParam(param);
+            alert.setAttack(attack);
+            alert.setOtherInfo(otherInfo);
+            alert.setSolution(solution);
+            alert.setReference(reference);
+            alert.setEvidence(evidence);
+            alert.setCweId(cweId);
+            alert.setWascId(wascId);
+            alert.setMessage(message);
+            alert.setSourceHistoryId(sourceHistoryId);
+            alert.setHistoryRef(historyRef);
+            alert.setSource(source);
+
+            return alert;
+        }
     }
 
     /**

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScriptsActiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScriptsActiveScanner.java
@@ -29,6 +29,7 @@ import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
+import org.parosproxy.paros.core.scanner.AbstractPlugin.AlertBuilder;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
@@ -237,6 +238,17 @@ public class ScriptsActiveScanner extends AbstractAppParamPlugin {
         super.sendAndReceive(msg, isFollowRedirect, handleAntiCSRF);
     }
 
+    /** @since TODO add version */
+    @Override
+    public AlertBuilder newAlert() {
+        return super.newAlert();
+    }
+
+    /**
+     * @deprecated (TODO add version) Use {@link #newAlert()} to build and {@link
+     *     AlertBuilder#raise() raise} alerts.
+     */
+    @Deprecated
     public void raiseAlert(
             int risk,
             int confidence,
@@ -267,6 +279,11 @@ public class ScriptsActiveScanner extends AbstractAppParamPlugin {
                 msg);
     }
 
+    /**
+     * @deprecated (TODO add version) Use {@link #newAlert()} to build and {@link
+     *     AlertBuilder#raise() raise} alerts.
+     */
+    @Deprecated
     public void raiseAlert(
             int risk,
             int confidence,

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
@@ -191,13 +191,22 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
                                 if (scanner.isEnabled()
                                         && (scanner.appliesToHistoryType(hrefHistoryType)
                                                 || optedInHistoryTypes.contains(hrefHistoryType))) {
-                                    scanner.setParent(this);
+                                    boolean cleanScanner = false;
+                                    if (scanner instanceof PluginPassiveScanner) {
+                                        ((PluginPassiveScanner) scanner).init(this, msg);
+                                        cleanScanner = true;
+                                    } else {
+                                        scanner.setParent(this);
+                                    }
                                     currentRuleName = scanner.getName();
                                     currentRuleStartTime = System.currentTimeMillis();
                                     scanner.scanHttpRequestSend(msg, href.getHistoryId());
                                     if (msg.isResponseFromTargetHost()) {
                                         scanner.scanHttpResponseReceive(
                                                 msg, href.getHistoryId(), src);
+                                    }
+                                    if (cleanScanner) {
+                                        ((PluginPassiveScanner) scanner).clean();
                                     }
                                     long timeTaken =
                                             System.currentTimeMillis() - currentRuleStartTime;

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
@@ -26,8 +26,11 @@ import java.util.List;
 import java.util.Set;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Alert.Source;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.utils.Enableable;
 
@@ -75,8 +78,23 @@ public abstract class PluginPassiveScanner extends Enableable implements Passive
     private Configuration config = null;
     private AddOn.Status status = AddOn.Status.unknown;
 
+    private PassiveScanThread parent;
+    private HttpMessage message;
+
     public PluginPassiveScanner() {
         super(true);
+    }
+
+    void init(PassiveScanThread parent, HttpMessage message) {
+        this.parent = parent;
+        this.message = message;
+
+        setParent(parent);
+    }
+
+    void clean() {
+        parent = null;
+        message = null;
     }
 
     /**
@@ -335,5 +353,165 @@ public abstract class PluginPassiveScanner extends Enableable implements Passive
     @Override
     public boolean appliesToHistoryType(int historyType) {
         return getDefaultHistoryTypes().contains(historyType);
+    }
+
+    /**
+     * Returns a new alert builder.
+     *
+     * <p>By default the alert builder sets the following fields of the alert:
+     *
+     * <ul>
+     *   <li>Plugin ID - using {@link #getPluginId()}
+     *   <li>Name - using {@link #getName()}
+     *   <li>Message - the message being scanned
+     *   <li>URI - from the alert message
+     * </ul>
+     *
+     * @return the alert builder.
+     * @since TODO add version
+     */
+    protected AlertBuilder newAlert() {
+        return new AlertBuilder(this, message);
+    }
+
+    /**
+     * An alert builder to fluently build and {@link #raise() raise alerts}.
+     *
+     * @since TODO add version
+     */
+    public static final class AlertBuilder extends Alert.Builder {
+
+        private final PluginPassiveScanner plugin;
+        private final HttpMessage message;
+
+        private AlertBuilder(PluginPassiveScanner plugin, HttpMessage message) {
+            this.plugin = plugin;
+            this.message = message;
+
+            setPluginId(plugin.getPluginId());
+            setName(plugin.getName());
+            setMessage(message);
+        }
+
+        @Override
+        public AlertBuilder setAlertId(int alertId) {
+            super.setAlertId(alertId);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setPluginId(int pluginId) {
+            super.setPluginId(pluginId);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setName(String name) {
+            super.setName(name);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setRisk(int risk) {
+            super.setRisk(risk);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setConfidence(int confidence) {
+            super.setConfidence(confidence);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setDescription(String description) {
+            super.setDescription(description);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setUri(String uri) {
+            super.setUri(uri);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setParam(String param) {
+            super.setParam(param);
+            return this;
+        }
+
+        /**
+         * @throws IllegalStateException always, passive scanners should not set the attack field.
+         */
+        @Override
+        public AlertBuilder setAttack(String attack) {
+            throw new IllegalStateException("Passive alerts should not have an attack.");
+        }
+
+        @Override
+        public AlertBuilder setOtherInfo(String otherInfo) {
+            super.setOtherInfo(otherInfo);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setSolution(String solution) {
+            super.setSolution(solution);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setReference(String reference) {
+            super.setReference(reference);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setEvidence(String evidence) {
+            super.setEvidence(evidence);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setCweId(int cweId) {
+            super.setCweId(cweId);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setWascId(int wascId) {
+            super.setWascId(wascId);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setMessage(HttpMessage message) {
+            super.setMessage(message);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setSourceHistoryId(int sourceHistoryId) {
+            super.setSourceHistoryId(sourceHistoryId);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setHistoryRef(HistoryReference historyRef) {
+            super.setHistoryRef(historyRef);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder setSource(Source source) {
+            super.setSource(source);
+            return this;
+        }
+
+        /** Raises the alert with specified data. */
+        public void raise() {
+            plugin.parent.raiseAlert(message.getHistoryRef().getHistoryId(), build());
+        }
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
@@ -25,7 +25,6 @@ import net.htmlparser.jericho.Source;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
-import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
@@ -122,6 +121,17 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
         }
     }
 
+    /** @since TODO add version */
+    @Override
+    public AlertBuilder newAlert() {
+        return super.newAlert();
+    }
+
+    /**
+     * @deprecated (TODO add version) Use {@link #newAlert()} to build and {@link
+     *     AlertBuilder#raise() raise} alerts.
+     */
+    @Deprecated
     public void raiseAlert(
             int risk,
             int confidence,
@@ -154,6 +164,11 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
                 msg);
     }
 
+    /**
+     * @deprecated (TODO add version) Use {@link #newAlert()} to build and {@link
+     *     AlertBuilder#raise() raise} alerts.
+     */
+    @Deprecated
     public void raiseAlert(
             int risk,
             int confidence,
@@ -170,22 +185,20 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
             int wascId,
             HttpMessage msg) {
 
-        Alert alert = new Alert(getPluginId(), risk, confidence, name);
-
-        alert.setDetail(
-                description,
-                msg.getRequestHeader().getURI().toString(),
-                param,
-                attack,
-                otherInfo,
-                solution,
-                reference,
-                evidence,
-                cweId,
-                wascId,
-                msg);
-
-        this.parent.raiseAlert(currentHRefId, alert);
+        newAlert()
+                .setRisk(risk)
+                .setConfidence(confidence)
+                .setName(name)
+                .setDescription(description)
+                .setParam(param)
+                .setOtherInfo(otherInfo)
+                .setSolution(solution)
+                .setReference(reference)
+                .setEvidence(evidence)
+                .setCweId(cweId)
+                .setWascId(wascId)
+                .setMessage(msg)
+                .raise();
     }
 
     public void addTag(String tag) {

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/AbstractPluginUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/AbstractPluginUnitTest.java
@@ -533,6 +533,7 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRaiseAlertWith7ParamsBingo() {
         // Given
         AbstractPlugin plugin = createDefaultPlugin();
@@ -567,6 +568,7 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRaiseAlertWith7ParamsBingoDefaultingToMessageUriWhenGivenUriIsNull() {
         // Given
         AbstractPlugin plugin = createDefaultPlugin();
@@ -583,6 +585,7 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRaiseAlertWith7ParamsBingoDefaultingToMessageUriWhenGivenUriIsEmpty() {
         // Given
         AbstractPlugin plugin = createDefaultPlugin();
@@ -599,6 +602,7 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRaiseAlertWith8ParamsBingo() {
         // Given
         AbstractPlugin plugin = createDefaultPlugin();
@@ -634,6 +638,7 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRaiseAlertWith8ParamsBingoDefaultingToMessageUriWhenGivenUriIsNull() {
         // Given
         AbstractPlugin plugin = createDefaultPlugin();
@@ -650,6 +655,7 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRaiseAlertWith8ParamsBingoDefaultingToMessageUriWhenGivenUriIsEmpty() {
         // Given
         AbstractPlugin plugin = createDefaultPlugin();
@@ -666,6 +672,7 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRaiseAlertWith10ParamsBingo() {
         // Given
         AbstractPlugin plugin = createDefaultPlugin();
@@ -713,6 +720,7 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRaiseAlertWith10ParamsBingoDefaultingToMessageUriWhenGivenUriIsNull() {
         // Given
         AbstractPlugin plugin = createDefaultPlugin();
@@ -730,6 +738,7 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRaiseAlertWith10ParamsBingoDefaultingToMessageUriWhenGivenUriIsEmpty() {
         // Given
         AbstractPlugin plugin = createDefaultPlugin();
@@ -747,6 +756,7 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRaiseAlertWith11ParamsBingo() {
         // Given
         AbstractPlugin plugin = createDefaultPlugin();
@@ -796,6 +806,7 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRaiseAlertWith11ParamsBingoDefaultingToMessageUriWhenGivenUriIsNull() {
         // Given
         AbstractPlugin plugin = createDefaultPlugin();
@@ -823,6 +834,7 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRaiseAlertWith11ParamsBingoDefaultingToMessageUriWhenGivenUriIsEmpty() {
         // Given
         AbstractPlugin plugin = createDefaultPlugin();
@@ -850,6 +862,7 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRaiseAlertWith13ParamsBingo() {
         // Given
         AbstractPlugin plugin = createDefaultPlugin();
@@ -903,6 +916,7 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRaiseAlertWith13ParamsBingoDefaultingToMessageUriWhenGivenUriIsNull() {
         // Given
         AbstractPlugin plugin = createDefaultPlugin();
@@ -932,6 +946,7 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRaiseAlertWith13ParamsBingoDefaultingToMessageUriWhenGivenUriIsEmpty() {
         // Given
         AbstractPlugin plugin = createDefaultPlugin();
@@ -961,6 +976,7 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRaiseAlertWith14ParamsBingo() {
         // Given
         AbstractPlugin plugin = createDefaultPlugin();
@@ -1016,6 +1032,7 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRaiseAlertWith14ParamsBingoDefaultingToMessageUriWhenGivenUriIsNull() {
         // Given
         AbstractPlugin plugin = createDefaultPlugin();
@@ -1046,6 +1063,7 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void shouldRaiseAlertWith14ParamsBingoDefaultingToMessageUriWhenGivenUriIsEmpty() {
         // Given
         AbstractPlugin plugin = createDefaultPlugin();
@@ -1073,6 +1091,100 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
         // Then
         Alert alert = getRaisedAlert(hostProcess);
         assertThat(alert.getUri(), is(equalTo(messageUri)));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldFailToRaiseAlertWithNewAlertIfNoMessageProvided() {
+        // Given
+        AbstractPlugin plugin = createDefaultPlugin();
+        // When
+        plugin.newAlert().raise();
+        // Then = IllegalStateException
+    }
+
+    @Test
+    public void shouldRaiseAlertWithNewAlertUsingPluginData() {
+        // Given
+        AbstractPlugin plugin = createDefaultPlugin();
+        HostProcess hostProcess = mock(HostProcess.class);
+        plugin.init(mock(HttpMessage.class), hostProcess);
+        String uri = "http://example.com";
+        HttpMessage alertMessage = createAlertMessage(uri);
+        // When
+        plugin.newAlert().setMessage(alertMessage).raise();
+        // Then
+        Alert alert = getRaisedAlert(hostProcess);
+        assertThat(alert.getPluginId(), is(equalTo(plugin.getId())));
+        assertThat(alert.getName(), is(equalTo(plugin.getName())));
+        assertThat(alert.getRisk(), is(equalTo(plugin.getRisk())));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(alert.getDescription(), is(equalTo(plugin.getDescription())));
+        assertThat(alert.getUri(), is(equalTo(uri)));
+        assertThat(alert.getParam(), is(equalTo("")));
+        assertThat(alert.getAttack(), is(equalTo("")));
+        assertThat(alert.getEvidence(), is(equalTo("")));
+        assertThat(alert.getOtherInfo(), is(equalTo("")));
+        assertThat(alert.getSolution(), is(equalTo(plugin.getSolution())));
+        assertThat(alert.getReference(), is(equalTo(plugin.getReference())));
+        assertThat(alert.getCweId(), is(equalTo(plugin.getCweId())));
+        assertThat(alert.getWascId(), is(equalTo(plugin.getWascId())));
+        assertThat(alert.getMessage(), is(sameInstance(alertMessage)));
+    }
+
+    @Test
+    public void shouldRaiseAlertWithNewAlert() {
+        // Given
+        AbstractPlugin plugin = createDefaultPlugin();
+        HostProcess hostProcess = mock(HostProcess.class);
+        plugin.init(mock(HttpMessage.class), hostProcess);
+        int risk = Alert.RISK_LOW;
+        int confidence = Alert.CONFIDENCE_HIGH;
+        String name = "name";
+        String description = "description";
+        String uri = "uri";
+        String param = "param";
+        String attack = "attack";
+        String evidence = "evidence";
+        String otherInfo = "otherInfo";
+        String solution = "solution";
+        String reference = "reference";
+        int cweId = 111;
+        int wascId = 222;
+        HttpMessage alertMessage = createAlertMessage();
+        // When
+        plugin.newAlert()
+                .setRisk(risk)
+                .setConfidence(confidence)
+                .setName(name)
+                .setDescription(description)
+                .setUri(uri)
+                .setParam(param)
+                .setAttack(attack)
+                .setOtherInfo(otherInfo)
+                .setSolution(solution)
+                .setEvidence(evidence)
+                .setReference(reference)
+                .setCweId(cweId)
+                .setWascId(wascId)
+                .setMessage(alertMessage)
+                .raise();
+        // Then
+        Alert alert = getRaisedAlert(hostProcess);
+        assertThat(alert.getPluginId(), is(equalTo(plugin.getId())));
+        assertThat(alert.getName(), is(equalTo(name)));
+        assertThat(alert.getRisk(), is(equalTo(risk)));
+        assertThat(alert.getConfidence(), is(equalTo(confidence)));
+        assertThat(alert.getDescription(), is(equalTo(description)));
+        assertThat(alert.getUri(), is(equalTo(uri)));
+        assertThat(alert.getParam(), is(equalTo(param)));
+        assertThat(alert.getAttack(), is(equalTo(attack)));
+        assertThat(alert.getEvidence(), is(equalTo(evidence)));
+        assertThat(alert.getOtherInfo(), is(equalTo(otherInfo)));
+        assertThat(alert.getSolution(), is(equalTo(solution)));
+        assertThat(alert.getReference(), is(equalTo(reference)));
+        assertThat(alert.getCweId(), is(equalTo(cweId)));
+        assertThat(alert.getWascId(), is(equalTo(wascId)));
+        assertThat(alert.getMessage(), is(sameInstance(alertMessage)));
     }
 
     @Test(expected = Exception.class)


### PR DESCRIPTION
Add `Alert` builder to allow to create alerts fluently.
Expose the builder to passive/active scan rules to build and raise the
alerts.
Deprecate old way of raising alerts, which required to specify all/many
alert fields even if not needed.
Update passive/active script templates.