### PR TITLE
Include Common Library add-on in core package

### DIFF
--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/distributions.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/distributions.gradle.kts
@@ -102,6 +102,7 @@ tasks.register<Zip>("distCore") {
     val liteAddOns = listOf(
             "ascanrules",
             "bruteforce",
+            "commonlib",
             "coreLang",
             "diff",
             "gettingStarted",


### PR DESCRIPTION
The Common Library add-on is a dependency of other (included) add-ons
(e.g. passive scan rules), the size of the package increases from 36.9
to 40.2MiB.