### PR TITLE
Add `IS_CONTAINERIZED` env var to containerized check

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+###  2020-08-03
+ - Add `IS_CONTAINERIZED` environment variable to the container image, used in the python script to check for containerized environments (e.g. containerd) without relying on container runtime specific files.
+
 ###  2020-07-17
  - Make podman compatible
 

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -68,6 +68,7 @@ RUN git clone --depth 1 https://github.com/zaproxy/zaproxy.git && \
 ENV ZAP_PATH /zap/zap.sh
 # Default port for use with zapcli
 ENV ZAP_PORT 8080
+ENV IS_CONTAINERIZED true
 ENV HOME /home/zap/
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -60,6 +60,7 @@ ENV ZAP_PATH /zap/zap.sh
 
 # Default port for use with zapcli
 ENV ZAP_PORT 8080
+ENV IS_CONTAINERIZED true
 ENV HOME /home/zap/
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -61,6 +61,7 @@ ENV ZAP_PATH /zap/zap.sh
 
 # Default port for use with zapcli
 ENV ZAP_PORT 8080
+ENV IS_CONTAINERIZED true
 ENV HOME /home/zap/
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -244,7 +244,7 @@ def cp_to_docker(cid, file, dir):
 
 
 def running_in_docker():
-    return os.path.exists('/.dockerenv') or os.path.exists('/run/.containerenv')
+    return os.path.exists('/.dockerenv') or os.path.exists('/run/.containerenv') or os.environ.get("IS_CONTAINERIZED") is not None
 
 
 def add_zap_options(params, zap_options):

--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -244,7 +244,7 @@ def cp_to_docker(cid, file, dir):
 
 
 def running_in_docker():
-    return os.path.exists('/.dockerenv') or os.path.exists('/run/.containerenv') or os.environ.get("IS_CONTAINERIZED") is not None
+    return os.path.exists('/.dockerenv') or os.path.exists('/run/.containerenv') or os.environ.get("IS_CONTAINERIZED") == "true"
 
 
 def add_zap_options(params, zap_options):


### PR DESCRIPTION
Hi encountered a similar problem to #6080 when running ZAP on a Kubernetes cluster using `containerd`.

I could not find a similar file for containerd, so I've added a more generalized solution, which sets a custom env var in the docker image build, this should then be present in all container runtimes. 

This should allow the container to function correctly in all container runtimes, as it is not bound to a specific implementation.

This should also be able to replace the two existing checks (`os.path.exists('/.dockerenv') or os.path.exists('/run/.containerenv')`), as it should work for any container runtime.