### PR TITLE
Set default API element's description key

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ApiElement.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ApiElement.java
@@ -25,7 +25,7 @@ import java.util.List;
 public class ApiElement {
 
     private String name = null;
-    private String descriptionTag = null;
+    private String descriptionTag = "";
     private List<String> mandatoryParamNames = new ArrayList<>();
     private List<String> optionalParamNames = new ArrayList<>();
 
@@ -100,12 +100,17 @@ public class ApiElement {
         return mandatoryParamNames;
     }
 
+    /**
+     * Gets the description's resource key.
+     *
+     * @return the resource key, never {@code null} (since TODO add version).
+     */
     public String getDescriptionTag() {
         return descriptionTag;
     }
 
     public void setDescriptionTag(String descriptionTag) {
-        this.descriptionTag = descriptionTag;
+        this.descriptionTag = descriptionTag == null ? "" : descriptionTag;
     }
 
     public List<String> getOptionalParamNames() {

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ApiImplementor.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ApiImplementor.java
@@ -27,6 +27,7 @@ import java.util.Comparator;
 import java.util.List;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang3.StringUtils;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.common.AbstractParam;
 import org.parosproxy.paros.network.HttpInputStream;
@@ -83,8 +84,17 @@ public abstract class ApiImplementor {
     }
 
     public void addApiView(ApiView view) {
-        validateApiElement(apiViews, view);
-        this.apiViews.add(view);
+        addApiElement(apiViews, view, RequestType.view);
+    }
+
+    private <T extends ApiElement> void addApiElement(
+            List<T> elements, T element, RequestType type) {
+        validateApiElement(apiViews, element);
+        if (StringUtils.isEmpty(element.getDescriptionTag())) {
+            element.setDescriptionTag(
+                    getPrefix() + ".api." + type.name() + "." + element.getName());
+        }
+        elements.add(element);
     }
 
     /**
@@ -111,13 +121,11 @@ public abstract class ApiImplementor {
     }
 
     public void addApiOthers(ApiOther other) {
-        validateApiElement(apiOthers, other);
-        this.apiOthers.add(other);
+        addApiElement(apiOthers, other, RequestType.other);
     }
 
     public void addApiAction(ApiAction action) {
-        validateApiElement(apiActions, action);
-        this.apiActions.add(action);
+        addApiElement(apiActions, action, RequestType.action);
     }
 
     public void addApiShortcut(String shortcut) {
@@ -125,7 +133,7 @@ public abstract class ApiImplementor {
     }
 
     public void addApiPersistentConnection(ApiPersistentConnection pconn) {
-        this.apiPersistentConnections.add(pconn);
+        addApiElement(apiPersistentConnections, pconn, RequestType.pconn);
     }
 
     /**

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/DotNetAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/DotNetAPIGenerator.java
@@ -107,11 +107,6 @@ public class DotNetAPIGenerator extends AbstractAPIGenerator {
 
         // Add description if defined
         String descTag = element.getDescriptionTag();
-        if (descTag == null) {
-            // This is the default, but it can be overridden by the getDescriptionTag method if
-            // required
-            descTag = component + ".api." + type + "." + element.getName();
-        }
         try {
             String desc = getMessages().getString(descTag);
             out.write("\t\t/// <summary>\n");

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/GoAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/GoAPIGenerator.java
@@ -137,11 +137,6 @@ public class GoAPIGenerator extends AbstractAPIGenerator {
 
         // Add description if defined
         String descTag = element.getDescriptionTag();
-        if (descTag == null) {
-            // This is the default, but it can be overridden by the getDescriptionTag method if
-            // required
-            descTag = component + ".api." + type + "." + element.getName();
-        }
         try {
             String desc = getMessages().getString(descTag);
             out.write("// " + desc + "\n");

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/JavaAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/JavaAPIGenerator.java
@@ -108,11 +108,6 @@ public class JavaAPIGenerator extends AbstractAPIGenerator {
 
         // Add description if defined
         String descTag = element.getDescriptionTag();
-        if (descTag == null) {
-            // This is the default, but it can be overridden by the getDescriptionTag method if
-            // required
-            descTag = component + ".api." + type + "." + element.getName();
-        }
         try {
             String desc = getMessages().getString(descTag);
             out.write("\t/**\n");

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/NodeJSAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/NodeJSAPIGenerator.java
@@ -102,11 +102,6 @@ public class NodeJSAPIGenerator extends AbstractAPIGenerator {
 
         // Add description if defined
         String descTag = element.getDescriptionTag();
-        if (descTag == null) {
-            // This is the default, but it can be overridden by the getDescriptionTag method if
-            // required
-            descTag = component + ".api." + type + "." + element.getName();
-        }
         try {
             String desc = getMessages().getString(descTag);
             out.write("/**\n");

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/PhpAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/PhpAPIGenerator.java
@@ -102,11 +102,6 @@ public class PhpAPIGenerator extends AbstractAPIGenerator {
 
         // Add description if defined
         String descTag = element.getDescriptionTag();
-        if (descTag == null) {
-            // This is the default, but it can be overridden by the getDescriptionTag method if
-            // required
-            descTag = component + ".api." + type + "." + element.getName();
-        }
 
         try {
             String desc = getMessages().getString(descTag);

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/PythonAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/PythonAPIGenerator.java
@@ -132,11 +132,6 @@ public class PythonAPIGenerator extends AbstractAPIGenerator {
 
         // Add description if defined
         String descTag = element.getDescriptionTag();
-        if (descTag == null) {
-            // This is the default, but it can be overridden by the getDescriptionTag method if
-            // required
-            descTag = component + ".api." + type + "." + element.getName();
-        }
         try {
             String desc = getMessages().getString(descTag);
             out.write("        \"\"\"\n");

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/RustAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/RustAPIGenerator.java
@@ -87,11 +87,6 @@ public class RustAPIGenerator extends AbstractAPIGenerator {
             throws IOException {
         // Add description if defined
         String descTag = element.getDescriptionTag();
-        if (descTag == null) {
-            // This is the default, but it can be overridden by the getDescriptionTag method
-            // if required
-            descTag = component + ".api." + type + "." + element.getName();
-        }
         try {
             String desc = getMessages().getString(descTag);
             out.write("/**\n");

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/WebUI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/WebUI.java
@@ -157,11 +157,6 @@ public class WebUI {
             }
 
             String descTag = element.getDescriptionTag();
-            if (descTag == null) {
-                // This is the default, but it can be overridden by the getDescriptionTag method if
-                // required
-                descTag = component + ".api." + type + "." + element.getName();
-            }
             if (Constant.messages.containsKey(descTag)) {
                 sb.append(Constant.messages.getString(descTag));
             } else {
@@ -250,13 +245,7 @@ public class WebUI {
                 sb.append(Constant.messages.getString("api.html." + reqType.name()));
                 sb.append(element.getName());
                 sb.append("</h3>\n");
-                // Handle the (optional) description
                 String descTag = element.getDescriptionTag();
-                if (descTag == null) {
-                    // This is the default, but it can be overridden by the getDescriptionTag method
-                    // if required
-                    descTag = component + ".api." + reqType.name() + "." + name;
-                }
                 if (Constant.messages.containsKey(descTag)) {
                     sb.append(Constant.messages.getString(descTag));
                 }
@@ -338,8 +327,7 @@ public class WebUI {
                     sb.append("</tr>\n");
                 }
 
-                String descKeyPrefix =
-                        component + ".api." + reqType.name() + "." + name + ".param.";
+                String descKeyPrefix = descTag + ".param.";
                 appendParams(descKeyPrefix, sb, mandatoryParams, true);
                 appendParams(descKeyPrefix, sb, optionalParams, false);
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/WikiAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/WikiAPIGenerator.java
@@ -150,11 +150,6 @@ public class WikiAPIGenerator extends AbstractAPIGenerator {
         out.write(" | ");
         // Add description if defined
         String descTag = element.getDescriptionTag();
-        if (descTag == null) {
-            // This is the default, but it can be overridden by the getDescriptionTag method if
-            // required
-            descTag = component + ".api." + type + "." + element.getName();
-        }
         try {
             out.write(getMessages().getString(descTag));
         } catch (Exception e) {

--- a/zap/src/test/java/org/zaproxy/zap/extension/api/VerifyApiImplementors.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/api/VerifyApiImplementors.java
@@ -21,6 +21,8 @@ package org.zaproxy.zap.extension.api;
 
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
@@ -67,16 +69,16 @@ public class VerifyApiImplementors {
             ApiImplementor api, List<? extends ApiElement> elements, RequestType type) {
         elements.sort((a, b) -> a.getName().compareTo(b.getName()));
         for (ApiElement element : elements) {
-            String baseKey = api.getPrefix() + ".api." + type + "." + element.getName();
             String key = element.getDescriptionTag();
-            if (key == null || key.isEmpty()) {
-                key = baseKey;
-            }
+            assertThat(
+                    "API element: " + api.getPrefix() + "/" + element.getName(),
+                    key,
+                    not(isEmptyString()));
 
             checkKey(key);
 
-            checkParameters(baseKey + ".param.", element.getMandatoryParamNames());
-            checkParameters(baseKey + ".param.", element.getOptionalParamNames());
+            checkParameters(key + ".param.", element.getMandatoryParamNames());
+            checkParameters(key + ".param.", element.getOptionalParamNames());
         }
     }
 


### PR DESCRIPTION
Change `ApiImplementor` to set the default description key to the
`ApiElement`s when added, to not require rebuilding it whenever needed.