### PR TITLE
Remove hardcoded colour in titled borders

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsConnectionPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsConnectionPanel.java
@@ -40,11 +40,11 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/03/24 Remove hardcoded white background on some fields (part of Issue 5542).
+// ZAP: 2020/03/25 Remove hardcoded colour in titled borders (Issue 5542).
 package org.parosproxy.paros.extension.option;
 
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
-import java.awt.Color;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -249,8 +249,7 @@ public class OptionsConnectionPanel extends AbstractParamPanel {
                             Constant.messages.getString("conn.options.proxy.useProxyChain"),
                             javax.swing.border.TitledBorder.DEFAULT_JUSTIFICATION,
                             javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard),
-                            java.awt.Color.black));
+                            FontUtils.getFont(FontUtils.Size.standard)));
             jPanel.add(getChkUseProxyChain(), gridBagConstraints15);
             jPanel.add(jLabel5, gridBagConstraints2);
             jPanel.add(getTxtProxyChainName(), gridBagConstraints3);
@@ -303,8 +302,7 @@ public class OptionsConnectionPanel extends AbstractParamPanel {
                             Constant.messages.getString("conn.options.proxy.auth.auth"),
                             javax.swing.border.TitledBorder.DEFAULT_JUSTIFICATION,
                             javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard),
-                            java.awt.Color.black));
+                            FontUtils.getFont(FontUtils.Size.standard)));
             gridBagConstraints16.gridx = 0;
             gridBagConstraints16.gridy = 0;
             gridBagConstraints16.insets = new java.awt.Insets(2, 2, 2, 2);
@@ -420,8 +418,7 @@ public class OptionsConnectionPanel extends AbstractParamPanel {
                             Constant.messages.getString("conn.options.dns.title"),
                             javax.swing.border.TitledBorder.DEFAULT_JUSTIFICATION,
                             javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard),
-                            Color.black));
+                            FontUtils.getFont(FontUtils.Size.standard)));
 
             GroupLayout layout = new GroupLayout(dnsPanel);
             dnsPanel.setLayout(layout);
@@ -791,8 +788,7 @@ public class OptionsConnectionPanel extends AbstractParamPanel {
                             Constant.messages.getString("conn.options.general"),
                             javax.swing.border.TitledBorder.DEFAULT_JUSTIFICATION,
                             javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard),
-                            java.awt.Color.black));
+                            FontUtils.getFont(FontUtils.Size.standard)));
 
             gridBagConstraints00.gridx = 0;
             gridBagConstraints00.gridy = 0;

--- a/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsViewPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsViewPanel.java
@@ -35,6 +35,7 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/02/24 Use LookAndFeelInfo when setting the look and feel option.
+// ZAP: 2020/03/25 Remove hardcoded colour in titled border (Issue 5542).
 package org.parosproxy.paros.extension.option;
 
 import java.awt.BorderLayout;
@@ -363,8 +364,7 @@ public class OptionsViewPanel extends AbstractParamPanel {
                                 fontTypeLabels.get(fontType),
                                 TitledBorder.DEFAULT_JUSTIFICATION,
                                 TitledBorder.DEFAULT_POSITION,
-                                FontUtils.getFont(FontUtils.Size.standard),
-                                Color.black));
+                                FontUtils.getFont(FontUtils.Size.standard)));
 
                 panelMisc.add(
                         fontsPanel,

--- a/zap/src/main/java/org/parosproxy/paros/extension/option/SecurityProtocolsPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/option/SecurityProtocolsPanel.java
@@ -53,8 +53,7 @@ public class SecurityProtocolsPanel extends JPanel {
                                 "generic.options.panel.security.protocols.title"),
                         javax.swing.border.TitledBorder.DEFAULT_JUSTIFICATION,
                         javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                        FontUtils.getFont(FontUtils.Size.standard),
-                        java.awt.Color.black));
+                        FontUtils.getFont(FontUtils.Size.standard)));
 
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.gridy = 0;

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertViewPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertViewPanel.java
@@ -174,8 +174,7 @@ public class AlertViewPanel extends AbstractPanel {
                         name,
                         TitledBorder.DEFAULT_JUSTIFICATION,
                         javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                        FontUtils.getFont(FontUtils.Size.standard),
-                        java.awt.Color.black));
+                        FontUtils.getFont(FontUtils.Size.standard)));
         return jScrollPane;
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/OptionsApiPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/OptionsApiPanel.java
@@ -101,8 +101,7 @@ public class OptionsApiPanel extends AbstractParamPanel {
                             Constant.messages.getString("api.options.addr.title"),
                             javax.swing.border.TitledBorder.DEFAULT_JUSTIFICATION,
                             javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard),
-                            java.awt.Color.black));
+                            FontUtils.getFont(FontUtils.Size.standard)));
 
             jPanel.add(getProxyPermittedAddressesPanel(), LayoutHelper.getGBC(0, 0, 1, 1.0, 1.0));
             panelMisc.add(jPanel, LayoutHelper.getGBC(0, y++, 2, 1.0, 1.0));

