### PR TITLE
Update Python docker scripts to be Python 3 compatible

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2020-02-07
+ - Change zap-full-scan.py and zap-api-scan.py to be Python3 compatible
+
 ### 2020-01-22
  - Change `live`, `stable`, and `weekly` images to set the locale and lang to `C.UTF-8`,
  to improve interoperability with Python 3 (e.g. `zap-cli`).

--- a/docker/zap-api-scan.py
+++ b/docker/zap-api-scan.py
@@ -458,7 +458,7 @@ def main(argv):
                     f.write('# Active scan rules set to IGNORE will not be run which will speed up the scan\n')
                     f.write('# Only the rule identifiers are used - the names are just for info\n')
                     f.write('# You can add your own messages to each rule by appending them after a tab on each line.\n')
-                    for key, rule in sorted(all_dict.iteritems()):
+                    for key, rule in sorted(all_dict.items()):
                         f.write(key + '\tWARN\t(' + rule + ')\n')
 
             # print out the passing rules
@@ -467,17 +467,17 @@ def main(argv):
                 plugin_id = rule.get('id')
                 if plugin_id in blacklist:
                     continue
-                if (not alert_dict.has_key(plugin_id)):
+                if plugin_id not in alert_dict:
                     pass_dict[plugin_id] = rule.get('name')
             for rule in all_ascan_rules:
                 plugin_id = rule.get('id')
                 if plugin_id in blacklist:
                     continue
-                if not alert_dict.has_key(plugin_id) and not(config_dict.has_key(plugin_id) and config_dict[plugin_id] == 'IGNORE'):
+                if plugin_id not in alert_dict and not(plugin_id in config_dict and config_dict[plugin_id] == 'IGNORE'):
                     pass_dict[plugin_id] = rule.get('name')
 
             if min_level == zap_conf_lvls.index("PASS") and detailed_output:
-                for key, rule in sorted(pass_dict.iteritems()):
+                for key, rule in sorted(pass_dict.items()):
                     print('PASS: ' + rule + ' [' + key + ']')
 
             pass_count = len(pass_dict)
@@ -488,7 +488,7 @@ def main(argv):
                     plugin_id = rule.get('id')
                     if plugin_id in blacklist:
                         continue
-                    if config_dict.has_key(plugin_id) and config_dict[plugin_id] == 'IGNORE':
+                    if plugin_id in config_dict and config_dict[plugin_id] == 'IGNORE':
                         print('SKIP: ' + rule.get('name') + ' [' + plugin_id + ']')
 
             # print out the ignored rules

--- a/docker/zap-full-scan.py
+++ b/docker/zap-full-scan.py
@@ -386,7 +386,7 @@ def main(argv):
                     f.write('# Active scan rules set to IGNORE will not be run which will speed up the scan\n')
                     f.write('# Only the rule identifiers are used - the names are just for info\n')
                     f.write('# You can add your own messages to each rule by appending them after a tab on each line.\n')
-                    for key, rule in sorted(all_dict.iteritems()):
+                    for key, rule in sorted(all_dict.items()):
                         f.write(key + '\tWARN\t(' + rule + ')\n')
 
             # print out the passing rules
@@ -395,17 +395,17 @@ def main(argv):
                 plugin_id = rule.get('id')
                 if plugin_id in blacklist:
                     continue
-                if (not alert_dict.has_key(plugin_id)):
+                if plugin_id not in alert_dict:
                     pass_dict[plugin_id] = rule.get('name')
             for rule in all_ascan_rules:
                 plugin_id = rule.get('id')
                 if plugin_id in blacklist:
                     continue
-                if not alert_dict.has_key(plugin_id) and not(config_dict.has_key(plugin_id) and config_dict[plugin_id] == 'IGNORE'):
+                if plugin_id not in alert_dict and not(plugin_id in config_dict and config_dict[plugin_id] == 'IGNORE'):
                     pass_dict[plugin_id] = rule.get('name')
 
             if min_level == zap_conf_lvls.index("PASS") and detailed_output:
-                for key, rule in sorted(pass_dict.iteritems()):
+                for key, rule in sorted(pass_dict.items()):
                     print('PASS: ' + rule + ' [' + key + ']')
 
             pass_count = len(pass_dict)
@@ -416,7 +416,7 @@ def main(argv):
                     plugin_id = rule.get('id')
                     if plugin_id in blacklist:
                         continue
-                    if config_dict.has_key(plugin_id) and config_dict[plugin_id] == 'IGNORE':
+                    if plugin_id in config_dict and config_dict[plugin_id] == 'IGNORE':
                         print('SKIP: ' + rule.get('name') + ' [' + plugin_id + ']')
 
             # print out the ignored rules

--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -460,10 +460,6 @@ def get_latest_zap_client_version():
         logging.warning('Error fetching latest ZAP Python API client version: %s' % e)
         return None
 
-    if version_info is None:
-        logging.warning('Error fetching latest ZAP Python API client version: %s' % e)
-        return None
-
     version_json = json.loads(version_info.read().decode('utf-8'))
 
     if 'info' not in version_json:


### PR DESCRIPTION
The `/zap/zap-*.py` Python scripts in the Docker image are not Python3 compatible. This is because they still use `dict.has_key(x)` instead of `x in dict`, and `dict.iteritems()` instead of `dict.items()`. Moving to Python3 is important because Python2 is due to EOL in [April 2020](https://www.python.org/psf/press-release/pr20191220/).

I've done my best to test this change locally. I didn't test the API script changes, as I don't have an easy example locally to test, but they are essentially the same as the full script scan changes.




