### PR TITLE
Fix typo in extension name

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/component/all/ExtensionHttpPanelComponentAll.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/component/all/ExtensionHttpPanelComponentAll.java
@@ -30,7 +30,7 @@ import org.zaproxy.zap.view.HttpPanelManager.HttpPanelComponentFactory;
 
 public class ExtensionHttpPanelComponentAll extends ExtensionAdaptor {
 
-    public static final String NAME = "ExtensionHttpPanelComponentonentAll";
+    public static final String NAME = "ExtensionHttpPanelComponentAll";
 
     public ExtensionHttpPanelComponentAll() {
         super(NAME);


### PR DESCRIPTION
Extracted from #5719 since it does not require an upgrade from.

The change might affect add-ons using the constant to access the
extension but it's very unlikely that's happening, the add-ons wanting
to add "all" components would do so using the name of the component
itself not the extension.