### PR TITLE
Change default extension's URL

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/Extension.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/Extension.java
@@ -45,6 +45,7 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/09/12 Add defaults to getAuthor() and getURL().
+// ZAP: 2020/03/09 Default getURL() to null.
 package org.parosproxy.paros.extension;
 
 import java.net.URL;
@@ -203,16 +204,12 @@ public interface Extension {
     /**
      * Gets the URL to info about the extension.
      *
-     * <p>Since 2.9.0 defaults to the info URL of the add-on, if set, otherwise {@code null}.
+     * <p>Since TODO add version defaults to {@code null}.
      *
      * @return the URL to info about the extension, might be {@code null}.
      * @since 1.4.0
      */
     default URL getURL() {
-        AddOn addOn = getAddOn();
-        if (addOn != null) {
-            return addOn.getInfo();
-        }
         return null;
     }
 


### PR DESCRIPTION
Use null (none) instead of the add-on's URL, the latter is most likely a
URL to the online help (majority of the add-ons available in the
marketplace) which is already available in ZAP.