### PR TITLE
Add context menu item to mark false positives

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Alert.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Alert.java
@@ -621,6 +621,9 @@ public class Alert implements Comparable<Alert> {
                 this.solution,
                 this.reference,
                 this.historyRef);
+        item.setEvidence(this.evidence);
+        item.setCweId(this.cweId);
+        item.setWascId(this.wascId);
         item.setSource(this.source);
         return item;
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -79,6 +79,7 @@ public class ExtensionAlert extends ExtensionAdaptor
     private RecordScan recordScan = null;
     private PopupMenuAlert popupMenuAlertAdd;
     private PopupMenuAlertEdit popupMenuAlertEdit = null;
+    private PopupMenuAlertSetFalsePositive popupMenuAlertSetFalsePositive = null;
     private PopupMenuAlertDelete popupMenuAlertDelete = null;
     private PopupMenuAlertsRefresh popupMenuAlertsRefresh = null;
     private PopupMenuShowAlerts popupMenuShowAlerts = null;
@@ -105,6 +106,7 @@ public class ExtensionAlert extends ExtensionAdaptor
             extensionHook.getHookView().addOptionPanel(getOptionsPanel());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuAlertAdd());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuAlertEdit());
+            extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuAlertSetFalsePositive());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuAlertDelete());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuAlertsRefresh());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuShowAlerts());
@@ -616,6 +618,13 @@ public class ExtensionAlert extends ExtensionAdaptor
             popupMenuAlertEdit = new PopupMenuAlertEdit(this);
         }
         return popupMenuAlertEdit;
+    }
+
+    private PopupMenuAlertSetFalsePositive getPopupMenuAlertSetFalsePositive() {
+        if (popupMenuAlertSetFalsePositive == null) {
+            popupMenuAlertSetFalsePositive = new PopupMenuAlertSetFalsePositive();
+        }
+        return popupMenuAlertSetFalsePositive;
     }
 
     private PopupMenuAlertDelete getPopupMenuAlertDelete() {

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/PopupMenuAlertSetFalsePositive.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/PopupMenuAlertSetFalsePositive.java
@@ -1,0 +1,59 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.alert;
+
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.db.DatabaseException;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+
+/**
+ * A {@link PopupMenuItemAlert} that sets the Confidence of one or more {@link Alert alerts} to
+ * False Positive.
+ *
+ * @since TODO Add version
+ */
+public class PopupMenuAlertSetFalsePositive extends PopupMenuItemAlert {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOGGER = Logger.getLogger(PopupMenuAlertSetFalsePositive.class);
+
+    public PopupMenuAlertSetFalsePositive() {
+        super(Constant.messages.getString("scanner.false.positive.popup"), true);
+    }
+
+    @Override
+    protected void performAction(Alert alert) {
+        Alert newAlert = alert.newInstance();
+        newAlert.setAlertId(alert.getAlertId());
+        newAlert.setConfidence(Alert.CONFIDENCE_FALSE_POSITIVE);
+        try {
+            getExtensionAlert().updateAlert(newAlert);
+        } catch (HttpMalformedHeaderException | DatabaseException e) {
+            LOGGER.error("Unable to update confidence for alert: " + alert.getAlertId(), e);
+        }
+    }
+
+    @Override
+    public boolean isSafe() {
+        return true;
+    }
+}

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -2487,6 +2487,7 @@ scanner.category.undef   = Undefined
 scanner.delete.popup     = Delete
 scanner.delete.confirm   = Are you sure you want to delete the alert(s)?
 scanner.edit.popup       = Edit...
+scanner.false.positive.popup = Mark as False Positive
 scanner.save.warning     = Error saving policy.
 
 script.api.view.globalVar = Gets the value of the global variable with the given key. Returns an API error (DOES_NOT_EXIST) if no value was previously set.


### PR DESCRIPTION
Allow multi-select.

See zaproxy/zaproxy#1603, also see zaproxy/zaproxy#5843.

Alert class fix missed fields in `newInstance()` method. (Thanks @thc202)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>