### PR TITLE
Docker Java 11 Updates

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2020-04-01
+- Changed live and weekly images to use Java 11.
+
 ### 2020-02-21
  - Changed zap-full-scan.py, zap-api-scan.py, and zap-baseline-scan.py to include the missing check for markdown file.
 

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	automake \
 	autoconf \
 	gcc g++ \
-	openjdk-8-jdk \
+	openjdk-11-jdk \
 	wget \
 	curl \
 	xmlstarlet \
@@ -45,7 +45,7 @@ USER zap
 
 RUN mkdir /home/zap/.vnc
 
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64/
 ENV PATH $JAVA_HOME/bin:/zap/:$PATH
 
 # Pull the ZAP repo

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	automake \
 	autoconf \
 	gcc g++ \
-	openjdk-8-jdk \
+	openjdk-11-jdk \
 	wget \
 	curl \
 	xmlstarlet \
@@ -56,7 +56,7 @@ RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersio
 	touch AcceptedLicense
 
 
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64/
 ENV PATH $JAVA_HOME/bin:/zap/:$PATH
 ENV ZAP_PATH /zap/zap.sh
 


### PR DESCRIPTION
There doesn't appear to be an OpenJDK Alpine option for the bare image.
We could switch to: https://github.com/docker-library/openjdk/tree/master/11/jdk/slim ?

I've updated the other 3 standard images to OpenJDK 11.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>