### PR TITLE
Do not delete add-on data dir if not empty

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnInstaller.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnInstaller.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import org.apache.commons.lang.Validate;
@@ -70,6 +71,13 @@ public final class AddOnInstaller {
 
     /** The base directory to where add-on data (e.g. libraries) is copied. */
     private static final String ADD_ON_DATA_DIR = "addOnData";
+
+    /**
+     * The name of the directory that contains the libraries of an add-on.
+     *
+     * @see #getAddOnLibsDir(AddOn)
+     */
+    private static final String ADD_ON_DATA_LIBS_DIR = "libs";
 
     private AddOnInstaller() {}
 
@@ -480,7 +488,7 @@ public final class AddOnInstaller {
             return true;
         }
 
-        Path targetDir = getAddOnDataDir(addOn).resolve("libs");
+        Path targetDir = getAddOnLibsDir(addOn);
         try {
             Files.createDirectories(targetDir);
         } catch (IOException e) {
@@ -539,8 +547,21 @@ public final class AddOnInstaller {
      * @return the path to the directory.
      * @see #ADD_ON_DATA_DIR
      */
-    private static Path getAddOnDataDir(AddOn addOn) {
+    static Path getAddOnDataDir(AddOn addOn) {
         return Paths.get(Constant.getZapHome(), ADD_ON_DATA_DIR, addOn.getId());
+    }
+
+    /**
+     * Gets the path to the libraries directory of the given add-on.
+     *
+     * <p>The path is built as: {@code <zapHome>/addOnData/<addOnId>/libs/}
+     *
+     * @param addOn the add-on.
+     * @return the path to the directory.
+     * @see #ADD_ON_DATA_LIBS_DIR
+     */
+    static Path getAddOnLibsDir(AddOn addOn) {
+        return getAddOnDataDir(addOn).resolve(ADD_ON_DATA_LIBS_DIR);
     }
 
     /**
@@ -562,18 +583,34 @@ public final class AddOnInstaller {
      * @param addOn the add-on that will have the declared libraries uninstalled.
      * @see #installAddOnLibs(AddOn)
      * @see #installMissingAddOnLibs(AddOn)
+     * @return {@code true} if the libraries were uninstalled without errors, {@code false}
+     *     otherwise.
      */
-    static void uninstallAddOnLibs(AddOn addOn) {
+    static boolean uninstallAddOnLibs(AddOn addOn) {
         List<AddOn.Lib> libs = addOn.getLibs();
         if (libs.isEmpty()) {
-            return;
+            return true;
         }
 
+        Path addOnLibsDir = getAddOnLibsDir(addOn);
         try {
-            deleteDir(getAddOnDataDir(addOn));
+            deleteDir(addOnLibsDir);
         } catch (IOException e) {
             logger.error("An error occurred while uninstalling libraries for " + addOn, e);
+            return false;
         }
+
+        Path addOnDataDir = addOnLibsDir.getParent();
+        try (Stream<Path> entries = Files.list(addOnDataDir)) {
+            if (!entries.findAny().isPresent()) {
+                Files.delete(addOnDataDir);
+            }
+        } catch (IOException e) {
+            logger.warn("An error occurred while removing the directory " + addOnDataDir, e);
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/zap/src/test/java/org/zaproxy/zap/control/AddOnInstallerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/AddOnInstallerUnitTest.java
@@ -1,0 +1,218 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.control;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+
+/** Unit test for {@link AddOnInstaller}. */
+public class AddOnInstallerUnitTest extends AddOnTestUtils {
+
+    @BeforeEach
+    public void createZapHome() throws Exception {
+        Constant.setZapHome(newTempDir("home").toAbsolutePath().toString());
+    }
+
+    @Test
+    public void shouldReturnAddOnDataDir() throws Exception {
+        // Given
+        AddOn addOn = new AddOn(createAddOnFile("addOnId.zap"));
+        // When
+        Path addOnDataDir = AddOnInstaller.getAddOnDataDir(addOn);
+        // Then
+        assertThat(
+                Paths.get(Constant.getZapHome()).relativize(addOnDataDir),
+                is(equalTo(Paths.get("addOnData/addOnId"))));
+    }
+
+    @Test
+    public void shouldReturnAddOnLibsDir() throws Exception {
+        // Given
+        AddOn addOn = new AddOn(createAddOnFile("addOnId.zap"));
+        // When
+        Path addOnLibsDir = AddOnInstaller.getAddOnLibsDir(addOn);
+        // Then
+        assertThat(
+                Paths.get(Constant.getZapHome()).relativize(addOnLibsDir),
+                is(equalTo(Paths.get("addOnData/addOnId/libs"))));
+    }
+
+    @Test
+    public void shouldNotInstallAddOnLibsIfNone() throws Exception {
+        // Given
+        AddOn addOn = new AddOn(createAddOnFile("addon.zap"));
+        // When
+        boolean successfully = AddOnInstaller.installAddOnLibs(addOn);
+        // Then
+        assertThat(successfully, is(equalTo(true)));
+        assertThat(Files.notExists(AddOnInstaller.getAddOnDataDir(addOn)), is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldInstallAddOnLibs() throws Exception {
+        // Given
+        AddOn addOn = new AddOn(createAddOnWithLibs("lib1", "lib2"));
+        // When
+        boolean successfully = AddOnInstaller.installAddOnLibs(addOn);
+        // Then
+        assertThat(successfully, is(equalTo(true)));
+        assertInstalledLibs(addOn, "lib1", "lib2");
+    }
+
+    @Test
+    public void shouldInstallAddOnLibsOverwritingExisting() throws Exception {
+        // Given
+        AddOn addOn = new AddOn(createAddOnWithLibs("lib1", "lib2"));
+        Path lib2 = installLib(addOn, "lib2", "FileContents");
+        // When
+        boolean successfully = AddOnInstaller.installAddOnLibs(addOn);
+        // Then
+        assertThat(successfully, is(equalTo(true)));
+        assertThat(contents(lib2), is(equalTo(DEFAULT_LIB_CONTENTS)));
+    }
+
+    @Test
+    public void shouldInstallMissingAddOnLibs() throws Exception {
+        // Given
+        AddOn addOn = new AddOn(createAddOnWithLibs("lib1", "lib2"));
+        installLib(addOn, "lib2");
+        // When
+        boolean successfully = AddOnInstaller.installMissingAddOnLibs(addOn);
+        // Then
+        assertThat(successfully, is(equalTo(true)));
+        assertInstalledLibs(addOn, "lib1", "lib2");
+    }
+
+    @Test
+    public void shouldInstallMissingAddOnLibsNotOverwritingExisting() throws Exception {
+        // Given
+        AddOn addOn = new AddOn(createAddOnWithLibs("lib1", "lib2"));
+        Path lib2 = installLib(addOn, "lib2", "FileContents");
+        // When
+        boolean successfully = AddOnInstaller.installMissingAddOnLibs(addOn);
+        // Then
+        assertThat(successfully, is(equalTo(true)));
+        assertInstalledLibs(addOn, "lib1", "lib2");
+        assertThat(contents(lib2), is(equalTo("FileContents")));
+    }
+
+    @Test
+    public void shouldUninstallAddOnLibsAndRemoveDataDirIfEmpty() throws Exception {
+        // Given
+        AddOn addOn = new AddOn(createAddOnWithLibs("lib1", "lib2"));
+        installLib(addOn, "lib1");
+        installLib(addOn, "lib2");
+        // When
+        boolean successfully = AddOnInstaller.uninstallAddOnLibs(addOn);
+        // Then
+        assertThat(successfully, is(equalTo(true)));
+        assertThat(Files.notExists(AddOnInstaller.getAddOnDataDir(addOn)), is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldUninstallAddOnLibsAndKeepDataDirIfNotEmpty() throws Exception {
+        // Given
+        AddOn addOn = new AddOn(createAddOnWithLibs("lib1", "lib2"));
+        Path customFile = createFile(AddOnInstaller.getAddOnDataDir(addOn).resolve("customFile"));
+        // When
+        boolean successfully = AddOnInstaller.uninstallAddOnLibs(addOn);
+        // Then
+        assertThat(successfully, is(equalTo(true)));
+        assertThat(Files.notExists(addOnDataLibsDir(addOn)), is(equalTo(true)));
+        assertThat(Files.exists(customFile), is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldUninstallAllAddOnLibsEvenIfSomeNotDeclared() throws Exception {
+        // Given
+        AddOn addOn = new AddOn(createAddOnWithLibs("lib1", "lib2"));
+        installLib(addOn, "lib1");
+        installLib(addOn, "lib2");
+        installLib(addOn, "libNotDeclared");
+        // When
+        boolean successfully = AddOnInstaller.uninstallAddOnLibs(addOn);
+        // Then
+        assertThat(successfully, is(equalTo(true)));
+        assertThat(Files.notExists(AddOnInstaller.getAddOnDataDir(addOn)), is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldNotUninstallAddOnLibsIfNoneDeclared() throws Exception {
+        // Given
+        AddOn addOn = new AddOn(createAddOnFile("addon.zap"));
+        installLib(addOn, "lib1");
+        installLib(addOn, "lib2");
+        // When
+        boolean successfully = AddOnInstaller.uninstallAddOnLibs(addOn);
+        // Then
+        assertThat(successfully, is(equalTo(true)));
+        assertInstalledLibs(addOn, "lib1", "lib2");
+    }
+
+    private static Path addOnDataLibsDir(AddOn addOn) {
+        return AddOnInstaller.getAddOnDataDir(addOn).resolve("libs");
+    }
+
+    private static Path installLib(AddOn addOn, String name) throws IOException {
+        return installLib(addOn, name, null);
+    }
+
+    private static Path installLib(AddOn addOn, String name, String contents) throws IOException {
+        Path addOnLibsDir = addOnDataLibsDir(addOn);
+        return createFile(addOnLibsDir.resolve(name), contents);
+    }
+
+    private static Path createFile(Path file) throws IOException {
+        return createFile(file, null);
+    }
+
+    private static Path createFile(Path file, String contents) throws IOException {
+        Files.createDirectories(file.getParent());
+        String data = contents != null ? contents : DEFAULT_LIB_CONTENTS;
+        Files.write(file, data.getBytes(StandardCharsets.UTF_8));
+        return file;
+    }
+
+    private static void assertInstalledLibs(AddOn addOn, String... fileNames) throws IOException {
+        Path addOnLibsDir = addOnDataLibsDir(addOn);
+        assertThat(
+                Files.list(addOnLibsDir)
+                        .map(Path::getFileName)
+                        .map(Path::toString)
+                        .collect(Collectors.toList()),
+                containsInAnyOrder(fileNames));
+    }
+
+    private static String contents(Path file) throws IOException {
+        return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/control/AddOnTestUtils.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/AddOnTestUtils.java
@@ -1,0 +1,167 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.control;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.function.Consumer;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.zaproxy.zap.WithConfigsTest;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+class AddOnTestUtils extends WithConfigsTest {
+
+    static final String DEFAULT_LIB_CONTENTS = "Default Lib Content";
+    private static final byte[] DEFAULT_LIB_CONTENTS_BYTES =
+            DEFAULT_LIB_CONTENTS.getBytes(StandardCharsets.UTF_8);
+
+    protected Path createEmptyAddOnFile(String fileName) {
+        try {
+            Path file = newTempDir().resolve(fileName);
+            new ZipOutputStream(Files.newOutputStream(file)).close();
+            return file;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected Path createAddOnWithLibs(String... libs) {
+        return createAddOnFile(
+                "addon.zap",
+                "release",
+                "1.0.0",
+                manifest -> {
+                    if (libs == null || libs.length == 0) {
+                        return;
+                    }
+
+                    manifest.append("<libs>");
+                    for (String lib : libs) {
+                        manifest.append("<lib>").append(lib).append("</lib>");
+                    }
+                    manifest.append("</libs>");
+                },
+                addOnContents -> {
+                    if (libs == null || libs.length == 0) {
+                        return;
+                    }
+                    try {
+                        for (String lib : libs) {
+                            ZipEntry ze = new ZipEntry(lib);
+                            addOnContents.putNextEntry(ze);
+                            addOnContents.write(
+                                    DEFAULT_LIB_CONTENTS_BYTES,
+                                    0,
+                                    DEFAULT_LIB_CONTENTS_BYTES.length);
+                            addOnContents.closeEntry();
+                        }
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                });
+    }
+
+    protected Path createAddOnFile(String fileName) {
+        return createAddOnFile(fileName, "release", "1.0.0", (String) null);
+    }
+
+    protected Path createAddOnFile(String fileName, String status, String version) {
+        return createAddOnFile(fileName, status, version, (String) null);
+    }
+
+    protected Path createAddOnFile(
+            String fileName, String status, String version, String javaVersion) {
+        return createAddOnFile(fileName, status, version, javaVersion, null, null);
+    }
+
+    protected Path createAddOnFile(
+            String fileName,
+            String status,
+            String version,
+            Consumer<StringBuilder> manifestConsumer) {
+        return createAddOnFile(fileName, status, version, null, manifestConsumer, null);
+    }
+
+    protected Path createAddOnFile(
+            String fileName,
+            String status,
+            String version,
+            Consumer<StringBuilder> manifestConsumer,
+            Consumer<ZipOutputStream> addOnConsumer) {
+        return createAddOnFile(fileName, status, version, null, manifestConsumer, addOnConsumer);
+    }
+
+    protected Path createAddOnFile(
+            String fileName,
+            String status,
+            String version,
+            String javaVersion,
+            Consumer<StringBuilder> manifestConsumer,
+            Consumer<ZipOutputStream> addOnConsumer) {
+        try {
+            Path file = newTempDir().resolve(fileName);
+            try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(file))) {
+                ZipEntry manifest = new ZipEntry(AddOn.MANIFEST_FILE_NAME);
+                zos.putNextEntry(manifest);
+                StringBuilder strBuilder = new StringBuilder(150);
+                strBuilder.append("<zapaddon>");
+                strBuilder.append("<version>").append(version).append("</version>");
+                strBuilder.append("<status>").append(status).append("</status>");
+                if (javaVersion != null && !javaVersion.isEmpty()) {
+                    strBuilder.append("<dependencies>");
+                    strBuilder.append("<javaversion>").append(javaVersion).append("</javaversion>");
+                    strBuilder.append("</dependencies>");
+                }
+                if (manifestConsumer != null) {
+                    manifestConsumer.accept(strBuilder);
+                }
+                strBuilder.append("</zapaddon>");
+                byte[] bytes = strBuilder.toString().getBytes(StandardCharsets.UTF_8);
+                zos.write(bytes, 0, bytes.length);
+                zos.closeEntry();
+                if (addOnConsumer != null) {
+                    addOnConsumer.accept(zos);
+                }
+            }
+            return file;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected static AddOn createAddOn(String addOnId, ZapXmlConfiguration zapVersions)
+            throws Exception {
+        return new AddOn(
+                addOnId, Paths.get("").toFile(), zapVersions.configurationAt("addon_" + addOnId));
+    }
+
+    protected static Path newTempDir() throws IOException {
+        return newTempDir("");
+    }
+
+    protected static Path newTempDir(String prefix) throws IOException {
+        return Files.createTempDirectory(tempDir, prefix);
+    }
+}


### PR DESCRIPTION
Keep the add-on data directory when deleting the libraries if it's not
empty, to allow add-ons to place other custom files there.

Extract helper test methods (that create add-ons) into a new class,
`AddOnTestUtils`, to be used by the new tests.