### PR TITLE
Add the -I 'ignore only warnings' command line option 

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
-### 2020-04-06
+### 2020-04-08
 - Changed zap-full-scan.py and zap-api-scan.py to include the -I option to ignore only warning used by zap-baseline-scan.py
 
 ### 2020-04-06

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to the docker containers will be documented in this file.
 
 ### 2020-04-06
+- Changed zap-full-scan.py and zap-api-scan.py to include the -I option to ignore only warning used by zap-baseline-scan.py
+
+### 2020-04-06
 - Make API scan policy available to the root user, otherwise it would fail to start the active scan.
 
 ### 2020-04-01

--- a/docker/zap-api-scan.py
+++ b/docker/zap-api-scan.py
@@ -99,6 +99,7 @@ def usage():
     print('    -P                specify listen port')
     print('    -D                delay in seconds to wait for passive scanning ')
     print('    -i                default rules not in the config file to INFO')
+    print('    -I                do not return failure on warning')
     print('    -l level          minimum level to show: PASS, IGNORE, INFO, WARN or FAIL, use with -s to hide example URLs')
     print('    -n context_file   context file which will be loaded prior to scanning the target')
     print('    -p progress_file  progress file which specifies issues that are being addressed')
@@ -141,6 +142,7 @@ def main(argv):
     zap_options = ''
     delay = 0
     timeout = 0
+    ignore_warn = False
     hook_file = None
 
     pass_count = 0
@@ -195,6 +197,8 @@ def main(argv):
             zap_alpha = True
         elif opt == '-i':
             info_unspecified = True
+        elif opt == '-I':
+            ignore_warn = True
         elif opt == '-l':
             try:
                 min_level = zap_conf_lvls.index(arg)
@@ -556,7 +560,7 @@ def main(argv):
 
     if fail_count > 0:
         sys.exit(1)
-    elif warn_count > 0:
+    elif (not ignore_warn) and warn_count > 0:
         sys.exit(2)
     elif pass_count > 0:
         sys.exit(0)

--- a/docker/zap-api-scan.py
+++ b/docker/zap-api-scan.py
@@ -154,7 +154,7 @@ def main(argv):
     fail_inprog_count = 0
 
     try:
-        opts, args = getopt.getopt(argv, "t:f:c:u:g:m:n:r:J:w:x:l:hdaijSp:sz:P:D:T:I:O:", ["hook="])
+        opts, args = getopt.getopt(argv, "t:f:c:u:g:m:n:r:J:w:x:l:hdaijSp:sz:P:D:T:IO:", ["hook="])
     except getopt.GetoptError as exc:
         logging.warning('Invalid option ' + exc.opt + ' : ' + exc.msg)
         usage()

--- a/docker/zap-api-scan.py
+++ b/docker/zap-api-scan.py
@@ -154,7 +154,7 @@ def main(argv):
     fail_inprog_count = 0
 
     try:
-        opts, args = getopt.getopt(argv, "t:f:c:u:g:m:n:r:J:w:x:l:hdaijSp:sz:P:D:T:O:", ["hook="])
+        opts, args = getopt.getopt(argv, "t:f:c:u:g:m:n:r:J:w:x:l:hdaijSp:sz:P:D:T:I:O:", ["hook="])
     except getopt.GetoptError as exc:
         logging.warning('Invalid option ' + exc.opt + ' : ' + exc.msg)
         usage()

--- a/docker/zap-full-scan.py
+++ b/docker/zap-full-scan.py
@@ -90,6 +90,7 @@ def usage():
     print('    -P                specify listen port')
     print('    -D                delay in seconds to wait for passive scanning ')
     print('    -i                default rules not in the config file to INFO')
+    print('    -I                do not return failure on warning')
     print('    -j                use the Ajax spider in addition to the traditional one')
     print('    -l level          minimum level to show: PASS, IGNORE, INFO, WARN or FAIL, use with -s to hide example URLs')
     print('    -n context_file   context file which will be loaded prior to scanning the target')
@@ -128,6 +129,7 @@ def main(argv):
     zap_options = ''
     delay = 0
     timeout = 0
+    ignore_warn = False
     hook_file = None
 
     pass_count = 0
@@ -182,6 +184,8 @@ def main(argv):
             zap_alpha = True
         elif opt == '-i':
             info_unspecified = True
+        elif opt == '-I':
+            ignore_warn = True
         elif opt == '-j':
             ajax = True
         elif opt == '-l':
@@ -484,7 +488,7 @@ def main(argv):
 
     if fail_count > 0:
         sys.exit(1)
-    elif warn_count > 0:
+    elif (not ignore_warn) and warn_count > 0:
         sys.exit(2)
     elif pass_count > 0:
         sys.exit(0)

--- a/docker/zap-full-scan.py
+++ b/docker/zap-full-scan.py
@@ -141,7 +141,7 @@ def main(argv):
     fail_inprog_count = 0
 
     try:
-        opts, args = getopt.getopt(argv, "t:c:u:g:m:n:r:J:w:x:l:hdaijp:sz:P:D:T:", ["hook="])
+        opts, args = getopt.getopt(argv, "t:c:u:g:m:n:r:J:w:x:l:hdaijp:sz:P:D:T:I", ["hook="])
     except getopt.GetoptError as exc:
         logging.warning('Invalid option ' + exc.opt + ' : ' + exc.msg)
         usage()


### PR DESCRIPTION
zap-baseline.py contains a command line option "-I 'ignore only warnings'" that is missing from the zap-full-scan.py and zap-api-scan.py scripts.  This modifies both scripts to include the option.

Fixes zaproxy/zaproxy#5928.