### PR TITLE
HttpHeader provide List variant for getHeaders(String)

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantCookie.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantCookie.java
@@ -22,7 +22,6 @@ package org.parosproxy.paros.core.scanner;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Vector;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 
@@ -43,8 +42,8 @@ public class VariantCookie implements Variant {
             throw new IllegalArgumentException("Parameter message must not be null.");
         }
 
-        Vector<String> cookieLines = message.getRequestHeader().getHeaders(HttpHeader.COOKIE);
-        if (cookieLines == null) {
+        List<String> cookieLines = message.getRequestHeader().getHeaderValues(HttpHeader.COOKIE);
+        if (cookieLines.isEmpty()) {
             params = Collections.emptyList();
             return;
         }

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpHeader.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpHeader.java
@@ -41,9 +41,12 @@
 // ZAP: 2018/04/24 Add JSON Content-Type.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2019/12/09 Added getHeaderValues(String) method (returning List) and deprecated
+// getHeaders(String) method (returning Vector).
 package org.parosproxy.paros.network;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Locale;
@@ -199,12 +202,12 @@ public abstract class HttpHeader implements java.io.Serializable {
      * @return the header value. null if not found.
      */
     public String getHeader(String name) {
-        Vector<String> v = getHeaders(name);
-        if (v == null) {
+        List<String> headers = getHeaderValues(name);
+        if (headers.isEmpty()) {
             return null;
         }
 
-        return v.firstElement();
+        return headers.get(0);
     }
 
     /**
@@ -212,9 +215,23 @@ public abstract class HttpHeader implements java.io.Serializable {
      *
      * @param name
      * @return a vector holding the value as string.
+     * @deprecated since TODO Add version. See {@link #getHeaderValues(String)} instead
      */
+    @Deprecated
     public Vector<String> getHeaders(String name) {
         return mHeaderFields.get(normalisedHeaderName(name));
+    }
+
+    /**
+     * Get header(s) with the name. Multiple values can be returned.
+     *
+     * @param name the name of the header(s) to return.
+     * @return a {@code List} holding the value(s) as String(s).
+     * @since TODO Add version
+     */
+    public List<String> getHeaderValues(String name) {
+        List<String> values = mHeaderFields.get(normalisedHeaderName(name));
+        return values == null ? Collections.emptyList() : Collections.unmodifiableList(values);
     }
 
     public List<HttpHeaderField> getHeaders() {
@@ -253,7 +270,7 @@ public abstract class HttpHeader implements java.io.Serializable {
         //		int crlfpos = 0;
         Pattern pattern = null;
 
-        if (getHeaders(name) == null && value != null) {
+        if (getHeaderValues(name).isEmpty() && value != null) {
             // header value not found, append to end
             addHeader(name, value);
         } else {

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpMessage.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpMessage.java
@@ -53,6 +53,7 @@
 // ZAP: 2018/08/10 Use non-deprecated HttpRequestHeader constructor (Issue 4846).
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2019/12/09 Address deprecation of getHeaders(String) Vector method.
 package org.parosproxy.paros.network;
 
 import java.net.HttpCookie;
@@ -713,11 +714,11 @@ public class HttpMessage implements Message {
     public String getCookieParamsAsString() {
         List<String> cookies = new LinkedList<>();
         if (!this.getRequestHeader().isEmpty()) {
-            addAll(cookies, this.getRequestHeader().getHeaders(HttpHeader.COOKIE));
+            cookies.addAll(this.getRequestHeader().getHeaderValues(HttpHeader.COOKIE));
         }
         if (!this.getResponseHeader().isEmpty()) {
-            addAll(cookies, this.getResponseHeader().getHeaders(HttpHeader.SET_COOKIE));
-            addAll(cookies, this.getResponseHeader().getHeaders(HttpHeader.SET_COOKIE2));
+            cookies.addAll(this.getResponseHeader().getHeaderValues(HttpHeader.SET_COOKIE));
+            cookies.addAll(this.getResponseHeader().getHeaderValues(HttpHeader.SET_COOKIE2));
         }
 
         // Fix error requesting cookies, but there are none
@@ -730,12 +731,6 @@ public class HttpMessage implements Message {
             sb.append(header);
         }
         return sb.toString();
-    }
-
-    private void addAll(List<String> dest, Vector<String> src) {
-        if (src != null) {
-            dest.addAll(src);
-        }
     }
 
     // ZAP: Added getCookieParams

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpRequestHeader.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpRequestHeader.java
@@ -55,6 +55,7 @@
 // ZAP: 2019/03/19 Changed the parse method to only parse the authority on CONNECT requests
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2019/12/09 Address deprecation of getHeaders(String) Vector method.
 package org.parosproxy.paros.network;
 
 import java.io.UnsupportedEncodingException;
@@ -66,7 +67,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.TreeSet;
-import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.httpclient.URI;
@@ -780,26 +780,23 @@ public class HttpRequestHeader extends HttpHeader {
     public TreeSet<HtmlParameter> getCookieParams() {
         TreeSet<HtmlParameter> set = new TreeSet<>();
 
-        Vector<String> cookieLines = getHeaders(HttpHeader.COOKIE);
-        if (cookieLines != null) {
-            for (String cookieLine : cookieLines) {
-                // watch out for the scenario where the first cookie name starts with "cookie"
-                // (uppercase or lowercase)
-                if (cookieLine.toUpperCase().startsWith(HttpHeader.COOKIE.toUpperCase() + ":")) {
-                    // HttpCookie wont parse lines starting with "Cookie:"
-                    cookieLine = cookieLine.substring(HttpHeader.COOKIE.length() + 1);
-                }
+        for (String cookieLine : getHeaderValues(HttpHeader.COOKIE)) {
+            // watch out for the scenario where the first cookie name starts with "cookie"
+            // (uppercase or lowercase)
+            if (cookieLine.toUpperCase().startsWith(HttpHeader.COOKIE.toUpperCase() + ":")) {
+                // HttpCookie wont parse lines starting with "Cookie:"
+                cookieLine = cookieLine.substring(HttpHeader.COOKIE.length() + 1);
+            }
 
-                if (cookieLine.isEmpty()) {
-                    // Nothing to parse.
-                    continue;
-                }
+            if (cookieLine.isEmpty()) {
+                // Nothing to parse.
+                continue;
+            }
 
-                // These can be comma separated type=value
-                String[] cookieArray = cookieLine.split(";");
-                for (String cookie : cookieArray) {
-                    set.add(new HtmlParameter(cookie));
-                }
+            // These can be comma separated type=value
+            String[] cookieArray = cookieLine.split(";");
+            for (String cookie : cookieArray) {
+                set.add(new HtmlParameter(cookie));
             }
         }
 

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpResponseHeader.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpResponseHeader.java
@@ -38,6 +38,7 @@
 // ZAP: 2018/08/15 Add Server header.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2019/12/09 Address deprecation of getHeaders(String) Vector method.
 package org.parosproxy.paros.network;
 
 import java.net.HttpCookie;
@@ -47,7 +48,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.TreeSet;
-import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.log4j.Logger;
@@ -303,19 +303,15 @@ public class HttpResponseHeader extends HttpHeader {
     public List<HttpCookie> getHttpCookies(String defaultDomain) {
         List<HttpCookie> cookies = new LinkedList<>();
 
-        Vector<String> cookiesS = getHeaders(HttpHeader.SET_COOKIE);
+        List<String> cookiesS = getHeaderValues(HttpHeader.SET_COOKIE);
 
-        if (cookiesS != null) {
-            for (String c : cookiesS) {
-                cookies.addAll(parseCookieString(c, defaultDomain));
-            }
+        for (String c : cookiesS) {
+            cookies.addAll(parseCookieString(c, defaultDomain));
         }
 
-        cookiesS = getHeaders(HttpHeader.SET_COOKIE2);
-        if (cookiesS != null) {
-            for (String c : cookiesS) {
-                cookies.addAll(parseCookieString(c, defaultDomain));
-            }
+        cookiesS = getHeaderValues(HttpHeader.SET_COOKIE2);
+        for (String c : cookiesS) {
+            cookies.addAll(parseCookieString(c, defaultDomain));
         }
 
         return cookies;
@@ -372,20 +368,14 @@ public class HttpResponseHeader extends HttpHeader {
     public TreeSet<HtmlParameter> getCookieParams() {
         TreeSet<HtmlParameter> set = new TreeSet<>();
 
-        Vector<String> cookies = getHeaders(HttpHeader.SET_COOKIE);
-        if (cookies != null) {
-            Iterator<String> it = cookies.iterator();
-            while (it.hasNext()) {
-                set.add(new HtmlParameter(it.next()));
-            }
+        Iterator<String> cookiesIt = getHeaderValues(HttpHeader.SET_COOKIE).iterator();
+        while (cookiesIt.hasNext()) {
+            set.add(new HtmlParameter(cookiesIt.next()));
         }
 
-        Vector<String> cookies2 = getHeaders(HttpHeader.SET_COOKIE2);
-        if (cookies2 != null) {
-            Iterator<String> it = cookies2.iterator();
-            while (it.hasNext()) {
-                set.add(new HtmlParameter(it.next()));
-            }
+        Iterator<String> cookies2It = getHeaderValues(HttpHeader.SET_COOKIE2).iterator();
+        while (cookies2It.hasNext()) {
+            set.add(new HtmlParameter(cookies2It.next()));
         }
         return set;
     }

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantCookieUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantCookieUnitTest.java
@@ -27,7 +27,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import java.util.List;
-import java.util.Vector;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -435,9 +434,9 @@ public class VariantCookieUnitTest {
             @Override
             public boolean matches(Object actualValue) {
                 HttpMessage message = (HttpMessage) actualValue;
-                Vector<String> cookieLines =
-                        message.getRequestHeader().getHeaders(HttpHeader.COOKIE);
-                if (cookieLines == null || cookieLines.size() != 1) {
+                List<String> cookieLines =
+                        message.getRequestHeader().getHeaderValues(HttpHeader.COOKIE);
+                if (cookieLines.size() != 1) {
                     return false;
                 }
                 return cookies.equals(cookieLines.get(0));
@@ -451,9 +450,9 @@ public class VariantCookieUnitTest {
             @Override
             public void describeMismatch(Object item, Description description) {
                 HttpMessage message = (HttpMessage) item;
-                Vector<String> cookieLines =
-                        message.getRequestHeader().getHeaders(HttpHeader.COOKIE);
-                if (cookieLines == null) {
+                List<String> cookieLines =
+                        message.getRequestHeader().getHeaderValues(HttpHeader.COOKIE);
+                if (cookieLines.isEmpty()) {
                     description.appendText("has no cookie headers");
                 } else if (cookieLines.size() == 1) {
                     description.appendText("was ").appendValue(cookieLines.get(0));
@@ -470,12 +469,7 @@ public class VariantCookieUnitTest {
             @Override
             public boolean matches(Object actualValue) {
                 HttpMessage message = (HttpMessage) actualValue;
-                Vector<String> cookieLines =
-                        message.getRequestHeader().getHeaders(HttpHeader.COOKIE);
-                if (cookieLines == null || cookieLines.isEmpty()) {
-                    return true;
-                }
-                return false;
+                return message.getRequestHeader().getHeaderValues(HttpHeader.COOKIE).isEmpty();
             }
 
             @Override
@@ -486,8 +480,8 @@ public class VariantCookieUnitTest {
             @Override
             public void describeMismatch(Object item, Description description) {
                 HttpMessage message = (HttpMessage) item;
-                Vector<String> cookieLines =
-                        message.getRequestHeader().getHeaders(HttpHeader.COOKIE);
+                List<String> cookieLines =
+                        message.getRequestHeader().getHeaderValues(HttpHeader.COOKIE);
                 if (cookieLines.size() == 1) {
                     description
                             .appendText("has one cookie header ")

--- a/zap/src/test/java/org/parosproxy/paros/network/HttpRequestHeaderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/network/HttpRequestHeaderUnitTest.java
@@ -19,10 +19,10 @@
  */
 package org.parosproxy.paros.network;
 
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import java.util.TreeSet;
@@ -108,7 +108,7 @@ public class HttpRequestHeaderUnitTest {
         header.setCookieParams(cookies);
         // Then
         assertThat(header.getHeader(HttpHeader.COOKIE), is(equalTo("c1=v1")));
-        assertThat(header.getHeaders(HttpHeader.COOKIE), hasSize(1));
+        assertThat(header.getHeaderValues(HttpHeader.COOKIE), hasSize(1));
     }
 
     @Test
@@ -121,7 +121,7 @@ public class HttpRequestHeaderUnitTest {
         header.setCookieParams(cookies);
         // Then
         assertThat(header.getHeader(HttpHeader.COOKIE), is(equalTo("v3; c1=v1; c2=v2")));
-        assertThat(header.getHeaders(HttpHeader.COOKIE), hasSize(1));
+        assertThat(header.getHeaderValues(HttpHeader.COOKIE), hasSize(1));
     }
 
     @Test
@@ -133,7 +133,7 @@ public class HttpRequestHeaderUnitTest {
         header.setCookieParams(cookies);
         // Then
         assertThat(header.getHeader(HttpHeader.COOKIE), is(equalTo("v1")));
-        assertThat(header.getHeaders(HttpHeader.COOKIE), hasSize(1));
+        assertThat(header.getHeaderValues(HttpHeader.COOKIE), hasSize(1));
     }
 
     @Test
@@ -144,7 +144,7 @@ public class HttpRequestHeaderUnitTest {
         // When
         header.setCookieParams(cookies);
         // Then
-        assertThat(header.getHeaders(HttpHeader.COOKIE), is(nullValue()));
+        assertThat(header.getHeaderValues(HttpHeader.COOKIE), is(empty()));
     }
 
     @Test
@@ -155,19 +155,19 @@ public class HttpRequestHeaderUnitTest {
         // When
         header.setCookieParams(noCookies);
         // Then
-        assertThat(header.getHeaders(HttpHeader.COOKIE), is(nullValue()));
+        assertThat(header.getHeaderValues(HttpHeader.COOKIE), is(empty()));
     }
 
     @Test
     public void shouldRemoveCookieHeadersWhenSettingNoCookieTypeParams() {
         // Given
         HttpRequestHeader header = createRequestHeaderWithCookies();
-        TreeSet<HtmlParameter> paramsWithouCookies =
+        TreeSet<HtmlParameter> paramsWithoutCookies =
                 parameters(urlParam("p1", "v1"), formParam("p2", "v2"));
         // When
-        header.setCookieParams(paramsWithouCookies);
+        header.setCookieParams(paramsWithoutCookies);
         // Then
-        assertThat(header.getHeaders(HttpHeader.COOKIE), is(nullValue()));
+        assertThat(header.getHeaderValues(HttpHeader.COOKIE), is(empty()));
     }
 
     @Test
@@ -180,7 +180,7 @@ public class HttpRequestHeaderUnitTest {
         header.setCookieParams(cookies);
         // Then
         assertThat(header.getHeader(HttpHeader.COOKIE), is(equalTo("v3; c1=v1; c2=v2")));
-        assertThat(header.getHeaders(HttpHeader.COOKIE), hasSize(1));
+        assertThat(header.getHeaderValues(HttpHeader.COOKIE), hasSize(1));
     }
 
     private static HtmlParameter urlParam(String name, String value) {


### PR DESCRIPTION
`HttpHeader.getHeaders(String)` which returns vector is now deprecated. `HttpHeader.getHeaderValues(String)` has been added as a replacement. `VariantCookie` also updated, as well as related UnitTest classes.

`HttpMessage`, `HttpRequestHeader`, and `HttpResponseHeader` adapted to address deprecation, as well as related UnitTest classes.

Fixed a typo in `HttpRequesHeaderUnitTest`.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>