### PR TITLE
Include Common Library add-on in weekly releases

### DIFF
--- a/zap/src/main/weekly-add-ons.json
+++ b/zap/src/main/weekly-add-ons.json
@@ -8,6 +8,7 @@
       ":addOns:ascanrules",
       ":addOns:ascanrulesBeta",
       ":addOns:bruteforce",
+      ":addOns:commonlib",
       ":addOns:coreLang",
       ":addOns:diff",
       ":addOns:directorylistv1",


### PR DESCRIPTION
The add-on is now a dependency of several active/passive scan rules
add-ons (zaproxy/zap-extensions#2392).