### PR TITLE
Sonar suggested fixes

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakpointsOptionsPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakpointsOptionsPanel.java
@@ -129,7 +129,7 @@ public class BreakpointsOptionsPanel extends AbstractParamPanel {
 
         getCheckBoxConfirmDropMessage().setSelected(param.isConfirmDropMessage());
         // Note param.alwaysOnTop will be null if the user hasn't specified a preference yet
-        getCheckBoxAlwaysOnTop().setSelected(param.getAlwaysOnTop() != Boolean.FALSE);
+        getCheckBoxAlwaysOnTop().setSelected(!Boolean.FALSE.equals(param.getAlwaysOnTop()));
         getCheckBoxInScopeOnly().setSelected(param.isInScopeOnly());
         getButtonMode().setSelectedIndex(param.getButtonMode() - 1);
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakpointsParam.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakpointsParam.java
@@ -114,7 +114,7 @@ public class BreakpointsParam extends AbstractParam {
 
     public void setAlwaysOnTop(Boolean alwaysOnTop) {
         this.alwaysOnTop = alwaysOnTop;
-        getConfig().setProperty(PARAM_BRK_ALWAYS_ON_TOP, Boolean.valueOf(alwaysOnTop));
+        getConfig().setProperty(PARAM_BRK_ALWAYS_ON_TOP, alwaysOnTop);
     }
 
     public boolean isInScopeOnly() {

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/DialogAddAutoTagScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/DialogAddAutoTagScanner.java
@@ -394,7 +394,6 @@ class DialogAddAutoTagScanner extends AbstractFormDialog {
                     (getNameTextField().getDocument().getLength() > 0)
                             && (getConfigurationTextField().getDocument().getLength() > 0)
                             && (getRequestUrlRegexTextField().getDocument().getLength() > 0
-                                    || getRequestUrlRegexTextField().getDocument().getLength() > 0
                                     || getRequestHeaderRegexTextField().getDocument().getLength()
                                             > 0
                                     || getResponseHeaderRegexTextField().getDocument().getLength()

--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderAPI.java
@@ -292,32 +292,20 @@ public class SpiderAPI extends ApiImplementor {
 
             case ACTION_PAUSE_SCAN:
                 scan = getSpiderScan(params);
-                if (scan == null) {
-                    throw new ApiException(ApiException.Type.DOES_NOT_EXIST, PARAM_SCAN_ID);
-                }
                 extension.pauseScan(scan.getScanId());
                 break;
             case ACTION_RESUME_SCAN:
                 scan = getSpiderScan(params);
-                if (scan == null) {
-                    throw new ApiException(ApiException.Type.DOES_NOT_EXIST, PARAM_SCAN_ID);
-                }
                 extension.resumeScan(scan.getScanId());
                 break;
             case ACTION_STOP_SCAN:
                 // The action is to stop a pending scan
                 scan = getSpiderScan(params);
-                if (scan == null) {
-                    throw new ApiException(ApiException.Type.DOES_NOT_EXIST, PARAM_SCAN_ID);
-                }
                 extension.stopScan(scan.getScanId());
                 break;
             case ACTION_REMOVE_SCAN:
                 // Note that we're removing the scan with this call, not just getting it ;)
                 scan = getSpiderScan(params);
-                if (scan == null) {
-                    throw new ApiException(ApiException.Type.DOES_NOT_EXIST, PARAM_SCAN_ID);
-                }
                 extension.removeScan(scan.getScanId());
                 break;
             case ACTION_PAUSE_ALL_SCANS:

--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderMessagesTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderMessagesTableModel.java
@@ -137,7 +137,7 @@ class SpiderMessagesTableModel
                     @Override
                     public void run() {
                         final int row = resources.size();
-                        idsToRows.put(Integer.valueOf(entry.getHistoryId()), row);
+                        idsToRows.put(entry.getHistoryId(), row);
                         resources.add(entry);
                         fireTableRowsInserted(row, row);
                     }

--- a/zap/src/main/java/org/zaproxy/zap/view/ContextListTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ContextListTableModel.java
@@ -58,16 +58,8 @@ public class ContextListTableModel extends AbstractTableModel {
 
     @Override
     public boolean isCellEditable(int rowIndex, int columnIndex) {
-        switch (columnIndex) {
-            case 0:
-                return false;
-            case 1:
-                return false;
-            case 2:
-                return false; // TODO ideally want to be able to change this here...
-            default:
-                return false;
-        }
+        // TODO ideally columnIndex == 2 (enable) would be able to change here...
+        return false;
     }
 
     @Override


### PR DESCRIPTION
- ContextListTableModel > Removed conditional in which all branches resulted in the same behavior.
https://sonarcloud.io/project/issues?id=zaproxy_zaproxy&open=AW06pGlUwvaFA2N5WchU&resolved=false&rules=java%3AS3923&types=BUG
- BreakpointsOptionsPanel > Ensure boolean/boxed comparison uses .equals.
https://sonarcloud.io/project/issues?id=zaproxy_zaproxy&open=AW06pF-TwvaFA2N5WcJg&resolved=false&rules=java%3AS4973&types=BUG
- SpiderMessagesTableModel > Remove un-necessary boxing.
https://sonarcloud.io/project/issues?id=zaproxy_zaproxy&open=AW06pFtTwvaFA2N5Wb8U&resolved=false&rules=java%3AS2153&types=BUG
- BreakpointsParam > Remove un-necessary boxing.
https://sonarcloud.io/project/issues?id=zaproxy_zaproxy&open=AW06pF-DwvaFA2N5WcJT&resolved=false&rules=java%3AS2153&types=BUG
- SpiderAPI.java > Remove un-necessary conditionals. All of these were preceded by `getSpiderScan` which already performs the null check and exception.
https://sonarcloud.io/project/issues?id=zaproxy_zaproxy&open=AW06pFsgwvaFA2N5Wb7r&resolved=false&rules=java%3AS2583&types=BUG
https://sonarcloud.io/project/issues?id=zaproxy_zaproxy&open=AW06pFsgwvaFA2N5Wb7o&resolved=false&rules=java%3AS2583&types=BUG
https://sonarcloud.io/project/issues?id=zaproxy_zaproxy&open=AW06pFsgwvaFA2N5Wb7q&resolved=false&rules=java%3AS2583&types=BUG
https://sonarcloud.io/project/issues?id=zaproxy_zaproxy&open=AW06pFsgwvaFA2N5Wb7p&resolved=false&rules=java%3AS2583&types=BUG
- DialogAddAutoTagScanner > Remove duplicate condition.
https://sonarcloud.io/project/issues?id=zaproxy_zaproxy&open=AW06pGRdwvaFA2N5WcTs&resolved=false&rules=java%3AS1764&types=BUG

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>