--- a/zap/src/main/java/org/zaproxy/zap/extension/authentication/ContextAuthenticationPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authentication/ContextAuthenticationPanel.java
@@ -309,8 +309,7 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
                             PANEL_TITLE_CONFIG,
                             javax.swing.border.TitledBorder.DEFAULT_JUSTIFICATION,
                             javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard),
-                            java.awt.Color.black));
+                            FontUtils.getFont(FontUtils.Size.standard)));
         }
         return configContainerPanel;
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/authorization/ContextAuthorizationPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authorization/ContextAuthorizationPanel.java
@@ -123,8 +123,7 @@ public class ContextAuthorizationPanel extends AbstractContextPropertiesPanel {
                         "",
                         javax.swing.border.TitledBorder.DEFAULT_JUSTIFICATION,
                         javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                        FontUtils.getFont(FontUtils.Size.standard),
-                        java.awt.Color.black));
+                        FontUtils.getFont(FontUtils.Size.standard)));
         this.add(configContainerPanel, LayoutHelper.getGBC(0, 2, 2, 0.0D));
 
         configContainerPanel.add(

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
@@ -250,8 +250,7 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
                             Constant.messages.getString("cfu.label.zap.border"),
                             TitledBorder.DEFAULT_JUSTIFICATION,
                             javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard),
-                            java.awt.Color.black));
+                            FontUtils.getFont(FontUtils.Size.standard)));
 
             if (latestInfo == null || this.latestInfo.getZapRelease() == null) {
                 // Haven't checked for updates yet
@@ -310,8 +309,7 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
                             Constant.messages.getString("cfu.label.addons.border"),
                             TitledBorder.DEFAULT_JUSTIFICATION,
                             javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard),
-                            java.awt.Color.black));
+                            FontUtils.getFont(FontUtils.Size.standard)));
 
             getInstalledAddOnsTable();
 
@@ -387,8 +385,7 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
                             Constant.messages.getString("cfu.label.addons.border"),
                             TitledBorder.DEFAULT_JUSTIFICATION,
                             javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard),
-                            java.awt.Color.black));
+                            FontUtils.getFont(FontUtils.Size.standard)));
 
             if (latestInfo != null) {
                 getMarketplaceCardLayout().show(getMarketplacePanel(), MARKETPLACE_PANEL);

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/OptionsCheckForUpdatesPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/OptionsCheckForUpdatesPanel.java
@@ -88,8 +88,7 @@ public class OptionsCheckForUpdatesPanel extends AbstractParamPanel {
                             Constant.messages.getString("cfu.options.zap.border"),
                             TitledBorder.DEFAULT_JUSTIFICATION,
                             javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard),
-                            java.awt.Color.black));
+                            FontUtils.getFont(FontUtils.Size.standard)));
 
             zapPanel.add(getChkDownloadNewRelease(), LayoutHelper.getGBC(0, 1, 1, 1.0D));
 
@@ -101,8 +100,7 @@ public class OptionsCheckForUpdatesPanel extends AbstractParamPanel {
                             Constant.messages.getString("cfu.options.updates.border"),
                             TitledBorder.DEFAULT_JUSTIFICATION,
                             javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard),
-                            java.awt.Color.black));
+                            FontUtils.getFont(FontUtils.Size.standard)));
 
             updPanel.add(getChkCheckAddonUpdates(), LayoutHelper.getGBC(0, 0, 1, 1.0D));
             updPanel.add(getChkInstallAddonUpdates(), LayoutHelper.getGBC(0, 1, 1, 1.0D));
@@ -116,8 +114,7 @@ public class OptionsCheckForUpdatesPanel extends AbstractParamPanel {
                             Constant.messages.getString("cfu.options.new.border"),
                             TitledBorder.DEFAULT_JUSTIFICATION,
                             javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard),
-                            java.awt.Color.black));
+                            FontUtils.getFont(FontUtils.Size.standard)));
 
             newPanel.add(getChkReportReleaseAddons(), LayoutHelper.getGBC(0, 0, 1, 1.0D));
             newPanel.add(getChkReportBetaAddons(), LayoutHelper.getGBC(0, 1, 1, 1.0D));
@@ -131,8 +128,7 @@ public class OptionsCheckForUpdatesPanel extends AbstractParamPanel {
                             Constant.messages.getString("cfu.options.dir.border"),
                             TitledBorder.DEFAULT_JUSTIFICATION,
                             javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard),
