### PR TITLE
Use user's context during authentication

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodType.java
@@ -120,6 +120,8 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
 
     private static final Logger LOGGER = Logger.getLogger(PostBasedAuthenticationMethodType.class);
 
+    private static ExtensionAntiCSRF extAntiCsrf;
+
     private final String methodName;
     private final int methodIdentifier;
     private final String apiMethodName;
@@ -182,8 +184,6 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
         private String loginPageUrl;
 
         private String loginRequestBody;
-
-        private ExtensionAntiCSRF extAntiCsrf;
 
         /**
          * Constructs a {@code PostBasedAuthenticationMethod} with the given data.
@@ -336,7 +336,7 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
                 msg = prepareRequestMessage(cred);
                 msg.setRequestingUser(user);
 
-                replaceAntiCsrfTokenValueIfRequired(msg, loginMsgToRenewCookie);
+                replaceAntiCsrfTokenValueIfRequired(msg, loginMsgToRenewCookie, paramEncoder);
             } catch (Exception e) {
                 LOGGER.error("Unable to prepare authentication message: " + e.getMessage(), e);
                 return null;
@@ -370,98 +370,6 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
 
             // Return the web session as extracted by the session management method
             return sessionManagementMethod.extractWebSession(msg);
-        }
-
-        /**
-         * <strong>Modifies</strong> the input {@code requestMessage} by replacing old
-         * anti-CSRF(ACSRF) token value with the fresh one in the request body. It first checks if
-         * the input {@code loginMsgWithFreshAcsrfToken} has any ACSRF token. If yes, then it
-         * modifies the input {@code requestMessage} with the fresh ACSRF token value. If the {@code
-         * loginMsgWithFreshAcsrfToken} does not have any ACSRF token then the input {@code
-         * requestMessage} is left as it is.
-         *
-         * <p>This logic relies on {@code ExtensionAntiCSRF} to extract the ACSRF token value from
-         * the response. If {@code ExtensionAntiCSRF} is not available for some reason, no further
-         * processing is done.
-         *
-         * @param requestMessage the login ({@code POST})request message with correct credentials
-         * @param loginMsgWithFreshAcsrfToken the {@code HttpMessage} of the login page(form) with
-         *     fresh cookie and ACSRF token.
-         */
-        private void replaceAntiCsrfTokenValueIfRequired(
-                HttpMessage requestMessage, HttpMessage loginMsgWithFreshAcsrfToken) {
-            if (extAntiCsrf == null) {
-                extAntiCsrf =
-                        Control.getSingleton()
-                                .getExtensionLoader()
-                                .getExtension(ExtensionAntiCSRF.class);
-            }
-            List<AntiCsrfToken> freshAcsrfTokens = null;
-            if (extAntiCsrf != null) {
-                freshAcsrfTokens = extAntiCsrf.getTokensFromResponse(loginMsgWithFreshAcsrfToken);
-            } else {
-                LOGGER.debug("ExtensionAntiCSRF is not available, skipping ACSRF replacing task");
-                return;
-            }
-            if (freshAcsrfTokens == null || freshAcsrfTokens.size() == 0) {
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug(
-                            "No ACSRF token found in the response of "
-                                    + loginMsgWithFreshAcsrfToken.getRequestHeader());
-                }
-                return;
-            }
-
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("The login page has " + freshAcsrfTokens.size() + " ACSRF token(s)");
-            }
-
-            String postRequestBody = requestMessage.getRequestBody().toString();
-            Map<String, String> parameters =
-                    extractParametersFromPostData(
-                            requestMessage.getRequestingUser().getContext(), postRequestBody);
-            if (!parameters.isEmpty()) {
-                String oldAcsrfTokenValue = null;
-                String replacedPostData = postRequestBody;
-                for (AntiCsrfToken antiCsrfToken : freshAcsrfTokens) {
-                    oldAcsrfTokenValue = parameters.get(antiCsrfToken.getName());
-                    if (oldAcsrfTokenValue == null) {
-                        if (LOGGER.isDebugEnabled()) {
-                            LOGGER.debug(
-                                    "ACSRF token "
-                                            + antiCsrfToken.getName()
-                                            + " not found in the POST data: "
-                                            + postRequestBody);
-                        }
-                        continue;
-                    }
-
-                    replacedPostData =
-                            replacedPostData.replace(
-                                    oldAcsrfTokenValue,
-                                    paramEncoder.apply(antiCsrfToken.getValue()));
-
-                    if (LOGGER.isDebugEnabled()) {
-                        LOGGER.debug(
-                                "replaced "
-                                        + oldAcsrfTokenValue
-                                        + " old ACSRF token value with "
-                                        + antiCsrfToken.getValue());
-                    }
-                }
-                requestMessage.getRequestBody().setBody(replacedPostData);
-            } else {
-                LOGGER.debug("ACSRF token found but could not replace old value with fresh value");
-            }
-        }
-
-        private Map<String, String> extractParametersFromPostData(
-                Context context, String postRequestBody) {
-            Map<String, String> map = new HashMap<>();
-            context.getPostParamParser()
-                    .parseParameters(postRequestBody)
-                    .forEach(nvp -> map.put(nvp.getName(), nvp.getValue()));
-            return map;
         }
 
         /**
@@ -624,6 +532,103 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
             } else if (!loginPageUrl.equals(other.loginPageUrl)) return false;
             return true;
         }
+    }
+
+    static void setExtAntiCsrf(ExtensionAntiCSRF ext) {
+        extAntiCsrf = ext;
+    }
+
+    /**
+     * <strong>Modifies</strong> the input {@code requestMessage} by replacing old anti-CSRF(ACSRF)
+     * token value with the fresh one in the request body. It first checks if the input {@code
+     * loginMsgWithFreshAcsrfToken} has any ACSRF token. If yes, then it modifies the input {@code
+     * requestMessage} with the fresh ACSRF token value. If the {@code loginMsgWithFreshAcsrfToken}
+     * does not have any ACSRF token then the input {@code requestMessage} is left as it is.
+     *
+     * <p>This logic relies on {@code ExtensionAntiCSRF} to extract the ACSRF token value from the
+     * response. If {@code ExtensionAntiCSRF} is not available for some reason, no further
+     * processing is done.
+     *
+     * @param requestMessage the login ({@code POST})request message with correct credentials
+     * @param loginMsgWithFreshAcsrfToken the {@code HttpMessage} of the login page(form) with fresh
+     *     cookie and ACSRF token.
+     * @param paramEncoder the encoder to be used on the anti-csrf parameters.
+     */
+    static void replaceAntiCsrfTokenValueIfRequired(
+            HttpMessage requestMessage,
+            HttpMessage loginMsgWithFreshAcsrfToken,
+            UnaryOperator<String> paramEncoder) {
+        if (extAntiCsrf == null) {
+            extAntiCsrf =
+                    Control.getSingleton()
+                            .getExtensionLoader()
+                            .getExtension(ExtensionAntiCSRF.class);
+        }
+        List<AntiCsrfToken> freshAcsrfTokens = null;
+        if (extAntiCsrf != null) {
+            freshAcsrfTokens = extAntiCsrf.getTokensFromResponse(loginMsgWithFreshAcsrfToken);
+        } else {
+            LOGGER.debug("ExtensionAntiCSRF is not available, skipping ACSRF replacing task");
+            return;
+        }
+        if (freshAcsrfTokens == null || freshAcsrfTokens.size() == 0) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
+                        "No ACSRF token found in the response of "
+                                + loginMsgWithFreshAcsrfToken.getRequestHeader());
+            }
+            return;
+        }
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("The login page has " + freshAcsrfTokens.size() + " ACSRF token(s)");
+        }
+
+        String postRequestBody = requestMessage.getRequestBody().toString();
+        Map<String, String> parameters =
+                extractParametersFromPostData(
+                        requestMessage.getRequestingUser().getContext(), postRequestBody);
+        if (!parameters.isEmpty()) {
+            String oldAcsrfTokenValue = null;
+            String replacedPostData = postRequestBody;
+            for (AntiCsrfToken antiCsrfToken : freshAcsrfTokens) {
+                oldAcsrfTokenValue = parameters.get(antiCsrfToken.getName());
+                if (oldAcsrfTokenValue == null) {
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug(
+                                "ACSRF token "
+                                        + antiCsrfToken.getName()
+                                        + " not found in the POST data: "
+                                        + postRequestBody);
+                    }
+                    continue;
+                }
+
+                replacedPostData =
+                        replacedPostData.replace(
+                                oldAcsrfTokenValue, paramEncoder.apply(antiCsrfToken.getValue()));
+
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(
+                            "replaced "
+                                    + oldAcsrfTokenValue
+                                    + " old ACSRF token value with "
+                                    + antiCsrfToken.getValue());
+                }
+            }
+            requestMessage.getRequestBody().setBody(replacedPostData);
+        } else {
+            LOGGER.debug("ACSRF token found but could not replace old value with fresh value");
+        }
+    }
+
+    private static Map<String, String> extractParametersFromPostData(
+            Context context, String postRequestBody) {
+        Map<String, String> map = new HashMap<>();
+        context.getPostParamParser()
+                .parseParameters(postRequestBody)
+                .forEach(nvp -> map.put(nvp.getName(), nvp.getValue()));
+        return map;
     }
 
     private static URI createLoginUrl(String loginData, String username, String password)

