### PR TITLE
Update FlatLaf to v0.30

### DIFF
--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
         setTransitive(false)
     }
     implementation("org.javadelight:delight-nashorn-sandbox:0.1.26")
-    implementation("com.formdev:flatlaf:0.29")
+    implementation("com.formdev:flatlaf:0.30")
 
     runtimeOnly("commons-jxpath:commons-jxpath:1.3")
     runtimeOnly("commons-logging:commons-logging:1.2")


### PR DESCRIPTION
Update to latest version, 0.30, to pick the latest features (e.g. use composite font).

Part of zaproxy/zaproxy#5542.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>