### PR TITLE
Properly decode gzip in UI and decode request

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/HttpPanelViewModelUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/HttpPanelViewModelUtils.java
@@ -19,9 +19,25 @@
  */
 package org.zaproxy.zap.extension.httppanel.view.impl.models.http;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.regex.Pattern;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.network.HttpBody;
+import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 
 public final class HttpPanelViewModelUtils {
+
+    private static final Pattern GZIP_PATTERN =
+            Pattern.compile("\\s*(?:x-)?gzip\\s*", Pattern.CASE_INSENSITIVE);
+
+    private static final Logger logger = Logger.getLogger(HttpPanelViewModelUtils.class);
 
     private HttpPanelViewModelUtils() {}
 
@@ -31,5 +47,92 @@ public final class HttpPanelViewModelUtils {
 
     public static void updateResponseContentLength(HttpMessage message) {
         message.getResponseHeader().setContentLength(message.getResponseBody().length());
+    }
+
+    public static byte[] getBodyBytes(HttpHeader header, HttpBody body) {
+        if (!isEncoded(header)) {
+            return body.getBytes();
+        }
+
+        try {
+            return decode(body);
+        } catch (IOException e) {
+            logger.debug("Failed to decode the body:", e);
+            return body.getBytes();
+        }
+    }
+
+    private static boolean isEncoded(HttpHeader header) {
+        String encoding = header.getHeader(HttpHeader.CONTENT_ENCODING);
+        return encoding != null && GZIP_PATTERN.matcher(encoding).matches();
+    }
+
+    private static byte[] decode(HttpBody body) throws IOException {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(body.getBytes());
+                GZIPInputStream gis = new GZIPInputStream(bais);
+                BufferedInputStream bis = new BufferedInputStream(gis);
+                ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[4096];
+            int len;
+            while ((len = bis.read(buffer)) != -1) {
+                out.write(buffer, 0, len);
+            }
+            return out.toByteArray();
+        }
+    }
+
+    public static String getBodyString(HttpHeader header, HttpBody body) {
+        if (!isEncoded(header)) {
+            return body.toString();
+        }
+
+        try {
+            return new String(decode(body), body.getCharset());
+        } catch (UnsupportedEncodingException ignore) {
+            // Shouldn't happen, the body has a supported charset.
+        } catch (IOException e) {
+            logger.debug("Failed to decode the body:", e);
+        }
+        return body.toString();
+    }
+
+    public static void setBody(HttpHeader header, HttpBody body, String value) {
+        body.setCharset(header.getCharset());
+
+        if (!isEncoded(header)) {
+            body.setBody(value);
+            header.setContentLength(body.length());
+            return;
+        }
+
+        try {
+            setBodyGzip(header, body, value.getBytes(body.getCharset()));
+        } catch (UnsupportedEncodingException ignore) {
+            // Shouldn't happen, the body has a supported charset.
+        }
+    }
+
+    private static void setBodyGzip(HttpHeader header, HttpBody body, byte[] value) {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                GZIPOutputStream gis = new GZIPOutputStream(baos, true)) {
+            gis.write(value);
+            gis.finish();
+            body.setBody(baos.toByteArray());
+        } catch (IOException e) {
+            logger.error("Failed to encode and set the body:", e);
+        }
+        header.setContentLength(body.length());
+    }
+
+    public static void setBody(HttpHeader header, HttpBody body, byte[] value) {
+        body.setCharset(header.getCharset());
+
+        if (!isEncoded(header)) {
+            body.setBody(value);
+            header.setContentLength(body.length());
+            return;
+        }
+
+        setBodyGzip(header, body, value);
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestBodyByteHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestBodyByteHttpPanelViewModel.java
@@ -30,7 +30,8 @@ public class RequestBodyByteHttpPanelViewModel extends AbstractHttpByteHttpPanel
             return new byte[0];
         }
 
-        return httpMessage.getRequestBody().getBytes();
+        return HttpPanelViewModelUtils.getBodyBytes(
+                httpMessage.getRequestHeader(), httpMessage.getRequestBody());
     }
 
     @Override
@@ -39,7 +40,7 @@ public class RequestBodyByteHttpPanelViewModel extends AbstractHttpByteHttpPanel
             return;
         }
 
-        httpMessage.getRequestBody().setBody(data);
-        HttpPanelViewModelUtils.updateRequestContentLength(httpMessage);
+        HttpPanelViewModelUtils.setBody(
+                httpMessage.getRequestHeader(), httpMessage.getRequestBody(), data);
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestBodyStringHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestBodyStringHttpPanelViewModel.java
@@ -30,7 +30,8 @@ public class RequestBodyStringHttpPanelViewModel extends AbstractHttpStringHttpP
             return "";
         }
 
-        return httpMessage.getRequestBody().toString();
+        return HttpPanelViewModelUtils.getBodyString(
+                httpMessage.getRequestHeader(), httpMessage.getRequestBody());
     }
 
     @Override
@@ -39,7 +40,7 @@ public class RequestBodyStringHttpPanelViewModel extends AbstractHttpStringHttpP
             return;
         }
 
-        httpMessage.getRequestBody().setBody(data);
-        HttpPanelViewModelUtils.updateRequestContentLength(httpMessage);
+        HttpPanelViewModelUtils.setBody(
+                httpMessage.getRequestHeader(), httpMessage.getRequestBody(), data);
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestByteHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestByteHttpPanelViewModel.java
@@ -48,6 +48,10 @@ public class RequestByteHttpPanelViewModel extends AbstractHttpByteHttpPanelView
 
     @Override
     public void setData(byte[] data) {
+        if (httpMessage == null) {
+            return;
+        }
+
         int pos = findHeaderLimit(data);
 
         if (pos == -1) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModel.java
@@ -36,11 +36,16 @@ public class RequestStringHttpPanelViewModel extends AbstractHttpStringHttpPanel
         }
 
         return httpMessage.getRequestHeader().toString().replaceAll(HttpHeader.CRLF, HttpHeader.LF)
