### PR TITLE
Root Cert Download from Main API Page

### DIFF
--- a/zap/src/main/dist/lang/Messages_es_ES.properties
+++ b/zap/src/main/dist/lang/Messages_es_ES.properties
@@ -123,6 +123,10 @@ api.home.links.header=<h2>Enlaces</h2>
 api.home.links.api.enabled=<li><a href\="/UI"> API local</a></li>
 api.home.links.api.disabled=<li>API local desactivada - Puede ser activada a trav\u00e9s de Herramientas / Opciones... /</li>
 api.home.links.online=<li><a href\="https\://www.owasp.org/index.php/ZAP">Pagina de ZAP</a></li>\n<li><a href\="https\://github.com/zaproxy/zaproxy/wiki/Introduction">ZAP Wiki</a></li>\n<li><a href\="https\://groups.google.com/group/zaproxy-users">Grupo de Usuarios de ZAP</a></li>\n<li><a href\="https\://groups.google.com/group/zaproxy-develop">Grupo de desarrolladores ZAP</a></li>\n<li><a href\="https\://github.com/zaproxy/zaproxy/issues">Reportar una falla</a></li>
+api.home.cacert=<h2>Evitar Advertencias de HTTPS</h2>\
+<p>Para evitar los errores y advertencias sobre HTTPS <a href="/OTHER/core/other/rootcert{0}">descargue</a> e \
+<a href="https://github.com/zaproxy/zap-core-help-es_ES/wiki/HelpUiDialogsOptionsDynsslcert#install-zap-root-ca-certificate" target="_blank">\
+ instale el certficado ra\u00edz de la AC de ZAP</a> en su computadora o dispositivo m\u00f3vil.</p>
 api.home.proxypac=<h2>Configuraci\u00f3n del servidor proxy</h2>\n<p>Para usar ZAP de forma efectiva es recomendable configurar el navegador para que use ZAP a modo de proxy.</p> <p></p> \n<p>Puedes hacerlo manualmente o mediante la configuraci\u00f3n de tu navegador utilizando el <a href\="/OTHER/core/other/proxy.pac"> archivo PAC</a> pregenerado.</p></html>
 api.home.topmsg=<h1>Bienvenido OWASP Zed Attack Proxy (ZAP)</h1>\n<p>ZAP es una herramienta de <i>pentesting</i> f\u00e1cil de usar orientada a la b\u00fasqueda de vulnerabilidades en aplicaciones web.</p><p></p>\n<p>Por favor, ten en cuenta que s\u00f3lo debes auditar aplicaciones para las que has obtenido permiso expl\u00edcito.</p>
 api.menu.tools.url=Buscar en la API

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -1386,9 +1386,8 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                     String response = sw.toString();
                     msg.setResponseHeader(
                             API.getDefaultResponseHeader(
-                                    "application/pkix-cert;", response.length()) +
-                            "Content-Disposition: attachment; filename=\"ZapCACert.cer\"\r\n"
-                    		);
+                                            "application/pkix-cert;", response.length())
+                                    + "Content-Disposition: attachment; filename=\"ZapCACert.cer\"\r\n");
 
                     msg.setResponseBody(response);
                 } catch (Exception e) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -1386,7 +1386,9 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                     String response = sw.toString();
                     msg.setResponseHeader(
                             API.getDefaultResponseHeader(
-                                    "application/pkix-cert;", response.length()));
+                                    "application/pkix-cert;", response.length()) +
+                            "Content-Disposition: attachment; filename=\"ZapCACert.cer\"\r\n"
+                    		);
 
                     msg.setResponseBody(response);
                 } catch (Exception e) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/WebUI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/WebUI.java
@@ -480,7 +480,15 @@ public class WebUI {
                                 + "="
                                 + API.getInstance()
                                         .getLongLivedNonce("/OTHER/core/other/proxy.pac/")));
-        sb.append(Constant.messages.getString("api.home.links.header"));
+        sb.append(
+                Constant.messages.getString(
+                        "api.home.cacert",
+                        "/?"
+                                + API.API_NONCE_PARAM
+                                + "="
+                                + API.getInstance()
+                                        .getLongLivedNonce("/OTHER/core/other/rootcert/")));
+		sb.append(Constant.messages.getString("api.home.links.header"));
         if (apiEnabled) {
             sb.append(Constant.messages.getString("api.home.links.api.enabled"));
         } else {

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/WebUI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/WebUI.java
@@ -488,7 +488,7 @@ public class WebUI {
                                 + "="
                                 + API.getInstance()
                                         .getLongLivedNonce("/OTHER/core/other/rootcert/")));
-		sb.append(Constant.messages.getString("api.home.links.header"));
+        sb.append(Constant.messages.getString("api.home.links.header"));
         if (apiEnabled) {
             sb.append(Constant.messages.getString("api.home.links.api.enabled"));
         } else {

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -191,6 +191,10 @@ api.home.links.online		= <li><a href="https://www.zaproxy.org/">ZAP Homepage</a>
 <li><a href="https://groups.google.com/group/zaproxy-users">ZAP User Group</a></li>\
 <li><a href="https://groups.google.com/group/zaproxy-develop">ZAP Developer Group</a></li>\
 <li><a href="https://github.com/zaproxy/zaproxy/issues">Report an issue</a></li>
+api.home.cacert			= <h2>HTTPS Warnings Prevention</h2>\
+<p>To avoid HTTPS Warnings <a href="/OTHER/core/other/rootcert{0}">download</a> and \
+<a href="https://www.zaproxy.org/docs/desktop/ui/dialogs/options/dynsslcert/#install" target="_blank">\
+ install CA root Certificate</a> in your Mobile device or computer.</p>
 api.home.proxypac			= <h2>Proxy Configuration</h2>\
 <p>To use ZAP effectively it is recommended that you configure your browser to proxy via ZAP.</p><p></p>\
 <p>You can do that manually or by configuring your browser to use the generated <a href="/OTHER/core/other/proxy.pac{0}">PAC file</a>.</p>


### PR DESCRIPTION
Hello, I wanted to facilitate Mobile security testing using ZAP by allowing download of the CA certificate directly from the API home page.

Please consider merging my changes and let me know if you have any questions or comments.

Regards,
Juan C Calderon