### PR TITLE
Copy scan policies for root in Docker scans

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2020-04-06
+- Make API scan policy available to the root user, otherwise it would fail to start the active scan.
+
 ### 2020-04-01
 - Changed live and weekly images to use Java 11.
 

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -76,6 +76,7 @@ ENV LANG=C.UTF-8
 COPY zap* CHANGELOG.md /zap/
 COPY webswing.config /zap/webswing/
 COPY policies /home/zap/.ZAP_D/policies/
+COPY policies /root/.ZAP_D/policies/
 COPY scripts /home/zap/.ZAP_D/scripts/
 COPY .xinitrc /home/zap/
 

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -68,6 +68,7 @@ ENV LANG=C.UTF-8
 COPY zap* CHANGELOG.md /zap/
 COPY webswing.config /zap/webswing/
 COPY policies /home/zap/.ZAP/policies/
+COPY policies /root/.ZAP/policies/
 # The scan script loads the scripts from dev home dir.
 COPY scripts /home/zap/.ZAP_D/scripts/
 COPY .xinitrc /home/zap/

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -69,6 +69,7 @@ ENV LANG=C.UTF-8
 COPY zap* CHANGELOG.md /zap/
 COPY webswing.config /zap/webswing/
 COPY policies /home/zap/.ZAP_D/policies/
+COPY policies /root/.ZAP_D/policies/
 COPY scripts /home/zap/.ZAP_D/scripts/
 COPY .xinitrc /home/zap/
 

--- a/docker/zap-api-scan.py
+++ b/docker/zap-api-scan.py
@@ -541,7 +541,7 @@ def main(argv):
             logging.warning('I/O error: ' + str(e))
         dump_log_file(cid)
 
-    except NoUrlsException:
+    except (NoUrlsException, ScanNotStartedException):
         dump_log_file(cid)
 
     except:

--- a/docker/zap-full-scan.py
+++ b/docker/zap-full-scan.py
@@ -469,6 +469,9 @@ def main(argv):
             logging.warning('I/O error: ' + str(e))
         dump_log_file(cid)
 
+    except ScanNotStartedException:
+        dump_log_file(cid)
+
     except:
         print("ERROR " + str(sys.exc_info()[0]))
         logging.warning('Unexpected error: ' + str(sys.exc_info()[0]))

--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -43,6 +43,10 @@ except ImportError:
     logging.warning('Error importing pkg_resources. Is setuptools installed?')
 
 
+class ScanNotStartedException(Exception):
+    pass
+
+
 OLD_ZAP_CLIENT_WARNING = '''A newer version of python_owasp_zap_v2.4
  is available. Please run \'pip install -U python_owasp_zap_v2.4\' to update to
  the latest version.'''.replace('\n', '')
@@ -395,6 +399,10 @@ def zap_ajax_spider(zap, target, max_time):
 def zap_active_scan(zap, target, policy):
     logging.debug('Active Scan ' + target + ' with policy ' + policy)
     ascan_scan_id = zap.ascan.scan(target, recurse=True, scanpolicyname=policy)
+    try:
+        int(ascan_scan_id)
+    except ValueError:
+        raise ScanNotStartedException('Failed to start the scan, check the log/output for more details.')
     time.sleep(5)
 
     while(int(zap.ascan.status(ascan_scan_id)) < 100):


### PR DESCRIPTION
Copy the scan policies for the root user to ensure they are available
when starting the active scan.
Also, verify that the scan really started to provide early/accurate
error message.

Fix #5581 - Error when using zap-api-scan.py in docker