### PR TITLE
Issue 2016: Handle proxy conflict

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/control/Control.java
+++ b/zap/src/main/java/org/parosproxy/paros/control/Control.java
@@ -79,6 +79,8 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/09/30 Reduce View singleton usage and replace null checks with hasView().
 // ZAP: 2019/12/16 Log path of new session.
+// ZAP: 2019/12/13 Enable prompting/suggesting a new port when there's a proxy port conflict (Issue
+// 2016).
 package org.parosproxy.paros.control;
 
 import java.awt.Desktop;
@@ -150,7 +152,10 @@ public class Control extends AbstractControl implements SessionListener {
         model.postInit();
 
         if (startProxy) {
-            return proxy.startServer();
+            proxy.setShouldPrompt(true);
+            boolean started = proxy.startServer();
+            proxy.setShouldPrompt(false);
+            return started;
         }
         return false;
     }

--- a/zap/src/main/java/org/parosproxy/paros/control/Proxy.java
+++ b/zap/src/main/java/org/parosproxy/paros/control/Proxy.java
@@ -35,6 +35,7 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/09/17 Remove irrelevant conditional in stopServer().
+// ZAP: 2019/12/13 Save the proxy port if it had to be selected during startup (Issue 2016).
 package org.parosproxy.paros.control;
 
 import java.util.List;
@@ -101,8 +102,11 @@ public class Proxy {
                 proxyPort = model.getOptionsParam().getProxyParam().getProxyPort();
             }
 
-            if (proxyServer.startServer(proxyHost, proxyPort, false) == -1) {
+            int pPort = proxyServer.startServer(proxyHost, proxyPort, false);
+            if (pPort == -1) {
                 return false;
+            } else {
+                model.getOptionsParam().getProxyParam().setProxyPort(pPort);
             }
         }
         return true;
@@ -212,5 +216,16 @@ public class Proxy {
         if (proxyServer != null) {
             proxyServer.setExcludeList(urls);
         }
+    }
+
+    /**
+     * Sets whether or not the {@code ProxyServer} should prompt the user for an alternate port when
+     * there is a conflict.
+     *
+     * @param shouldPrompt {@code true} if the user should be prompted, {@code false} otherwise
+     * @since TODO Add version
+     */
+    public void setShouldPrompt(boolean shouldPrompt) {
+        this.proxyServer.setShouldPrompt(shouldPrompt);
     }
 }

--- a/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyPortRetryPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyPortRetryPanel.java
@@ -1,0 +1,56 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.core.proxy;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import org.zaproxy.zap.utils.ZapPortNumberSpinner;
+
+class ProxyPortRetryPanel extends JPanel {
+
+    private static final long serialVersionUID = 1L;
+    private final ZapPortNumberSpinner spinnerProxyPort;
+
+    /** Constructs an {@code ProxyPortRetryPanel}. */
+    public ProxyPortRetryPanel(String message, int newPort) {
+        super(new GridBagLayout(), true);
+
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.ipadx = 0;
+        gbc.ipady = 0;
+        gbc.anchor = GridBagConstraints.NORTHWEST;
+        gbc.insets = new Insets(2, 2, 2, 2);
+
+        JLabel prompt = new JLabel(message);
+        this.add(prompt, gbc);
+        spinnerProxyPort = new ZapPortNumberSpinner(newPort);
+        gbc.gridx = 1;
+        this.add(spinnerProxyPort, gbc);
+    }
+
+    public int getProxyPort() {
+        return spinnerProxyPort.getValue();
+    }
+}

--- a/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyServer.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyServer.java
@@ -39,6 +39,7 @@
 // ZAP: 2017/03/15 Disable API by default and allow thread name to be set
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2019/12/13 Handle proxy port conflict at startup (issue 2016).
 package org.parosproxy.paros.core.proxy;
 
 import java.io.IOException;
@@ -54,6 +55,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Vector;
 import java.util.regex.Pattern;
