### PR TITLE
Allow add-ons to declare/bundle its dependencies

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnClassLoader.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnClassLoader.java
@@ -25,6 +25,7 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A {@code URLClassLoader} that search for classes and resources (first) in a given add-on file
@@ -253,6 +254,17 @@ public class AddOnClassLoader extends URLClassLoader {
         this.childClassLoaders = Collections.emptyList();
         this.addOnClassnames = addOnClassnames;
         this.classLoadingLockProvider = parent::getClassLoadingLock;
+    }
+
+    /**
+     * Adds the given URLs to the class loader, to search for classes and resources.
+     *
+     * @param urls the URLs to add to the class loader.
+     * @throws NullPointerException if the given list is {@code null}.
+     */
+    void addUrls(List<URL> urls) {
+        Objects.requireNonNull(urls);
+        urls.forEach(this::addURL);
     }
 
     /**

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnCollection.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnCollection.java
@@ -64,9 +64,9 @@ public class AddOnCollection {
             while (!checkedAddOns.isEmpty()) {
                 AddOn addOn = checkedAddOns.remove(0);
                 // Shouldn't happen but make sure to not show add-ons that wouldn't run, or one of
-                // its extensions
-                // because of dependency issues or
-                AddOn.AddOnRunRequirements requirements = addOn.calculateRunRequirements(addOns);
+                // its extensions because of dependency issues.
+                AddOn.AddOnRunRequirements requirements =
+                        addOn.calculateInstallRequirements(addOns);
                 if (requirements.hasDependencyIssue()) {
                     if (logger.isDebugEnabled()) {
                         logger.debug(

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnInstaller.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnInstaller.java
@@ -24,13 +24,23 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 import org.apache.commons.lang.Validate;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -57,6 +67,9 @@ import org.zaproxy.zap.utils.ZapResourceBundleControl;
 public final class AddOnInstaller {
 
     private static final Logger logger = Logger.getLogger(AddOnInstaller.class);
+
+    /** The base directory to where add-on data (e.g. libraries) is copied. */
+    private static final String ADD_ON_DATA_DIR = "addOnData";
 
     private AddOnInstaller() {}
 
@@ -442,6 +455,160 @@ public final class AddOnInstaller {
         }
 
         return uninstalledWithoutErrors;