-                + httpMessage.getRequestBody().toString();
+                + HttpPanelViewModelUtils.getBodyString(
+                        httpMessage.getRequestHeader(), httpMessage.getRequestBody());
     }
 
     @Override
     public void setData(String data) {
+        if (httpMessage == null) {
+            return;
+        }
+
         String[] parts = data.split(HttpHeader.LF + HttpHeader.LF);
         String header = parts[0].replaceAll("(?<!\r)\n", HttpHeader.CRLF);
         // Note that if the body has LF, those characters will not be replaced by CRLF.
@@ -51,11 +56,11 @@ public class RequestStringHttpPanelViewModel extends AbstractHttpStringHttpPanel
             logger.warn("Could not Save Header: " + header, e);
         }
 
+        String body = "";
         if (parts.length > 1) {
-            httpMessage.setRequestBody(data.substring(parts[0].length() + 2));
-        } else {
-            httpMessage.setRequestBody("");
+            body = data.substring(parts[0].length() + 2);
         }
-        HttpPanelViewModelUtils.updateRequestContentLength(httpMessage);
+        HttpPanelViewModelUtils.setBody(
+                httpMessage.getRequestHeader(), httpMessage.getRequestBody(), body);
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseBodyByteHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseBodyByteHttpPanelViewModel.java
@@ -19,16 +19,6 @@
  */
 package org.zaproxy.zap.extension.httppanel.view.impl.models.http.response;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
-import org.parosproxy.paros.network.HttpHeader;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.AbstractHttpByteHttpPanelViewModel;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.HttpPanelViewModelUtils;
 
@@ -40,32 +30,8 @@ public class ResponseBodyByteHttpPanelViewModel extends AbstractHttpByteHttpPane
             return new byte[0];
         }
 
-        if (HttpHeader.GZIP.equals(
-                httpMessage.getResponseHeader().getHeader(HttpHeader.CONTENT_ENCODING))) {
-            // Uncompress gziped content
-            try {
-                ByteArrayInputStream bais =
-                        new ByteArrayInputStream(httpMessage.getResponseBody().getBytes());
-                GZIPInputStream gis = new GZIPInputStream(bais);
-                InputStreamReader isr = new InputStreamReader(gis);
-                BufferedReader br = new BufferedReader(isr);
-                StringBuilder sb = new StringBuilder();
-                String line = null;
-                while ((line = br.readLine()) != null) {
-                    sb.append(line);
-                }
-                br.close();
-                isr.close();
-                gis.close();
-                bais.close();
-                return sb.toString().getBytes();
-            } catch (IOException e) {
-                // this.log.error(e.getMessage(), e);
-                System.out.println(e);
-            }
-        }
-
-        return httpMessage.getResponseBody().getBytes();
+        return HttpPanelViewModelUtils.getBodyBytes(
+                httpMessage.getResponseHeader(), httpMessage.getResponseBody());
     }
 
     @Override
@@ -73,26 +39,8 @@ public class ResponseBodyByteHttpPanelViewModel extends AbstractHttpByteHttpPane
         if (httpMessage == null) {
             return;
         }
