### PR TITLE
Set RSyntaxTextArea dark mode if dark LookAndFeel used

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/HttpPanelSyntaxHighlightTextArea.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/HttpPanelSyntaxHighlightTextArea.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.httppanel.view.syntaxhighlight;
 
 import java.awt.Color;
 import java.awt.Component;
+import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
@@ -39,6 +40,7 @@ import org.fife.ui.rsyntaxtextarea.AbstractTokenMakerFactory;
 import org.fife.ui.rsyntaxtextarea.RSyntaxDocument;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
+import org.fife.ui.rsyntaxtextarea.Theme;
 import org.fife.ui.rtextarea.RTextArea;
 import org.fife.ui.rtextarea.RTextScrollPane;
 import org.parosproxy.paros.Constant;
@@ -48,6 +50,7 @@ import org.zaproxy.zap.extension.httppanel.Message;
 import org.zaproxy.zap.extension.httppanel.view.syntaxhighlight.menus.SyntaxMenu;
 import org.zaproxy.zap.extension.httppanel.view.syntaxhighlight.menus.ViewMenu;
 import org.zaproxy.zap.extension.search.SearchMatch;
+import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.utils.FontUtils.FontType;
 import org.zaproxy.zap.view.HighlightSearchEntry;
@@ -129,6 +132,17 @@ public abstract class HttpPanelSyntaxHighlightTextArea extends RSyntaxTextArea {
         this.setFont(
                 FontUtils.getFontWithFallback(FontType.workPanels, this.getFont().getFontName()));
 
+        if (DisplayUtils.isDarkLookAndFeel()) {
+            try {
+                Theme theme =
+                        Theme.load(
+                                HttpPanelSyntaxHighlightTextArea.class.getResourceAsStream(
+                                        "/org/fife/ui/rsyntaxtextarea/themes/dark.xml"));
+                theme.apply(this);
+            } catch (IOException e) {
+                log.error("Failed to set RSyntaxTextArea dark theme", e);
+            }
+        }
         initHighlighter();
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/utils/DisplayUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/DisplayUtils.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.utils;
 
+import com.formdev.flatlaf.FlatLaf;
 import java.awt.Dimension;
 import java.awt.Image;
 import java.awt.Insets;
@@ -32,6 +33,8 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JToggleButton;
+import javax.swing.LookAndFeel;
+import javax.swing.UIManager;
 import org.parosproxy.paros.model.Model;
 
 public class DisplayUtils {
@@ -211,5 +214,19 @@ public class DisplayUtils {
         return new Insets(
                 (int) (top * FontUtils.getScale()), (int) (left * FontUtils.getScale()),
                 (int) (bottom * FontUtils.getScale()), (int) (right * FontUtils.getScale()));
+    }
+
+    /**
+     * Returns true if a known dark LookAndFeel is being used
+     *
+     * @since TODO add version
+     */
+    public static boolean isDarkLookAndFeel() {
+        LookAndFeel laf = UIManager.getLookAndFeel();
+        if (laf instanceof FlatLaf) {
+            FlatLaf flaf = (FlatLaf) laf;
+            return flaf.isDark();
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Part of https://github.com/zaproxy/zaproxy/issues/5542

Fixes the request / response / break panels and manual request dialog.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>