### PR TITLE
added check for running threads

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/utils/PausableThreadPoolExecutor.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/PausableThreadPoolExecutor.java
@@ -218,7 +218,9 @@ public class PausableThreadPoolExecutor extends ThreadPoolExecutor
     }
 
     /**
-     * @return boolean value denoting if there are threads currently being executed.
+     * Get boolean value denoting if there are threads currently being executed
+     *
+     * @return true if it has running threads, false otherwise
      */
     public boolean hasRunningThreads() {
         return runningCount.get() > 0;


### PR DESCRIPTION
Fixes #6213 
This maintains a counter on the number of threads under execution
the counter is incremented when the runnable is allowed to be submitted when the state is 'unpaused' and the counter is decremented after execution.
added an API to return if there are no threads under execution by checking on the runningCount.