### PR TITLE
Fix OSX id_kp_serverAuth requirement

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/security/SslCertificateServiceImpl.java
+++ b/zap/src/main/java/org/parosproxy/paros/security/SslCertificateServiceImpl.java
@@ -45,9 +45,11 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
 import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
@@ -189,6 +191,10 @@ public final class SslCertificateServiceImpl implements SslCertificateService {
                 false,
                 new SubjectKeyIdentifier(pubKey.getEncoded()));
         certGen.addExtension(Extension.basicConstraints, false, new BasicConstraints(false));
+        certGen.addExtension(
+                Extension.extendedKeyUsage,
+                false,
+                new ExtendedKeyUsage(new KeyPurposeId[] {KeyPurposeId.id_kp_serverAuth}));
 
         if (subjectAlternativeNames.length > 0) {
             certGen.addExtension(


### PR DESCRIPTION
SslCertificateServiceImpl > Update createCertForHost(CertData) to include the ExtendedKeyUsage id_kp_serverAuth OID.

Fixes zaproxy/zaproxy#5710 
Related to zaproxy/zaproxy#4673

![image](https://user-images.githubusercontent.com/7570458/69756904-920edb80-1129-11ea-8467-76933bfcea5c.png)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>