### PR TITLE
Catch NPE on panel level when saving/validating

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/view/AbstractParamDialog.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/AbstractParamDialog.java
@@ -36,6 +36,7 @@
 // ZAP: 2019/03/19 Log the exception when validating/saving the AbstractParamPanels.
 // ZAP: 2019/04/04 Log NullPointerException as error when validating/saving the AbstractParamPanels.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2020/08/25 Move NullPointerException log to AbstractParamContainerPanel.
 package org.parosproxy.paros.view;
 
 import java.awt.Component;
@@ -217,25 +218,20 @@ public class AbstractParamDialog extends AbstractDialog {
 
                                 AbstractParamDialog.this.setVisible(false);
 
-                            } catch (NullPointerException ex) {
-                                LOGGER.error("Failed to validate or save the panels: ", ex);
-                                showSaveErrorDialog(ex.getMessage());
                             } catch (Exception ex) {
                                 if (LOGGER.isDebugEnabled()) {
                                     LOGGER.debug("Failed to validate or save the panels: ", ex);
                                 }
-                                showSaveErrorDialog(ex.getMessage());
+                                View.getSingleton()
+                                        .showWarningDialog(
+                                                Constant.messages.getString(
+                                                        "options.dialog.save.error",
+                                                        ex.getMessage()));
                             }
                         }
                     });
         }
         return btnOK;
-    }
-
-    private static void showSaveErrorDialog(String message) {
-        View.getSingleton()
-                .showWarningDialog(
-                        Constant.messages.getString("options.dialog.save.error", message));
     }
 
     /**

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -1652,6 +1652,8 @@ footer.scans.label           = Current Scans
 
 form.dialog.button.cancel = Cancel
 
+generic.error.internal.title = Internal Error
+generic.error.internal.msg = An error occurred while performing the action.\nConsider reporting the error with following details:
 generic.filter.label = Filter:
 generic.filter.tooltip = The filtering system supports regular expressions.
 generic.options.panel.security.protocols.title = Security Protocols


### PR DESCRIPTION
Move the catch of the NullPointerException from the container panel to
the individual panels to still allow to validate/save other panels that
do not have issues.
Make the error generic now used for save/validate and provide the
details of the exception for easier report.

Related to #6136.
Improvement of #5306.