### PR TITLE
Set locale/lang to use UTF-8 in Docker images

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2020-01-22
+ - Change `live`, `stable`, and `weekly` images to set the locale and lang to `C.UTF-8`,
+ to improve interoperability with Python 3 (e.g. `zap-cli`).
+
 ### 2019-10-16
  - Added response code after each URL reported on standard out:
 

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -70,6 +70,8 @@ ENV ZAP_PATH /zap/zap.sh
 # Default port for use with zapcli
 ENV ZAP_PORT 8080
 ENV HOME /home/zap/
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
 
 COPY zap* CHANGELOG.md /zap/
 COPY webswing.config /zap/webswing/

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -62,6 +62,8 @@ ENV ZAP_PATH /zap/zap.sh
 # Default port for use with zapcli
 ENV ZAP_PORT 8080
 ENV HOME /home/zap/
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
 
 COPY zap* CHANGELOG.md /zap/
 COPY webswing.config /zap/webswing/

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -63,6 +63,8 @@ ENV ZAP_PATH /zap/zap.sh
 # Default port for use with zapcli
 ENV ZAP_PORT 8080
 ENV HOME /home/zap/
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
 
 COPY zap* CHANGELOG.md /zap/
 COPY webswing.config /zap/webswing/


### PR DESCRIPTION
Change `live`, `stable`, and `weekly` to use `C.UTF-8` for the locale
and lang, to improve interoperability with Python 3 (more specifically
with Click library, used by `zap-cli`).

Close #5818 and close #5632.