### PR TITLE
Use vararg in TechSet

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/model/TechSet.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/TechSet.java
@@ -30,7 +30,7 @@ public class TechSet {
 
     public TechSet() {}
 
-    public TechSet(Tech[] include) {
+    public TechSet(Tech... include) {
         this(include, (Tech[]) null);
     }
 


### PR DESCRIPTION
Change TechSet to use vararg in the constructor of included techs, to
make it less verbose (i.e. don't require the explicit creation of an
array).