-                            java.awt.Color.black));
+                            FontUtils.getFont(FontUtils.Size.standard)));
 
             dirsPanel.add(
                     new CfuDirsOptionsPanel(getScriptDirModel()),

--- a/zap/src/main/java/org/zaproxy/zap/extension/encoder2/EncodeDecodeDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/encoder2/EncodeDecodeDialog.java
@@ -110,8 +110,7 @@ public class EncodeDecodeDialog extends AbstractFrame {
                         title,
                         TitledBorder.DEFAULT_JUSTIFICATION,
                         javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                        FontUtils.getFont(FontUtils.Size.standard),
-                        java.awt.Color.black));
+                        FontUtils.getFont(FontUtils.Size.standard)));
 
         parent.add(jsp, gbc);
     }
@@ -289,8 +288,7 @@ public class EncodeDecodeDialog extends AbstractFrame {
                             Constant.messages.getString("enc2.label.text"),
                             TitledBorder.DEFAULT_JUSTIFICATION,
                             javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard),
-                            java.awt.Color.black));
+                            FontUtils.getFont(FontUtils.Size.standard)));
 
             // addField(jPanel, 1, getInputField(), "Text to be encoded/decoded/hashed");
             // addField(jPanel, 2, jTabbed, "Text to be encoded/decoded/hashed");

--- a/zap/src/main/java/org/zaproxy/zap/extension/encoder2/EncodeDecodeParamPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/encoder2/EncodeDecodeParamPanel.java
@@ -82,8 +82,7 @@ public class EncodeDecodeParamPanel extends AbstractParamPanel {
                             NAME_BASE64,
                             TitledBorder.DEFAULT_JUSTIFICATION,
                             TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard),
-                            java.awt.Color.black));
+                            FontUtils.getFont(FontUtils.Size.standard)));
 
             gbc.gridx = 0;
             gbc.gridy = 0;

--- a/zap/src/main/java/org/zaproxy/zap/extension/proxies/OptionsLocalProxyPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/proxies/OptionsLocalProxyPanel.java
@@ -132,8 +132,7 @@ public class OptionsLocalProxyPanel extends JPanel {
                         Constant.messages.getString("options.proxy.local.title"),
                         javax.swing.border.TitledBorder.DEFAULT_JUSTIFICATION,
                         javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                        FontUtils.getFont(FontUtils.Size.standard),
-                        java.awt.Color.black));
+                        FontUtils.getFont(FontUtils.Size.standard)));
 
         jLabel.setText(Constant.messages.getString("options.proxy.local.label.address"));
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/proxies/OptionsProxiesPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/proxies/OptionsProxiesPanel.java
@@ -139,8 +139,7 @@ public class OptionsProxiesPanel extends AbstractParamPanel {
                             Constant.messages.getString("options.proxy.additional.title"),
                             javax.swing.border.TitledBorder.DEFAULT_JUSTIFICATION,
                             javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard),
-                            java.awt.Color.black));
+                            FontUtils.getFont(FontUtils.Size.standard)));
         }
         return proxiesOptionsPanel;
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/sessions/ContextSessionManagementPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/sessions/ContextSessionManagementPanel.java
@@ -215,8 +215,7 @@ public class ContextSessionManagementPanel extends AbstractContextPropertiesPane
                             Constant.messages.getString("sessionmanagement.panel.config.title"),
                             javax.swing.border.TitledBorder.DEFAULT_JUSTIFICATION,
                             javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard),
-                            java.awt.Color.black));
+                            FontUtils.getFont(FontUtils.Size.standard)));
         }
         return configContainerPanel;
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/stats/OptionsStatsPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stats/OptionsStatsPanel.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.stats;
 
 import java.awt.CardLayout;
-import java.awt.Color;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -76,8 +75,7 @@ public class OptionsStatsPanel extends AbstractParamPanel {
                             Constant.messages.getString("stats.options.statsd.panel"),
                             TitledBorder.DEFAULT_JUSTIFICATION,
                             TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard),
-                            Color.black));
+                            FontUtils.getFont(FontUtils.Size.standard)));
 
             statsdPanel.add(
                     new JLabel(Constant.messages.getString("stats.options.label.statsd.host")),

--- a/zap/src/main/java/org/zaproxy/zap/view/OptionsConnectionPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/OptionsConnectionPanel.java
@@ -104,8 +104,7 @@ public class OptionsConnectionPanel extends AbstractParamPanel {
                             Constant.messages.getString("conn.options.proxy.auth.auth"),
                             javax.swing.border.TitledBorder.DEFAULT_JUSTIFICATION,
                             javax.swing.border.TitledBorder.DEFAULT_POSITION,
-                            FontUtils.getFont(FontUtils.Size.standard),
-                            java.awt.Color.black));
+                            FontUtils.getFont(FontUtils.Size.standard)));
             gridBagConstraints16.gridx = 0;
             gridBagConstraints16.gridy = 0;
             gridBagConstraints16.insets = new java.awt.Insets(2, 2, 2, 2);


### PR DESCRIPTION
Do not specify any colour when creating the titled border, let the look
and feel use the most appropriate one.

Part of #5542.