### PR TITLE
Apply macOS integrations even with custom look and feel

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/GuiBootstrap.java
+++ b/zap/src/main/java/org/zaproxy/zap/GuiBootstrap.java
@@ -336,6 +336,10 @@ public class GuiBootstrap extends ZapBootstrap {
         }
         lookAndFeelSet = true;
 
+        if (Constant.isMacOsX()) {
+            OsXGui.setup();
+        }
+
         if (setLookAndFeel(System.getProperty("swing.defaultlaf"))) {
             return;
         }
@@ -347,9 +351,7 @@ public class GuiBootstrap extends ZapBootstrap {
             return;
         }
 
-        if (Constant.isMacOsX()) {
-            OsXGui.setup();
-        } else if (setLookAndFeel(getLookAndFeelClassname("Nimbus"))) {
+        if (!Constant.isMacOsX() && setLookAndFeel(getLookAndFeelClassname("Nimbus"))) {
             return;
         }
 


### PR DESCRIPTION
Closes #6037

I'm not quite sure if this doesn't introduce other problems but this allows me to use change the display settings with the MacOS integration still working correctly.

Would appreciate feedback whether this is makes sense 😀
I've commented the parts below which confused me.

Signed-off-by: Jannik Hollenbach <13718901+J12934@users.noreply.github.com>