### PR TITLE
Expose Context details to passive scan rules

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanData.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanData.java
@@ -1,0 +1,122 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscan;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.users.ExtensionUserManagement;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.users.User;
+
+/**
+ * A utility class to simplify providing {@code Context} data to passive scan rules. Details will be
+ * based on the first {@code Context} matched (if any).
+ *
+ * @see PassiveScanThread
+ * @see PluginPassiveScanner
+ * @since TODO add version
+ */
+public final class PassiveScanData {
+
+    private static final Logger LOGGER = Logger.getLogger(PassiveScanData.class);
+
+    private final HttpMessage message;
+    private final Context context;
+
+    private List<User> userList = null;
+
+    PassiveScanData(HttpMessage msg) {
+        this.message = msg;
+        this.context = getContext(message);
+
+        if (getContext() == null) {
+            userList = Collections.emptyList();
+        }
+    }
+
+    private static Context getContext(HttpMessage message) {
+        List<Context> contextList =
+                Model.getSingleton()
+                        .getSession()
+                        .getContextsForUrl(message.getRequestHeader().getURI().toString());
+        if (contextList.isEmpty()) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
+                        "No Context found for: " + message.getRequestHeader().getURI().toString());
+            }
+            return null;
+        }
+        return contextList.get(0);
+    }
+
+    /**
+     * Returns a list of {@Code User}'s for the {@code HttpMessage} being passively scanned. The
+     * list returned is based on the first {@code Context} matched.
+     *
+     * @return A list of users if some are available, an empty list otherwise.
+     */
+    public List<User> getUsers() {
+        if (userList != null) {
+            return userList;
+        }
+        if (getExtensionUserManagement() == null) {
+            userList = Collections.emptyList();
+            return userList;
+        }
+        userList =
+                Collections.unmodifiableList(
+                        new ArrayList<>(
+                                getExtensionUserManagement()
+                                        .getContextUserAuthManager(getContext().getId())
+                                        .getUsers()));
+        return userList;
+    }
+
+    private static ExtensionUserManagement getExtensionUserManagement() {
+        return Control.getSingleton()
+                .getExtensionLoader()
+                .getExtension(ExtensionUserManagement.class);
+    }
+
+    /**
+     * Returns a boolean indicating whether or not the {@code HttpMessage} being passively scanned
+     * is currently associated with a {@code Context}.
+     *
+     * @return true if there is an associated context, false if not.
+     */
+    public boolean hasContext() {
+        return context != null;
+    }
+
+    /**
+     * Returns the {@code Context} associated with the message being passively scanned.
+     *
+     * @return the {@code Context} if the message has been matched to a Context, {@code null}
+     *     otherwise.
+     */
+    public Context getContext() {
+        return context;
+    }
+}

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
@@ -181,6 +181,7 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
                         HttpMessage msg = href.getHttpMessage();
                         Source src = new Source(msg.getResponseBody().toString());
                         currentUrl = msg.getRequestHeader().getURI().toString();
+                        PassiveScanData passiveScanData = new PassiveScanData(msg);
 
                         for (PassiveScanner scanner : scannerList.list()) {
                             try {
@@ -193,7 +194,8 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
                                                 || optedInHistoryTypes.contains(hrefHistoryType))) {
                                     boolean cleanScanner = false;
                                     if (scanner instanceof PluginPassiveScanner) {
-                                        ((PluginPassiveScanner) scanner).init(this, msg);
+                                        ((PluginPassiveScanner) scanner)
+                                                .init(this, msg, passiveScanData);
                                         cleanScanner = true;
                                     } else {
                                         scanner.setParent(this);

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
@@ -80,14 +80,16 @@ public abstract class PluginPassiveScanner extends Enableable implements Passive
 
     private PassiveScanThread parent;
     private HttpMessage message;
+    private PassiveScanData passiveScanData;
 
     public PluginPassiveScanner() {
         super(true);
     }
 
-    void init(PassiveScanThread parent, HttpMessage message) {
+    void init(PassiveScanThread parent, HttpMessage message, PassiveScanData psd) {
         this.parent = parent;
         this.message = message;
+        this.passiveScanData = psd;
 
         setParent(parent);
     }
@@ -95,6 +97,7 @@ public abstract class PluginPassiveScanner extends Enableable implements Passive
     void clean() {
         parent = null;
         message = null;
+        passiveScanData = null;
     }
 
     /**
@@ -353,6 +356,17 @@ public abstract class PluginPassiveScanner extends Enableable implements Passive
     @Override
     public boolean appliesToHistoryType(int historyType) {
         return getDefaultHistoryTypes().contains(historyType);
+    }
+
+    /**
+     * Gets a helper object to be used by scan rules in order to retrieve {@code Context}
+     * information.
+     *
+     * @return the {@code PassiveScanData} related to the message being scanned.
+     * @since TODO add version
+     */
+    public PassiveScanData getHelper() {
+        return passiveScanData;
     }
 
     /**


### PR DESCRIPTION
- PassiveScanData > A new helper class which exposes the utility methods (getUsers(), and hasContext()) for the HttpMessage currently being passively scanned.
- PluginPassiveScanner > Added new member and getter (getHelper()) for the PassiveScanData (which is set in the init() method).
- PassiveScanThread > Instantiates a PassiveScanData variable with the current HttpMessage and passes it to PluginPassiveScanner.init().

As far as usage goes: Passive scan rules will be able to do things like `getHelper().getUsers()` etc.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>