### PR TITLE
Correct file pattern in Test Packaged Scans

### DIFF
--- a/.github/workflows/test-packaged-scans.yml
+++ b/.github/workflows/test-packaged-scans.yml
@@ -3,7 +3,7 @@ name: Test Packaged Scans
 on:
   pull_request:
     paths:
-    - docker/*
+    - docker/**
 
 jobs:
   test:


### PR DESCRIPTION
Include all files under docker directory, not just in the docker
directory.