### PR TITLE
Correct extraction of the add-on ID

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
@@ -555,7 +555,7 @@ public class AddOn {
     }
 
     private static String extractAddOnId(String fileName) {
-        return fileName.substring(0, fileName.indexOf('.')).split("-")[0];
+        return fileName.substring(0, fileName.lastIndexOf('.')).split("-")[0];
     }
 
     private void loadManifestFile() throws IOException {

--- a/zap/src/test/java/org/zaproxy/zap/control/AddOnUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/AddOnUnitTest.java
@@ -568,6 +568,18 @@ public class AddOnUnitTest extends TestUtils {
     }
 
     @Test
+    public void shouldCreateAddOnWithDotsInId() throws Exception {
+        // Given
+        Path file = createAddOnFile("addon.x.zap", "release", "1.0.0");
+        // When
+        AddOn addOn = new AddOn(file);
+        // Then
+        assertThat(addOn.getId(), is(equalTo("addon.x")));
+        assertThat(addOn.getStatus(), is(equalTo(AddOn.Status.release)));
+        assertThat(addOn.getVersion().toString(), is(equalTo("1.0.0")));
+    }
+
+    @Test
     public void shouldIgnoreStatusInFileNameWhenCreatingAddOnFromFile() throws Exception {
         // Given
         Path file = createAddOnFile("addon-alpha.zap", "release", "1");


### PR DESCRIPTION
Find the last dot not the first, when parsing the file name of the
add-on, otherwise IDs with dots would be incorrect.