### PR TITLE
Remove license related actions from installer

### DIFF
--- a/zap/src/main/installer/zap.install4j
+++ b/zap/src/main/installer/zap.install4j
@@ -1021,29 +1021,6 @@ return;</preActivation>
                 </serializedBean>
                 <condition />
               </action>
-              <action name="Create AcceptedLicense (Linux/Win)" id="57" customizedId="" beanClass="com.install4j.runtime.beans.actions.text.WriteTextFileAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
-                <serializedBean>
-                  <java class="java.beans.XMLDecoder">
-                    <object class="com.install4j.runtime.beans.actions.text.WriteTextFileAction">
-                      <void property="escaped">
-                        <boolean>false</boolean>
-                      </void>
-                      <void property="file">
-                        <object class="java.io.File">
-                          <string>AcceptedLicense</string>
-                        </object>
-                      </void>
-                      <void property="logText">
-                        <boolean>false</boolean>
-                      </void>
-                      <void property="text">
-                        <string>AcceptedLicense</string>
-                      </void>
-                    </object>
-                  </java>
-                </serializedBean>
-                <condition />
-              </action>
               <action name="CFU config updates (Linux/Win)" id="570" customizedId="" beanClass="com.install4j.runtime.beans.actions.xml.InsertXmlFragmentAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
                 <serializedBean>
                   <java class="java.beans.XMLDecoder">
@@ -1212,24 +1189,6 @@ return;</preActivation>
             <preActivation />
             <postActivation />
             <actions>
-              <action name="" id="85" customizedId="" beanClass="com.install4j.runtime.beans.actions.files.DeleteFileAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
-                <serializedBean>
-                  <java class="java.beans.XMLDecoder">
-                    <object class="com.install4j.runtime.beans.actions.files.DeleteFileAction">
-                      <void property="files">
-                        <array class="java.io.File" length="1">
-                          <void index="0">
-                            <object class="java.io.File">
-                              <string>AcceptedLicense</string>
-                            </object>
-                          </void>
-                        </array>
-                      </void>
-                    </object>
-                  </java>
-                </serializedBean>
-                <condition />
-              </action>
               <action name="" id="17" customizedId="" beanClass="com.install4j.runtime.beans.actions.UninstallFilesAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
                 <serializedBean>
                   <java class="java.beans.XMLDecoder">


### PR DESCRIPTION
No longer create/remove the `AcceptedLicense` file, the file is no
longer used/needed.

Part of #5672 - Do not prompt to accept the license on first start