### PR TITLE
encoder2: Deprecate and address dependence

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/encoder/Base64.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/encoder/Base64.java
@@ -159,7 +159,10 @@ import org.parosproxy.paros.Constant;
  * @author Robert Harder
  * @author rob@iharder.net
  * @version 2.3.7
+ *
+ * @deprecated (TODO Add version) use {@link java.util.Base64}.
  */
+@Deprecated
 public class Base64
 {
     

--- a/zap/src/main/java/org/parosproxy/paros/extension/encoder/Encoder.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/encoder/Encoder.java
@@ -39,6 +39,8 @@ import java.security.NoSuchAlgorithmException;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.log4j.Logger;
 
+/** @deprecated (TODO Add version) */
+@Deprecated
 public class Encoder {
 
     private static final Logger logger = Logger.getLogger(Encoder.class);

--- a/zap/src/main/java/org/zaproxy/zap/control/CoreFunctionality.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/CoreFunctionality.java
@@ -84,7 +84,6 @@ public final class CoreFunctionality {
             extensions.add(new org.zaproxy.zap.extension.callback.ExtensionCallback());
             extensions.add(new org.zaproxy.zap.extension.compare.ExtensionCompare());
             extensions.add(new org.zaproxy.zap.extension.dynssl.ExtensionDynSSL());
-            extensions.add(new org.zaproxy.zap.extension.encoder2.ExtensionEncoder2());
             extensions.add(new org.zaproxy.zap.extension.ext.ExtensionExtension());
             extensions.add(new org.zaproxy.zap.extension.forceduser.ExtensionForcedUser());
             extensions.add(

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/AddOnsTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/AddOnsTableModel.java
@@ -29,9 +29,9 @@ import java.util.List;
 import java.util.Set;
 import javax.swing.event.TableModelEvent;
 import javax.swing.table.AbstractTableModel;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.extension.encoder.Encoder;
 import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.control.AddOn.AddOnRunRequirements;
 import org.zaproxy.zap.control.AddOnCollection;
@@ -328,13 +328,12 @@ public abstract class AddOnsTableModel extends AbstractTableModel {
 
     private static String getHtmlFromIssues(String title, List<String> issues) {
         StringBuilder strBuilder = new StringBuilder(150);
-        Encoder encoder = new Encoder();
         strBuilder
                 .append("<html><strong>")
-                .append(encoder.getHTMLString(title))
+                .append(StringEscapeUtils.escapeHtml(title))
                 .append("</strong><ul>");
         for (String issue : issues) {
-            strBuilder.append("<li>").append(encoder.getHTMLString(issue)).append("</li>");
+            strBuilder.append("<li>").append(StringEscapeUtils.escapeHtml(issue)).append("</li>");
         }
         strBuilder.append("</ul></html>");
         return strBuilder.toString();

--- a/zap/src/main/java/org/zaproxy/zap/extension/encoder2/EncodeDecodeDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/encoder2/EncodeDecodeDialog.java
@@ -36,12 +36,13 @@ import javax.swing.event.DocumentListener;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.extension.encoder.Encoder;
 import org.parosproxy.paros.view.AbstractFrame;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.utils.ZapTextArea;
 
+/** @deprecated No alternative. */
+@Deprecated
 public class EncodeDecodeDialog extends AbstractFrame {
 
     private static final long serialVersionUID = 1L;
@@ -75,7 +76,7 @@ public class EncodeDecodeDialog extends AbstractFrame {
     private ZapTextArea escapedTextField = null;
     private ZapTextArea unescapedTextField = null;
 
-    private Encoder encoder = null;
+    private org.parosproxy.paros.extension.encoder.Encoder encoder = null;
 
     /** @throws HeadlessException */
     public EncodeDecodeDialog() throws HeadlessException {
@@ -494,9 +495,9 @@ public class EncodeDecodeDialog extends AbstractFrame {
         return unescapedTextField;
     }
 
-    private Encoder getEncoder() {
+    private org.parosproxy.paros.extension.encoder.Encoder getEncoder() {
         if (encoder == null) {
-            encoder = new Encoder();
+            encoder = new org.parosproxy.paros.extension.encoder.Encoder();
         }
         return encoder;
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/encoder2/EncodeDecodeParam.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/encoder2/EncodeDecodeParam.java
@@ -21,6 +21,8 @@ package org.zaproxy.zap.extension.encoder2;
 
 import org.parosproxy.paros.common.AbstractParam;
 
+/** @deprecated No alternative. */
+@Deprecated
 class EncodeDecodeParam extends AbstractParam {
 
     private static final String PARAM_BASE64_CHARSET = "encode.param.base64charset";

--- a/zap/src/main/java/org/zaproxy/zap/extension/encoder2/EncodeDecodeParamPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/encoder2/EncodeDecodeParamPanel.java
@@ -35,6 +35,8 @@ import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.view.AbstractParamPanel;
 import org.zaproxy.zap.utils.FontUtils;
 
+/** @deprecated No alternative. */
+@Deprecated
 public class EncodeDecodeParamPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = -6357927982804314157L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/encoder2/ExtensionEncoder2.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/encoder2/ExtensionEncoder2.java
@@ -28,6 +28,8 @@ import org.parosproxy.paros.extension.OptionsChangedListener;
 import org.parosproxy.paros.model.OptionsParam;
 import org.zaproxy.zap.view.ZapMenuItem;
 
+/** @deprecated No alternative. */
+@Deprecated
 public class ExtensionEncoder2 extends ExtensionAdaptor implements OptionsChangedListener {
 
     private static final String NAME = "ExtensionEncode2";

--- a/zap/src/main/java/org/zaproxy/zap/extension/encoder2/PopupEncoder2Menu.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/encoder2/PopupEncoder2Menu.java
@@ -24,6 +24,8 @@ import javax.swing.text.JTextComponent;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 
+/** @deprecated No alternative. */
+@Deprecated
 public class PopupEncoder2Menu extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/utils/HarUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/HarUtils.java
@@ -41,6 +41,7 @@ import edu.umass.cs.benchlab.har.tools.HarFileWriter;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.HttpCookie;
+import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -49,7 +50,6 @@ import org.apache.log4j.Logger;
 import org.codehaus.jackson.JsonFactory;
 import org.codehaus.jackson.JsonParser;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.extension.encoder.Base64;
 import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpHeaderField;
@@ -329,7 +329,7 @@ public final class HarUtils {
 
             if (!lcContentType.startsWith("text")) {
                 encoding = "base64";
-                text = Base64.encodeBytes(httpMessage.getResponseBody().getBytes());
+                text = Base64.getEncoder().encodeToString(httpMessage.getResponseBody().getBytes());
             } else {
                 text = httpMessage.getResponseBody().toString();
             }

--- a/zap/src/main/java/org/zaproxy/zap/utils/ViewState.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/ViewState.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import org.parosproxy.paros.extension.encoder.Base64;
+import java.util.Base64;
 
 /**
  * THIS CODE IS FROM THE PROJECT LOCATED AT http://code.google.com/p/embeddednode/ AND THE RIGHT HAS
@@ -41,7 +41,9 @@ import org.parosproxy.paros.extension.encoder.Base64;
  *
  * @author embeddednode
  * @version 1.2 June 10, 2009
+ * @deprecated in ZAP (TODO add version)
  */
+@Deprecated
 public class ViewState {
 
     /**
@@ -60,7 +62,7 @@ public class ViewState {
             } finally {
                 oos.close();
             }
-            return Base64.encodeBytes(bos.toByteArray());
+            return Base64.getEncoder().encodeToString(bos.toByteArray());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -78,7 +80,7 @@ public class ViewState {
         // BASE64Decoder decoder = new BASE64Decoder();
         try {
             // byte[]               b    = decoder.decodeBuffer(base64);
-            byte[] b = Base64.decode(base64);
+            byte[] b = Base64.getDecoder().decode(base64);
             ByteArrayInputStream bais = new ByteArrayInputStream(b);
             ObjectInputStream ois = new ObjectInputStream(bais);
             return (T) ois.readObject();


### PR DESCRIPTION
- AddOnsTableModel, ExtensionAntiCSRF, HarUtils, ViewState > Use JRE or Commons methods directly.
- CoreFunctionality > Remove encoder2 from core, weekly is now including addon from zap-extensions.
- others > Deprecated.

Part of: zaproxy/zaproxy#5996

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>