### PR TITLE
Cope with extensions without package

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/ExtensionAdaptor.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/ExtensionAdaptor.java
@@ -47,6 +47,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/09/12 Remove getURL().
 // ZAP: 2019/09/30 Add hasView().
+// ZAP: 2020/03/09 Handle extensions without package.
 package org.parosproxy.paros.extension;
 
 import java.util.Collections;
@@ -251,9 +252,14 @@ public abstract class ExtensionAdaptor implements Extension {
     @Override
     public String getI18nPrefix() {
         if (this.i18nPrefix == null) {
-            // Default to the (last part of the )name of the package
-            String packageName = this.getClass().getPackage().getName();
-            this.i18nPrefix = packageName.substring(packageName.lastIndexOf(".") + 1);
+            Package extPackage = this.getClass().getPackage();
+            if (extPackage == null) {
+                this.i18nPrefix = "";
+            } else {
+                // Default to the (last part of the) name of the package
+                String packageName = extPackage.getName();
+                this.i18nPrefix = packageName.substring(packageName.lastIndexOf(".") + 1);
+            }
         }
         return this.i18nPrefix;
     }

--- a/zap/src/main/java/org/zaproxy/zap/control/ExtensionFactory.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/ExtensionFactory.java
@@ -341,15 +341,16 @@ public class ExtensionFactory {
     }
 
     private static ResourceBundle getExtensionResourceBundle(Extension ext) {
-        String extensionPackage = ext.getClass().getPackage().getName();
+        Package extPackage = ext.getClass().getPackage();
+        String extensionPackage = extPackage != null ? extPackage.getName() + "." : "";
         ClassLoader classLoader = ext.getClass().getClassLoader();
         try {
             // Try to load a message bundle in the new/default location
-            String name = extensionPackage + ".resources." + Constant.MESSAGES_PREFIX;
+            String name = extensionPackage + "resources." + Constant.MESSAGES_PREFIX;
             return getPropertiesResourceBundle(name, classLoader);
         } catch (MissingResourceException ignore) {
             // Try to load in the old location
-            String oldLocation = extensionPackage + "." + Constant.MESSAGES_PREFIX;
+            String oldLocation = extensionPackage + Constant.MESSAGES_PREFIX;
             try {
                 return getPropertiesResourceBundle(oldLocation, classLoader);
             } catch (MissingResourceException ignoreAgain) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/help/ExtensionHelp.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/help/ExtensionHelp.java
@@ -312,13 +312,14 @@ public class ExtensionHelp extends ExtensionAdaptor {
     }
 
     private static URL getExtensionHelpSetUrl(Extension extension) {
-        String extensionPackage = extension.getClass().getPackage().getName();
+        Package extPackage = extension.getClass().getPackage();
+        String extensionPackage = extPackage != null ? extPackage.getName() + "." : "";
         String localeToken = "%LC%";
         Function<String, URL> getResource = extension.getClass().getClassLoader()::getResource;
         URL helpSetUrl =
                 LocaleUtils.findResource(
                         extensionPackage
-                                + ".resources.help"
+                                + "resources.help"
                                 + localeToken
                                 + "."
                                 + HELP_SET_FILE_NAME,
@@ -331,7 +332,7 @@ public class ExtensionHelp extends ExtensionAdaptor {
             helpSetUrl =
                     LocaleUtils.findResource(
                             extensionPackage
-                                    + ".resource.help"
+                                    + "resource.help"
                                     + localeToken
                                     + "."
                                     + HELP_SET_FILE_NAME,


### PR DESCRIPTION
Prevent `NullPointerException`s when an extension is not defined in a
package.