### PR TITLE
Use specific label for 3rd party add-on issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/Third_party_addon.md
+++ b/.github/ISSUE_TEMPLATE/Third_party_addon.md
@@ -1,7 +1,7 @@
 ---
 name: '3rd party add-on '
 about: Tell us about a 3rd party add-on that we should add or update in the ZAP Marketplace
-labels: Type-Task, add-on, third-party
+labels: marketplace
 
 ---
 


### PR DESCRIPTION
Easier to filter/find with specific label (`marketplace`).