+import javax.swing.JOptionPane;
 import org.apache.commons.httpclient.URI;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -84,6 +86,7 @@ public class ProxyServer implements Runnable {
     private boolean enableApi = false;
     private static Logger log = Logger.getLogger(ProxyServer.class);
     private String threadName = "ZAP-ProxyServer";
+    private boolean shouldPrompt = false;
 
     /** @return Returns the enableCacheProcessing. */
     public boolean isEnableCacheProcessing() {
@@ -191,10 +194,18 @@ public class ProxyServer implements Runnable {
                 } else if (message.startsWith("Permission denied")
                         || message.startsWith("Address already in use")) {
                     if (!isDynamicPort) {
-                        showErrorMessage(
-                                Constant.messages.getString(
-                                        "proxy.error.port", ip, Integer.toString(port)));
-                        return -1;
+                        int originalPort = port;
+                        if (shouldPrompt) {
+                            port = promptForPort(ip, port);
+                        }
+                        if (!shouldPrompt || port == -1) {
+                            showErrorMessage(
+                                    Constant.messages.getString(
+                                            "proxy.error.port",
+                                            ip,
+                                            Integer.toString(originalPort)));
+                            return -1;
+                        }
                     } else if (port < 65535) {
                         port++;
                     }
@@ -215,6 +226,40 @@ public class ProxyServer implements Runnable {
         thread.start();
 
         return proxySocket.getLocalPort();
+    }
+
+    private int promptForPort(String ip, int port) {
+        if (!View.isInitialised()) {
+            return -1;
+        }
+        String retryMessage =
+                Constant.messages.getString("proxy.error.port.retry", String.valueOf(port));
+        int tryPort;
+        if (port > 65535 - 20) {
+            port = 1024;
+        }
+        for (tryPort = port + 1; tryPort < port + 21; tryPort++) {
+            try (ServerSocket trySocket = createServerSocket(ip, tryPort)) {
+                if (trySocket != null) {
+                    break;
+                }
+            } catch (IOException ioe) {
+                // Do nothing
+            }
+        }
+        ProxyPortRetryPanel pprp = new ProxyPortRetryPanel(retryMessage, tryPort);
+        int result =
+                JOptionPane.showConfirmDialog(
+                        null,
+                        pprp,
+                        "",
+                        JOptionPane.YES_NO_OPTION,
+                        JOptionPane.WARNING_MESSAGE,
+                        null);
+        if (result == JOptionPane.YES_OPTION) {
+            return pprp.getProxyPort();
+        }
+        return -1;
     }
 
     private static void showErrorMessage(String error) {
@@ -478,5 +523,16 @@ public class ProxyServer implements Runnable {
 
     public boolean isEnableApi() {
         return enableApi;
+    }
+
+    /**
+     * Sets whether or not the {@code ProxyServer} should prompt the user for an alternate port when
+     * there is a conflict.
+     *
+     * @param shouldPrompt {@code true} if the user should be prompted, {@code false} otherwise
+     * @since TODO Add version
+     */
+    public void setShouldPrompt(boolean shouldPrompt) {
+        this.shouldPrompt = shouldPrompt;
     }
 }

--- a/zap/src/main/java/org/parosproxy/paros/view/MainFooterPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/MainFooterPanel.java
@@ -39,6 +39,8 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JToolBar;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.proxy.ProxyParam;
+import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.utils.DisplayUtils;
 
 public class MainFooterPanel extends JPanel {
@@ -50,6 +52,7 @@ public class MainFooterPanel extends JPanel {
     private JLabel alertMedium = null;
     private JLabel alertLow = null;
     private JLabel alertInfo = null;
+    private JLabel primaryProxy = null;
 
     public MainFooterPanel() {
         super();
@@ -106,6 +109,9 @@ public class MainFooterPanel extends JPanel {
         footerToolbarLeft.add(getAlertLow());
 
         footerToolbarLeft.add(getAlertInfo());
+
+        footerToolbarLeft.addSeparator();
+        footerToolbarLeft.add(getPrimaryProxyLabel());
 
         // Current Scans (Right)
         footerToolbarRight.add(new JLabel(Constant.messages.getString("footer.scans.label")));
@@ -223,6 +229,30 @@ public class MainFooterPanel extends JPanel {
         return label;
     }
 
+    private JLabel getPrimaryProxyLabel() {
+        if (primaryProxy == null) {
+            ProxyParam proxyParam = Model.getSingleton().getOptionsParam().getProxyParam();
+            primaryProxy =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "footer.primary.proxy",
+                                    getProxyRepresentation(
+                                            proxyParam.getProxyIp(), proxyParam.getProxyPort())));
+        }
+        return primaryProxy;
+    }
+
+    /**
+     * Set the footer label for the primary proxy, the format should be host:port.
+     *
+     * @param proxyStr the string representation of the proxy setting that should be displayed.
+     * @since TODO Add version
+     */
+    private void setPrimaryProxyLabel(String proxyStr) {
+        getPrimaryProxyLabel()
+                .setText(Constant.messages.getString("footer.primary.proxy", proxyStr));
+    }
+
     // Support for dynamic scanning results in the footer
     public void addFooterToolbarRightLabel(JLabel label) {
         DisplayUtils.scaleIcon(label);
@@ -273,5 +303,16 @@ public class MainFooterPanel extends JPanel {
     // FIXME Still needed?
     public void addFooterSeparator() {
         this.footerToolbarRight.addSeparator();
+    }
+
+    private static String getProxyRepresentation(String address, int port) {
+        return Constant.messages.getString(
+                "footer.proxy.representation", address, String.valueOf(port));
+    }
+
+    void optionsChanged() {
+        ProxyParam proxyParam = Model.getSingleton().getOptionsParam().getProxyParam();
+        setPrimaryProxyLabel(
+                getProxyRepresentation(proxyParam.getProxyIp(), proxyParam.getProxyPort()));
     }
 }

--- a/zap/src/main/java/org/parosproxy/paros/view/MainFrame.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/MainFrame.java
@@ -32,6 +32,7 @@
 // ZAP: 2018/02/14 Add button for ResponsePanelPosition.TAB_SIDE_BY_SIDE (Issue 4331).
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2019/12/13 Display the primary proxy details (host:port) in the footer (Issue 2016).
 package org.parosproxy.paros.view;
 
 import java.awt.CardLayout;
@@ -587,6 +588,7 @@ public class MainFrame extends AbstractFrame {
         setResponsePanelPosition(position);
 
         setShowTabNames(options.getViewParam().getShowTabNames());
+        getMainFooterPanel().optionsChanged();
     }
 
     /**

--- a/zap/src/main/java/org/parosproxy/paros/view/View.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/View.java
@@ -87,6 +87,7 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/07/10 Update to use Context.getId following deprecation of Context.getIndex
+// ZAP: 2019/12/13 Update new footer proxy label in postInit (Issue 2016)
 package org.parosproxy.paros.view;
 
 import java.awt.Component;
@@ -348,6 +349,7 @@ public class View implements ViewDelegate {
                 });
         mainFrame.getMainMenuBar().getMenuView().add(unpinAllMenu);
 
+        mainFrame.getMainFooterPanel().optionsChanged();
         postInitialisation = true;
     }
 

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -1662,6 +1662,8 @@ footer.alerts.info.tooltip   = Informational Priority Alerts
 footer.alerts.label          = <html>&nbsp;Alerts&nbsp;</html>
 footer.alerts.low.tooltip    = Low Priority Alerts
 footer.alerts.medium.tooltip = Medium Priority Alerts
+footer.primary.proxy = Primary Proxy: {0}
+footer.proxy.representation = {0}:{1} 
 footer.scans.label           = Current Scans
 
 form.dialog.button.cancel = Cancel
@@ -2341,6 +2343,7 @@ paste.paste.popup = Paste
 
 proxy.error.host.unknown = Unknown host
 proxy.error.port = Cannot listen on port {0}:{1} - try specifying a different port for ZAP to use
+proxy.error.port.retry = Proxy port {0} was in use. Try:  
 proxy.error.address = Cannot listen on address
 proxy.error.generic = An error occurred while starting the proxy:\n
 proxy.error.readtimeout = Failed to read {0} within {1} seconds, check to see if the site is available and if so consider adjusting ZAP''s read time out in the Connection options panel.


### PR DESCRIPTION
- ProxyServer.java - Add functionality to pick a random port and prompt the user to use it (or try one they want).
- Proxy.java - Save the proxy port if it had to be selected during startup.
- ProxyPortRetryPanel - Added to display a custom yes/no dialog and a portSpinner.
- Messages.properties - Added keys/values to support these changes.
- MainFooterPanel.java - Add left footer to display the primary proxy details.
- MainFrame > Used to hook options update functionality.
- View > Used to update the new footer in postInit.

Fixes zaproxy/zaproxy#2016

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>