### PR TITLE
Offer a table based on kind of alert

### DIFF
--- a/zap/src/main/resources/org/zaproxy/zap/resources/xml/report.html.xsl
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/xml/report.html.xsl
@@ -72,6 +72,9 @@ th{
 .summary th{
   color: #FFF;
 }
+.alerts th{
+  color: #FFF;
+}
 </style>
 </head>
 
@@ -119,10 +122,48 @@ ZAP Scanning Report
   </tr>
 </table>
 <div class="spacer-lg"></div>
+
+<h3>Alerts</h3>
+<table width="75%" class="alerts">
+  <tr bgcolor="#666666"> 
+    <th width="60%" height="24">Name</th>
+    <th width="20%" align="center">Risk Level</th>
+    <th width="20%" align="center">Number of Instances</th>
+  </tr>
+  <xsl:key name="alerts-by-name-risk" match="alertitem" use="concat(name, ' ', riskcode)"/>
+  <xsl:for-each select="descendant::alertitem[count(. | key('alerts-by-name-risk', concat(name, ' ', riskcode))[1]) = 1]">
+    <xsl:sort order="descending" data-type="number" select="riskcode"/>
+    <xsl:sort order="ascending" data-type="text" select="name"/>
+    <tr bgcolor="#e8e8e8"> 
+      <td>
+        <xsl:value-of select="name"/>
+      </td>
+      <td align="center">
+        <xsl:value-of select="substring-before(riskdesc, ' ')"/>
+      </td>
+      <td align="center">
+        <xsl:variable name="same-name-alerts" select="key('alerts-by-name-risk', concat(name, ' ', riskcode))"/>
+        <xsl:choose>
+          <!-- Add <count>s when merge is on -->
+          <xsl:when test="$same-name-alerts/count">
+            <xsl:value-of select="sum($same-name-alerts/count)"/>
+          </xsl:when>
+          <!-- Count alerts when merge is off -->
+          <xsl:otherwise>
+            <xsl:value-of select="count($same-name-alerts)"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </td>
+    </tr>
+  </xsl:for-each>
+</table>
+<div class="spacer-lg"></div>
+
 <h3>Alert Detail</h3>
 
 <xsl:apply-templates select="descendant::alertitem">
   <xsl:sort order="descending" data-type="number" select="riskcode"/>
+  <xsl:sort order="ascending" data-type="text" select="name"/>
   <xsl:sort order="descending" data-type="number" select="confidence"/>
 </xsl:apply-templates>
 </body>

--- a/zap/src/main/resources/org/zaproxy/zap/resources/xml/report.md.xsl
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/xml/report.md.xsl
@@ -24,10 +24,29 @@
 | Low | <xsl:value-of select="count(descendant::alertitem[riskcode='1'])"/> |
 | Informational | <xsl:value-of select="count(descendant::alertitem[riskcode='0'])"/> |
 
+## Alerts
+
+| Name | Risk Level | Number of Instances |
+| --- | --- | --- | <xsl:key name="alerts-by-name-risk" match="alertitem" use="concat(name, ' ', riskcode)"/>
+<xsl:for-each select="descendant::alertitem[count(. | key('alerts-by-name-risk', concat(name, ' ', riskcode))[1]) = 1]">
+<xsl:sort order="descending" data-type="number" select="riskcode"/>
+<xsl:sort order="ascending" data-type="text" select="name"/>
+| <xsl:value-of select="name"/> | <xsl:value-of select="substring-before(riskdesc, ' ')"/> | <xsl:variable name="same-name-alerts" select="key('alerts-by-name-risk', concat(name, ' ', riskcode))"/>
+<xsl:choose>
+<!-- Add <count>s when merge is on -->
+<xsl:when test="$same-name-alerts/count">
+  <xsl:value-of select="sum($same-name-alerts/count)"/>
+</xsl:when>
+<!-- Count alerts when merge is off -->
+<xsl:otherwise>
+  <xsl:value-of select="count($same-name-alerts)"/>
+</xsl:otherwise></xsl:choose> | </xsl:for-each>
+
 ## Alert Detail
 
 <xsl:apply-templates select="descendant::alertitem">
   <xsl:sort order="descending" data-type="number" select="riskcode"/>
+  <xsl:sort order="ascending" data-type="text" select="name"/>
   <xsl:sort order="descending" data-type="number" select="confidence"/>
 </xsl:apply-templates>
 </xsl:template>


### PR DESCRIPTION
In addition to 'Summary of Alerts', also provide an 'Alerts' table in HTML and markdown reports. Also, sort 'Alert Details' as risk-name-confidence. Closes zaproxy/zaproxy#5732.

Signed-off-by: Akshath Kothari <akshath.kothari@gmail.com>