### PR TITLE
Add tooltip listing all proxies to the footer Primary Proxy label

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/proxies/ExtensionProxies.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/proxies/ExtensionProxies.java
@@ -61,9 +61,6 @@ public class ExtensionProxies extends ExtensionAdaptor implements OptionsChanged
     }
 
     @Override
-    public void init() {}
-
-    @Override
     public boolean supportsDb(String type) {
         return true;
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/proxies/ProxiesParamProxy.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/proxies/ProxiesParamProxy.java
@@ -21,7 +21,7 @@ package org.zaproxy.zap.extension.proxies;
 
 import org.zaproxy.zap.utils.Enableable;
 
-class ProxiesParamProxy extends Enableable {
+public class ProxiesParamProxy extends Enableable {
 
     private String address = "localhost";
     private int port = 8080;

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -1664,6 +1664,9 @@ footer.alerts.low.tooltip    = Low Priority Alerts
 footer.alerts.medium.tooltip = Medium Priority Alerts
 footer.primary.proxy = Primary Proxy: {0}
 footer.proxy.representation = {0}:{1} 
+footer.proxy.tooltip = <html>Primary Proxy:<br>{0}<html>
+footer.proxy.tooltip.enabled.alts = Alternate (Enabled):<br>{0}
+footer.proxy.tooltip.disabled.alts = Alternate (Disabled):<br>{0}
 footer.scans.label           = Current Scans
 
 form.dialog.button.cancel = Cancel


### PR DESCRIPTION
Building on zaproxy/zaproxy#5764

Add a tooltip that displays the enabled and disabled additional proxies when pointer is hovering over primary proxy footer label.
(ExtensionProxies - Also removed empty init() method.)

Also addresses the smallest part of zaproxy/zaproxy#5308

![image](https://user-images.githubusercontent.com/7570458/71729964-fa2e9c80-2e0e-11ea-8bff-7b4ad2f9f40d.png)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>