### PR TITLE
darkmode: Tweak Options Headline and Connection Panel

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsConnectionPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsConnectionPanel.java
@@ -39,6 +39,7 @@
 // ZAP: 2017/06/19 Use ZapNumberSpinner for connection timeout.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2020/03/24 Remove hardcoded white background on some fields (part of Issue 5542).
 package org.parosproxy.paros.extension.option;
 
 import java.awt.BorderLayout;
@@ -607,12 +608,6 @@ public class OptionsConnectionPanel extends AbstractParamPanel {
         getProxyExcludedDomainsPanel().setComponentEnabled(isEnabled);
         chkProxyChainAuth.setEnabled(isEnabled);
         setProxyChainAuthEnabled(isEnabled && chkProxyChainAuth.isSelected());
-        Color color = Color.WHITE;
-        if (!isEnabled) {
-            color = panelProxyChain.getBackground();
-        }
-        txtProxyChainName.setBackground(color);
-        spinnerProxyChainPort.setBackground(color);
     }
 
     private void setProxyChainAuthEnabled(boolean isEnabled) {
@@ -627,28 +622,12 @@ public class OptionsConnectionPanel extends AbstractParamPanel {
         if (chkProxyChainPrompt.isSelected()) {
             setProxyChainPromptEnabled(true);
         }
-
-        Color color = Color.WHITE;
-        if (!isEnabled) {
-            // ZAP: Added prompt option
-            color = panelProxyChain.getBackground();
-        }
-        txtProxyChainRealm.setBackground(color);
-        txtProxyChainUserName.setBackground(color);
-        txtProxyChainPassword.setBackground(color);
     }
 
     private void setProxyChainPromptEnabled(boolean isEnabled) {
 
         txtProxyChainPassword.setEnabled(!isEnabled);
         chkShowPassword.setEnabled(!isEnabled);
-
-        Color color = Color.WHITE;
-        if (isEnabled) {
-            txtProxyChainPassword.setText("");
-            color = panelProxyChain.getBackground();
-        }
-        txtProxyChainPassword.setBackground(color);
     }
 
     @Override

--- a/zap/src/main/java/org/parosproxy/paros/view/AbstractParamContainerPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/AbstractParamContainerPanel.java
@@ -31,6 +31,7 @@
 // ZAP: 2018/04/12 Allow to check if a param panel is selected.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2020/03/24 Remove hardcoded white background on Headline field (part of Issue 5542).
 package org.parosproxy.paros.view;
 
 import java.awt.BorderLayout;
@@ -319,7 +320,6 @@ public class AbstractParamContainerPanel extends JSplitPane {
                             javax.swing.border.EtchedBorder.RAISED));
             txtHeadline.setEditable(false);
             txtHeadline.setEnabled(false);
-            txtHeadline.setBackground(java.awt.Color.white);
             txtHeadline.setFont(FontUtils.getFont(Font.BOLD));
         }
 


### PR DESCRIPTION
Remove hardcoded white background. Per: zaproxy/zaproxy#5542

Before Dark look:
![image](https://user-images.githubusercontent.com/7570458/75347787-8be6e300-586f-11ea-9717-096fe4e8728b.png)

After Nimbus look:
![image](https://user-images.githubusercontent.com/7570458/77490631-cb263680-6e11-11ea-873e-aa100abfd4c7.png)

After Dark look:
![image](https://user-images.githubusercontent.com/7570458/77490623-c1043800-6e11-11ea-9d51-40a26e9bc65e.png)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>