### PR TITLE
Fix "_XSERVTransmkdir: ERROR"

### DIFF
--- a/docker/zap-x.sh
+++ b/docker/zap-x.sh
@@ -2,7 +2,7 @@
 export DISPLAY=:1.0
 if [ ! -f /tmp/.X1-lock ]
 then
-  Xvfb :1 -screen 0 1024x768x16 -ac &
+  Xvfb :1 -screen 0 1024x768x16 -ac -nolisten tcp -nolisten unix &
 fi
 /zap/zap.sh "$@"
 


### PR DESCRIPTION
Without this patch, when running the docker container as non-root, the following error happens:

_XSERVTransmkdir: ERROR: euid != 0,directory /tmp/.X11-unix will not be created.