-        if (HttpHeader.GZIP.equals(
-                httpMessage.getResponseHeader().getHeader(HttpHeader.CONTENT_ENCODING))) {
-            // Uncompress gziped content
-            try {
-                ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                GZIPOutputStream gis = new GZIPOutputStream(baos);
-                BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(gis, "UTF-8"));
-                bw.append(new String(data));
-                bw.close();
-                gis.close();
-                baos.close();
-                httpMessage.getResponseBody().setBody(baos.toByteArray());
-                HttpPanelViewModelUtils.updateResponseContentLength(httpMessage);
-            } catch (IOException e) {
-                // this.log.error(e.getMessage(), e);
-                System.out.println(e);
-            }
-        } else {
-            httpMessage.getResponseBody().setBody(data);
-            HttpPanelViewModelUtils.updateResponseContentLength(httpMessage);
-        }
+
+        HttpPanelViewModelUtils.setBody(
+                httpMessage.getResponseHeader(), httpMessage.getResponseBody(), data);
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseByteHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseByteHttpPanelViewModel.java
@@ -49,6 +49,10 @@ public class ResponseByteHttpPanelViewModel extends AbstractHttpByteHttpPanelVie
 
     @Override
     public void setData(byte[] data) {
+        if (httpMessage == null) {
+            return;
+        }
+
         int pos = findHeaderLimit(data);
 
         if (pos == -1) {

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/BodyByteHttpPanelViewModelTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/BodyByteHttpPanelViewModelTest.java
@@ -1,0 +1,153 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.httppanel.view.impl.models.http;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.zip.GZIPOutputStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpBody;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+
+public abstract class BodyByteHttpPanelViewModelTest<T1 extends HttpHeader, T2 extends HttpBody> {
+
+    private static final Charset DEFAULT_CHARSET = Charset.forName(HttpBody.DEFAULT_CHARSET);
+
+    private static final byte[] BODY = "Body 123 ABC".getBytes(DEFAULT_CHARSET);
+    private static final byte[] EMPTY_ARRAY = {};
+
+    private AbstractHttpByteHttpPanelViewModel model;
+
+    protected HttpMessage message;
+    protected T1 header;
+    protected T2 body;
+
+    @BeforeEach
+    void setup() {
+        model = createModel();
+
+        message = mock(HttpMessage.class);
+        header = mock(getHeaderClass());
+        body = mock(getBodyClass());
+
+        given(body.getBytes()).willReturn(BODY);
+
+        prepareMessage();
+    }
+
+    protected abstract AbstractHttpByteHttpPanelViewModel createModel();
+
+    protected abstract Class<T1> getHeaderClass();
+
+    protected abstract Class<T2> getBodyClass();
+
+    protected abstract void prepareMessage();
+
+    @Test
+    void shouldGetEmptyDataFromNullMessage() {
+        // Given
+        model.setMessage(null);
+        // When
+        byte[] data = model.getData();
+        // Then
+        assertThat(data, is(EMPTY_ARRAY));
+    }
+
+    @Test
+    void shouldGetDataFromBody() {
+        // Given
+        model.setMessage(message);
+        // When
+        byte[] data = model.getData();
+        // Then
+        assertThat(data, is(equalTo(BODY)));
+    }
+
+    @Test
+    void shouldGetDataFromBodyGzipDecoded() {
+        // Given
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn("gzip");
+        given(body.getCharset()).willReturn(DEFAULT_CHARSET.name());
+        given(body.getBytes()).willReturn(gzip(BODY));
+        model.setMessage(message);
+        // When
+        byte[] data = model.getData();
+        // Then
+        assertThat(data, is(equalTo(BODY)));
+    }
+
+    @Test
+    void shouldNotSetDataWithNullMessage() {
+        // Given
+        model.setMessage(null);
+        // When / Then
+        assertDoesNotThrow(() -> model.setData(BODY));
+    }
+
+    @Test
+    void shouldSetDataIntoBody() {
+        // Given
+        model.setMessage(message);
+        byte[] otherBodyContent = "Other Body".getBytes(DEFAULT_CHARSET);
+        given(body.length()).willReturn(otherBodyContent.length);
+        // When
+        model.setData(otherBodyContent);
+        // Then
+        verify(body).setBody(otherBodyContent);
+        verify(header).setContentLength(otherBodyContent.length);
+    }
+
+    @Test
+    void shouldSetDataIntoBodyGzipEncoded() {
+        // Given
+        model.setMessage(message);
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn("gzip");
+        given(body.getCharset()).willReturn(DEFAULT_CHARSET.name());
+        byte[] otherBodyContent = "Other Body".getBytes(DEFAULT_CHARSET);
+        byte[] encodedBody = gzip(otherBodyContent);
+        given(body.length()).willReturn(encodedBody.length);
+        // When
+        model.setData(otherBodyContent);
+        // Then
+        verify(body).setBody(encodedBody);
+        verify(header).setContentLength(encodedBody.length);
+    }
+
+    private static byte[] gzip(byte[] value) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gis = new GZIPOutputStream(baos)) {
+            gis.write(value);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return baos.toByteArray();
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/BodyStringHttpPanelViewModelTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/BodyStringHttpPanelViewModelTest.java
@@ -1,0 +1,154 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.httppanel.view.impl.models.http;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.Mockito.mock;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.zip.GZIPOutputStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpBody;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+
+public abstract class BodyStringHttpPanelViewModelTest<T1 extends HttpHeader, T2 extends HttpBody> {
+
+    private static final Charset DEFAULT_CHARSET = Charset.forName(HttpBody.DEFAULT_CHARSET);
+
+    private static final String BODY = "Body 123 ABC";
+    private static final byte[] BODY_BYTES_DEFAULT_CHARSET = BODY.getBytes(DEFAULT_CHARSET);
+
+    private AbstractHttpStringHttpPanelViewModel model;
+
+    protected HttpMessage message;
+    protected T1 header;
+    protected T2 body;
+
+    @BeforeEach
+    void setup() {
+        model = createModel();
+
+        message = mock(HttpMessage.class);
+        header = mock(getHeaderClass());
+        body = mock(getBodyClass());
+
+        given(body.toString()).willReturn(BODY);
+
+        prepareMessage();
+    }
+
+    protected abstract AbstractHttpStringHttpPanelViewModel createModel();
+
+    protected abstract Class<T1> getHeaderClass();
+
+    protected abstract Class<T2> getBodyClass();
+
+    protected abstract void prepareMessage();
+
+    @Test
+    void shouldGetEmptyDataFromNullMessage() {
+        // Given
+        model.setMessage(null);
+        // When
+        String data = model.getData();
+        // Then
+        assertThat(data, isEmptyString());
+    }
+
+    @Test
+    void shouldGetDataFromBody() {
+        // Given
+        model.setMessage(message);
+        // When
+        String data = model.getData();
+        // Then
+        assertThat(data, is(equalTo(BODY)));
+    }
+
+    @Test
+    void shouldGetDataFromBodyGzipDecoded() {
+        // Given
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn("gzip");
+        given(body.getCharset()).willReturn(DEFAULT_CHARSET.name());
+        given(body.getBytes()).willReturn(gzip(BODY_BYTES_DEFAULT_CHARSET));
+        model.setMessage(message);
+        // When
+        String data = model.getData();
+        // Then
+        assertThat(data, is(equalTo(BODY)));
+    }
+
+    @Test
+    void shouldNotSetDataWithNullMessage() {
+        // Given
+        model.setMessage(null);
+        // When / Then
+        assertDoesNotThrow(() -> model.setData(BODY));
+    }
+
+    @Test
+    void shouldSetDataIntoBody() {
+        // Given
+        model.setMessage(message);
+        String otherBodyContent = "Other Body";
+        given(body.length()).willReturn(otherBodyContent.length());
+        // When
+        model.setData(otherBodyContent);
+        // Then
+        verify(body).setBody(otherBodyContent);
+        verify(header).setContentLength(otherBodyContent.length());
+    }
+
+    @Test
+    void shouldSetDataIntoBodyGzipEncoded() {
+        // Given
+        model.setMessage(message);
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn("gzip");
+        given(body.getCharset()).willReturn(DEFAULT_CHARSET.name());
+        String otherBodyContent = "Other Body";
+        byte[] encodedBody = gzip(otherBodyContent.getBytes(DEFAULT_CHARSET));
+        given(body.length()).willReturn(encodedBody.length);
+        // When
+        model.setData(otherBodyContent);
+        // Then
+        verify(body).setBody(encodedBody);
+        verify(header).setContentLength(encodedBody.length);
+    }
+
+    private static byte[] gzip(byte[] value) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gis = new GZIPOutputStream(baos)) {
+            gis.write(value);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return baos.toByteArray();
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/HttpPanelViewModelUtilsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/HttpPanelViewModelUtilsUnitTest.java
@@ -1,0 +1,344 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.httppanel.view.impl.models.http;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+import java.util.zip.GZIPOutputStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.parosproxy.paros.network.HttpBody;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.zaproxy.zap.network.HttpRequestBody;
+import org.zaproxy.zap.network.HttpResponseBody;
+
+/** Unit test for {@link HttpPanelViewModelUtils}. */
+class HttpPanelViewModelUtilsUnitTest {
+
+    private static final String UNSUPPORTED_ENCODING = "UnsupportedEncoding";
+
+    private static final Charset DEFAULT_CHARSET = Charset.forName(HttpBody.DEFAULT_CHARSET);
+
+    private static final String BODY = "Body 123 ABC";
+    private static final byte[] BODY_BYTES_DEFAULT_CHARSET = BODY.getBytes(DEFAULT_CHARSET);
+
+    private HttpHeader header;
+    private HttpBody body;
+
+    @BeforeEach
+    void setup() {
+        header = mock(HttpHeader.class);
+        body = mock(HttpBody.class);
+    }
+
+    @Test
+    void shouldUpdateRequestContentLength() {
+        // Given
+        HttpMessage message = mock(HttpMessage.class);
+        HttpRequestHeader requestHeader = spy(HttpRequestHeader.class);
+        given(message.getRequestHeader()).willReturn(requestHeader);
+        HttpRequestBody requestBody = mock(HttpRequestBody.class);
+        given(message.getRequestBody()).willReturn(requestBody);
+        int length = 1234;
+        given(requestBody.length()).willReturn(length);
+        // When
+        HttpPanelViewModelUtils.updateRequestContentLength(message);
+        // Then
+        verify(requestHeader).setContentLength(length);
+    }
+
+    @Test
+    void shouldUpdateResponseContentLength() {
+        // Given
+        HttpMessage message = mock(HttpMessage.class);
+        HttpResponseHeader responseHeader = spy(HttpResponseHeader.class);
+        given(message.getResponseHeader()).willReturn(responseHeader);
+        HttpResponseBody responseBody = mock(HttpResponseBody.class);
+        given(message.getResponseBody()).willReturn(responseBody);
+        int length = 1234;
+        given(responseBody.length()).willReturn(length);
+        // When
+        HttpPanelViewModelUtils.updateResponseContentLength(message);
+        // Then
+        verify(responseHeader).setContentLength(length);
+    }
+
+    @Test
+    void shouldGetBodyString() {
+        // Given
+        given(body.toString()).willReturn(BODY);
+        // When
+        String bodyString = HttpPanelViewModelUtils.getBodyString(header, body);
+        // Then
+        assertThat(bodyString, is(equalTo(BODY)));
+    }
+
+    @Test
+    void shouldGetBodyStringIgnoringUnsupportedEncoding() {
+        // Given
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn(UNSUPPORTED_ENCODING);
+        given(body.toString()).willReturn(BODY);
+        // When
+        String bodyString = HttpPanelViewModelUtils.getBodyString(header, body);
+        // Then
+        assertThat(bodyString, is(equalTo(BODY)));
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "gzipEncodingProvider")
+    void shouldGetBodyStringGzipDecoded(String contentEncoding) {
+        // Given
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn(contentEncoding);
+        given(body.getCharset()).willReturn(DEFAULT_CHARSET.name());
+        given(body.getBytes()).willReturn(gzip(BODY_BYTES_DEFAULT_CHARSET));
+        // When
+        String bodyString = HttpPanelViewModelUtils.getBodyString(header, body);
+        // Then
+        assertThat(bodyString, is(equalTo(BODY)));
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "gzipEncodingProvider")
+    void shouldGetBodyStringAsOriginalIfNotProperlyGzipEncoded(String contentEncoding) {
+        // Given
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn(contentEncoding);
+        given(body.getCharset()).willReturn(DEFAULT_CHARSET.name());
+        given(body.getBytes()).willReturn(new byte[] {'N', 'o', 't', ' ', 'G', 'Z', 'I', 'P'});
+        given(body.toString()).willReturn(BODY);
+        // When
+        String bodyString = HttpPanelViewModelUtils.getBodyString(header, body);
+        // Then
+        assertThat(bodyString, is(equalTo(BODY)));
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "gzipEncodingProvider")
+    void shouldGetBodyStringGzipDecodedEvenWithDataLossDueStringToByteConversion(
+            String contentEncoding) {
+        // Given
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn(contentEncoding);
+        given(body.getCharset()).willReturn(DEFAULT_CHARSET.name());
+        byte[] bytes = " a → z ".getBytes(StandardCharsets.UTF_8);
+        given(body.getBytes()).willReturn(gzip(bytes));
+        String expectedBodyString = new String(bytes, DEFAULT_CHARSET);
+        // When
+        String bodyString = HttpPanelViewModelUtils.getBodyString(header, body);
+        // Then
+        assertThat(bodyString, is(equalTo(expectedBodyString)));
+    }
+
+    @Test
+    void shouldGetBodyBytes() {
+        // Given
+        given(body.getBytes()).willReturn(BODY_BYTES_DEFAULT_CHARSET);
+        // When
+        byte[] bodyBytes = HttpPanelViewModelUtils.getBodyBytes(header, body);
+        // Then
+        assertThat(bodyBytes, is(equalTo(BODY_BYTES_DEFAULT_CHARSET)));
+    }
+
+    @Test
+    void shouldGetBodyBytesIgnoringUnsupportedEncoding() {
+        // Given
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn(UNSUPPORTED_ENCODING);
+        given(body.getBytes()).willReturn(BODY_BYTES_DEFAULT_CHARSET);
+        // When
+        byte[] bodyBytes = HttpPanelViewModelUtils.getBodyBytes(header, body);
+        // Then
+        assertThat(bodyBytes, is(equalTo(BODY_BYTES_DEFAULT_CHARSET)));
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "gzipEncodingProvider")
+    void shouldGetBodyBytesGzipDecoded(String contentEncoding) {
+        // Given
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn(contentEncoding);
+        given(body.getBytes()).willReturn(gzip(BODY_BYTES_DEFAULT_CHARSET));
+        // When
+        byte[] bodyBytes = HttpPanelViewModelUtils.getBodyBytes(header, body);
+        // Then
+        assertThat(bodyBytes, is(equalTo(BODY_BYTES_DEFAULT_CHARSET)));
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "gzipEncodingProvider")
+    void shouldGetBodyBytesAsOriginalIfNotProperlyGzipEncoded(String contentEncoding) {
+        // Given
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn(contentEncoding);
+        byte[] content = new byte[] {'N', 'o', 't', ' ', 'G', 'Z', 'I', 'P'};
+        given(body.getBytes()).willReturn(content);
+        // When
+        byte[] bodyBytes = HttpPanelViewModelUtils.getBodyBytes(header, body);
+        // Then
+        assertThat(bodyBytes, is(equalTo(content)));
+    }
+
+    @Test
+    void shouldSetBodyString() {
+        // Given
+        given(body.length()).willReturn(BODY.length());
+        // When
+        HttpPanelViewModelUtils.setBody(header, body, BODY);
+        // Then
+        verify(body).setBody(BODY);
+        verify(header).setContentLength(BODY.length());
+    }
+
+    @Test
+    void shouldSetBodyStringIgnoringUnsupportedEncoding() {
+        // Given
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn(UNSUPPORTED_ENCODING);
+        given(body.length()).willReturn(BODY.length());
+        // When
+        HttpPanelViewModelUtils.setBody(header, body, BODY);
+        // Then
+        verify(body).setBody(BODY);
+        verify(header).setContentLength(BODY.length());
+    }
+
+    @Test
+    void shouldSetBodyStringWithHeaderCharset() {
+        // Given
+        Charset charset = StandardCharsets.UTF_8;
+        given(header.getCharset()).willReturn(charset.name());
+        String bodyContent = " a → z ";
+        given(body.length()).willReturn(bodyContent.length());
+        // When
+        HttpPanelViewModelUtils.setBody(header, body, bodyContent);
+        // Then
+        verify(body).setCharset(charset.name());
+        verify(body).setBody(bodyContent);
+        verify(header).setContentLength(bodyContent.length());
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "gzipEncodingProvider")
+    void shouldSetBodyStringAndGzipEncode(String contentEncoding) {
+        // Given
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn(contentEncoding);
+        byte[] gzip = gzip(BODY_BYTES_DEFAULT_CHARSET);
+        given(body.length()).willReturn(gzip.length);
+        given(body.getCharset()).willReturn(DEFAULT_CHARSET.name());
+        // When
+        HttpPanelViewModelUtils.setBody(header, body, BODY);
+        // Then
+        verify(body).setBody(gzip);
+        verify(header).setContentLength(gzip.length);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "gzipEncodingProvider")
+    void shouldSetBodyStringAndGzipEncodeEvenWithDataLossDueStringToByteConversion(
+            String contentEncoding) {
+        // Given
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn(contentEncoding);
+        String bodyContent = " a → z ";
+        byte[] gzip = gzip(bodyContent.getBytes(DEFAULT_CHARSET));
+        given(body.length()).willReturn(gzip.length);
+        given(body.getCharset()).willReturn(DEFAULT_CHARSET.name());
+        // When
+        HttpPanelViewModelUtils.setBody(header, body, bodyContent);
+        // Then
+        verify(body).setBody(gzip);
+        verify(header).setContentLength(gzip.length);
+    }
+
+    @Test
+    void shouldSetBodyBytes() {
+        // Given
+        given(body.length()).willReturn(BODY_BYTES_DEFAULT_CHARSET.length);
+        // When
+        HttpPanelViewModelUtils.setBody(header, body, BODY_BYTES_DEFAULT_CHARSET);
+        // Then
+        verify(body).setBody(BODY_BYTES_DEFAULT_CHARSET);
+        verify(header).setContentLength(BODY_BYTES_DEFAULT_CHARSET.length);
+    }
+
+    @Test
+    void shouldSetBodyBytesIgnoringUnsupportedEncoding() {
+        // Given
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn(UNSUPPORTED_ENCODING);
+        given(body.length()).willReturn(BODY_BYTES_DEFAULT_CHARSET.length);
+        // When
+        HttpPanelViewModelUtils.setBody(header, body, BODY_BYTES_DEFAULT_CHARSET);
+        // Then
+        verify(body).setBody(BODY_BYTES_DEFAULT_CHARSET);
+        verify(header).setContentLength(BODY_BYTES_DEFAULT_CHARSET.length);
+    }
+
+    @Test
+    void shouldSetBodyBytesWithHeaderCharset() {
+        // Given
+        Charset charset = StandardCharsets.UTF_8;
+        given(header.getCharset()).willReturn(charset.name());
+        byte[] bodyContent = " a → z ".getBytes(charset);
+        given(body.length()).willReturn(bodyContent.length);
+        // When
+        HttpPanelViewModelUtils.setBody(header, body, bodyContent);
+        // Then
+        verify(body).setCharset(charset.name());
+        verify(body).setBody(bodyContent);
+        verify(header).setContentLength(bodyContent.length);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "gzipEncodingProvider")
+    void shouldSetBodyBytesAndGzipEncode(String contentEncoding) {
+        // Given
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn(contentEncoding);
+        byte[] gzip = gzip(BODY_BYTES_DEFAULT_CHARSET);
+        given(body.length()).willReturn(gzip.length);
+        // When
+        HttpPanelViewModelUtils.setBody(header, body, BODY_BYTES_DEFAULT_CHARSET);
+        // Then
+        verify(body).setBody(gzip);
+        verify(header).setContentLength(gzip.length);
+    }
+
+    static Stream<String> gzipEncodingProvider() {
+        return Stream.of("gzip", "gZiP", " gzip  ", "x-gzip", "X-gZiP", "  x-gzip ");
+    }
+
+    private static byte[] gzip(byte[] value) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gis = new GZIPOutputStream(baos)) {
+            gis.write(value);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return baos.toByteArray();
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/StringHttpPanelViewModelTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/StringHttpPanelViewModelTest.java
@@ -1,0 +1,205 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.httppanel.view.impl.models.http;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.Mockito.mock;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.zip.GZIPOutputStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpBody;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+
+public abstract class StringHttpPanelViewModelTest<T1 extends HttpHeader, T2 extends HttpBody> {
+
+    private static final Charset DEFAULT_CHARSET = Charset.forName(HttpBody.DEFAULT_CHARSET);
+
+    private static final String HEADER = "Start Line\r\nHeader1: A\r\nHeader2: B";
+    private static final String HEADER_WITH_SEPARATOR = HEADER + "\r\n\r\n";
+    private static final String HEADER_LINEFEEDS = HEADER.replace(HttpHeader.CRLF, HttpHeader.LF);
+
+    private static final String BODY = "Body\r\n 123\n ABC";
+    private static final byte[] BODY_BYTES_DEFAULT_CHARSET = BODY.getBytes(DEFAULT_CHARSET);
+
+    protected AbstractHttpStringHttpPanelViewModel model;
+
+    protected HttpMessage message;
+    protected T1 header;
+    protected T2 body;
+
+    @BeforeEach
+    void setup() {
+        model = createModel();
+
+        message = mock(HttpMessage.class);
+        header = mock(getHeaderClass());
+        body = mock(getBodyClass());
+
+        prepareHeader();
+        given(body.toString()).willReturn(BODY);
+
+        prepareMessage();
+    }
+
+    protected abstract AbstractHttpStringHttpPanelViewModel createModel();
+
+    protected abstract Class<T1> getHeaderClass();
+
+    protected void prepareHeader() {
+        given(header.toString()).willReturn(HEADER_WITH_SEPARATOR);
+    }
+
+    protected abstract void verifyHeader(String header) throws HttpMalformedHeaderException;
+
+    protected abstract void headerThrowsHttpMalformedHeaderException()
+            throws HttpMalformedHeaderException;
+
+    protected abstract Class<T2> getBodyClass();
+
+    protected abstract void prepareMessage();
+
+    @Test
+    void shouldGetEmptyDataFromNullMessage() {
+        // Given
+        model.setMessage(null);
+        // When
+        String data = model.getData();
+        // Then
+        assertThat(data, isEmptyString());
+    }
+
+    @Test
+    void shouldGetDataFromHeaderAndBody() {
+        // Given
+        model.setMessage(message);
+        // When
+        String data = model.getData();
+        // Then
+        assertThat(data, is(equalTo(HEADER_LINEFEEDS + "\n\n" + BODY)));
+    }
+
+    @Test
+    void shouldGetDataFromBodyGzipDecoded() {
+        // Given
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn("gzip");
+        given(body.getCharset()).willReturn(DEFAULT_CHARSET.name());
+        given(body.getBytes()).willReturn(gzip(BODY_BYTES_DEFAULT_CHARSET));
+        model.setMessage(message);
+        // When
+        String data = model.getData();
+        // Then
+        assertThat(data, endsWith(BODY));
+    }
+
+    @Test
+    void shouldNotSetDataWithNullMessage() {
+        // Given
+        model.setMessage(null);
+        // When / Then
+        assertDoesNotThrow(() -> model.setData(BODY));
+    }
+
+    @Test
+    void shouldSetDataIntoHeaderAndBody() throws HttpMalformedHeaderException {
+        // Given
+        model.setMessage(message);
+        String otherHeaderContent = "Other Start Line\\r\\nHeader1: A\\r\\nHeader2: B";
+        String otherBodyContent = "Other Body\r\n 123\n ABC";
+        String data = otherHeaderContent + "\n\n" + otherBodyContent;
+        given(body.length()).willReturn(otherBodyContent.length());
+        // When
+        model.setData(data);
+        // Then
+        verifyHeader(otherHeaderContent);
+        verify(header).setContentLength(otherBodyContent.length());
+        verify(body).setBody(otherBodyContent);
+    }
+
+    @Test
+    void shouldSetDataIntoBodyAndIgnoreMalformedHeader() throws HttpMalformedHeaderException {
+        // Given
+        model.setMessage(message);
+        String otherHeaderContent = "Malformed Header";
+        headerThrowsHttpMalformedHeaderException();
+        String otherBodyContent = "Other Body\r\n 123\n ABC";
+        String data = otherHeaderContent + "\n\n" + otherBodyContent;
+        given(body.length()).willReturn(otherBodyContent.length());
+        // When
+        model.setData(data);
+        // Then
+        verify(header).setContentLength(otherBodyContent.length());
+        verify(body).setBody(otherBodyContent);
+    }
+
+    @Test
+    void shouldSetDataOnlyIntoHeaderIfBodyEmpty() throws HttpMalformedHeaderException {
+        // Given
+        model.setMessage(message);
+        String data = HEADER_LINEFEEDS;
+        given(body.length()).willReturn(0);
+        // When
+        model.setData(data);
+        // Then
+        verifyHeader(HEADER);
+        verify(header).setContentLength(0);
+        verify(body).setBody("");
+    }
+
+    @Test
+    void shouldSetDataIntoBodyGzipEncoded() throws HttpMalformedHeaderException {
+        // Given
+        model.setMessage(message);
+        given(header.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn("gzip");
+        given(body.getCharset()).willReturn(DEFAULT_CHARSET.name());
+        String otherBodyContent = "Other Body\r\n 123\n ABC";
+        String data = HEADER_LINEFEEDS + "\n\n" + otherBodyContent;
+        byte[] encodedBody = gzip(otherBodyContent.getBytes(DEFAULT_CHARSET));
+        given(body.length()).willReturn(encodedBody.length);
+        // When
+        model.setData(data);
+        // Then
+        verifyHeader(HEADER);
+        verify(header).setContentLength(encodedBody.length);
+        verify(body).setBody(encodedBody);
+    }
+
+    private static byte[] gzip(byte[] value) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gis = new GZIPOutputStream(baos)) {
+            gis.write(value);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return baos.toByteArray();
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestBodyByteHttpPanelViewModelUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestBodyByteHttpPanelViewModelUnitTest.java
@@ -1,0 +1,52 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.httppanel.view.impl.models.http.request;
+
+import static org.mockito.BDDMockito.given;
+
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.extension.httppanel.view.impl.models.http.BodyByteHttpPanelViewModelTest;
+import org.zaproxy.zap.network.HttpRequestBody;
+
+/** Unit test for {@link RequestBodyByteHttpPanelViewModel}. */
+class RequestBodyByteHttpPanelViewModelUnitTest
+        extends BodyByteHttpPanelViewModelTest<HttpRequestHeader, HttpRequestBody> {
+
+    @Override
+    protected RequestBodyByteHttpPanelViewModel createModel() {
+        return new RequestBodyByteHttpPanelViewModel();
+    }
+
+    @Override
+    protected Class<HttpRequestHeader> getHeaderClass() {
+        return HttpRequestHeader.class;
+    }
+
+    @Override
+    protected Class<HttpRequestBody> getBodyClass() {
+        return HttpRequestBody.class;
+    }
+
+    @Override
+    protected void prepareMessage() {
+        given(message.getRequestHeader()).willReturn(header);
+        given(message.getRequestBody()).willReturn(body);
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestBodyStringHttpPanelViewModelUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestBodyStringHttpPanelViewModelUnitTest.java
@@ -1,0 +1,52 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.httppanel.view.impl.models.http.request;
+
+import static org.mockito.BDDMockito.given;
+
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.extension.httppanel.view.impl.models.http.BodyStringHttpPanelViewModelTest;
+import org.zaproxy.zap.network.HttpRequestBody;
+
+/** Unit test for {@link RequestBodyStringHttpPanelViewModel}. */
+class RequestBodyStringHttpPanelViewModelUnitTest
+        extends BodyStringHttpPanelViewModelTest<HttpRequestHeader, HttpRequestBody> {
+
+    @Override
+    protected RequestBodyStringHttpPanelViewModel createModel() {
+        return new RequestBodyStringHttpPanelViewModel();
+    }
+
+    @Override
+    protected Class<HttpRequestHeader> getHeaderClass() {
+        return HttpRequestHeader.class;
+    }
+
+    @Override
+    protected Class<HttpRequestBody> getBodyClass() {
+        return HttpRequestBody.class;
+    }
+
+    @Override
+    protected void prepareMessage() {
+        given(message.getRequestHeader()).willReturn(header);
+        given(message.getRequestBody()).willReturn(body);
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModelUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModelUnitTest.java
@@ -1,0 +1,74 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.httppanel.view.impl.models.http.request;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.apache.commons.httpclient.URI;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.extension.httppanel.view.impl.models.http.StringHttpPanelViewModelTest;
+import org.zaproxy.zap.network.HttpRequestBody;
+
+/** Unit test for {@link RequestStringHttpPanelViewModel}. */
+public class RequestStringHttpPanelViewModelUnitTest
+        extends StringHttpPanelViewModelTest<HttpRequestHeader, HttpRequestBody> {
+
+    @Override
+    protected RequestStringHttpPanelViewModel createModel() {
+        return new RequestStringHttpPanelViewModel();
+    }
+
+    @Override
+    protected Class<HttpRequestHeader> getHeaderClass() {
+        return HttpRequestHeader.class;
+    }
+
+    @Override
+    protected void prepareHeader() {
+        given(header.getURI()).willReturn(mock(URI.class));
+        super.prepareHeader();
+    }
+
+    @Override
+    protected void verifyHeader(String header) throws HttpMalformedHeaderException {
+        verify(message).setRequestHeader(header);
+    }
+
+    @Override
+    protected void headerThrowsHttpMalformedHeaderException() throws HttpMalformedHeaderException {
+        willThrow(HttpMalformedHeaderException.class).given(message).setRequestHeader(anyString());
+    }
+
+    @Override
+    protected Class<HttpRequestBody> getBodyClass() {
+        return HttpRequestBody.class;
+    }
+
+    @Override
+    protected void prepareMessage() {
+        given(message.getRequestHeader()).willReturn(header);
+        given(message.getRequestBody()).willReturn(body);
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseBodyByteHttpPanelViewModelUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseBodyByteHttpPanelViewModelUnitTest.java
@@ -1,0 +1,52 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.httppanel.view.impl.models.http.response;
+
+import static org.mockito.BDDMockito.given;
+
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.zaproxy.zap.extension.httppanel.view.impl.models.http.BodyByteHttpPanelViewModelTest;
+import org.zaproxy.zap.network.HttpResponseBody;
+
+/** Unit test for {@link ResponseBodyByteHttpPanelViewModel}. */
+class ResponseBodyByteHttpPanelViewModelUnitTest
+        extends BodyByteHttpPanelViewModelTest<HttpResponseHeader, HttpResponseBody> {
+
+    @Override
+    protected ResponseBodyByteHttpPanelViewModel createModel() {
+        return new ResponseBodyByteHttpPanelViewModel();
+    }
+
+    @Override
+    protected Class<HttpResponseHeader> getHeaderClass() {
+        return HttpResponseHeader.class;
+    }
+
+    @Override
+    protected Class<HttpResponseBody> getBodyClass() {
+        return HttpResponseBody.class;
+    }
+
+    @Override
+    protected void prepareMessage() {
+        given(message.getResponseHeader()).willReturn(header);
+        given(message.getResponseBody()).willReturn(body);
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseBodyStringHttpPanelViewModelUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseBodyStringHttpPanelViewModelUnitTest.java
@@ -1,0 +1,52 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.httppanel.view.impl.models.http.response;
+
+import static org.mockito.BDDMockito.given;
+
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.zaproxy.zap.extension.httppanel.view.impl.models.http.BodyStringHttpPanelViewModelTest;
+import org.zaproxy.zap.network.HttpResponseBody;
+
+/** Unit test for {@link ResponseBodyStringHttpPanelViewModel}. */
+class ResponseBodyStringHttpPanelViewModelUnitTest
+        extends BodyStringHttpPanelViewModelTest<HttpResponseHeader, HttpResponseBody> {
+
+    @Override
+    protected ResponseBodyStringHttpPanelViewModel createModel() {
+        return new ResponseBodyStringHttpPanelViewModel();
+    }
+
+    @Override
+    protected Class<HttpResponseHeader> getHeaderClass() {
+        return HttpResponseHeader.class;
+    }
+
+    @Override
+    protected Class<HttpResponseBody> getBodyClass() {
+        return HttpResponseBody.class;
+    }
+
+    @Override
+    protected void prepareMessage() {
+        given(message.getResponseHeader()).willReturn(header);
+        given(message.getResponseBody()).willReturn(body);
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseStringHttpPanelViewModelUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseStringHttpPanelViewModelUnitTest.java
@@ -1,0 +1,86 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.httppanel.view.impl.models.http.response;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.zaproxy.zap.extension.httppanel.view.impl.models.http.StringHttpPanelViewModelTest;
+import org.zaproxy.zap.network.HttpResponseBody;
+
+/** Unit test for {@link ResponseStringHttpPanelViewModel}. */
+public class ResponseStringHttpPanelViewModelUnitTest
+        extends StringHttpPanelViewModelTest<HttpResponseHeader, HttpResponseBody> {
+
+    @Override
+    protected ResponseStringHttpPanelViewModel createModel() {
+        return new ResponseStringHttpPanelViewModel();
+    }
+
+    @Override
+    protected Class<HttpResponseHeader> getHeaderClass() {
+        return HttpResponseHeader.class;
+    }
+
+    @Override
+    protected void prepareHeader() {
+        super.prepareHeader();
+        given(header.isEmpty()).willReturn(false);
+    }
+
+    @Override
+    protected void verifyHeader(String header) throws HttpMalformedHeaderException {
+        verify(message).setResponseHeader(header);
+    }
+
+    @Override
+    protected void headerThrowsHttpMalformedHeaderException() throws HttpMalformedHeaderException {
+        willThrow(HttpMalformedHeaderException.class).given(message).setResponseHeader(anyString());
+    }
+
+    @Override
+    protected Class<HttpResponseBody> getBodyClass() {
+        return HttpResponseBody.class;
+    }
+
+    @Override
+    protected void prepareMessage() {
+        given(message.getResponseHeader()).willReturn(header);
+        given(message.getResponseBody()).willReturn(body);
+    }
+
+    @Test
+    void shouldGetEmptyDataWithEmptyHeader() {
+        // Given
+        given(header.isEmpty()).willReturn(true);
+        model.setMessage(message);
+        // When
+        String data = model.getData();
+        // Then
+        assertThat(data, isEmptyString());
+    }
+}


### PR DESCRIPTION
Do not gzip decode reading lines, read byte chunks instead to not lose
the new line characters.
Change request view models (body and header+body) to decode the body,
like done for the response.
Extract common code to `HttpPanelViewModelUtils` and change the models
accordingly.
Normalise behaviour when setting data with null message, by ignoring the
data being set.

Fix #1351 - Decode gzip'ed content in Request tab
Fix #1584 - GZip de-compression causes loss of newlines