### PR TITLE
Check -config override when determining the locale

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/ZapBootstrap.java
+++ b/zap/src/main/java/org/zaproxy/zap/ZapBootstrap.java
@@ -73,7 +73,7 @@ abstract class ZapBootstrap {
         Logger.getLogger(DefaultFileSystem.class).addAppender(na);
 
         try {
-            Constant.getInstance();
+            Constant.createInstance(controlOverrides);
         } catch (final Throwable e) {
             System.err.println(e.getMessage());
             return 1;


### PR DESCRIPTION
Initialise the `Constant` with the `ControlOverrides` so that it can
check if the locale config is being set.

Fix #5934 - Allow language to be specified on commandline