### PR TITLE
Do not show outdated add-ons in marketplace

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/UninstalledAddOnsTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/UninstalledAddOnsTableModel.java
@@ -165,6 +165,12 @@ public class UninstalledAddOnsTableModel extends AddOnsTableModel {
     }
 
     public void setAddOns(List<AddOn> addOnsNotInstalled, AddOnCollection olderAddOns) {
+        if (!getAddOnWrappers().isEmpty()) {
+            int rows = getAddOnWrappers().size();
+            getAddOnWrappers().clear();
+            fireTableRowsDeleted(0, rows - 1);
+        }
+
         for (AddOn addOn : addOnsNotInstalled) {
             AddOnWrapper.Status status = null;
             if (olderAddOns != null && olderAddOns.getAddOn(addOn.getId()) == null) {


### PR DESCRIPTION
Make sure to remove old add-ons from marketplace panel before showing
the new ones, when checking for updates again.