### PR TITLE
Custom Pages analyzer fallback & clean code

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -580,17 +580,18 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
     }
 
     /**
-     * Tells whether or not the file exists, based on previous analysis.
+     * Tells whether or not the file exists, based on {@code CustomPage} definition or previous
+     * analysis.
      *
      * @param msg the message that will be checked
      * @return {@code true} if the file exists, {@code false} otherwise
      */
     protected boolean isFileExist(HttpMessage msg) {
-        return parent.getAnalyser().isFileExist(msg);
+        return isPage200(msg);
     }
 
     /**
-     * Tells whether or not the message matches the specific {@code CustomPageType}
+     * Tells whether or not the message matches the specific {@code CustomPage.Type}.
      *
      * @param msg the message that will be checked
      * @param cpType the custom page type to be checked
@@ -602,18 +603,20 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
     }
 
     /**
-     * Tells whether or not the message matches {@code CustomPageType.OK_200} definitions.
+     * Tells whether or not the message matches {@code CustomPage.Type.OK_200} definitions. Falls
+     * back to use {@code Analyser}.
      *
      * @param msg the message that will be checked
      * @return {@code true} if the message matches, {@code false} otherwise
      * @since TODO Add version
      */
     protected boolean isPage200(HttpMessage msg) {
-        return isCustomPage(msg, CustomPage.Type.OK_200);
+        boolean is200 = isCustomPage(msg, CustomPage.Type.OK_200);
+        return is200 ? is200 : parent.getAnalyser().isFileExist(msg);
     }
 
     /**
-     * Tells whether or not the message matches {@code CustomPageType.ERROR_500} definitions.
+     * Tells whether or not the message matches {@code CustomPage.Type.ERROR_500} definitions.
      *
      * @param msg the message that will be checked
      * @return {@code true} if the message matches, {@code false} otherwise
@@ -624,18 +627,20 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
     }
 
     /**
-     * Tells whether or not the message matches {@code CustomPageType.NOTFOUND_404} definitions.
+     * Tells whether or not the message matches a {@code CustomPage.Type.NOTFOUND_404} definition.
+     * Falls back to {@code Analyser}.
      *
      * @param msg the message that will be checked
      * @return {@code true} if the message matches, {@code false} otherwise
      * @since TODO Add version
      */
     protected boolean isPage404(HttpMessage msg) {
-        return isCustomPage(msg, CustomPage.Type.NOTFOUND_404);
+        boolean is404 = isCustomPage(msg, CustomPage.Type.NOTFOUND_404);
+        return is404 ? is404 : !parent.getAnalyser().isFileExist(msg);
     }
 
     /**
-     * Tells whether or not the message matches {@code CustomPageType.OTHER} definitions.
+     * Tells whether or not the message matches {@code CustomPage.Type.OTHER} definitions.
      *
      * @param msg the message that will be checked
      * @return {@code true} if the message matches, {@code false} otherwise

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/HostProcess.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/HostProcess.java
@@ -1289,7 +1289,7 @@ public class HostProcess implements Runnable {
     }
 
     /**
-     * Tells whether or not the message matches the specific {@code CustomPageType}
+     * Tells whether or not the message matches the specific {@code CustomPage.Type}.
      *
      * @param msg the message that will be checked
      * @param cpType the custom page type to be checked

--- a/zap/src/main/java/org/zaproxy/zap/extension/custompages/CustomPage.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/custompages/CustomPage.java
@@ -102,7 +102,7 @@ public interface CustomPage extends EnableableInterface {
      * Determines if a {@code HttpMessage} is a Custom Page of a particular {@code CustomPage.Type}.
      *
      * @param msg the HTTP message to be evaluated
-     * @param cpt the CustomPageType of the Custom Pages against which the HTTP message should be
+     * @param cpt the CustomPage.Type of the Custom Pages against which the HTTP message should be
      *     evaluated
      * @return {@code true} if the HTTP message is a Custom Page of the type in question, {@code
      *     false} otherwise

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanData.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanData.java
@@ -142,7 +142,7 @@ public final class PassiveScanData {
     }
 
     /**
-     * Tells whether or not the message matches the specific {@code CustomPageType}
+     * Tells whether or not the message matches the specific {@code CustomPage.Type}
      *
      * @param msg the message that will be checked
      * @param cpType the custom page type to be checked
@@ -160,7 +160,7 @@ public final class PassiveScanData {
     }
 
     /**
-     * Tells whether or not the message matches {@code CustomPageType.OK_200} definitions.
+     * Tells whether or not the message matches {@code CustomPage.Type.OK_200} definitions.
      *
      * @param msg the message that will be checked
      * @return {@code true} if the message matches, {@code false} otherwise
@@ -171,7 +171,7 @@ public final class PassiveScanData {
     }
 
     /**
-     * Tells whether or not the message matches {@code CustomPageType.ERROR_500} definitions.
+     * Tells whether or not the message matches {@code CustomPage.Type.ERROR_500} definitions.
      *
      * @param msg the message that will be checked
      * @return {@code true} if the message matches, {@code false} otherwise
@@ -182,7 +182,7 @@ public final class PassiveScanData {
     }
 
     /**
-     * Tells whether or not the message matches {@code CustomPageType.NOTFOUND_404} definitions.
+     * Tells whether or not the message matches {@code CustomPage.Type.NOTFOUND_404} definitions.
      *
      * @param msg the message that will be checked
      * @return {@code true} if the message matches, {@code false} otherwise
@@ -193,7 +193,7 @@ public final class PassiveScanData {
     }
 
     /**
-     * Tells whether or not the message matches {@code CustomPageType.OTHER} definitions.
+     * Tells whether or not the message matches {@code CustomPage.Type.OTHER} definitions.
      *
      * @param msg the message that will be checked
      * @return {@code true} if the message matches, {@code false} otherwise

--- a/zap/src/main/java/org/zaproxy/zap/model/Context.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/Context.java
@@ -758,7 +758,7 @@ public class Context {
 
     /**
      * Returns {@code true} if the {@code Context} has Custom Page definitions of a specific {@code
-     * CustomPageType}.
+     * CustomPage.Type}.
      *
      * @return {@code true} if this context has Custom Pages, {@code false} otherwise.
      */


### PR DESCRIPTION
- In `AbstractPlugin.isPage404` fallback to use `Analyser.isFileExist`. In `Abstractplugin.isFileExist` check `isPage200` first then use `Analyser`.
- Tweak various references to CustomPageType -> CustomPage.Type.

See zaproxy/zaproxy#9.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>