### PR TITLE
Add SonarCloud as a Scheduled GitHub Action

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,34 @@
+name: Run Sonar
+
+on: 
+  push:
+  schedule:
+    - cron: '30 15 * * SAT'
+
+jobs:
+  sonar:
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Setup JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Gradle Cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+    - name: Gradle Test & Coverage Report
+      run: ./gradlew test jacocoTestReport -Dorg.gradle.jvmargs=-Xmx4096m
+    - name: Sonarcloud Scan
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: ./gradlew sonarqube --stacktrace

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.diffplug.gradle.spotless")
+    id("org.sonarqube") version "3.0"
 }
 
 apply(from = "$rootDir/gradle/travis-ci.gradle.kts")
@@ -27,5 +28,13 @@ allprojects {
     tasks.withType<JavaCompile>().configureEach {
         options.encoding = "utf-8"
         options.compilerArgs = listOf("-Xlint:all", "-Xlint:-options", "-Werror", "-parameters")
+    }
+}
+
+sonarqube {
+    properties {
+        property("sonar.projectKey", "zaproxy_zaproxy")
+        property("sonar.organization", "zaproxy")
+        property("sonar.host.url", "https://sonarcloud.io")
     }
 }

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -34,6 +34,12 @@ jacoco {
     toolVersion = "0.8.5"
 }
 
+tasks.named<JacocoReport>("jacocoTestReport") {
+    reports {
+        xml.isEnabled = true
+    }
+}
+
 dependencies {
     api("com.fifesoft:rsyntaxtextarea:3.0.4")
     api("com.github.zafarkhaja:java-semver:0.9.0")


### PR DESCRIPTION
- addOns.gradle.kts > Modified so that jacoco reports include XML output.
- build.gradle.kts > Modified to include sonarqube.
- sonar.yml > Added to run a GitHub action workflow every Saturday in order to update the SonarCloud SAST results and coverage info.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>
