### PR TITLE
Expose enable related state in scripts API

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptAPI.java
@@ -199,6 +199,10 @@ public class ScriptAPI extends ApiImplementor {
                                 ? Constant.messages.getString(descKey)
                                 : "";
                 data.put("description", description);
+                data.put("enableable", String.valueOf(type.isEnableable()));
+                if (type.isEnableable()) {
+                    data.put("enabledByDefault", String.valueOf(type.isEnabledByDefault()));
+                }
                 result.addItem(new ApiResponseSet<>("type", data));
             }
             return result;


### PR DESCRIPTION
Allow to know if a script type can be enabled and whether it's enabled
by default.