### PR TITLE
Set latest version to default config

### DIFF
--- a/zap/src/main/resources/org/zaproxy/zap/resources/config.xml
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/config.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config>
-	<version>1004000</version>
 
 	<pscans>
 		<autoTagScanners>


### PR DESCRIPTION
Remove hardcoded version in default configuration file and set the
latest version after copying the default configuration to the home dir.
Extract method to set the latest version and extract a constant for
the version element.
Update the tests to match the new behaviour.