### PR TITLE
Ensure scripts loaded from config have engine

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptAPI.java
@@ -291,6 +291,12 @@ public class ScriptAPI extends ApiImplementor {
                 throw new ApiException(
                         ApiException.Type.ILLEGAL_PARAMETER, ACTION_PARAM_SCRIPT_NAME);
             }
+            if (script.getEngine() == null) {
+                throw new ApiException(
+                        ApiException.Type.BAD_STATE,
+                        "Unable to enable the script, script engine not available: "
+                                + script.getEngineName());
+            }
             extension.setEnabled(script, true);
             return ApiResponseElement.OK;
 


### PR DESCRIPTION
Attempt to set the engine when loading/adding the scripts to ensure they
can be used.
Change the enable script API endpoint to return an error when trying to
enable a script without engine (it would return OK even if the script
was not actually enabled).

Fix #6008.