### PR TITLE
Enable running zap using podman

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+###  2020-07-17
+ - Make podman compatible
+
 ###  2020-05-20
  - Make docker stable use ubuntu 20.04
 

--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -244,7 +244,7 @@ def cp_to_docker(cid, file, dir):
 
 
 def running_in_docker():
-    return os.path.exists('/.dockerenv')
+    return os.path.exists('/.dockerenv') or os.path.exists('/run/.containerenv')
 
 
 def add_zap_options(params, zap_options):


### PR DESCRIPTION
Podman uses /run/.containerenv instead of .dockerenv
You can find more info here: https://github.com/containers/podman/issues/648
