### PR TITLE
Improve error message when starting packaged scans

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2020-09-18
+ - Fail immediately if the spider scans were not started to provide better error message.
+
 ###  2020-08-28
  - Packaged scans will use the provided context when spidering and active scanning.
 

--- a/docker/tests/suite.py
+++ b/docker/tests/suite.py
@@ -35,11 +35,11 @@ def run_tests(directory="./"):
     test_load = unittest.TestLoader()
     cases = [test_load.loadTestsFromTestCase(t) for t in test_list]
     test_suite = unittest.TestSuite(cases)
-    unittest.TextTestRunner(verbosity=9).run(test_suite)
+    return unittest.TextTestRunner(verbosity=9).run(test_suite)
 
 if __name__ == '__main__':
     tests_dir = os.path.dirname(os.path.realpath(__file__))
     # Include modules from parent directory
     sys.path.append("{}/..".format(tests_dir))
-    run_tests(tests_dir)
+    sys.exit(run_tests(tests_dir).wasSuccessful() is False)
     

--- a/docker/tests/test_zap_common.py
+++ b/docker/tests/test_zap_common.py
@@ -38,6 +38,18 @@ class TestZapCommon(unittest.TestCase):
         zap.spider.status.assert_called_with(scan_id)
         self.assertEqual(3, zap.spider.status.call_count)
 
+    def test_zap_spider_raises_exception_if_not_started(self):
+        """Spider raises exception if not started."""
+        zap = Mock()
+        zap.spider.scan.return_value = "url_not_in_context"
+        target = "http://target.example.com"
+
+        with self.assertRaises(zap_common.ScanNotStartedException):
+            zap_common.zap_spider(zap, target)
+
+        zap.spider.scan.assert_called_once_with(target, contextname=None)
+        zap.spider.status.assert_not_called()
+
     def test_zap_ajax_spider(self):
         """AJAX Spider is started and waits until finished."""
         zap = Mock()
@@ -57,6 +69,21 @@ class TestZapCommon(unittest.TestCase):
         self.assertEqual(3, status.call_count)
         number_of_results.assert_called_with()
         self.assertEqual(2, number_of_results.call_count)
+
+    def test_zap_ajax_spider_raises_exception_if_not_started(self):
+        """AJAX Spider raises exception if not started."""
+        zap = Mock()
+        zap.ajaxSpider.scan.return_value = "url_not_in_context"
+        status = PropertyMock()
+        type(zap.ajaxSpider).status = status
+        target = "http://target.example.com"
+        max_time = None
+
+        with self.assertRaises(zap_common.ScanNotStartedException):
+            zap_common.zap_ajax_spider(zap, target, max_time)
+
+        zap.ajaxSpider.scan.assert_called_once_with(target, contextname=None)
+        status.assert_not_called()
 
     def test_zap_ajax_spider_with_max_time(self):
         """AJAX Spider is started with specified maximum time."""

--- a/docker/tests/test_zap_hooks.py
+++ b/docker/tests/test_zap_hooks.py
@@ -204,7 +204,9 @@ class TestZapHooks(unittest.TestCase):
         hooks = Mock(zap_spider=Mock(return_value=[]))
         zap_common.zap_hooks = hooks
 
-        zap = Mock(spider=Mock(status=Mock(return_value="100")))
+        zap = Mock()
+        zap.spider.scan.return_value = "1"
+        zap.spider.status.side_effect = ["100"]
         target = "http://target.example.com"
 
         with patch("time.sleep"):
@@ -218,7 +220,8 @@ class TestZapHooks(unittest.TestCase):
         hooks = Mock(zap_ajax_spider=Mock(return_value=[]))
         zap_common.zap_hooks = hooks
 
-        zap = Mock(ascan=Mock(status=Mock(return_value="stopped")))
+        zap = Mock()
+        zap.ajaxSpider.scan.return_value = "OK"
         target = "http://target.example.com"
         max_time = 10
 


### PR DESCRIPTION
Fail immediately if the spider scans were not started to provide better
error message, show:
`Failed to start the scan, check the log/output for more details.`

instead of, e.g.:
`invalid literal for int() with base 10: 'does_not_exist'`.

when checking the status of the scan.

Correct `suite.py` to exit with expected code when tests fail.