### PR TITLE
Handle quoted URL in meta refresh

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderHtmlParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderHtmlParser.java
@@ -41,7 +41,7 @@ public class SpiderHtmlParser extends SpiderParser {
 
     /** The Constant urlPattern defining the pattern for a meta url. */
     private static final Pattern urlPattern =
-            Pattern.compile("url\\s*=\\s*([^;]+)", Pattern.CASE_INSENSITIVE);
+            Pattern.compile("url\\s*=\\s*[\"']?([^;'\"]+)", Pattern.CASE_INSENSITIVE);
 
     private static final Pattern PLAIN_COMMENTS_URL_PATTERN =
             Pattern.compile(

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlParserUnitTest.java
@@ -530,7 +530,7 @@ public class SpiderHtmlParserUnitTest extends SpiderParserTestUtils {
                 htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
         // Then
         assertThat(completelyParsed, is(equalTo(false)));
-        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(10)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(12)));
         assertThat(
                 listener.getUrlsFound(),
                 contains(
@@ -538,6 +538,8 @@ public class SpiderHtmlParserUnitTest extends SpiderParserTestUtils {
                         "https://meta.example.com/refresh",
                         "http://example.com/sample/meta/refresh/relative",
                         "http://example.com/meta/refresh/absolute",
+                        "http://meta.example.com/refresh/url/quoted/single",
+                        "http://meta.example.com/refresh/url/quoted/double",
                         "ftp://meta.example.com/refresh",
                         "http://meta.example.com:8080/location/base/scheme",
                         "https://meta.example.com/location",

--- a/zap/src/test/resources/org/zaproxy/zap/spider/parser/html/MetaElementsSpiderHtmlParser.html
+++ b/zap/src/test/resources/org/zaproxy/zap/spider/parser/html/MetaElementsSpiderHtmlParser.html
@@ -9,6 +9,8 @@
 <meta http-equiv="refresh" content="0;URL=https://meta.example.com/refresh">
 <meta http-equiv="refresh" content="0;URL=meta/refresh/relative">
 <meta http-equiv="refresh" content="0;URL=/meta/refresh/absolute">
+<meta http-equiv="refresh" content="0;URL='http://meta.example.com/refresh/url/quoted/single'">
+<meta http-equiv="refresh" content='0;URL="http://meta.example.com/refresh/url/quoted/double"'>
 <meta http-equiv="refresh" content="0;URL=ftp://meta.example.com/refresh">
 
 <meta http-equiv="location" content="url=//meta.example.com:8080/location/base/scheme">


### PR DESCRIPTION
Change `SpiderHtmlParser` to ignore single/double quote chars in the
URL of meta refresh, the HTML standard allows that.