### PR TITLE
added known csrf token for pfsense

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/AntiCsrfParam.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/AntiCsrfParam.java
@@ -53,7 +53,8 @@ public class AntiCsrfParam extends AbstractParam {
         "anoncsrf",
         "csrf_token",
         "_csrf",
-        "_csrfSecret"
+        "_csrfSecret",
+        "__csrf_magic"
     };
 
     private List<AntiCsrfParamToken> tokens = null;


### PR DESCRIPTION
the pfsense opensource security router/firewall distribution uses a known csrf token which has been added to the list.