--- a/zap/src/main/java/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodType.java
@@ -417,8 +417,10 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
             }
 
             String postRequestBody = requestMessage.getRequestBody().toString();
-            Map<String, String> parameters = extractParametersFromPostData(postRequestBody);
-            if (parameters != null) {
+            Map<String, String> parameters =
+                    extractParametersFromPostData(
+                            requestMessage.getRequestingUser().getContext(), postRequestBody);
+            if (!parameters.isEmpty()) {
                 String oldAcsrfTokenValue = null;
                 String replacedPostData = postRequestBody;
                 for (AntiCsrfToken antiCsrfToken : freshAcsrfTokens) {
@@ -453,18 +455,13 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
             }
         }
 
-        private Map<String, String> extractParametersFromPostData(String postRequestBody) {
-            Context context =
-                    Model.getSingleton().getSession().getContextsForUrl(loginRequestURL).get(0);
-            if (context != null) {
-                Map<String, String> map = new HashMap<String, String>();
-                context.getPostParamParser()
-                        .parseParameters(postRequestBody)
-                        .forEach((nvp) -> map.put(nvp.getName(), nvp.getValue()));
-                return map;
-            } else {
-                return null;
-            }
+        private Map<String, String> extractParametersFromPostData(
+                Context context, String postRequestBody) {
+            Map<String, String> map = new HashMap<>();
+            context.getPostParamParser()
+                    .parseParameters(postRequestBody)
+                    .forEach(nvp -> map.put(nvp.getName(), nvp.getValue()));
+            return map;
         }
 
         /**

--- a/zap/src/test/java/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodTypeUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodTypeUnitTest.java
@@ -1,0 +1,274 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.authentication;
+
+import static java.util.Arrays.asList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.UnaryOperator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.anticsrf.AntiCsrfToken;
+import org.zaproxy.zap.extension.anticsrf.ExtensionAntiCSRF;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.model.NameValuePair;
+import org.zaproxy.zap.model.StandardParameterParser;
+import org.zaproxy.zap.network.HttpRequestBody;
+import org.zaproxy.zap.users.User;
+import org.zaproxy.zap.utils.I18N;
+
+/** Unit test for {@link PostBasedAuthenticationMethodType}. */
+class PostBasedAuthenticationMethodTypeUnitTest {
+
+    /**
+     * Test {@link
+     * PostBasedAuthenticationMethodType#replaceAntiCsrfTokenValueIfRequired(HttpMessage,
+     * HttpMessage, UnaryOperator)}.
+     */
+    static class ReplaceAntiCsrfTokenValueIfRequired {
+
+        private HttpMessage requestMessage;
+        private User user;
+        private Context context;
+        private StandardParameterParser postParamParser;
+        private HttpRequestBody requestMessageBody;
+        private HttpMessage loginMsgWithFreshAcsrfToken;
+        private Encoder paramEncoder;
+
+        private ExtensionAntiCSRF extAntiCsrf;
+
+        @BeforeEach
+        void setup() {
+            Constant.messages = mock(I18N.class);
+            Control.initSingletonForTesting();
+
+            requestMessage = mock(HttpMessage.class);
+            user = mock(User.class);
+            given(requestMessage.getRequestingUser()).willReturn(user);
+            context = mock(Context.class);
+            given(user.getContext()).willReturn(context);
+            postParamParser = mock(StandardParameterParser.class);
+            given(context.getPostParamParser()).willReturn(postParamParser);
+
+            requestMessageBody = spy(new HttpRequestBody());
+            given(requestMessage.getRequestBody()).willReturn(requestMessageBody);
+
+            loginMsgWithFreshAcsrfToken = mock(HttpMessage.class);
+
+            paramEncoder = spy(Encoder.class);
+
+            PostBasedAuthenticationMethodType.setExtAntiCsrf(null);
+            extAntiCsrf = mock(ExtensionAntiCSRF.class);
+        }
+
+        @Test
+        void shouldNotReplaceAnyTokensIfExtensionAntiCSRFNotEnabled() {
+            // Given / When
+            PostBasedAuthenticationMethodType.replaceAntiCsrfTokenValueIfRequired(
+                    requestMessage, loginMsgWithFreshAcsrfToken, paramEncoder);
+            // Then
+            verify(requestMessageBody, times(0)).setBody(anyString());
+        }
+
+        @Test
+        void shouldNotReplaceAnyTokensIfRefreshMessageDoesNotHaveAny() {
+            // Given
+            PostBasedAuthenticationMethodType.setExtAntiCsrf(extAntiCsrf);
+            given(extAntiCsrf.getTokensFromResponse(loginMsgWithFreshAcsrfToken))
+                    .willReturn(Collections.emptyList());
+            // When
+            PostBasedAuthenticationMethodType.replaceAntiCsrfTokenValueIfRequired(
+                    requestMessage, loginMsgWithFreshAcsrfToken, paramEncoder);
+            // Then
+            verify(requestMessageBody, times(0)).setBody(anyString());
+        }
+
+        @Test
+        void shouldNotReplaceAnyTokensIfRequestMessageDoesNotHaveAnyParameters() {
+            // Given
+            PostBasedAuthenticationMethodType.setExtAntiCsrf(extAntiCsrf);
+            given(extAntiCsrf.getTokensFromResponse(loginMsgWithFreshAcsrfToken))
+                    .willReturn(asList(mock(AntiCsrfToken.class)));
+            String postRequestBody = "";
+            given(requestMessageBody.toString()).willReturn(postRequestBody);
+            given(postParamParser.parseParameters(postRequestBody))
+                    .willReturn(Collections.emptyList());
+            // When
+            PostBasedAuthenticationMethodType.replaceAntiCsrfTokenValueIfRequired(
+                    requestMessage, loginMsgWithFreshAcsrfToken, paramEncoder);
+            // Then
+            verify(requestMessageBody, times(0)).setBody(anyString());
+        }
+
+        @Test
+        void shouldNotReplaceAnyTokensIfRequestMessageDoesNotHaveAnyAntiCsrfTokens() {
+            // Given
+            PostBasedAuthenticationMethodType.setExtAntiCsrf(extAntiCsrf);
+            List<AntiCsrfToken> tokens = asList(token("acsrf", "1234"));
+            given(extAntiCsrf.getTokensFromResponse(loginMsgWithFreshAcsrfToken))
+                    .willReturn(tokens);
+            String postRequestBody = "uid=1";
+            given(requestMessageBody.toString()).willReturn(postRequestBody);
+            List<NameValuePair> parameters = asList(parameter("uid", "1"));
+            given(postParamParser.parseParameters(postRequestBody)).willReturn(parameters);
+            // When
+            PostBasedAuthenticationMethodType.replaceAntiCsrfTokenValueIfRequired(
+                    requestMessage, loginMsgWithFreshAcsrfToken, paramEncoder);
+            // Then
+            verify(requestMessageBody).setBody(postRequestBody);
+        }
+
+        @Test
+        void shouldReplaceToken() {
+            // Given
+            PostBasedAuthenticationMethodType.setExtAntiCsrf(extAntiCsrf);
+            List<AntiCsrfToken> tokens = asList(token("acsrf", "1234"));
+            given(extAntiCsrf.getTokensFromResponse(loginMsgWithFreshAcsrfToken))
+                    .willReturn(tokens);
+            String postRequestBody = "uid=1&acsrf=abcd";
+            given(requestMessageBody.toString()).willReturn(postRequestBody);
+            List<NameValuePair> parameters =
+                    asList(parameter("uid", "1"), parameter("acsrf", "abcd"));
+            given(postParamParser.parseParameters(postRequestBody)).willReturn(parameters);
+            // When
+            PostBasedAuthenticationMethodType.replaceAntiCsrfTokenValueIfRequired(
+                    requestMessage, loginMsgWithFreshAcsrfToken, paramEncoder);
+            // Then
+            verify(requestMessageBody).setBody("uid=1&acsrf=1234");
+            verify(paramEncoder).apply("1234");
+        }
+
+        @Test
+        void shouldReplaceMultipleTokens() {
+            // Given
+            PostBasedAuthenticationMethodType.setExtAntiCsrf(extAntiCsrf);
+            List<AntiCsrfToken> tokens = asList(token("acsrf", "1234"), token("acsrf_", "5678"));
+            given(extAntiCsrf.getTokensFromResponse(loginMsgWithFreshAcsrfToken))
+                    .willReturn(tokens);
+            String postRequestBody = "uid=1&acsrf=abcd&acsrf_=efgh";
+            given(requestMessageBody.toString()).willReturn(postRequestBody);
+            List<NameValuePair> parameters =
+                    asList(
+                            parameter("uid", "1"),
+                            parameter("acsrf", "abcd"),
+                            parameter("acsrf_", "efgh"));
+            given(postParamParser.parseParameters(postRequestBody)).willReturn(parameters);
+            // When
+            PostBasedAuthenticationMethodType.replaceAntiCsrfTokenValueIfRequired(
+                    requestMessage, loginMsgWithFreshAcsrfToken, paramEncoder);
+            // Then
+            verify(requestMessageBody).setBody("uid=1&acsrf=1234&acsrf_=5678");
+            verify(paramEncoder).apply("1234");
+            verify(paramEncoder).apply("5678");
+        }
+
+        @Test
+        void shouldReplaceTokenValueEverywhere() {
+            // Given
+            PostBasedAuthenticationMethodType.setExtAntiCsrf(extAntiCsrf);
+            List<AntiCsrfToken> tokens = asList(token("acsrf", "1234"));
+            given(extAntiCsrf.getTokensFromResponse(loginMsgWithFreshAcsrfToken))
+                    .willReturn(tokens);
+            String postRequestBody = "uid=1&acsrf=1";
+            given(requestMessageBody.toString()).willReturn(postRequestBody);
+            List<NameValuePair> parameters = asList(parameter("uid", "1"), parameter("acsrf", "1"));
+            given(postParamParser.parseParameters(postRequestBody)).willReturn(parameters);
+            // When
+            PostBasedAuthenticationMethodType.replaceAntiCsrfTokenValueIfRequired(
+                    requestMessage, loginMsgWithFreshAcsrfToken, paramEncoder);
+            // Then
+            verify(requestMessageBody).setBody("uid=1234&acsrf=1234");
+            verify(paramEncoder).apply("1234");
+        }
+
+        @Test
+        void shouldNotReplaceTokenIfItHasDifferentCase() {
+            // Given
+            PostBasedAuthenticationMethodType.setExtAntiCsrf(extAntiCsrf);
+            List<AntiCsrfToken> tokens = asList(token("ACSRF", "1234"));
+            given(extAntiCsrf.getTokensFromResponse(loginMsgWithFreshAcsrfToken))
+                    .willReturn(tokens);
+            String postRequestBody = "uid=1&acsrf=1";
+            given(requestMessageBody.toString()).willReturn(postRequestBody);
+            List<NameValuePair> parameters = asList(parameter("uid", "1"), parameter("acsrf", "1"));
+            given(postParamParser.parseParameters(postRequestBody)).willReturn(parameters);
+            // When
+            PostBasedAuthenticationMethodType.replaceAntiCsrfTokenValueIfRequired(
+                    requestMessage, loginMsgWithFreshAcsrfToken, paramEncoder);
+            // Then
+            verify(requestMessageBody).setBody(postRequestBody);
+        }
+
+        @Test
+        void shouldUseProvidedParameterEncoder() {
+            // Given
+            PostBasedAuthenticationMethodType.setExtAntiCsrf(extAntiCsrf);
+            List<AntiCsrfToken> tokens = asList(token("acsrf", "1234"));
+            given(extAntiCsrf.getTokensFromResponse(loginMsgWithFreshAcsrfToken))
+                    .willReturn(tokens);
+            String postRequestBody = "uid=1&acsrf=abcd";
+            given(requestMessageBody.toString()).willReturn(postRequestBody);
+            List<NameValuePair> parameters =
+                    asList(parameter("uid", "1"), parameter("acsrf", "abcd"));
+            given(postParamParser.parseParameters(postRequestBody)).willReturn(parameters);
+            given(paramEncoder.apply("1234")).willReturn("encoded");
+            // When
+            PostBasedAuthenticationMethodType.replaceAntiCsrfTokenValueIfRequired(
+                    requestMessage, loginMsgWithFreshAcsrfToken, paramEncoder);
+            // Then
+            verify(requestMessageBody).setBody("uid=1&acsrf=encoded");
+        }
+
+        private static AntiCsrfToken token(String name, String value) {
+            AntiCsrfToken token = mock(AntiCsrfToken.class, withSettings().lenient());
+            given(token.getName()).willReturn(name);
+            given(token.getValue()).willReturn(value);
+            return token;
+        }
+
+        private static NameValuePair parameter(String name, String value) {
+            NameValuePair parameter = mock(NameValuePair.class, withSettings().lenient());
+            given(parameter.getName()).willReturn(name);
+            given(parameter.getValue()).willReturn(value);
+            return parameter;
+        }
+
+        static class Encoder implements UnaryOperator<String> {
+
+            Encoder() {}
+
+            @Override
+            public String apply(String value) {
+                return value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Use the context from the user being authenticated instead of getting the
context form the login URL. The login URL does not need and might not be
included in the context.

Fix #6223.