+    }
+
+    /**
+     * Installs the libraries declared by the given add-on.
+     *
+     * <p>The libraries are copied to the directory with the following path: {@code
+     * <zapHome>/addOnData/<addOnId>/libs/}
+     *
+     * @param addOn the add-on that will have the declared libraries installed.
+     * @return {@code true} if no error occurred while installing the libraries, {@code false}
+     *     otherwise.
+     * @see #uninstallAddOnLibs(AddOn)
+     * @see #installMissingAddOnLibs(AddOn)
+     * @see #getAddOnDataDir(AddOn)
+     */
+    static boolean installAddOnLibs(AddOn addOn) {
+        return installAddOnLibs(addOn, true);
+    }
+
+    private static boolean installAddOnLibs(AddOn addOn, boolean overwrite) {
+        List<AddOn.Lib> libs = addOn.getLibs();
+        if (libs.isEmpty()) {
+            return true;
+        }
+
+        Path targetDir = getAddOnDataDir(addOn).resolve("libs");
+        try {
+            Files.createDirectories(targetDir);
+        } catch (IOException e) {
+            logger.warn("Failed to create libs directory for " + addOn.getId(), e);
+            return false;
+        }
+
+        try (ZipFile zip = new ZipFile(addOn.getFile())) {
+            for (AddOn.Lib lib : libs) {
+                String name = lib.getName();
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Installing library for " + addOn + ": " + name);
+                }
+
+                Path targetFile = targetDir.resolve(name);
+                try {
+                    lib.setFileSystemUrl(targetFile.toUri().toURL());
+                } catch (MalformedURLException e) {
+                    logger.warn(
+                            "Failed to convert lib's filesystem path to URL for " + addOn.getId(),
+                            e);
+                    return false;
+                }
+
+                if (!overwrite && Files.exists(targetFile)) {
+                    continue;
+                }
+
+                ZipEntry libZipEntry = zip.getEntry(lib.getJarPath());
+                if (libZipEntry == null) {
+                    logger.warn("Library not found in " + addOn + " add-on: " + lib);
+                    return false;
+                }
+
+                try (InputStream in = zip.getInputStream(libZipEntry)) {
+                    Files.copy(in, targetFile, StandardCopyOption.REPLACE_EXISTING);
+                } catch (IOException e) {
+                    logger.warn("Failed to copy the library for " + addOn + ": " + targetFile, e);
+                    return false;
+                }
+            }
+        } catch (IOException e) {
+            logger.error("An error occurred while installing libraries for " + addOn, e);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Gets the path to the data directory of the given add-on.
+     *
+     * <p>The path is built as: {@code <zapHome>/addOnData/<addOnId>/}
+     *
+     * @param addOn the add-on.
+     * @return the path to the directory.
+     * @see #ADD_ON_DATA_DIR
+     */
+    private static Path getAddOnDataDir(AddOn addOn) {
+        return Paths.get(Constant.getZapHome(), ADD_ON_DATA_DIR, addOn.getId());
+    }
+
+    /**
+     * Installs all the missing libraries declared by the given add-on.
+     *
+     * @param addOn the add-on that will have the missing declared libraries installed.
+     * @return {@code true} if no error occurred while installing the libraries, {@code false}
+     *     otherwise.
+     * @see #uninstallAddOnLibs(AddOn)
+     * @see #installAddOnLibs(AddOn, boolean)
+     */
+    static boolean installMissingAddOnLibs(AddOn addOn) {
+        return installAddOnLibs(addOn, false);
+    }
+
+    /**
+     * Uninstalls the libraries declared by the given add-on.
+     *
+     * @param addOn the add-on that will have the declared libraries uninstalled.
+     * @see #installAddOnLibs(AddOn)
+     * @see #installMissingAddOnLibs(AddOn)
+     */
+    static void uninstallAddOnLibs(AddOn addOn) {
+        List<AddOn.Lib> libs = addOn.getLibs();
+        if (libs.isEmpty()) {
+            return;
+        }
+
+        try {
+            deleteDir(getAddOnDataDir(addOn));
+        } catch (IOException e) {
+            logger.error("An error occurred while uninstalling libraries for " + addOn, e);
+        }
+    }
+
+    /**
+     * Deletes the given directory and all files/directories under it.
+     *
+     * @param dir the directory to delete.
+     * @throws IOException if an error occurred while deleting the directory or any file/directory
+     *     under it.
+     */
+    private static void deleteDir(Path dir) throws IOException {
+        if (Files.notExists(dir)) {
+            return;
+        }
+
+        Files.walkFileTree(
+                dir,
+                new SimpleFileVisitor<Path>() {
+
+                    @Override
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                            throws IOException {
+                        Files.delete(file);
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    @Override
+                    public FileVisitResult postVisitDirectory(Path dir, IOException e)
+                            throws IOException {
+                        if (e != null) {
+                            throw e;
+                        }
+                        Files.delete(dir);
+                        return FileVisitResult.CONTINUE;
+                    }
+                });
     }
 
     /**

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnLoader.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnLoader.java
@@ -46,6 +46,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
@@ -191,6 +192,7 @@ public class AddOnLoader extends URLClassLoader {
         for (Iterator<AddOn> iterator = aoc.getAddOns().iterator(); iterator.hasNext(); ) {
             AddOn addOn = iterator.next();
             if (canLoadAddOn(addOn)) {
+                AddOnInstaller.installMissingAddOnLibs(addOn);
                 AddOnRunRequirements reqs = calculateRunRequirements(addOn, aoc.getAddOns());
                 if (reqs.isRunnable()) {
                     AddOnRunState runState = oldRunnableAddOns.get(addOn);
@@ -302,8 +304,7 @@ public class AddOnLoader extends URLClassLoader {
                 addOnClassLoader =
                         new AddOnClassLoader(
                                 ao.getFile().toURI().toURL(), this, ao.getAddOnClassnames());
-                this.addOnLoaders.put(ao.getId(), addOnClassLoader);
-                ao.setClassLoader(addOnClassLoader);
+                putAddOnClassLoader(ao, addOnClassLoader);
                 return addOnClassLoader;
             }
 
@@ -322,14 +323,33 @@ public class AddOnLoader extends URLClassLoader {
                             this,
                             dependencies,
                             ao.getAddOnClassnames());
-            this.addOnLoaders.put(ao.getId(), addOnClassLoader);
-            ao.setClassLoader(addOnClassLoader);
+            putAddOnClassLoader(ao, addOnClassLoader);
             return addOnClassLoader;
         } catch (MalformedURLException e) {
             logger.error(e.getMessage(), e);
             throw new RuntimeException(
                     "Failed to convert URL for AddOnClassLoader " + ao.getFile().toURI(), e);
         }
+    }
+
+    /**
+     * Puts the given add-on class loader into the {@link #addOnLoaders} map and {@link
+     * AddOn#setClassLoader(ClassLoader) sets it into the add-on}.
+     *
+     * <p>The add-on libraries are added to the add-on class loader before that.
+     *
+     * @param ao the add-on to put in the map.
+     * @param addOnClassLoader the class loader of the add-on.
+     */
+    private void putAddOnClassLoader(AddOn ao, AddOnClassLoader addOnClassLoader) {
+        if (!ao.getLibs().isEmpty()) {
+            addOnClassLoader.addUrls(
+                    ao.getLibs().stream()
+                            .map(AddOn.Lib::getFileSystemUrl)
+                            .collect(Collectors.toList()));
+        }
+        ao.setClassLoader(addOnClassLoader);
+        addOnLoaders.put(ao.getId(), addOnClassLoader);
     }
 
     @Override
@@ -443,6 +463,11 @@ public class AddOnLoader extends URLClassLoader {
         }
 
         if (!isDynamicallyInstallable(ao)) {
+            return;
+        }
+
+        if (!AddOnInstaller.installAddOnLibs(ao)) {
+            ao.setInstallationStatus(AddOn.InstallationStatus.NOT_INSTALLED);
             return;
         }
 
@@ -597,7 +622,7 @@ public class AddOnLoader extends URLClassLoader {
             }
             AddOnInstaller.uninstallAddOnFiles(ao, NULL_CALLBACK, runnableAddOns.keySet());
             removeAddOnClassLoader(ao);
-            deleteAddOnFile(ao, upgrading);
+            deleteAddOn(ao, upgrading);
             ao.setInstallationStatus(AddOn.InstallationStatus.UNINSTALLATION_FAILED);
             Control.getSingleton().getExtensionLoader().addOnUninstalled(ao, false);
             return false;
@@ -613,7 +638,7 @@ public class AddOnLoader extends URLClassLoader {
                 saveAddOnsRunState(runnableAddOns);
             }
 
-            deleteAddOnFile(ao, upgrading);
+            deleteAddOn(ao, upgrading);
 
             return this.aoc.removeAddOn(ao);
         }
@@ -632,7 +657,7 @@ public class AddOnLoader extends URLClassLoader {
             removeAddOnClassLoader(ao);
         }
 
-        deleteAddOnFile(ao, upgrading);
+        deleteAddOn(ao, upgrading);
 
         if (runnableAddOns.remove(ao) != null) {
             saveAddOnsRunState(runnableAddOns);
@@ -647,7 +672,19 @@ public class AddOnLoader extends URLClassLoader {
         return uninstalledWithoutErrors;
     }
 
-    private void deleteAddOnFile(AddOn addOn, boolean upgrading) {
+    /**
+     * Deletes the file and libraries of the given add-on.
+     *
+     * <p>The add-on is added to the {@link #blockList block list} when not able to delete it and if
+     * not updating it.
+     *
+     * @param addOn the add-on to be deleted.
+     * @param upgrading {@code true} if the add-on is being updated, {@code false} otherwise.
+     * @see AddOnInstaller#uninstallAddOnLibs(AddOn)
+     */
+    private void deleteAddOn(AddOn addOn, boolean upgrading) {
+        AddOnInstaller.uninstallAddOnLibs(addOn);
+
         if (addOn.getFile() != null && addOn.getFile().exists()) {
             if (!addOn.getFile().delete() && !upgrading) {
                 logger.debug("Cant delete " + addOn.getFile().getAbsolutePath());

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnRunIssuesUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnRunIssuesUtils.java
@@ -152,7 +152,7 @@ public final class AddOnRunIssuesUtils {
     }
 
     /**
-     * Returns the textual representations of the running issues (Java version and dependency), if
+     * Returns the textual representations of the running issues (e.g. Java version, dependency), if
      * any.
      *
      * <p>The messages are internationalised thus suitable for UI components.
@@ -166,7 +166,19 @@ public final class AddOnRunIssuesUtils {
      */
     public static List<String> getUiRunningIssues(
             AddOn.BaseRunRequirements requirements, AddOnSearcher addOnSearcher) {
-        List<String> issues = new ArrayList<>(2);
+        List<String> issues = new ArrayList<>(3);
+        if (requirements.hasMissingLibs()) {
+            if (requirements.getAddOn() != requirements.getAddOnMissingLibs()) {
+                issues.add(
+                        Constant.messages.getString(
+                                "cfu.warn.addon.with.missing.requirements.libs.dependency",
+                                requirements.getAddOnMissingLibs().getName()));
+            } else {
+                issues.add(
+                        Constant.messages.getString(
+                                "cfu.warn.addon.with.missing.requirements.libs"));
+            }
+        }
         if (requirements.isNewerJavaVersionRequired()) {
             if (requirements.getAddOn() != requirements.getAddOnMinimumJavaVersion()) {
                 issues.add(
@@ -279,7 +291,7 @@ public final class AddOnRunIssuesUtils {
     }
 
     /**
-     * Returns the textual representations of the running issues (Java version and dependency), if
+     * Returns the textual representations of the running issues (e.g. Java version, dependency), if
      * any.
      *
      * <p>The messages are not internationalised, should be used only for logging and non UI uses.
@@ -291,8 +303,12 @@ public final class AddOnRunIssuesUtils {
      * @see #getUiExtensionsRunningIssues(AddOn.AddOnRunRequirements, AddOnSearcher)
      */
     public static List<String> getRunningIssues(AddOn.BaseRunRequirements requirements) {
-        List<String> issues = new ArrayList<>(2);
-        String issue = getJavaVersionIssue(requirements);
+        List<String> issues = new ArrayList<>(3);
+        String issue = getMissingLibsIssue(requirements);
+        if (issue != null) {
+            issues.add(issue);
+        }
+        issue = getJavaVersionIssue(requirements);
         if (issue != null) {
             issues.add(issue);
         }
@@ -348,6 +364,29 @@ public final class AddOnRunIssuesUtils {
         }
         return MessageFormat.format(
                 "Minimum Java version: {0}", requirements.getMinimumJavaVersion());
+    }
+
+    /**
+     * Returns the textual representation of the missing libraries issue that prevents the add-on or
+     * extension from being run, if any.
+     *
+     * <p>The message is not internationalised, should be used only for logging and non UI uses.
+     *
+     * @param requirements the run requirements of the add-on or extension
+     * @return a {@code String} representing the running issue, {@code null} if none.
+     * @since TODO add version
+     */
+    public static String getMissingLibsIssue(AddOn.BaseRunRequirements requirements) {
+        if (!requirements.hasMissingLibs()) {
+            return null;
+        }
+
+        if (requirements.getAddOn() != requirements.getAddOnMissingLibs()) {
+            return MessageFormat.format(
+                    "Bundled libraries of dependency: {0}",
+                    requirements.getAddOnMissingLibs().getName());
+        }
+        return "Bundled libraries.";
     }
 
     /**

--- a/zap/src/main/java/org/zaproxy/zap/control/ZapAddOnXmlFile.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/ZapAddOnXmlFile.java
@@ -37,6 +37,8 @@ public class ZapAddOnXmlFile extends BaseZapAddOnXmlData {
     private static final String PSCANRULES_ALL_ELEMENTS = "pscanrules/" + PSCANRULE_ELEMENT;
     private static final String FILE_ELEMENT = "file";
     private static final String FILES_ALL_ELEMENTS = "files/" + FILE_ELEMENT;
+    private static final String LIB_ELEMENT = "lib";
+    private static final String LIBS_ALL_ELEMENTS = "libs/" + LIB_ELEMENT;
     private static final String BUNDLE_ELEMENT = "bundle";
     private static final String BUNDLE_PREFIX_ATT = "bundle/@prefix";
     private static final String HELPSET_ELEMENT = "helpset";
@@ -45,6 +47,7 @@ public class ZapAddOnXmlFile extends BaseZapAddOnXmlData {
     private List<String> ascanrules;
     private List<String> pscanrules;
     private List<String> files;
+    private List<String> libs;
 
     private String bundleBaseName;
     private String bundlePrefix;
@@ -60,6 +63,7 @@ public class ZapAddOnXmlFile extends BaseZapAddOnXmlData {
         ascanrules = getStrings(zapAddOnXml, ASCANRULES_ALL_ELEMENTS, ASCANRULE_ELEMENT);
         pscanrules = getStrings(zapAddOnXml, PSCANRULES_ALL_ELEMENTS, PSCANRULE_ELEMENT);
         files = getStrings(zapAddOnXml, FILES_ALL_ELEMENTS, FILE_ELEMENT);
+        libs = getStrings(zapAddOnXml, LIBS_ALL_ELEMENTS, LIB_ELEMENT);
 
         bundleBaseName = zapAddOnXml.getString(BUNDLE_ELEMENT, "");
         bundlePrefix = zapAddOnXml.getString(BUNDLE_PREFIX_ATT, "");
@@ -77,6 +81,16 @@ public class ZapAddOnXmlFile extends BaseZapAddOnXmlData {
 
     public List<String> getFiles() {
         return files;
+    }
+
+    /**
+     * Gets the libraries of the add-on.
+     *
+     * @return the libraries, never {@code null}.
+     * @since TODO add version
+     */
+    public List<String> getLibs() {
+        return libs;
     }
 
     /**

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/AddOnDependencyChecker.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/AddOnDependencyChecker.java
@@ -119,7 +119,7 @@ class AddOnDependencyChecker {
             Set<AddOn> newVersions,
             Set<AddOn> installs) {
         AddOn.AddOnRunRequirements requirements =
-                addOn.calculateRunRequirements(availableAddOns.getAddOns());
+                addOn.calculateInstallRequirements(availableAddOns.getAddOns());
 
         for (AddOn dep : requirements.getDependencies()) {
             if (selectedAddOns.contains(dep)) {
@@ -496,7 +496,7 @@ class AddOnDependencyChecker {
 
         for (AddOn addOn : remainingInstalledAddOns) {
             if (addOn.dependsOn(changedAddOns)
-                    && addOn.calculateRunRequirements(expectedInstalledAddOns)
+                    && addOn.calculateInstallRequirements(expectedInstalledAddOns)
                             .hasDependencyIssue()) {
                 uninstalls.add(addOn);
             }
@@ -519,7 +519,7 @@ class AddOnDependencyChecker {
             AddOn addOn = it.next();
             if (contains(installs, addOn)
                     || contains(newVersions, addOn)
-                    || (addOn.calculateRunRequirements(installedAddOns.getAddOns())
+                    || (addOn.calculateInstallRequirements(installedAddOns.getAddOns())
                                     .hasDependencyIssue()
                             && !containsAny(addOn.getIdsAddOnDependencies(), uninstalls))) {
                 it.remove();
@@ -545,7 +545,8 @@ class AddOnDependencyChecker {
             List<String> extensionsWithDeps = addOn.getExtensionsWithDeps();
             for (Extension extension : addOn.getLoadedExtensionsWithDeps()) {
                 AddOn.AddOnRunRequirements requirements =
-                        addOn.calculateExtensionRunRequirements(extension, expectedInstalledAddOns);
+                        addOn.calculateExtensionInstallRequirements(
+                                extension, expectedInstalledAddOns);
                 AddOn.ExtensionRunRequirements extReqs =
                         requirements.getExtensionRequirements().get(0);
                 if (!extReqs.isRunnable()) {
@@ -558,7 +559,7 @@ class AddOnDependencyChecker {
 
             for (String classname : extensionsWithDeps) {
                 AddOn.AddOnRunRequirements requirements =
-                        addOn.calculateExtensionRunRequirements(
+                        addOn.calculateExtensionInstallRequirements(
                                 classname, availableAddOns.getAddOns());
                 AddOn.ExtensionRunRequirements extReqs =
                         requirements.getExtensionRequirements().get(0);
@@ -602,7 +603,7 @@ class AddOnDependencyChecker {
         while (!addOnsToCheck.isEmpty()) {
             AddOn addOn = addOnsToCheck.remove(0);
             AddOn.AddOnRunRequirements requirements =
-                    addOn.calculateRunRequirements(remainingAddOns);
+                    addOn.calculateInstallRequirements(remainingAddOns);
 
             if (!requirements.hasDependencyIssue()) {
                 addOnsToCheck.removeAll(requirements.getDependencies());
@@ -614,7 +615,7 @@ class AddOnDependencyChecker {
 
         for (Iterator<AddOn> it = uninstallations.iterator(); it.hasNext(); ) {
             AddOn addOn = it.next();
-            if (addOn.calculateRunRequirements(installedAddOns.getAddOns()).hasDependencyIssue()
+            if (addOn.calculateInstallRequirements(installedAddOns.getAddOns()).hasDependencyIssue()
                     && !containsAny(addOn.getIdsAddOnDependencies(), uninstallations)) {
                 it.remove();
             }
@@ -626,7 +627,7 @@ class AddOnDependencyChecker {
             if (addOn.hasExtensionsWithDeps()) {
                 for (Extension ext : addOn.getLoadedExtensions()) {
                     AddOn.AddOnRunRequirements requirements =
-                            addOn.calculateExtensionRunRequirements(ext, remainingAddOns);
+                            addOn.calculateExtensionInstallRequirements(ext, remainingAddOns);
                     if (!requirements.getExtensionRequirements().isEmpty()) {
                         AddOn.ExtensionRunRequirements extReqs =
                                 requirements.getExtensionRequirements().get(0);

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -358,6 +358,10 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                             Constant.messages.getString(
                                     "cfu.warn.invalidAddOn.invalidManifest", e.getMessage()));
                     break;
+                case INVALID_LIB:
+                    showWarningMessageInvalidAddOnFile(
+                            Constant.messages.getString("cfu.warn.invalidAddOn.invalidLib"));
+                    break;
                 default:
                     showWarningMessageInvalidAddOnFile(e.getMessage());
                     logger.warn(e);
@@ -426,7 +430,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
 
         if (result.getOldVersions().isEmpty() && result.getUninstalls().isEmpty()) {
             AddOnRunRequirements reqs =
-                    ao.calculateRunRequirements(getLocalVersionInfo().getAddOns());
+                    ao.calculateInstallRequirements(getLocalVersionInfo().getAddOns());
             if (!reqs.isRunnable()) {
                 if (!AddOnRunIssuesUtils.askConfirmationAddOnNotRunnable(
                         Constant.messages.getString("cfu.warn.addOnNotRunnable.message"),

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -1088,6 +1088,8 @@ cfu.warn.addon.with.missing.requirements.addon = A cyclic dependency was detecte
 cfu.warn.addon.with.missing.requirements.addon = Add-on "{0}"
 cfu.warn.addon.with.missing.requirements.addon.id = Add-On with ID "{0}"
 cfu.warn.addon.with.missing.requirements.addon.version = Add-on "{0}" with version matching "{1}" (found version {2})
+cfu.warn.addon.with.missing.requirements.libs = Bundled libraries
+cfu.warn.addon.with.missing.requirements.libs.dependency = Bundled libraries of dependency: "{0}"
 cfu.warn.addon.with.missing.requirements.unknown = Unknown (refer to log file for more information)
 cfu.warn.addon.with.missing.requirements.javaversion = Minimum Java version: {0} (found: "{1}")
 cfu.warn.addon.with.missing.requirements.javaversion.dependency = Minimum Java version: {0} (found: "{1}") by dependency: "{2}"
@@ -1098,6 +1100,7 @@ cfu.warn.addOnNotRunnable.message = The add-on will not run until the following 
 cfu.warn.addOnNotRunnable.question = Continue with the installation?
 cfu.warn.cantload      = Can not load the specified add-on\:\nNot before \= {0}\nNot from \= {1}
 cfu.warn.invalidAddOn = The selected file is not a valid ZAP add-on{0}
+cfu.warn.invalidAddOn.invalidLib = .\nIt declared missing/invalid library.
 cfu.warn.invalidAddOn.invalidPath = :\nThe path is not valid.
 cfu.warn.invalidAddOn.noZapExtension = :\nThe file does not have a "zap" extension.
 cfu.warn.invalidAddOn.notReadable = :\nThe file is not readable.

--- a/zap/src/test/java/org/zaproxy/zap/control/AddOnUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/AddOnUnitTest.java
@@ -19,15 +19,19 @@
  */
 package org.zaproxy.zap.control;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,6 +41,7 @@ import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.zip.ZipEntry;
@@ -476,6 +481,42 @@ public class AddOnUnitTest extends TestUtils {
     }
 
     @Test
+    public void shouldNotBeValidAddOnIfHasMissingLib() throws Exception {
+        // Given
+        Path file =
+                createAddOnFile(
+                        "addon.zap",
+                        "release",
+                        "1.0.0",
+                        manifest ->
+                                manifest.append("<libs>")
+                                        .append("<lib>missing.jar</lib>")
+                                        .append("</libs>"));
+        // When
+        ValidationResult result = AddOn.isValidAddOn(file);
+        // Then
+        assertThat(result.getValidity(), is(equalTo(ValidationResult.Validity.INVALID_LIB)));
+    }
+
+    @Test
+    public void shouldNotBeValidAddOnIfHasLibWithMissingName() throws Exception {
+        // Given
+        Path file =
+                createAddOnFile(
+                        "addon.zap",
+                        "release",
+                        "1.0.0",
+                        manifest ->
+                                manifest.append("<libs>")
+                                        .append("<lib>dir/</lib>")
+                                        .append("</libs>"));
+        // When
+        ValidationResult result = AddOn.isValidAddOn(file);
+        // Then
+        assertThat(result.getValidity(), is(equalTo(ValidationResult.Validity.INVALID_LIB)));
+    }
+
+    @Test
     public void shouldBeValidAddOnIfValid() throws Exception {
         // Given
         Path file = createAddOnFile("addon.zap", "release", "1.0.0");
@@ -865,6 +906,100 @@ public class AddOnUnitTest extends TestUtils {
         assertThat(canRun, is(equalTo(false)));
     }
 
+    @Test
+    public void shouldReturnLibsInManifest() throws Exception {
+        // Given
+        String lib1 = "lib1.jar";
+        String lib2 = "dir/lib2.jar";
+        Path file = createAddOnWithLibs(lib1, lib2);
+        // When
+        AddOn addOn = new AddOn(file);
+        // Then
+        assertThat(addOn.getLibs(), contains(new AddOn.Lib(lib1), new AddOn.Lib(lib2)));
+    }
+
+    @Test
+    public void shouldNotBeRunnableIfLibsAreNotInFileSystem() throws Exception {
+        // Given
+        AddOn addOn = new AddOn(createAddOnWithLibs("lib1.jar", "lib2.jar"));
+        // When
+        AddOn.AddOnRunRequirements reqs = addOn.calculateRunRequirements(Collections.emptyList());
+        // Then
+        assertThat(reqs.isRunnable(), is(equalTo(false)));
+        assertThat(reqs.hasMissingLibs(), is(equalTo(true)));
+        assertThat(reqs.getAddOnMissingLibs(), is(equalTo(addOn)));
+    }
+
+    @Test
+    public void shouldBeRunnableIfLibsAreInFileSystem() throws Exception {
+        // Given
+        String lib1 = "lib1.jar";
+        String lib2 = "lib2.jar";
+        AddOn addOn = new AddOn(createAddOnWithLibs(lib1, lib2));
+        File libsDir = tempDir.newFolder();
+        addOn.getLibs().get(0).setFileSystemUrl(new File(libsDir, lib1).toURI().toURL());
+        addOn.getLibs().get(1).setFileSystemUrl(new File(libsDir, lib2).toURI().toURL());
+        // When
+        AddOn.AddOnRunRequirements reqs = addOn.calculateRunRequirements(Collections.emptyList());
+        // Then
+        assertThat(reqs.isRunnable(), is(equalTo(true)));
+        assertThat(reqs.hasMissingLibs(), is(equalTo(false)));
+        assertThat(reqs.getAddOnMissingLibs(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldCreateAddOnLibFromRootJarPath() throws Exception {
+        // Given
+        String jarPath = "lib.jar";
+        // When
+        AddOn.Lib lib = new AddOn.Lib(jarPath);
+        // Then
+        assertThat(lib.getJarPath(), is(equalTo(jarPath)));
+        assertThat(lib.getName(), is(equalTo(jarPath)));
+    }
+
+    @Test
+    public void shouldCreateAddOnLibFromNonRootJarPath() throws Exception {
+        // Given
+        String name = "lib.jar";
+        String jarPath = "dir/" + name;
+        // When
+        AddOn.Lib lib = new AddOn.Lib(jarPath);
+        // Then
+        assertThat(lib.getJarPath(), is(equalTo(jarPath)));
+        assertThat(lib.getName(), is(equalTo(name)));
+    }
+
+    @Test
+    public void shouldNotHaveFileSystemUrlInAddOnLibByDefault() throws Exception {
+        // Given / When
+        AddOn.Lib lib = new AddOn.Lib("lib.jar");
+        // Then
+        assertThat(lib.getFileSystemUrl(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldSetFileSystemUrlToAddOnLib() throws Exception {
+        // Given
+        AddOn.Lib lib = new AddOn.Lib("lib.jar");
+        URL fsUrl = new URL("file:///some/path");
+        // When
+        lib.setFileSystemUrl(fsUrl);
+        // Then
+        assertThat(lib.getFileSystemUrl(), is(equalTo(fsUrl)));
+    }
+
+    @Test
+    public void shouldSetNullFileSystemUrlToAddOnLib() throws Exception {
+        // Given
+        AddOn.Lib lib = new AddOn.Lib("lib.jar");
+        lib.setFileSystemUrl(new URL("file:///some/path"));
+        // When
+        lib.setFileSystemUrl(null);
+        // Then
+        assertThat(lib.getFileSystemUrl(), is(nullValue()));
+    }
+
     private static ZapXmlConfiguration createZapVersionsXml() throws Exception {
         ZapXmlConfiguration zapVersionsXml = new ZapXmlConfiguration(ZAP_VERSIONS_XML);
         zapVersionsXml.setExpressionEngine(new XPathExpressionEngine());
@@ -881,13 +1016,44 @@ public class AddOnUnitTest extends TestUtils {
         }
     }
 
+    private Path createAddOnWithLibs(String... libs) {
+        String lib1 = "lib1.jar";
+        String lib2 = "dir/lib2.jar";
+        return createAddOnFile(
+                "addon.zap",
+                "release",
+                "1.0.0",
+                manifest ->
+                        manifest.append("<libs>")
+                                .append("<lib>")
+                                .append(lib1)
+                                .append("</lib>")
+                                .append("<lib>")
+                                .append(lib2)
+                                .append("</lib>")
+                                .append("</libs>"),
+                addOnContents -> {
+                    try {
+                        ZipEntry lib = new ZipEntry(lib1);
+                        addOnContents.putNextEntry(lib);
+                        addOnContents.closeEntry();
+
+                        lib = new ZipEntry(lib2);
+                        addOnContents.putNextEntry(lib);
+                        addOnContents.closeEntry();
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                });
+    }
+
     private Path createAddOnFile(String fileName, String status, String version) {
         return createAddOnFile(fileName, status, version, (String) null);
     }
 
     private Path createAddOnFile(
             String fileName, String status, String version, String javaVersion) {
-        return createAddOnFile(fileName, status, version, javaVersion, null);
+        return createAddOnFile(fileName, status, version, javaVersion, null, null);
     }
 
     private Path createAddOnFile(
@@ -895,7 +1061,16 @@ public class AddOnUnitTest extends TestUtils {
             String status,
             String version,
             Consumer<StringBuilder> manifestConsumer) {
-        return createAddOnFile(fileName, status, version, null, manifestConsumer);
+        return createAddOnFile(fileName, status, version, null, manifestConsumer, null);
+    }
+
+    private Path createAddOnFile(
+            String fileName,
+            String status,
+            String version,
+            Consumer<StringBuilder> manifestConsumer,
+            Consumer<ZipOutputStream> addOnConsumer) {
+        return createAddOnFile(fileName, status, version, null, manifestConsumer, addOnConsumer);
     }
 
     private Path createAddOnFile(
@@ -903,7 +1078,8 @@ public class AddOnUnitTest extends TestUtils {
             String status,
             String version,
             String javaVersion,
-            Consumer<StringBuilder> manifestConsumer) {
+            Consumer<StringBuilder> manifestConsumer,
+            Consumer<ZipOutputStream> addOnConsumer) {
         try {
             File file = new File(tempDir.newFolder(), fileName);
             try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(file))) {
@@ -925,6 +1101,9 @@ public class AddOnUnitTest extends TestUtils {
                 byte[] bytes = strBuilder.toString().getBytes(StandardCharsets.UTF_8);
                 zos.write(bytes, 0, bytes.length);
                 zos.closeEntry();
+                if (addOnConsumer != null) {
+                    addOnConsumer.accept(zos);
+                }
             }
             return file.toPath();
         } catch (IOException e) {

--- a/zap/src/test/java/org/zaproxy/zap/control/ZapAddOnXmlFileUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/ZapAddOnXmlFileUnitTest.java
@@ -86,6 +86,7 @@ public class ZapAddOnXmlFileUnitTest {
         assertThat(manifest.getAscanrules(), is(empty()));
         assertThat(manifest.getPscanrules(), is(empty()));
         assertThat(manifest.getFiles(), is(empty()));
+        assertThat(manifest.getLibs(), is(empty()));
     }
 
     @Test
@@ -182,6 +183,25 @@ public class ZapAddOnXmlFileUnitTest {
         assertThat(manifest.getBundlePrefix(), is(equalTo(bundlePrefix)));
         assertThat(manifest.getHelpSetBaseName(), is(equalTo(helpSetBaseName)));
         assertThat(manifest.getHelpSetLocaleToken(), is(equalTo(helpSetLocaleToken)));
+    }
+
+    @Test
+    public void shouldLoadManifestWithLibs() throws Exception {
+        // Given
+        String lib1 = "lib1.jar";
+        String lib2 = "dir/lib2.jar";
+        InputStream manifestData =
+                manifestData(
+                        "<zapaddon>",
+                        "<libs>",
+                        "  <lib>" + lib1 + "</lib>",
+                        "  <lib>" + lib2 + "</lib>",
+                        "</libs>",
+                        "</zapaddon>");
+        // When
+        ZapAddOnXmlFile manifest = new ZapAddOnXmlFile(manifestData);
+        // Then
+        assertThat(manifest.getLibs(), contains(lib1, lib2));
     }
 
     @Test


### PR DESCRIPTION
Change `ZapAddOnXmlFile` to read the libraries from the manifest,
declared as:
```xml
<libs>
  <lib>libs/lib1.jar</lib>
  <lib>libs/lib2.jar</lib>
</libs>
```
Each `lib` entry has the path of the library in the add-on/JAR, which
will be copied to the file system under the following path:
`<zapHome>/addOnData/<addOnId>/libs/`
(The directory structure declared in the add-on is not maintained.)

Change `AddOn` to:
 - Read/provide the libs contained in the manifest, so that they can be
   used elsewhere (e.g. un/installed, added to classloader);
 - Validate that the libraries are present in the add-on;
 - Check that the libraries are already present in the file system when
   verifying if the add-on is runnable;
 - Provide a method to check if the add-on/extensions can be installed
   (same check as runnable without checking if the libraries are already
   in the file system).

Change `AddOnCollection` and `AddOnDependencyChecker` to call the new
method that checks if the add-on/extensions can be installed.
Change `ExtensionAutoUpdate` to do the same and report invalid library
issue.
Change `AddOnRunIssuesUtils` to provide the error message when the
libraries are missing in the add-on.
Change `AddOnInstaller` to allow to install/uninstall the libraries of
an add-on and install missing libraries (in case a library was removed
after installing the add-on).
Change `AddOnClassLoader` to allow to add a list of URLs, to also search
for classes/resources in the add-on libraries.
Change `AddOnLoader` to:
 - Install and uninstall the libraries when the add-on is un/installed;
 - Install the missing libraries of an already installed add-on before
 checking if it's runnable;
 - Set the libraries to the respective `AddOnClassLoader`.

Fix #2619.