### PR TITLE
Expose Context techset directly to passive scan rules

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanData.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanData.java
@@ -28,6 +28,7 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.users.ExtensionUserManagement;
 import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.users.User;
 
 /**
@@ -45,6 +46,8 @@ public final class PassiveScanData {
     private final HttpMessage message;
     private final Context context;
 
+    private final TechSet techSet;
+
     private List<User> userList = null;
 
     PassiveScanData(HttpMessage msg) {
@@ -52,7 +55,10 @@ public final class PassiveScanData {
         this.context = getContext(message);
 
         if (getContext() == null) {
-            userList = Collections.emptyList();
+            this.userList = Collections.emptyList();
+            this.techSet = TechSet.AllTech;
+        } else {
+            this.techSet = getContext().getTechSet();
         }
     }
 
@@ -118,5 +124,16 @@ public final class PassiveScanData {
      */
     public Context getContext() {
         return context;
+    }
+
+    /**
+     * Returns the {@code TechSet} associated with the Context of the message being passively
+     * scanned.
+     *
+     * @return the {@code TechSet} if the message has been matched to a Context, {@code
+     *     TechSet.AllTech} otherwise.
+     */
+    public TechSet getTechSet() {
+        return techSet;
     }
 }


### PR DESCRIPTION
I also considered adding direct support for AuthMethod, AuthzDetectionMethod, DDN, SessionManagementMethod but couldn't think of use-cases. (Also they're available via the extra step
getHelper.getContext.getWhatever...)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>