### PR TITLE
Add application/vnd.api+json to expected API types

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2020-04-27
+- Add `application/vnd.api+json` to the list of expected API content types.
+
 ### 2020-04-08
 - Changed zap-full-scan.py and zap-api-scan.py to include the -I option to ignore only warning used by zap-baseline-scan.py
 

--- a/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
+++ b/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
@@ -13,6 +13,7 @@ var expectedTypes = [
 		"application/problem+json",
 		"application/problem+xml",
 		"application/soap+xml",
+		"application/vnd.api+json",
 		"application/xml",
 		"application/x-yaml",
 		"text/x-json",


### PR DESCRIPTION
Add application/vnd.api+json to the list of expected content types.
Ref:
https://www.iana.org/assignments/media-types/application/vnd.api+json

Fix #5939 - Add "application/vnd.api+json" to Content-Type