### PR TITLE
Don't display messages when deleting them

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -91,6 +91,7 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/09/30 Use hasView().
+// ZAP: 2020/01/02 Do not display messages being deleted.
 package org.parosproxy.paros.extension.history;
 
 import java.awt.EventQueue;
@@ -316,7 +317,13 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
 
     public void removeFromHistoryList(final HistoryReference href) {
         if (!hasView() || EventQueue.isDispatchThread()) {
+            if (hasView()) {
+                logPanel.setDisplaySelectedMessage(false);
+            }
             this.historyTableModel.removeEntry(href.getHistoryId());
+            if (hasView()) {
+                logPanel.setDisplaySelectedMessage(true);
+            }
             historyIdToRef.remove(href.getHistoryId());
         } else {
             EventQueue.invokeLater(

--- a/zap/src/main/java/org/parosproxy/paros/extension/history/HistoryTable.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/HistoryTable.java
@@ -44,4 +44,14 @@ class HistoryTable extends HistoryReferencesTable {
         getColumnExt(Constant.messages.getString("view.href.table.header.size.responseheader"))
                 .setVisible(false);
     }
+
+    /**
+     * Sets whether or not the selected message should be displayed in Request/Response tabs.
+     *
+     * @param display {@code true} if the selected message should be displayed, {@code false}
+     *     otherwise.
+     */
+    void setDisplaySelectedMessage(boolean display) {
+        getDefaultSelectionListener().setEnabled(display);
+    }
 }

--- a/zap/src/main/java/org/parosproxy/paros/extension/history/LogPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/LogPanel.java
@@ -49,6 +49,7 @@
 // ZAP: 2018/07/17 Use ViewDelegate.getMenuShortcutKeyStroke.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2020/01/02 Allow to set if messages are displayed.
 package org.parosproxy.paros.extension.history;
 
 import java.awt.BorderLayout;
@@ -88,7 +89,7 @@ public class LogPanel extends AbstractPanel {
     // ZAP: Added logger.
     private static final Logger logger = Logger.getLogger(LogPanel.class);
     private javax.swing.JScrollPane scrollLog = null;
-    private HistoryReferencesTable historyReferencesTable = null;
+    private HistoryTable historyReferencesTable = null;
     // ZAP: Added history (filter) toolbar
     private javax.swing.JPanel historyPanel = null;
     private javax.swing.JToolBar panelToolbar = null;
@@ -435,5 +436,9 @@ public class LogPanel extends AbstractPanel {
     public void setModel(
             HistoryReferencesTableModel<DefaultHistoryReferencesTableEntry> historyTableModel) {
         getHistoryReferenceTable().setModel(historyTableModel);
+    }
+
+    void setDisplaySelectedMessage(boolean display) {
+        historyReferencesTable.setDisplaySelectedMessage(display);
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/view/table/HistoryReferencesTable.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/table/HistoryReferencesTable.java
@@ -73,6 +73,7 @@ public class HistoryReferencesTable extends ZapTable {
 
     private static final int MAXIMUM_ROWS_FOR_TABLE_CONFIG = 75;
 
+    private final DisplayMessageOnSelectionValueChange defaultSelectionListener;
     private int maximumRowsForTableConfig;
 
     public HistoryReferencesTable() {
@@ -106,8 +107,10 @@ public class HistoryReferencesTable extends ZapTable {
         setRowSelectionAllowed(true);
 
         if (useDefaultSelectionListener) {
-            getSelectionModel()
-                    .addListSelectionListener(new DisplayMessageOnSelectionValueChange());
+            defaultSelectionListener = new DisplayMessageOnSelectionValueChange();
+            getSelectionModel().addListSelectionListener(defaultSelectionListener);
+        } else {
+            defaultSelectionListener = null;
         }
 
         setComponentPopupMenu(new CustomPopupMenu());
@@ -128,6 +131,17 @@ public class HistoryReferencesTable extends ZapTable {
 
     protected void displayMessage(final HttpMessage msg) {
         View.getSingleton().displayMessage(msg);
+    }
+
+    /**
+     * Gets the default selection listener, responsible to display the selected message in the
+     * Request/Response tabs.
+     *
+     * @return the default selection listener, or {@code null} if not in use.
+     * @since TODO add version
+     */
+    protected DisplayMessageOnSelectionValueChange getDefaultSelectionListener() {
+        return defaultSelectionListener;
     }
 
     public HistoryReference getSelectedHistoryReference() {
@@ -228,23 +242,42 @@ public class HistoryReferencesTable extends ZapTable {
 
     protected class DisplayMessageOnSelectionValueChange implements ListSelectionListener {
 
+        private boolean enabled;
+
+        public DisplayMessageOnSelectionValueChange() {
+            enabled = true;
+        }
+
+        /**
+         * Sets whether or not the selected message should be displayed.
+         *
+         * @param enabled {@code true} if the selected message should be displayed, {@code false}
+         *     otherwise.
+         * @since TODO add version
+         */
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
         @Override
         public void valueChanged(final ListSelectionEvent evt) {
-            if (!evt.getValueIsAdjusting()) {
-                HistoryReference hRef = getSelectedHistoryReference();
-                if (hRef == null) {
-                    return;
-                }
+            if (!enabled || evt.getValueIsAdjusting()) {
+                return;
+            }
 
-                boolean focusOwner = isFocusOwner();
-                try {
-                    displayMessage(hRef.getHttpMessage());
-                } catch (HttpMalformedHeaderException | DatabaseException e) {
-                    LOGGER.error(e.getMessage(), e);
-                } finally {
-                    if (focusOwner) {
-                        requestFocusInWindow();
-                    }
+            HistoryReference hRef = getSelectedHistoryReference();
+            if (hRef == null) {
+                return;
+            }
+
+            boolean focusOwner = isFocusOwner();
+            try {
+                displayMessage(hRef.getHttpMessage());
+            } catch (HttpMalformedHeaderException | DatabaseException e) {
+                LOGGER.error(e.getMessage(), e);
+            } finally {
+                if (focusOwner) {
+                    requestFocusInWindow();
                 }
             }
         }


### PR DESCRIPTION
Disable the History tab selection listener that displays the messages
while they are being deleted, unnecessary and makes the deletion slower
when deleting many selected messages.