### PR TITLE
fixing resize bug in the splash screen

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/view/SplashScreen.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/SplashScreen.java
@@ -75,8 +75,10 @@ public class SplashScreen extends JFrame {
 
     public SplashScreen() {
         super();
-
+        this.setUndecorated(true);
+        this.setAlwaysOnTop(true);
         setSize(DisplayUtils.getScaledDimension(420, 430));
+        setResizable(false);
         setLocationRelativeTo(null);
         setTitle(Constant.PROGRAM_NAME);
         setIconImages(DisplayUtils.getZapIconImages());


### PR DESCRIPTION
While zaproxy is loading, the user can change the size of the splash screen window, but the application does not handle it by resizing the image and loading bar.

**before changes:**
![image](https://user-images.githubusercontent.com/29213920/68958567-22086900-07ab-11ea-9faf-132f20535311.png)

**after changes:**
![image](https://user-images.githubusercontent.com/29213920/68959378-ac050180-07ac-11ea-8a9a-1c080ea57556.png)
