### PR TITLE
Handle API parameters uniformly

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/API.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/API.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
@@ -622,12 +621,14 @@ public class API {
             return;
         }
 
-        List<String> mandatoryParams = element.getMandatoryParamNames();
-        if (mandatoryParams != null) {
-            for (String param : mandatoryParams) {
-                if (!params.has(param) || params.getString(param).length() == 0) {
-                    throw new ApiException(ApiException.Type.MISSING_PARAMETER, param);
-                }
+        for (ApiParameter parameter : element.getParameters()) {
+            if (!parameter.isRequired()) {
+                continue;
+            }
+
+            String name = parameter.getName();
+            if (!params.has(name) || params.getString(name).length() == 0) {
+                throw new ApiException(ApiException.Type.MISSING_PARAMETER, name);
             }
         }
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ApiDynamicActionImplementor.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ApiDynamicActionImplementor.java
@@ -55,10 +55,8 @@ public abstract class ApiDynamicActionImplementor extends ApiElement {
      */
     public ApiResponse buildParamsDescription() {
         ApiResponseList configParams = new ApiResponseList("methodConfigParams");
-        for (String param : this.getMandatoryParamNames())
-            configParams.addItem(buildParamMap(param, true));
-        for (String param : this.getOptionalParamNames())
-            configParams.addItem(buildParamMap(param, false));
+        for (ApiParameter param : this.getParameters())
+            configParams.addItem(buildParamMap(param.getName(), param.isRequired()));
         return configParams;
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ApiElement.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ApiElement.java
@@ -20,14 +20,17 @@
 package org.zaproxy.zap.extension.api;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class ApiElement {
 
     private String name = null;
     private String descriptionTag = "";
-    private List<String> mandatoryParamNames = new ArrayList<>();
-    private List<String> optionalParamNames = new ArrayList<>();
+    private List<ApiParameter> parameters = new ArrayList<>();
 
     /**
      * Flag that indicates whether or not the API element is deprecated.
@@ -64,12 +67,9 @@ public class ApiElement {
             String name, List<String> mandatoryParamNames, List<String> optionalParamNames) {
         super();
         this.name = name;
-        if (this.mandatoryParamNames != null) {
-            this.mandatoryParamNames = mandatoryParamNames;
-        }
-        if (this.optionalParamNames != null) {
-            this.optionalParamNames = optionalParamNames;
-        }
+
+        addParameters(mandatoryParamNames, true);
+        addParameters(optionalParamNames, false);
     }
 
     public ApiElement(String name, String[] mandatoryParamNames) {
@@ -77,27 +77,44 @@ public class ApiElement {
     }
 
     public ApiElement(String name, String[] mandatoryParamNames, String[] optionalParamNames) {
-        super();
-        this.name = name;
-        this.setMandatoryParamNames(mandatoryParamNames);
-        this.setOptionalParamNames(optionalParamNames);
+        this(name, asList(mandatoryParamNames), asList(optionalParamNames));
+    }
+
+    private static List<String> asList(String[] elements) {
+        return elements != null ? Arrays.asList(elements) : null;
     }
 
     public void setMandatoryParamNames(String[] paramNames) {
-        if (paramNames != null) {
-            this.mandatoryParamNames = new ArrayList<>(paramNames.length);
-            for (String param : paramNames) {
-                this.mandatoryParamNames.add(param);
-            }
-        }
+        setMandatoryParamNames(asList(paramNames));
     }
 
     public void setMandatoryParamNames(List<String> paramNames) {
-        this.mandatoryParamNames = paramNames;
+        parameters.removeIf(ApiParameter::isRequired);
+
+        if (paramNames != null) {
+            List<ApiParameter> optionalParameters = parameters;
+            parameters = new ArrayList<>(optionalParameters.size() + paramNames.size());
+            addParameters(paramNames, true);
+            parameters.addAll(optionalParameters);
+        }
+    }
+
+    private void addParameters(List<String> names, boolean required) {
+        if (names == null) {
+            return;
+        }
+        names.forEach(param -> parameters.add(new ApiParameter(param, "", required)));
     }
 
     public List<String> getMandatoryParamNames() {
-        return mandatoryParamNames;
+        return getParametersNames(ApiParameter::isRequired);
+    }
+
+    private List<String> getParametersNames(Predicate<ApiParameter> predicate) {
+        return parameters.stream()
+                .filter(predicate)
+                .map(ApiParameter::getName)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -114,20 +131,26 @@ public class ApiElement {
     }
 
     public List<String> getOptionalParamNames() {
-        return optionalParamNames;
+        return getParametersNames(e -> !e.isRequired());
     }
 
     public void setOptionalParamNames(String[] optionalParamNames) {
-        if (optionalParamNames != null) {
-            this.optionalParamNames = new ArrayList<>(optionalParamNames.length);
-            for (String param : optionalParamNames) {
-                this.optionalParamNames.add(param);
-            }
-        }
+        setOptionalParamNames(asList(optionalParamNames));
     }
 
     public void setOptionalParamNames(List<String> optionalParamNames) {
-        this.optionalParamNames = optionalParamNames;
+        parameters.removeIf(e -> !e.isRequired());
+        addParameters(optionalParamNames, false);
+    }
+
+    /**
+     * Gets the parameters.
+     *
+     * @return an unmodifiable list with the parameters, never {@code null}.
+     * @since TODO add version
+     */
+    public List<ApiParameter> getParameters() {
+        return Collections.unmodifiableList(parameters);
     }
 
     /**

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ApiImplementor.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ApiImplementor.java
@@ -89,11 +89,20 @@ public abstract class ApiImplementor {
 
     private <T extends ApiElement> void addApiElement(
             List<T> elements, T element, RequestType type) {
-        validateApiElement(apiViews, element);
-        if (StringUtils.isEmpty(element.getDescriptionTag())) {
-            element.setDescriptionTag(
-                    getPrefix() + ".api." + type.name() + "." + element.getName());
+        validateApiElement(elements, element);
+        String descKey = element.getDescriptionTag();
+        if (StringUtils.isEmpty(descKey)) {
+            descKey = getPrefix() + ".api." + type.name() + "." + element.getName();
+            element.setDescriptionTag(descKey);
         }
+
+        String descParamKeyPrefix = descKey + ".param.";
+        for (ApiParameter parameter : element.getParameters()) {
+            if (parameter.getDescriptionKey().isEmpty()) {
+                parameter.setDescriptionKey(descParamKeyPrefix + parameter.getName());
+            }
+        }
+
         elements.add(element);
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ApiParameter.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ApiParameter.java
@@ -1,0 +1,85 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.api;
+
+import java.util.Objects;
+
+/**
+ * A parameter of an {@link ApiElement}.
+ *
+ * @since TODO add version
+ */
+public class ApiParameter {
+
+    private final String name;
+    private String descriptionKey;
+    private final boolean required;
+
+    /**
+     * Constructs an {@code ApiParameter} with the given details.
+     *
+     * @param name the name of the parameter.
+     * @param descriptionKey the resource key of the description.
+     * @param required {@code true} if the parameter is required, {@code false} otherwise.
+     * @throws NullPointerException if {@code name} or {@code descriptionKey} is {@code null}.
+     * @throws IllegalArgumentException if {@code name} is empty.
+     */
+    ApiParameter(String name, String descriptionKey, boolean required) {
+        Objects.requireNonNull(name);
+        if (name.isEmpty()) {
+            throw new IllegalArgumentException("The name must not be empty.");
+        }
+        this.name = name;
+        this.descriptionKey = Objects.requireNonNull(descriptionKey);
+        this.required = required;
+    }
+
+    /**
+     * Gets the name.
+     *
+     * @return the name, never {@code null}.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Gets the resource key of the description.
+     *
+     * @return the key of the description, never {@code null}.
+     * @see org.zaproxy.zap.utils.I18N#getString(String)
+     */
+    public String getDescriptionKey() {
+        return descriptionKey;
+    }
+
+    void setDescriptionKey(String key) {
+        this.descriptionKey = Objects.requireNonNull(key);
+    }
+
+    /**
+     * Tells whether or not the parameter is required.
+     *
+     * @return {@code true} if the parameter is required, {@code false} otherwise.
+     */
+    public boolean isRequired() {
+        return required;
+    }
+}

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/DotNetAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/DotNetAPIGenerator.java
@@ -29,6 +29,7 @@ import java.time.Year;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
 
@@ -153,38 +154,20 @@ public class DotNetAPIGenerator extends AbstractAPIGenerator {
             out.write("\t\tpublic IApiResponse " + createMethodName(element.getName()) + "(");
         }
 
-        if (element.getMandatoryParamNames() != null) {
-            for (String param : element.getMandatoryParamNames()) {
-                if (!hasParams) {
-                    hasParams = true;
-                } else {
-                    out.write(", ");
-                }
-                if (param.equalsIgnoreCase("boolean")) {
-                    out.write("bool boolean");
-                } else if (param.equalsIgnoreCase("integer")) {
-                    out.write("int i");
-                } else {
-                    out.write("string ");
-                    out.write(createParameterName(param.toLowerCase()));
-                }
+        for (ApiParameter parameter : element.getParameters()) {
+            if (!hasParams) {
+                hasParams = true;
+            } else {
+                out.write(", ");
             }
-        }
-        if (element.getOptionalParamNames() != null) {
-            for (String param : element.getOptionalParamNames()) {
-                if (!hasParams) {
-                    hasParams = true;
-                } else {
-                    out.write(", ");
-                }
-                if (param.equalsIgnoreCase("boolean")) {
-                    out.write("bool boolean");
-                } else if (param.equalsIgnoreCase("integer")) {
-                    out.write("int i");
-                } else {
-                    out.write("string ");
-                    out.write(createParameterName(param.toLowerCase()));
-                }
+            String name = parameter.getName();
+            if (name.equalsIgnoreCase("boolean")) {
+                out.write("bool boolean");
+            } else if (name.equalsIgnoreCase("integer")) {
+                out.write("int i");
+            } else {
+                out.write("string ");
+                out.write(createParameterName(name));
             }
         }
         out.write(")\n\t\t{\n");
@@ -194,31 +177,17 @@ public class DotNetAPIGenerator extends AbstractAPIGenerator {
         if (hasParams) {
             out.write("\t\t\tparameters = new Dictionary<string, string>();\n");
 
-            if (element.getMandatoryParamNames() != null) {
-                for (String param : element.getMandatoryParamNames()) {
-                    out.write("\t\t\tparameters.Add(\"" + param + "\", ");
-                    if (param.equalsIgnoreCase("boolean")) {
-                        out.write("Convert.ToString(boolean)");
-                    } else if (param.equalsIgnoreCase("integer")) {
-                        out.write("Convert.ToString(i)");
-                    } else {
-                        out.write(createParameterName(param.toLowerCase()));
-                    }
-                    out.write(");\n");
+            for (ApiParameter parameter : element.getParameters()) {
+                String name = parameter.getName();
+                out.write("\t\t\tparameters.Add(\"" + name + "\", ");
+                if (name.equalsIgnoreCase("boolean")) {
+                    out.write("Convert.ToString(boolean)");
+                } else if (name.equalsIgnoreCase("integer")) {
+                    out.write("Convert.ToString(i)");
+                } else {
+                    out.write(createParameterName(name));
                 }
-            }
-            if (element.getOptionalParamNames() != null) {
-                for (String param : element.getOptionalParamNames()) {
-                    out.write("\t\t\tparameters.Add(\"" + param + "\", ");
-                    if (param.equalsIgnoreCase("boolean")) {
-                        out.write("Convert.ToString(boolean)");
-                    } else if (param.equalsIgnoreCase("integer")) {
-                        out.write("Convert.ToString(i)");
-                    } else {
-                        out.write(createParameterName(param.toLowerCase()));
-                    }
-                    out.write(");\n");
-                }
+                out.write(");\n");
             }
         }
 
@@ -256,7 +225,8 @@ public class DotNetAPIGenerator extends AbstractAPIGenerator {
         return string.replaceAll("\\.", "");
     }
 
-    private static String createParameterName(String name) {
+    private static String createParameterName(String paramName) {
+        String name = paramName.toLowerCase(Locale.ROOT);
         if (nameMap.containsKey(name)) {
             name = nameMap.get(name);
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/GoAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/GoAPIGenerator.java
@@ -31,9 +31,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
-import org.apache.commons.lang.StringUtils;
 
 public class GoAPIGenerator extends AbstractAPIGenerator {
 
@@ -129,11 +129,7 @@ public class GoAPIGenerator extends AbstractAPIGenerator {
             throws IOException {
 
         boolean typeOther = type.equals(OTHER_ENDPOINT);
-        boolean hasParams =
-                (element.getMandatoryParamNames() != null
-                                && element.getMandatoryParamNames().size() > 0)
-                        || (element.getOptionalParamNames() != null
-                                && element.getOptionalParamNames().size() > 0);
+        boolean hasParams = !element.getParameters().isEmpty();
 
         // Add description if defined
         String descTag = element.getDescriptionTag();
@@ -157,18 +153,8 @@ public class GoAPIGenerator extends AbstractAPIGenerator {
         out.write(toTitleCase(createMethodName(element.getName())));
         out.write("(");
 
-        // Iterate through and write out mandatory function arguments
-        writeOutArgs(element.getMandatoryParamNames(), out, hasParams);
-
-        if (element.getMandatoryParamNames() != null
-                && element.getMandatoryParamNames().size() > 0
-                && element.getOptionalParamNames() != null
-                && element.getOptionalParamNames().size() > 0) {
-            out.write(", ");
-        }
-
-        // Iterate through and write out optional function arguments
-        writeOutArgs(element.getOptionalParamNames(), out, hasParams);
+        // Iterate through and write out the function arguments
+        writeOutArgs(element.getParameters(), out);
 
         out.write(")");
 
@@ -184,11 +170,8 @@ public class GoAPIGenerator extends AbstractAPIGenerator {
         if (hasParams) {
             out.write("\tm := map[string]string{");
 
-            // Iterate through and write out mandatory request parameters
-            writeOutRequestParams(element.getMandatoryParamNames(), out);
-
-            // Iterate through and write out optional request parameters
-            writeOutRequestParams(element.getOptionalParamNames(), out);
+            // Iterate through and write out the request parameters
+            writeOutRequestParams(element.getParameters(), out);
 
             out.write("\n\t}\n");
         }
@@ -231,47 +214,45 @@ public class GoAPIGenerator extends AbstractAPIGenerator {
     }
 
     // Writes the function arguments
-    private void writeOutArgs(List<String> elements, Writer out, boolean hasParams)
-            throws IOException {
-        if (elements != null && elements.size() > 0) {
-            ArrayList<String> args = new ArrayList<String>();
-            for (String param : elements) {
-                if (param.equalsIgnoreCase("boolean")) {
-                    args.add("boolean bool");
-                } else if (param.equalsIgnoreCase("integer")) {
-                    args.add("i int");
-                } else if (param.equalsIgnoreCase("string")) {
-                    args.add("str string");
-                } else if (param.equalsIgnoreCase("type")) {
-                    args.add("t string");
-                } else {
-                    args.add(param.toLowerCase() + " string");
-                }
+    private void writeOutArgs(List<ApiParameter> parameters, Writer out) throws IOException {
+        ArrayList<String> args = new ArrayList<String>();
+        for (ApiParameter parameter : parameters) {
+            String name = parameter.getName();
+            if (name.equalsIgnoreCase("boolean")) {
+                args.add("boolean bool");
+            } else if (name.equalsIgnoreCase("integer")) {
+                args.add("i int");
+            } else if (name.equalsIgnoreCase("string")) {
+                args.add("str string");
+            } else if (name.equalsIgnoreCase("type")) {
+                args.add("t string");
+            } else {
+                args.add(name.toLowerCase(Locale.ROOT) + " string");
             }
-            out.write(StringUtils.join(args, ", "));
         }
+        out.write(String.join(", ", args));
     }
 
     // Writes the request parameters
-    private void writeOutRequestParams(List<String> elements, Writer out) throws IOException {
-        if (elements != null && elements.size() > 0) {
-            for (String param : elements) {
-                out.write("\n\t\t\"" + param + "\": ");
-                if (param.equalsIgnoreCase("boolean")) {
-                    addImports = true;
-                    out.write("strconv.FormatBool(boolean)");
-                } else if (param.equalsIgnoreCase("integer")) {
-                    addImports = true;
-                    out.write("strconv.Itoa(i)");
-                } else if (param.equalsIgnoreCase("string")) {
-                    out.write("str");
-                } else if (param.equalsIgnoreCase("type")) {
-                    out.write("t");
-                } else {
-                    out.write(param.toLowerCase());
-                }
-                out.write(",");
+    private void writeOutRequestParams(List<ApiParameter> parameters, Writer out)
+            throws IOException {
+        for (ApiParameter parameter : parameters) {
+            String name = parameter.getName();
+            out.write("\n\t\t\"" + name + "\": ");
+            if (name.equalsIgnoreCase("boolean")) {
+                addImports = true;
+                out.write("strconv.FormatBool(boolean)");
+            } else if (name.equalsIgnoreCase("integer")) {
+                addImports = true;
+                out.write("strconv.Itoa(i)");
+            } else if (name.equalsIgnoreCase("string")) {
+                out.write("str");
+            } else if (name.equalsIgnoreCase("type")) {
+                out.write("t");
+            } else {
+                out.write(name.toLowerCase(Locale.ROOT));
             }
+            out.write(",");
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/JavaAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/JavaAPIGenerator.java
@@ -30,6 +30,7 @@ import java.time.Year;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
 
@@ -104,7 +105,6 @@ public class JavaAPIGenerator extends AbstractAPIGenerator {
 
     private void generateJavaElement(ApiElement element, String component, String type, Writer out)
             throws IOException {
-        boolean hasParams = false;
 
         // Add description if defined
         String descTag = element.getDescriptionTag();
@@ -146,71 +146,43 @@ public class JavaAPIGenerator extends AbstractAPIGenerator {
             out.write("\tpublic ApiResponse " + createMethodName(element.getName()) + "(");
         }
 
-        if (element.getMandatoryParamNames() != null) {
-            for (String param : element.getMandatoryParamNames()) {
-                if (!hasParams) {
-                    hasParams = true;
-                } else {
-                    out.write(", ");
-                }
-                if (param.equalsIgnoreCase("boolean")) {
-                    out.write("boolean bool");
-                } else if (param.equalsIgnoreCase("integer")) {
-                    out.write("int i");
-                } else {
-                    out.write("String ");
-                    out.write(param.toLowerCase());
-                }
+        boolean hasParams = false;
+        for (ApiParameter parameter : element.getParameters()) {
+            if (!hasParams) {
+                hasParams = true;
+            } else {
+                out.write(", ");
             }
-        }
-        if (element.getOptionalParamNames() != null) {
-            for (String param : element.getOptionalParamNames()) {
-                if (!hasParams) {
-                    hasParams = true;
-                } else {
-                    out.write(", ");
-                }
-                if (param.equalsIgnoreCase("boolean")) {
-                    out.write("boolean bool");
-                } else if (param.equalsIgnoreCase("integer")) {
-                    out.write("int i");
-                } else {
-                    out.write("String ");
-                    out.write(param.toLowerCase());
-                }
+            String name = parameter.getName();
+            if (name.equalsIgnoreCase("boolean")) {
+                out.write("boolean bool");
+            } else if (name.equalsIgnoreCase("integer")) {
+                out.write("int i");
+            } else {
+                out.write("String " + name.toLowerCase(Locale.ROOT));
             }
         }
         out.write(") throws ClientApiException {\n");
 
         if (hasParams) {
             out.write("\t\tMap<String, String> map = new HashMap<>();\n");
-            if (element.getMandatoryParamNames() != null) {
-                for (String param : element.getMandatoryParamNames()) {
-                    out.write("\t\tmap.put(\"" + param + "\", ");
-                    if (param.equalsIgnoreCase("boolean")) {
-                        out.write("Boolean.toString(bool)");
-                    } else if (param.equalsIgnoreCase("integer")) {
-                        out.write("Integer.toString(i)");
-                    } else {
-                        out.write(param.toLowerCase());
-                    }
-                    out.write(");\n");
-                }
-            }
-            if (element.getOptionalParamNames() != null) {
-                for (String param : element.getOptionalParamNames()) {
+            for (ApiParameter parameter : element.getParameters()) {
+                String name = parameter.getName();
+                if (!parameter.isRequired()) {
                     out.write("\t\tif (");
-                    out.write(param.toLowerCase());
-                    out.write(" != null) {\n");
-                    out.write("\t\t\tmap.put(\"" + param + "\", ");
-                    if (param.equalsIgnoreCase("boolean")) {
-                        out.write("Boolean.toString(bool)");
-                    } else if (param.equalsIgnoreCase("integer")) {
-                        out.write("Integer.toString(i)");
-                    } else {
-                        out.write(param.toLowerCase());
-                    }
-                    out.write(");\n");
+                    out.write(name.toLowerCase(Locale.ROOT));
+                    out.write(" != null) {\n\t");
+                }
+                out.write("\t\tmap.put(\"" + name + "\", ");
+                if (name.equalsIgnoreCase("boolean")) {
+                    out.write("Boolean.toString(bool)");
+                } else if (name.equalsIgnoreCase("integer")) {
+                    out.write("Integer.toString(i)");
+                } else {
+                    out.write(name.toLowerCase(Locale.ROOT));
+                }
+                out.write(");\n");
+                if (!parameter.isRequired()) {
                     out.write("\t\t}\n");
                 }
             }

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/NodeJSAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/NodeJSAPIGenerator.java
@@ -29,8 +29,10 @@ import java.time.Year;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
+import java.util.stream.Collectors;
 
 public class NodeJSAPIGenerator extends AbstractAPIGenerator {
 
@@ -98,7 +100,7 @@ public class NodeJSAPIGenerator extends AbstractAPIGenerator {
     private void generateNodeJSElement(
             ApiElement element, String component, String type, Writer out) throws IOException {
         String className = createClassName(component);
-        boolean hasParams = false;
+        boolean hasParams = !element.getParameters().isEmpty();
 
         // Add description if defined
         String descTag = element.getDescriptionTag();
@@ -123,68 +125,50 @@ public class NodeJSAPIGenerator extends AbstractAPIGenerator {
         out.write(
                 className + ".prototype." + createMethodName(element.getName()) + " = function (");
 
-        if (element.getMandatoryParamNames() != null) {
-            for (String param : element.getMandatoryParamNames()) {
-                if (!hasParams) {
-                    hasParams = true;
-                } else {
-                    out.write(", ");
-                }
-                out.write(safeName(param.toLowerCase()));
-            }
-        }
-        if (element.getOptionalParamNames() != null) {
-            for (String param : element.getOptionalParamNames()) {
-                if (!hasParams) {
-                    hasParams = true;
-                } else {
-                    out.write(", ");
-                }
-                out.write(safeName(param.toLowerCase()));
-            }
-        }
         if (hasParams) {
+            out.write(
+                    element.getParameters().stream()
+                            .map(ApiParameter::getName)
+                            .map(name -> safeName(name.toLowerCase(Locale.ROOT)))
+                            .collect(Collectors.joining(", ")));
             out.write(", ");
         }
         out.write("callback) {\n");
 
         // , {'url': url}))
-        StringBuilder reqParams = new StringBuilder();
+        String reqParams = "";
         if (hasParams) {
-            reqParams.append("{");
-            boolean first = true;
-            if (element.getMandatoryParamNames() != null) {
-                for (String param : element.getMandatoryParamNames()) {
-                    if (first) {
-                        first = false;
-                    } else {
-                        reqParams.append(", ");
-                    }
-                    reqParams.append("'" + param + "' : " + safeName(param.toLowerCase()));
-                }
-            }
-            reqParams.append("}");
+            StringBuilder reqParamsBuilder = new StringBuilder();
+            reqParamsBuilder.append("{");
+            reqParamsBuilder.append(
+                    element.getParameters().stream()
+                            .filter(ApiParameter::isRequired)
+                            .map(ApiParameter::getName)
+                            .map(
+                                    name ->
+                                            "'"
+                                                    + name
+                                                    + "': "
+                                                    + safeName(name.toLowerCase(Locale.ROOT)))
+                            .collect(Collectors.joining(", ")));
+            reqParamsBuilder.append("}");
+            reqParams = reqParamsBuilder.toString();
 
-            if (element.getOptionalParamNames() != null
-                    && !element.getOptionalParamNames().isEmpty()) {
+            List<ApiParameter> optionalParameters =
+                    element.getParameters().stream()
+                            .filter(e -> !e.isRequired())
+                            .collect(Collectors.toList());
+            if (!optionalParameters.isEmpty()) {
                 out.write("  const params = ");
-                out.write(reqParams.toString());
+                out.write(reqParams);
                 out.write(";\n");
-                reqParams.replace(0, reqParams.length(), "params");
+                reqParams = "params";
 
-                for (String param : element.getOptionalParamNames()) {
-                    out.write(
-                            "  if ("
-                                    + safeName(param.toLowerCase())
-                                    + " && "
-                                    + safeName(param.toLowerCase())
-                                    + " !== null) {\n");
-                    out.write(
-                            "    params['"
-                                    + param
-                                    + "'] = "
-                                    + safeName(param.toLowerCase())
-                                    + ";\n");
+                for (ApiParameter parameter : optionalParameters) {
+                    String name = parameter.getName();
+                    String varName = safeName(name.toLowerCase(Locale.ROOT));
+                    out.write("  if (" + varName + " && " + varName + " !== null) {\n");
+                    out.write("    params['" + name + "'] = " + varName + ";\n");
                     out.write("  }\n");
                 }
             }
@@ -207,7 +191,7 @@ public class NodeJSAPIGenerator extends AbstractAPIGenerator {
                         + "/'");
         if (hasParams) {
             out.write(", ");
-            out.write(reqParams.toString());
+            out.write(reqParams);
         }
         out.write(", callback);\n");
         out.write("    return;\n");
@@ -224,7 +208,7 @@ public class NodeJSAPIGenerator extends AbstractAPIGenerator {
                         + "/'");
         if (hasParams) {
             out.write(", ");
-            out.write(reqParams.toString());
+            out.write(reqParams);
         }
         out.write(");\n");
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/PhpAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/PhpAPIGenerator.java
@@ -28,8 +28,10 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
+import java.util.stream.Collectors;
 
 public class PhpAPIGenerator extends AbstractAPIGenerator {
 
@@ -94,11 +96,7 @@ public class PhpAPIGenerator extends AbstractAPIGenerator {
     private void generatePhpElement(ApiElement element, String component, String type, Writer out)
             throws IOException {
 
-        boolean hasParams =
-                (element.getMandatoryParamNames() != null
-                                && element.getMandatoryParamNames().size() > 0)
-                        || (element.getOptionalParamNames() != null
-                                && element.getOptionalParamNames().size() > 0);
+        boolean hasParams = !element.getParameters().isEmpty();
 
         // Add description if defined
         String descTag = element.getDescriptionTag();
@@ -123,26 +121,18 @@ public class PhpAPIGenerator extends AbstractAPIGenerator {
 
         out.write("\tpublic function " + createMethodName(element.getName()) + "(");
 
-        String paramMan = "";
-        if (element.getMandatoryParamNames() != null) {
-            for (String param : element.getMandatoryParamNames()) {
-                if (!paramMan.isEmpty()) {
-                    paramMan += ", ";
-                }
-                paramMan += "$" + param.toLowerCase();
-            }
-            out.write(paramMan);
-        }
-        String paramOpt = "";
-        if (element.getOptionalParamNames() != null) {
-            for (String param : element.getOptionalParamNames()) {
-                if (!paramMan.isEmpty() || !paramOpt.isEmpty()) {
-                    paramOpt += ", ";
-                }
-                paramOpt += "$" + param.toLowerCase() + "=NULL";
-            }
-            out.write(paramOpt);
-        }
+        out.write(
+                element.getParameters().stream()
+                        .map(
+                                parameter -> {
+                                    String varName =
+                                            "$" + parameter.getName().toLowerCase(Locale.ROOT);
+                                    if (parameter.isRequired()) {
+                                        return varName;
+                                    }
+                                    return varName + "=NULL";
+                                })
+                        .collect(Collectors.joining(", ")));
 
         if (type.equals(ACTION_ENDPOINT) || type.equals(OTHER_ENDPOINT)) {
             if (hasParams) {
@@ -158,17 +148,21 @@ public class PhpAPIGenerator extends AbstractAPIGenerator {
         StringBuilder reqParams = new StringBuilder();
         if (hasParams) {
             reqParams.append("array(");
-            boolean first = true;
-            if (element.getMandatoryParamNames() != null) {
-                for (String param : element.getMandatoryParamNames()) {
-                    if (first) {
-                        first = false;
-                    } else {
-                        reqParams.append(", ");
-                    }
-                    reqParams.append("'" + param + "' => $" + param.toLowerCase());
-                }
-            }
+            String params =
+                    element.getParameters().stream()
+                            .filter(ApiParameter::isRequired)
+                            .map(
+                                    parameter -> {
+                                        String name = parameter.getName();
+                                        return "'"
+                                                + name
+                                                + "' => $"
+                                                + name.toLowerCase(Locale.ROOT);
+                                    })
+                            .collect(Collectors.joining(", "));
+            reqParams.append(params);
+            boolean first = params.isEmpty();
+
             if (type.equals(ACTION_ENDPOINT) || type.equals(OTHER_ENDPOINT)) {
                 // Always add the API key - we've no way of knowing if it will be required or not
                 if (!first) {
@@ -182,16 +176,21 @@ public class PhpAPIGenerator extends AbstractAPIGenerator {
             }
             reqParams.append(")");
 
-            if (element.getOptionalParamNames() != null
-                    && !element.getOptionalParamNames().isEmpty()) {
+            List<ApiParameter> optionalParameters =
+                    element.getParameters().stream()
+                            .filter(e -> !e.isRequired())
+                            .collect(Collectors.toList());
+            if (!optionalParameters.isEmpty()) {
                 out.write("\t\t$params = ");
                 out.write(reqParams.toString());
                 out.write(";\n");
                 reqParams.replace(0, reqParams.length(), "$params");
 
-                for (String param : element.getOptionalParamNames()) {
-                    out.write("\t\tif ($" + param.toLowerCase() + " !== NULL) {\n");
-                    out.write("\t\t\t$params['" + param + "'] = $" + param.toLowerCase() + ";\n");
+                for (ApiParameter parameter : optionalParameters) {
+                    String name = parameter.getName();
+                    String varName = name.toLowerCase(Locale.ROOT);
+                    out.write("\t\tif ($" + varName + " !== NULL) {\n");
+                    out.write("\t\t\t$params['" + name + "'] = $" + varName + ";\n");
                     out.write("\t\t}\n");
                 }
             }

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/PythonAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/PythonAPIGenerator.java
@@ -30,8 +30,10 @@ import java.time.Year;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
+import java.util.stream.Collectors;
 
 public class PythonAPIGenerator extends AbstractAPIGenerator {
 
@@ -100,25 +102,17 @@ public class PythonAPIGenerator extends AbstractAPIGenerator {
             ApiElement element, String component, String type, Writer out) throws IOException {
 
         out.write("\n\n");
-        boolean hasParams =
-                (element.getMandatoryParamNames() != null
-                                && element.getMandatoryParamNames().size() > 0)
-                        || (element.getOptionalParamNames() != null
-                                && element.getOptionalParamNames().size() > 0);
+        boolean hasParams = !element.getParameters().isEmpty();
 
         if (!hasParams && type.equals(VIEW_ENDPOINT)) {
             out.write("    @property\n");
         }
         out.write("    def " + createFunctionName(element.getName()) + "(self");
 
-        if (element.getMandatoryParamNames() != null) {
-            for (String param : element.getMandatoryParamNames()) {
-                out.write(", " + param.toLowerCase());
-            }
-        }
-        if (element.getOptionalParamNames() != null) {
-            for (String param : element.getOptionalParamNames()) {
-                out.write(", " + param.toLowerCase() + "=None");
+        for (ApiParameter parameter : element.getParameters()) {
+            out.write(", " + parameter.getName().toLowerCase(Locale.ROOT));
+            if (!parameter.isRequired()) {
+                out.write("=None");
             }
         }
 
@@ -160,20 +154,16 @@ public class PythonAPIGenerator extends AbstractAPIGenerator {
         StringBuilder reqParams = new StringBuilder();
         if (hasParams) {
             reqParams.append("{");
-            boolean first = true;
-            if (element.getMandatoryParamNames() != null) {
-                for (String param : element.getMandatoryParamNames()) {
-                    if (first) {
-                        first = false;
-                    } else {
-                        reqParams.append(", ");
-                    }
-                    reqParams.append("'" + param + "': " + param.toLowerCase());
-                }
-            }
+            String mandatoryParameters =
+                    element.getParameters().stream()
+                            .filter(ApiParameter::isRequired)
+                            .map(ApiParameter::getName)
+                            .map(name -> "'" + name + "': " + name.toLowerCase(Locale.ROOT))
+                            .collect(Collectors.joining(", "));
+            reqParams.append(mandatoryParameters);
             if (type.equals(ACTION_ENDPOINT) || type.equals(OTHER_ENDPOINT)) {
                 // Always add the API key - we've no way of knowing if it will be required or not
-                if (!first) {
+                if (!mandatoryParameters.isEmpty()) {
                     reqParams.append(", ");
                 }
                 reqParams
@@ -184,17 +174,21 @@ public class PythonAPIGenerator extends AbstractAPIGenerator {
             }
             reqParams.append("}");
 
-            if (element.getOptionalParamNames() != null
-                    && !element.getOptionalParamNames().isEmpty()) {
+            List<ApiParameter> optionalParameters =
+                    element.getParameters().stream()
+                            .filter(e -> !e.isRequired())
+                            .collect(Collectors.toList());
+            if (!optionalParameters.isEmpty()) {
                 out.write("        params = ");
                 out.write(reqParams.toString());
                 out.write("\n");
                 reqParams.replace(0, reqParams.length(), "params");
 
-                for (String param : element.getOptionalParamNames()) {
-                    out.write("        if " + param.toLowerCase() + " is not None:\n");
-                    out.write(
-                            "            params['" + param + "'] = " + param.toLowerCase() + "\n");
+                for (ApiParameter parameter : optionalParameters) {
+                    String name = parameter.getName();
+                    String varName = name.toLowerCase(Locale.ROOT);
+                    out.write("        if " + varName + " is not None:\n");
+                    out.write("            params['" + name + "'] = " + varName + "\n");
                 }
             }
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/RustAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/RustAPIGenerator.java
@@ -29,6 +29,7 @@ import java.nio.file.Paths;
 import java.time.Year;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
 
@@ -113,14 +114,7 @@ public class RustAPIGenerator extends AbstractAPIGenerator {
                 out.write(" */\n");
             }
         }
-        int paramCount = 0;
-        if (element.getMandatoryParamNames() != null) {
-            paramCount += element.getMandatoryParamNames().size();
-        }
-        if (element.getOptionalParamNames() != null) {
-            paramCount += element.getOptionalParamNames().size();
-        }
-
+        int paramCount = element.getParameters().size();
         if (paramCount > 6) {
             // Clippy defaults to 6, but we also have the service parameter
             out.write("#[allow(clippy::too_many_arguments)]\n");
@@ -128,19 +122,10 @@ public class RustAPIGenerator extends AbstractAPIGenerator {
 
         out.write("pub fn " + getSafeName(element.getName()) + "(service: &ZapService");
 
-        if (element.getMandatoryParamNames() != null) {
-            for (String param : element.getMandatoryParamNames()) {
-                out.write(", ");
-                out.write(getSafeName(param.toLowerCase()));
-                out.write(": String");
-            }
-        }
-        if (element.getOptionalParamNames() != null) {
-            for (String param : element.getOptionalParamNames()) {
-                out.write(", ");
-                out.write(getSafeName(param.toLowerCase()));
-                out.write(": String");
-            }
+        for (ApiParameter parameter : element.getParameters()) {
+            out.write(", ");
+            out.write(getSafeName(parameter.getName().toLowerCase(Locale.ROOT)));
+            out.write(": String");
         }
         out.write(") -> Result<Value, ZapApiError> {\n");
 
@@ -150,25 +135,10 @@ public class RustAPIGenerator extends AbstractAPIGenerator {
             out.write("    let params = HashMap::new();\n");
         }
 
-        if (element.getMandatoryParamNames() != null) {
-            for (String param : element.getMandatoryParamNames()) {
-                out.write(
-                        "    params.insert(\""
-                                + param
-                                + "\".to_string(), "
-                                + getSafeName(param.toLowerCase())
-                                + ");\n");
-            }
-        }
-        if (element.getOptionalParamNames() != null) {
-            for (String param : element.getOptionalParamNames()) {
-                out.write(
-                        "    params.insert(\""
-                                + param
-                                + "\".to_string(), "
-                                + getSafeName(param.toLowerCase())
-                                + ");\n");
-            }
+        for (ApiParameter parameter : element.getParameters()) {
+            String name = parameter.getName();
+            String varName = getSafeName(name.toLowerCase(Locale.ROOT));
+            out.write("    params.insert(\"" + name + "\".to_string(), " + varName + ");\n");
         }
 
         out.write(

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/WebUI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/WebUI.java
@@ -113,8 +113,6 @@ public class WebUI {
 
         sb.append("\n<table>\n");
         for (ApiElement element : elementList) {
-            List<String> mandatoryParams = element.getMandatoryParamNames();
-            List<String> optionalParams = element.getOptionalParamNames();
             sb.append("<tr>");
             sb.append("<td>");
             sb.append("<a href=\"/");
@@ -127,19 +125,14 @@ public class WebUI {
             sb.append(element.getName());
             sb.append("/\">");
             sb.append(element.getName());
-            if (mandatoryParams != null || optionalParams != null) {
+            if (!element.getParameters().isEmpty()) {
                 sb.append(" (");
-                if (mandatoryParams != null) {
-                    for (String param : mandatoryParams) {
-                        sb.append(param);
-                        sb.append("* ");
+                for (ApiParameter parameter : element.getParameters()) {
+                    sb.append(parameter.getName());
+                    if (parameter.isRequired()) {
+                        sb.append('*');
                     }
-                }
-                if (optionalParams != null) {
-                    for (String param : optionalParams) {
-                        sb.append(param);
-                        sb.append(" ");
-                    }
+                    sb.append(' ');
                 }
                 sb.append(") ");
             }
@@ -239,8 +232,6 @@ public class WebUI {
             if (name != null) {
                 ApiElement element = this.getElement(impl, name, reqType);
 
-                List<String> mandatoryParams = element.getMandatoryParamNames();
-                List<String> optionalParams = element.getOptionalParamNames();
                 sb.append("<h3>");
                 sb.append(Constant.messages.getString("api.html." + reqType.name()));
                 sb.append(element.getName());
@@ -327,9 +318,7 @@ public class WebUI {
                     sb.append("</tr>\n");
                 }
 
-                String descKeyPrefix = descTag + ".param.";
-                appendParams(descKeyPrefix, sb, mandatoryParams, true);
-                appendParams(descKeyPrefix, sb, optionalParams, false);
+                appendParams(sb, element.getParameters());
 
                 sb.append("<tr>");
                 sb.append("<td>");
@@ -448,30 +437,25 @@ public class WebUI {
         return sb.toString();
     }
 
-    private static void appendParams(
-            String keyPrefix, StringBuilder sb, List<String> params, boolean mandatory) {
-        if (params == null || params.isEmpty()) {
-            return;
-        }
-
-        for (String param : params) {
+    private static void appendParams(StringBuilder sb, List<ApiParameter> params) {
+        for (ApiParameter param : params) {
             sb.append("<tr>");
             sb.append("<td>");
-            sb.append(param);
-            if (mandatory) {
+            sb.append(param.getName());
+            if (param.isRequired()) {
                 sb.append('*');
             }
             sb.append("</td>");
             sb.append("<td>");
             sb.append("<input id=\"");
-            sb.append(param);
+            sb.append(param.getName());
             sb.append("\" name=\"");
-            sb.append(param);
+            sb.append(param.getName());
             sb.append("\"/>");
             sb.append("</td><td>");
-            String descTag = keyPrefix + param;
-            if (Constant.messages.containsKey(descTag)) {
-                sb.append(Constant.messages.getString(descTag));
+            String descKey = param.getDescriptionKey();
+            if (Constant.messages.containsKey(descKey)) {
+                sb.append(Constant.messages.getString(descKey));
             }
             sb.append("</td>");
             sb.append("</tr>\n");

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/WikiAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/WikiAPIGenerator.java
@@ -137,15 +137,12 @@ public class WikiAPIGenerator extends AbstractAPIGenerator {
             out.write("| " + component);
         }
         out.write("| " + element.getName() + "| " + type + " | ");
-        if (element.getMandatoryParamNames() != null) {
-            for (String param : element.getMandatoryParamNames()) {
-                out.write(param + "* ");
+        for (ApiParameter parameter : element.getParameters()) {
+            out.write(parameter.getName());
+            if (parameter.isRequired()) {
+                out.write('*');
             }
-        }
-        if (element.getOptionalParamNames() != null) {
-            for (String param : element.getOptionalParamNames()) {
-                out.write(param + " ");
-            }
+            out.write(' ');
         }
         out.write(" | ");
         // Add description if defined

--- a/zap/src/test/java/org/zaproxy/zap/extension/api/VerifyApiImplementors.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/api/VerifyApiImplementors.java
@@ -69,26 +69,14 @@ public class VerifyApiImplementors {
             ApiImplementor api, List<? extends ApiElement> elements, RequestType type) {
         elements.sort((a, b) -> a.getName().compareTo(b.getName()));
         for (ApiElement element : elements) {
-            String key = element.getDescriptionTag();
             assertThat(
                     "API element: " + api.getPrefix() + "/" + element.getName(),
-                    key,
+                    element.getDescriptionTag(),
                     not(isEmptyString()));
-
-            checkKey(key);
-
-            checkParameters(key + ".param.", element.getMandatoryParamNames());
-            checkParameters(key + ".param.", element.getOptionalParamNames());
-        }
-    }
-
-    private static void checkParameters(String keyPrefix, List<String> params) {
-        if (params == null || params.isEmpty()) {
-            return;
-        }
-
-        for (String param : params) {
-            checkKey(keyPrefix + param);
+            checkKey(element.getDescriptionTag());
+            element.getParameters().stream()
+                    .map(ApiParameter::getDescriptionKey)
+                    .forEach(VerifyApiImplementors::checkKey);
         }
     }
 


### PR DESCRIPTION
Add `ApiParameter` which provides information about the parameter
(currently its name, if required, and the description key), to allow to
handle mandatory and optional parameters the same way.
Update codebase to use the new parameter.