### PR TITLE
Improve permissions and space handling when saving/exporting

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/history/PopupMenuExportMessage.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/PopupMenuExportMessage.java
@@ -32,6 +32,7 @@
 // ZAP: 2018/03/29 Use FileNameExtensionFilter.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2019/11/05 Use WritableFileChooser for saves.
 package org.parosproxy.paros.extension.history;
 
 import java.io.BufferedWriter;
@@ -48,6 +49,7 @@ import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
 public class PopupMenuExportMessage extends JMenuItem {
 
@@ -170,7 +172,7 @@ public class PopupMenuExportMessage extends JMenuItem {
     private File getOutputFile() {
 
         JFileChooser chooser =
-                new JFileChooser(extension.getModel().getOptionsParam().getUserDirectory());
+                new WritableFileChooser(extension.getModel().getOptionsParam().getUserDirectory());
         chooser.setFileFilter(
                 new FileNameExtensionFilter(
                         Constant.messages.getString("file.format.ascii"), "txt"));
@@ -181,7 +183,6 @@ public class PopupMenuExportMessage extends JMenuItem {
             if (file == null) {
                 return file;
             }
-            extension.getModel().getOptionsParam().setUserDirectory(chooser.getCurrentDirectory());
             String fileName = file.getAbsolutePath();
             if (!fileName.toLowerCase(Locale.ROOT).endsWith(".txt")) {
                 fileName += ".txt";

--- a/zap/src/main/java/org/parosproxy/paros/extension/history/PopupMenuExportResponse.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/PopupMenuExportResponse.java
@@ -28,6 +28,7 @@
 // ZAP: 2018/08/15 Added null check
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2019/11/05 Use WritableFileChooser for saves.
 package org.parosproxy.paros.extension.history;
 
 import java.io.BufferedOutputStream;
@@ -41,6 +42,7 @@ import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
 public class PopupMenuExportResponse extends JMenuItem {
 
@@ -144,7 +146,7 @@ public class PopupMenuExportResponse extends JMenuItem {
         String filename = "untitled.txt";
 
         JFileChooser chooser =
-                new JFileChooser(extension.getModel().getOptionsParam().getUserDirectory());
+                new WritableFileChooser(extension.getModel().getOptionsParam().getUserDirectory());
         if (filename.length() > 0) {
             chooser.setSelectedFile(new File(filename));
         }
@@ -156,8 +158,6 @@ public class PopupMenuExportResponse extends JMenuItem {
             if (file == null) {
                 return file;
             }
-
-            extension.getModel().getOptionsParam().setUserDirectory(chooser.getCurrentDirectory());
 
             return file;
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyManagerDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyManagerDialog.java
@@ -42,6 +42,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.SingleColumnTableModel;
 import org.zaproxy.zap.view.StandardFieldsDialog;
+import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
 public class PolicyManagerDialog extends StandardFieldsDialog {
 
@@ -222,7 +223,8 @@ public class PolicyManagerDialog extends StandardFieldsDialog {
                                                     .getValueAt(
                                                             getParamsTable().getSelectedRow(), 0);
                             if (name != null) {
-                                JFileChooser chooser = new JFileChooser(Constant.getPoliciesDir());
+                                JFileChooser chooser =
+                                        new WritableFileChooser(Constant.getPoliciesDir());
                                 File file =
                                         new File(
                                                 Constant.getZapHome(),

--- a/zap/src/main/java/org/zaproxy/zap/extension/compare/ExtensionCompare.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/compare/ExtensionCompare.java
@@ -54,6 +54,7 @@ import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SessionListener;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.zaproxy.zap.utils.DesktopUtils;
+import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
 public class ExtensionCompare extends ExtensionAdaptor
         implements SessionChangedListener, SessionListener {
@@ -343,7 +344,8 @@ public class ExtensionCompare extends ExtensionAdaptor
 
     private File getOutputFile() {
 
-        JFileChooser chooser = new JFileChooser(getModel().getOptionsParam().getUserDirectory());
+        JFileChooser chooser =
+                new WritableFileChooser(getModel().getOptionsParam().getUserDirectory());
         chooser.setFileFilter(
                 new FileNameExtensionFilter(
                         Constant.messages.getString("file.format.html"), "htm", "html"));
@@ -355,7 +357,6 @@ public class ExtensionCompare extends ExtensionAdaptor
             if (file == null) {
                 return file;
             }
-            getModel().getOptionsParam().setUserDirectory(chooser.getCurrentDirectory());
             String fileNameLc = file.getAbsolutePath().toLowerCase();
             if (!fileNameLc.endsWith(".htm") && !fileNameLc.endsWith(".html")) {
                 file = new File(file.getAbsolutePath() + ".html");

--- a/zap/src/main/java/org/zaproxy/zap/extension/dynssl/DynamicSSLPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/dynssl/DynamicSSLPanel.java
@@ -58,6 +58,7 @@ import org.parosproxy.paros.view.AbstractParamPanel;
 import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.utils.ZapTextArea;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
+import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
 public class DynamicSSLPanel extends AbstractParamPanel {
 
@@ -488,7 +489,7 @@ public class DynamicSSLPanel extends AbstractParamPanel {
             logger.error("Illegal state! There seems to be no certificate available.");
             bt_save.setEnabled(false);
         }
-        final JFileChooser fc = new JFileChooser(System.getProperty("user.home"));
+        final JFileChooser fc = new WritableFileChooser(new File(System.getProperty("user.home")));
         fc.setFileSelectionMode(JFileChooser.FILES_ONLY);
         fc.setMultiSelectionEnabled(false);
         fc.setSelectedFile(new File(OWASP_ZAP_ROOT_CA_FILENAME));


### PR DESCRIPTION
Various classes changed from using JFileChooser to WritableFileChooser which has better handling for permissions, read-only, and ensuring space is available. Paros classes also include ZAP comment.  Removed calls to setUserDirectory as that is done by WritableFileChooser.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>