### PR TITLE
Make python command use Python 3 in Docker images

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+###  2020-05-13
+ - Make `python` command use Python 3.
+
 ### 2020-05-12
  - Removed python 2, only python 3 will be supported going forward.
 

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	xterm \
 	net-tools \
 	python3-pip \
+	python-is-python3
 	firefox \
 	vim \
 	xvfb \

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	xterm \
 	net-tools \
 	python3-pip \
+	python-is-python3
 	firefox \
 	xvfb \
 	x11vnc && \

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	xterm \
 	net-tools \
 	python3-pip \
+	python-is-python3
 	firefox \
 	xvfb \
 	x11vnc && \


### PR DESCRIPTION
Install the package `python-is-python3` to use Python 3 with `python`.

Fix #5978.