### PR TITLE
Update FlatLaf

### DIFF
--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
         setTransitive(false)
     }
     implementation("org.javadelight:delight-nashorn-sandbox:0.1.26")
-    implementation("com.formdev:flatlaf:0.27")
+    implementation("com.formdev:flatlaf:0.29")
 
     runtimeOnly("commons-jxpath:commons-jxpath:1.3")
     runtimeOnly("commons-logging:commons-logging:1.2")


### PR DESCRIPTION
Update to latest version, 0.29, to pick the latest features (e.g. use
default font).

Part of #5542.