### PR TITLE
Just warn if ECMAScript engine is not found

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -170,7 +170,8 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
         if (se != null) {
             this.registerScriptEngineWrapper(new JavascriptEngineWrapper(se.getFactory()));
         } else {
-            logger.error("No Javascript/ECMAScript engine found");
+            logger.warn(
+                    "No default JavaScript/ECMAScript engine found, some scripts might no longer work.");
         }
     }
 


### PR DESCRIPTION
Warn instead of logging an error, the engine will no longer be available
in Java 15.

Part of #4851 - Nashorn deprecated in Java 11.