### PR TITLE
Run apt update and cleanup before snap build and add xdg desktop file

### DIFF
--- a/snap/.gitignore
+++ b/snap/.gitignore
@@ -1,5 +1,5 @@
+/snap/.snapcraft/
 /parts/
 /prime/
-/snap/
 /stage/
 /*.snap

--- a/snap/build-snap.sh
+++ b/snap/build-snap.sh
@@ -1,3 +1,3 @@
 export DOCKER=snapcore/snapcraft:stable
 docker pull $DOCKER
-docker run -it -v "$PWD:$PWD" -w "$PWD" $DOCKER snapcraft
+docker run -it -v "$PWD:$PWD" -w "$PWD" $DOCKER /bin/sh -c 'apt update && snapcraft clean && snapcraft'

--- a/snap/snap/gui/zaproxy.desktop
+++ b/snap/snap/gui/zaproxy.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.0
+Name=OWASP ZAP
+Exec=zaproxy
+Icon=${SNAP}/meta/gui/icon.png
+Terminal=false
+Type=Application
+Comment=OWASP ZAP is an open-source web application security scanner
+Keywords=network;scan;scanner;web;security;zed;attack;proxy;


### PR DESCRIPTION
- Run apt update and cleanup steps before building the snap since the
  build often fails with mirror issues (404s/...). [See below]

- Add xdg desktop file to make the application visible in the desktop
  menu / app overview.

Currently the build fails with:
```


E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/libj/libjpeg-turbo/libjpeg-turbo8_1.4.2-0ubuntu3.1_amd64.deb  404  Not Found [IP: 91.189.88.173 80]

E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/l/linux/linux-libc-dev_4.4.0-166.195_amd64.deb  404  Not Found [IP: 91.189.88.173 80]

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Sorry, an error occurred in Snapcraft:
Could not install all requested build packages: binutils build-essential bzip2 ca-certificates ca-certificates-java cpp cpp-5 dbus dpkg-dev fakeroot file fontconfig-config fonts-dejavu-core g++ g++-5 gcc gcc-5 git git-man ifupdown iproute2 isc-dhcp-client isc-dhcp-common java-common krb5-locales less libalgorithm-diff-perl libalgorithm-diff-xs-perl libalgorithm-merge-perl libasan2 libasn1-8-heimdal libatm1 libatomic1 libavahi-client3 libavahi-common-data libavahi-common3 libbsd0 libc-dev-bin libc6-dev libcap-ng0 libcc1-0 libcilkrts5 libcups2 libcurl3-gnutls libdbus-1-3 libdns-export162 libdpkg-perl libedit2 libelf1 liberror-perl libexpat1 libfakeroot libffi6 libfile-fcntllock-perl libfontconfig1 libfreetype6 libgcc-5-dev libgdbm3 libglib2.0-0 libglib2.0-bin libglib2.0-data libglib2.0-dev libgmp10 libgnutls30 libgomp1 libgssapi-krb5-2 libgssapi3-heimdal libhcrypto4-heimdal libheimbase1-heimdal libheimntlm0-heimdal libhogweed4 libhx509-5-heimdal libicu55 libidn11 libisc-export160 libisl15 libitm1 libjpeg-turbo8 libjpeg8 libk5crypto3 libkeyutils1 libkrb5-26-heimdal libkrb5-3 libkrb5support0 liblcms2-2 libldap-2.4-2 liblsan0 libmagic1 libmnl0 libmpc3 libmpfr4 libmpx0 libnettle6 libnspr4 libnss3 libnss3-nssdb libp11-kit0 libpcre16-3 libpcre3-dev libpcre32-3 libpcrecpp0v5 libpcsclite1 libperl5.22 libpng12-0 libpopt0 libpython-stdlib libpython2.7-minimal libpython2.7-stdlib libquadmath0 libroken18-heimdal librtmp1 libsasl2-2 libsasl2-modules libsasl2-modules-db libsqlite3-0 libssl1.0.0 libstdc++-5-dev libtasn1-6 libtsan0 libubsan0 libwind0-heimdal libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxext6 libxi6 libxml2 libxmuu1 libxrender1 libxtables11 libxtst6 linux-libc-dev make manpages manpages-dev mime-support netbase openjdk-8-jre-headless openssh-client openssl patch perl perl-modules-5.22 pkg-config python python-minimal python2.7 python2.7-minimal rename rsync sgml-base shared-mime-info ucf x11-common xauth xdg-user-dirs xml-core xz-utils zlib1g-dev


```