### PR TITLE
Check for updates in daemon mode

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/DaemonBootstrap.java
+++ b/zap/src/main/java/org/zaproxy/zap/DaemonBootstrap.java
@@ -109,6 +109,8 @@ class DaemonBootstrap extends HeadlessBootstrap {
                                     System.out.println(message);
                                 }
 
+                                HeadlessBootstrap.checkForUpdates();
+
                                 // This is the only non-daemon thread, so should keep running
                                 // CoreAPI.handleApiAction uses System.exit to shutdown
                                 while (true) {

--- a/zap/src/main/java/org/zaproxy/zap/GuiBootstrap.java
+++ b/zap/src/main/java/org/zaproxy/zap/GuiBootstrap.java
@@ -50,7 +50,6 @@ import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.control.AddOnLoader;
 import org.zaproxy.zap.control.AddOnRunIssuesUtils;
 import org.zaproxy.zap.control.ExtensionFactory;
-import org.zaproxy.zap.extension.autoupdate.ExtensionAutoUpdate;
 import org.zaproxy.zap.model.SessionUtils;
 import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.utils.LocaleUtils;
@@ -207,13 +206,7 @@ public class GuiBootstrap extends ZapBootstrap {
 
                                 warnAddOnsAndExtensionsNoLongerRunnable();
 
-                                final ExtensionAutoUpdate eau =
-                                        Control.getSingleton()
-                                                .getExtensionLoader()
-                                                .getExtension(ExtensionAutoUpdate.class);
-                                if (eau != null) {
-                                    eau.alertIfNewVersions();
-                                }
+                                HeadlessBootstrap.checkForUpdates();
                             }
                         });
         bootstrap.setName("ZAP-BootstrapGUI");

--- a/zap/src/main/java/org/zaproxy/zap/HeadlessBootstrap.java
+++ b/zap/src/main/java/org/zaproxy/zap/HeadlessBootstrap.java
@@ -30,6 +30,7 @@ import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.control.AddOnLoader;
 import org.zaproxy.zap.control.AddOnRunIssuesUtils;
 import org.zaproxy.zap.control.ExtensionFactory;
+import org.zaproxy.zap.extension.autoupdate.ExtensionAutoUpdate;
 import org.zaproxy.zap.model.SessionUtils;
 
 /**
@@ -155,6 +156,14 @@ abstract class HeadlessBootstrap extends ZapBootstrap {
                                     + addOn.getId()
                                     + "\" or its extensions will no longer be run until its requirements are restored: "
                                     + issues);
+        }
+    }
+
+    protected static void checkForUpdates() {
+        ExtensionAutoUpdate eau =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionAutoUpdate.class);
+        if (eau != null) {
+            eau.alertIfNewVersions();
         }
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
@@ -484,7 +484,7 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
                     new java.awt.event.ActionListener() {
                         @Override
                         public void actionPerformed(java.awt.event.ActionEvent e) {
-                            checkForUpdates();
+                            checkForUpdates(false);
                         }
                     });
             retrievePanel.add(new JLabel(""), LayoutHelper.getGBC(0, 0, 1, 1.0D));
@@ -798,16 +798,16 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
                     new java.awt.event.ActionListener() {
                         @Override
                         public void actionPerformed(java.awt.event.ActionEvent e) {
-                            checkForUpdates();
+                            checkForUpdates(false);
                         }
                     });
         }
         return checkForUpdatesButton;
     }
 
-    protected void checkForUpdates() {
+    protected void checkForUpdates(boolean force) {
         this.setCursor(new Cursor(Cursor.WAIT_CURSOR));
-        extension.getLatestVersionInfo(this);
+        extension.getLatestVersionInfo(this, force);
         this.setCursor(Cursor.getDefaultCursor());
     }
 

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -136,7 +136,10 @@ val japicmp by tasks.registering(JapicmpTask::class) {
     methodExcludes = listOf(
         // Implementation moved to interface
         "org.parosproxy.paros.extension.ExtensionAdaptor#getURL()",
-        "org.parosproxy.paros.extension.ExtensionAdaptor#getAuthor()"
+        "org.parosproxy.paros.extension.ExtensionAdaptor#getAuthor()",
+        // Not expected to be used by add-ons
+        "org.zaproxy.zap.extension.autoupdate.ExtensionAutoUpdate#getLatestVersionInfo(org.zaproxy.zap.extension.autoupdate.CheckForUpdateCallback)",
+        "org.zaproxy.zap.extension.autoupdate.ManageAddOnsDialog#checkForUpdates()"
     )
 
     richReport {


### PR DESCRIPTION
Currently ZAP only checks for updates in daemon mode if the -addonupdate option is used.
This change means that ZAP will check for updates (to a separate bitly url) in daemon mode if it would do that in desktop mode, ie if the relevant options havnt been turned off.
Also changed the toolbar 'check for updates' button to ignore the last checked date, so this can now be used to check for updates published after ZAP was started today.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>