### PR TITLE
Upgrade SQLite to 3.32.3.2

### DIFF
--- a/LEGALNOTICE.md
+++ b/LEGALNOTICE.md
@@ -64,7 +64,7 @@ and subject to their respective licenses.
 | json-lib-2.4-jdk15.jar              | MIT + "Good, Not Evil"    |
 | log4j-1.2.17.jar                    | Apache 2.0                |
 | rsyntaxtextarea-3.0.4.jar           | BSD-3 clause              |
-| sqlite-jdbc-3.28.0.jar              | BSD-2 clause              |
+| sqlite-jdbc-3.32.3.2.jar            | BSD-2 clause              |
 | - NestedVM                          | Apache 2.0                |
 | swingx-all-1.6.5-1.jar              | LGPL 2.1                  |
 | xom-1.2.10.jar                      | LGPL                      |

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
     api("org.jfree:jfreechart:1.0.19")
     api("org.jgrapht:jgrapht-core:0.9.0")
     api("org.swinglabs.swingx:swingx-all:1.6.5-1")
-    api("org.xerial:sqlite-jdbc:3.28.0")
+    api("org.xerial:sqlite-jdbc:3.32.3.2")
 
     implementation("commons-validator:commons-validator:1.6")
     // Don't need its dependencies, for now.


### PR DESCRIPTION
Upgraded the version of SQLite to a more recent version. 

The reason for this is that SQLite 3.28.0 was flagged as a vulnerable JAR file in a recent Nexus container scan of ZAP.