### PR TITLE
#6098: Allowing to pass request headers from a spider parser to the spider task

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/spider/SpiderController.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/SpiderController.java
@@ -19,21 +19,18 @@
  */
 package org.zaproxy.zap.spider;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import net.htmlparser.jericho.Config;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpHeaderField;
 import org.zaproxy.zap.spider.filters.FetchFilter;
 import org.zaproxy.zap.spider.filters.FetchFilter.FetchStatus;
 import org.zaproxy.zap.spider.filters.ParseFilter;
@@ -44,6 +41,7 @@ import org.zaproxy.zap.spider.parser.SpiderODataAtomParser;
 import org.zaproxy.zap.spider.parser.SpiderParser;
 import org.zaproxy.zap.spider.parser.SpiderParserListener;
 import org.zaproxy.zap.spider.parser.SpiderRedirectParser;
+import org.zaproxy.zap.spider.parser.SpiderResourceFound;
 import org.zaproxy.zap.spider.parser.SpiderRobotstxtParser;
 import org.zaproxy.zap.spider.parser.SpiderSVNEntriesParser;
 import org.zaproxy.zap.spider.parser.SpiderSitemapXMLParser;
@@ -74,11 +72,8 @@ public class SpiderController implements SpiderParserListener {
     /** The spider. */
     private Spider spider;
 
-    /** The resources visited using GET method. */
-    private Set<String> visitedGet;
-
-    /** The resources visited using POST method. */
-    private Map<String, ArrayList<String>> visitedPost;
+    /** The resources visited as a set. */
+    private Set<String> visitedResources;
 
     /** The Constant log. */
     private static final Logger log = LogManager.getLogger(SpiderController.class);
@@ -94,8 +89,7 @@ public class SpiderController implements SpiderParserListener {
         this.spider = spider;
         this.fetchFilters = new LinkedList<>();
         this.parseFilters = new LinkedList<>();
-        this.visitedGet = new HashSet<>();
-        this.visitedPost = new HashMap<>();
+        this.visitedResources = new HashSet<>();
 
         prepareDefaultParsers();
         for (SpiderParser parser : customParsers) {
@@ -167,27 +161,25 @@ public class SpiderController implements SpiderParserListener {
      * @param method the http method used for fetching the resource
      */
     protected void addSeed(URI uri, String method) {
+        SpiderResourceFound resourceFound =
+                SpiderResourceFound.builder().setUri(uri.toString()).setMethod(method).build();
         // Check if the uri was processed already
-        String visitedURI;
+        String resourceIdentifier = "";
         try {
-            visitedURI =
-                    URLCanonicalizer.buildCleanedParametersURIRepresentation(
-                            uri,
-                            spider.getSpiderParam().getHandleParameters(),
-                            spider.getSpiderParam().isHandleODataParametersVisited());
+            resourceIdentifier = buildCanonicalResourceIdentifier(uri, resourceFound);
         } catch (URIException e) {
             return;
         }
-        synchronized (visitedGet) {
-            if (visitedGet.contains(visitedURI)) {
-                log.debug("URI already visited: " + visitedURI);
+        synchronized (visitedResources) {
+            if (visitedResources.contains(resourceIdentifier)) {
+                log.debug("URI already visited: " + uri);
                 return;
             } else {
-                visitedGet.add(visitedURI);
+                visitedResources.add(resourceIdentifier);
             }
         }
         // Create and submit the new task
-        SpiderTask task = new SpiderTask(spider, null, uri, 0, method);
+        SpiderTask task = new SpiderTask(spider, resourceFound, uri);
         spider.submitTask(task);
         // Add the uri to the found list
         spider.notifyListenersFoundURI(uri.toString(), method, FetchStatus.SEED);
@@ -241,8 +233,7 @@ public class SpiderController implements SpiderParserListener {
     }
 
     public void init() {
-        visitedGet.clear();
-        visitedPost.clear();
+        visitedResources.clear();
 
         for (SpiderParser parser : parsers) {
             parser.addSpiderParserListener(this);
@@ -251,46 +242,62 @@ public class SpiderController implements SpiderParserListener {
 
     /** Clears the previous process. */
     public void reset() {
-        visitedGet.clear();
-        visitedPost.clear();
+        visitedResources.clear();
 
         for (SpiderParser parser : parsers) {
             parser.removeSpiderParserListener(this);
         }
     }
 
-    @Override
-    public void resourceURIFound(
-            HttpMessage responseMessage, int depth, String uri, boolean shouldIgnore) {
-        log.debug("New resource found: " + uri);
+    /**
+     * Builds a canonical identifier for found resources considering the method, URI, headers, and
+     * body.
+     *
+     * @param uri uniform resource identifier for resource
+     * @param resourceFound resource found
+     * @return identifier as a string representation usable for equality checks
+     */
+    private String buildCanonicalResourceIdentifier(URI uri, SpiderResourceFound resourceFound)
+            throws URIException {
+        StringBuilder identifierBuilder = new StringBuilder(50);
+        String visitedURI =
+                URLCanonicalizer.buildCleanedParametersURIRepresentation(
+                        uri,
+                        spider.getSpiderParam().getHandleParameters(),
+                        spider.getSpiderParam().isHandleODataParametersVisited());
+        identifierBuilder.append(resourceFound.getMethod());
+        identifierBuilder.append(" ");
+        identifierBuilder.append(visitedURI);
+        identifierBuilder.append("\n");
+        identifierBuilder.append(getCanonicalHeadersString(resourceFound.getHeaders()));
+        identifierBuilder.append("\n");
+        identifierBuilder.append(resourceFound.getBody());
+        return identifierBuilder.toString();
+    }
 
-        if (uri == null) {
-            return;
-        }
+    @Override
+    public void resourceFound(SpiderResourceFound resourceFound) {
+        log.debug("New {} resource found: {}", resourceFound.getMethod(), resourceFound.getUri());
 
         // Create the uri
-        URI uriV = createURI(uri);
+        URI uriV = createURI(resourceFound.getUri());
         if (uriV == null) {
             return;
         }
 
-        // Check if the uri was processed already
-        String visitedURI;
+        // Check if the resource was processed already
+        String resourceIdentifier = "";
         try {
-            visitedURI =
-                    URLCanonicalizer.buildCleanedParametersURIRepresentation(
-                            uriV,
-                            spider.getSpiderParam().getHandleParameters(),
-                            spider.getSpiderParam().isHandleODataParametersVisited());
+            resourceIdentifier = buildCanonicalResourceIdentifier(uriV, resourceFound);
         } catch (URIException e) {
             return;
         }
-        synchronized (visitedGet) {
-            if (visitedGet.contains(visitedURI)) {
-                // log.debug("URI already visited: " + visitedURI);
+        synchronized (visitedResources) {
+            if (visitedResources.contains(resourceIdentifier)) {
+                log.debug("Resource already visited: {}", resourceIdentifier.trim());
                 return;
             } else {
-                visitedGet.add(visitedURI);
+                visitedResources.add(resourceIdentifier);
             }
         }
 
@@ -299,107 +306,48 @@ public class SpiderController implements SpiderParserListener {
             FetchStatus s = f.checkFilter(uriV);
             if (s != FetchStatus.VALID) {
                 log.debug("URI: " + uriV + " was filtered by a filter with reason: " + s);
-                spider.notifyListenersFoundURI(uri, HttpRequestHeader.GET, s);
+                spider.notifyListenersFoundURI(
+                        resourceFound.getUri(), resourceFound.getMethod(), s);
                 return;
             }
         }
 
-        // Check if should be ignored and not fetched
-        if (shouldIgnore) {
+        // Check if resource should be ignored and not fetched
+        if (resourceFound.isShouldIgnore()) {
             log.debug(
                     "URI: "
                             + uriV
                             + " is valid, but will not be fetched, by parser recommendation.");
-            spider.notifyListenersFoundURI(uri, HttpRequestHeader.GET, FetchStatus.VALID);
+            spider.notifyListenersFoundURI(
+                    resourceFound.getUri(), resourceFound.getMethod(), FetchStatus.VALID);
             return;
         }
 
-        spider.notifyListenersFoundURI(uri, HttpRequestHeader.GET, FetchStatus.VALID);
+        spider.notifyListenersFoundURI(
+                resourceFound.getUri(), resourceFound.getMethod(), FetchStatus.VALID);
 
         // Submit the task
-        SpiderTask task =
-                new SpiderTask(
-                        spider,
-                        responseMessage.getRequestHeader().getURI(),
-                        uriV,
-                        depth,
-                        HttpRequestHeader.GET);
-        spider.submitTask(task);
-    }
-
-    @Override
-    public void resourceURIFound(HttpMessage responseMessage, int depth, String uri) {
-        resourceURIFound(responseMessage, depth, uri, false);
-    }
-
-    @Override
-    public void resourcePostURIFound(
-            HttpMessage responseMessage, int depth, String uri, String requestBody) {
-        log.debug("New POST resource found: " + uri);
-
-        // Check if the uri was processed already
-        synchronized (visitedPost) {
-            if (arrayKeyValueExists(uri, requestBody)) {
-                log.debug("URI already visited: " + uri);
-                return;
-            } else {
-                if (visitedPost.containsKey(uri)) {
-                    visitedPost.get(uri).add(requestBody);
-                } else {
-                    ArrayList<String> l = new ArrayList<>();
-                    l.add(requestBody);
-                    visitedPost.put(uri, l);
-                }
-            }
-        }
-
-        // Create the uri
-        URI uriV = createURI(uri);
-        if (uriV == null) {
-            return;
-        }
-
-        // Check if any of the filters disallows this uri
-        for (FetchFilter f : fetchFilters) {
-            FetchStatus s = f.checkFilter(uriV);
-            if (s != FetchStatus.VALID) {
-                log.debug("URI: " + uriV + " was filtered by a filter with reason: " + s);
-                spider.notifyListenersFoundURI(uri, HttpRequestHeader.POST, s);
-                return;
-            }
-        }
-
-        spider.notifyListenersFoundURI(uri, HttpRequestHeader.POST, FetchStatus.VALID);
-
-        // Submit the task
-        SpiderTask task =
-                new SpiderTask(
-                        spider,
-                        responseMessage.getRequestHeader().getURI(),
-                        uriV,
-                        depth,
-                        HttpRequestHeader.POST,
-                        requestBody);
+        SpiderTask task = new SpiderTask(spider, resourceFound, uriV);
         spider.submitTask(task);
     }
 
     /**
-     * Checks whether the value exists in an ArrayList of certain key.
+     * Builds a canonical string representation for HTTP header fields by sorting the headers based
+     * on the name, trimming and lowercasing the name and value, and removing duplicates.
      *
-     * @param key the string of the uri
-     * @param value the request body of the uri
-     * @return true or false depending whether the uri and request body have already been processed
+     * @param headers list of HTTP headers
+     * @return canonical string representation of headers
      */
-    private boolean arrayKeyValueExists(String key, String value) {
-        if (visitedPost.containsKey(key)) {
-            for (String s : visitedPost.get(key)) {
-                if (s.equals(value)) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
+    private String getCanonicalHeadersString(List<HttpHeaderField> headers) {
+        return headers.stream()
+                .sorted((h1, h2) -> h1.getName().compareTo(h2.getName()))
+                .map(
+                        h ->
+                                h.getName().trim().toLowerCase()
+                                        + "="
+                                        + h.getValue().trim().toLowerCase())
+                .distinct()
+                .collect(Collectors.joining("|"));
     }
 
     /**

--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderHtmlFormParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderHtmlFormParser.java
@@ -407,7 +407,14 @@ public class SpiderHtmlFormParser extends SpiderParser {
                 .debug(
                         "Submitting form with POST method and message body with form parameters (normal encoding): "
                                 + requestBody);
-        notifyListenersPostResourceFound(message, depth + 1, url, requestBody);
+        notifyListenersResourceFound(
+                SpiderResourceFound.builder()
+                        .setMessage(message)
+                        .setDepth(depth + 1)
+                        .setUri(url)
+                        .setMethod(METHOD_POST)
+                        .setBody(requestBody)
+                        .build());
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderParser.java
@@ -25,6 +25,7 @@ import net.htmlparser.jericho.Source;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.zap.spider.URLCanonicalizer;
 
 /**
@@ -79,14 +80,31 @@ public abstract class SpiderParser {
     /**
      * Notify the listeners that a resource was found.
      *
+     * @param resourceFound the resource found.
+     * @since 2.11.0
+     */
+    protected void notifyListenersResourceFound(SpiderResourceFound resourceFound) {
+        for (SpiderParserListener l : listeners) {
+            l.resourceFound(resourceFound);
+        }
+    }
+
+    /**
+     * Notify the listeners that a resource was found.
+     *
      * @param message the http message containing the response.
      * @param depth the depth of this resource in the crawling tree
      * @param uri the uri
+     * @deprecated (2.11.0) Use {@link #notifyListenersResourceFound(SpiderResourceFound)} instead.
      */
+    @Deprecated
     protected void notifyListenersResourceFound(HttpMessage message, int depth, String uri) {
-        for (SpiderParserListener l : listeners) {
-            l.resourceURIFound(message, depth, uri);
-        }
+        notifyListenersResourceFound(
+                SpiderResourceFound.builder()
+                        .setMessage(message)
+                        .setDepth(depth)
+                        .setUri(uri)
+                        .build());
     }
 
     /**
@@ -97,12 +115,19 @@ public abstract class SpiderParser {
      * @param depth the depth of this resource in the crawling tree
      * @param uri the uri
      * @param requestBody the request body
+     * @deprecated (2.11.0) Use {@link #notifyListenersResourceFound(SpiderResourceFound)} instead.
      */
+    @Deprecated
     protected void notifyListenersPostResourceFound(
             HttpMessage message, int depth, String uri, String requestBody) {
-        for (SpiderParserListener l : listeners) {
-            l.resourcePostURIFound(message, depth, uri, requestBody);
-        }
+        notifyListenersResourceFound(
+                SpiderResourceFound.builder()
+                        .setMessage(message)
+                        .setDepth(depth)
+                        .setUri(uri)
+                        .setMethod(HttpRequestHeader.POST)
+                        .setBody(requestBody)
+                        .build());
     }
 
     /**
@@ -120,8 +145,13 @@ public abstract class SpiderParser {
             return;
         }
 
-        log.debug("Canonical URL constructed using '" + localURL + "': " + fullURL);
-        notifyListenersResourceFound(message, depth + 1, fullURL);
+        getLogger().debug("Canonical URL constructed using '{}': {}", localURL, fullURL);
+        notifyListenersResourceFound(
+                SpiderResourceFound.builder()
+                        .setMessage(message)
+                        .setDepth(depth + 1)
+                        .setUri(fullURL)
+                        .build());
     }
 
     /**
@@ -129,9 +159,8 @@ public abstract class SpiderParser {
      * if possible, a Jericho source with the Response Body is provided.
      *
      * <p>When a link is encountered, implementations can use {@link #processURL(HttpMessage, int,
-     * String, String)}, {@link #notifyListenersPostResourceFound(HttpMessage, int, String, String)}
-     * and {@link #notifyListenersResourceFound(HttpMessage, int, String)} to announce the found
-     * URIs.
+     * String, String)} and {@link #notifyListenersResourceFound(SpiderResourceFound)} to announce
+     * the found URIs.
      *
      * <p>The return value specifies whether the resource should be considered 'completely
      * processed'/consumed and should be treated accordingly by subsequent parsers. For example, any

--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderParserListener.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderParserListener.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.spider.parser;
 
-import org.parosproxy.paros.network.HttpMessage;
-
 /**
  * The listener interface for receiving spiderParser events. The class that is interested in
  * processing a spiderParser event implements this interface, and the object created with that class
@@ -30,47 +28,10 @@ import org.parosproxy.paros.network.HttpMessage;
 public interface SpiderParserListener {
 
     /**
-     * Event triggered when a new resource URI is found. The responseMessage contains all the
-     * required information regarding the page which contains the URI.
+     * Event triggered when a new resource is found. The resourceFound contains all the required
+     * information about the resource (source message, URI, depth, method, etc.).
      *
-     * @param responseMessage the response message
-     * @param depth the depth of this resource in the crawling process
-     * @param uri the universal resource locator
+     * @param resourceFound definition of found spider resource
      */
-    void resourceURIFound(HttpMessage responseMessage, int depth, String uri);
-
-    /**
-     * Event triggered when a new resource URI is found. The responseMessage contains all the
-     * required information regarding the page which contains the URI.
-     *
-     * <p>Also provides a {@code shouldIgnore} boolean that states that this resourceURI should be
-     * ignored in the fetching process, as it's probably a dead end (e.g. binary data, image, etc.).
-     *
-     * @param responseMessage the response message
-     * @param depth the depth of this resource in the crawling process
-     * @param uri the universal resource locator
-     * @param shouldIgnore whether this resource has a high chance of being not useful if fetched
-     */
-    void resourceURIFound(HttpMessage responseMessage, int depth, String uri, boolean shouldIgnore);
-
-    /**
-     * Event triggered when a new resource URI is found. However, if the URI needs to be fetched, it
-     * should be accessed with the HTTP POST method and the content of the request body message
-     * should be the one specified in {@code requestBody}.
-     *
-     * <p>For example, this method can be triggered if a parser finds the {@code uri} inside a form
-     * with the method set as {@code POST}. In this case, the messageContent should contain the form
-     * data set necessary for a successful submission of the form.
-     *
-     * <p>The responseMessage contains all the required information regarding the page which
-     * contains the URI.
-     *
-     * @param responseMessage the response message
-     * @param depth the depth of this resource in the crawling process
-     * @param uri the universal resource locator
-     * @param requestBody represents the content that a request message should have in its body, if
-     *     fetching the resource
-     */
-    void resourcePostURIFound(
-            HttpMessage responseMessage, int depth, String uri, String requestBody);
+    void resourceFound(SpiderResourceFound resourceFound);
 }

--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderResourceFound.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderResourceFound.java
@@ -1,0 +1,363 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.spider.parser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.parosproxy.paros.network.HttpHeaderField;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+
+/**
+ * Class SpiderResourceFound is used to store information about found resources by spider parsers.
+ *
+ * @since 2.11.0
+ */
+public class SpiderResourceFound {
+    /** The message where the resource was found. */
+    private final HttpMessage message;
+    /** Spider depth for resource. */
+    private final int depth;
+    /** HTTP method for resource. */
+    private final String method;
+    /** Uniform resource identifier of resource. */
+    private final String uri;
+    /** Body for the resource. */
+    private final String body;
+    /** Defines resource as useful or not useful in the fetching process. */
+    private final boolean shouldIgnore;
+    /** Additional request headers to be passed for the resource. */
+    private final List<HttpHeaderField> headers;
+
+    /**
+     * Instantiates a spider resource found.
+     *
+     * @param message the message for the found resource
+     * @param depth the depth of this resource in the crawling process
+     * @param uri the universal resource locator
+     * @param method HTTP method for the resource found
+     * @param body request body for the resource
+     * @param shouldIgnore flag to ignore the resource found
+     * @param headers additional request headers for the resource
+     */
+    private SpiderResourceFound(
+            HttpMessage message,
+            int depth,
+            String uri,
+            String method,
+            String body,
+            boolean shouldIgnore,
+            List<HttpHeaderField> headers) {
+        this.message = message;
+        this.depth = depth;
+        this.uri = uri;
+        this.method = method;
+        this.body = body;
+        this.shouldIgnore = shouldIgnore;
+        this.headers = headers;
+    }
+
+    /**
+     * Returns the message where the resource was found.
+     *
+     * @return HTTP message
+     */
+    public HttpMessage getMessage() {
+        return message;
+    }
+
+    /**
+     * Returns the spider depth of the resource.
+     *
+     * @return depth value
+     */
+    public int getDepth() {
+        return depth;
+    }
+
+    /**
+     * Gives back the method to be applied for the found resource.
+     *
+     * @return HTTP method
+     */
+    public String getMethod() {
+        return method;
+    }
+
+    /**
+     * Returns the URI of the found resource.
+     *
+     * @return uniform resource identifier
+     */
+    public String getUri() {
+        return uri;
+    }
+
+    /**
+     * Returns request body for the found resource.
+     *
+     * @return body string (empty if resource is GET-based)
+     */
+    public String getBody() {
+        return body;
+    }
+
+    /**
+     * States if the found resource should be ignored in the fetching process.
+     *
+     * @return boolean whether resource should be ignored
+     */
+    public boolean isShouldIgnore() {
+        return shouldIgnore;
+    }
+
+    /**
+     * Returns the additional request headers for the resource found.
+     *
+     * @return list of HTTP header fields
+     */
+    public List<HttpHeaderField> getHeaders() {
+        return headers;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(body, depth, headers, message, method, shouldIgnore, uri);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof SpiderResourceFound)) {
+            return false;
+        }
+        SpiderResourceFound other = (SpiderResourceFound) obj;
+        return Objects.equals(body, other.body)
+                && depth == other.depth
+                && Objects.equals(headers, other.headers)
+                && Objects.equals(message, other.message)
+                && Objects.equals(method, other.method)
+                && shouldIgnore == other.shouldIgnore
+                && Objects.equals(uri, other.uri);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder strBuilder = new StringBuilder(75);
+        strBuilder
+                .append("[Method=")
+                .append(method)
+                .append(", URI=")
+                .append(uri)
+                .append(", Headers=")
+                .append(headers)
+                .append(", Body=")
+                .append(body)
+                .append(", ShouldIgnore=")
+                .append(shouldIgnore)
+                .append(", Depth=")
+                .append(depth)
+                .append(", Message=")
+                .append(message);
+        return strBuilder.toString();
+    }
+
+    /**
+     * Gets a new builder for a spider resource found.
+     *
+     * @return a new spider resource found builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Gets a new spider resource found builder, using the values of the supplied resource found.
+     *
+     * @param spiderResourceFound spider resource found for reference.
+     * @return a new spider resource found builder.
+     * @throws IllegalArgumentException if the given parameter is {@code null}.
+     */
+    public static Builder builder(SpiderResourceFound spiderResourceFound) {
+        if (spiderResourceFound == null) {
+            throw new IllegalArgumentException("Parameter spiderResourceFound must not be null.");
+        }
+        return new Builder(spiderResourceFound);
+    }
+
+    /** Builder of {@link SpiderResourceFound}. */
+    public static class Builder {
+        private HttpMessage message;
+        private int depth;
+        private String method;
+        private String uri;
+        private String body;
+        private boolean shouldIgnore;
+        private List<HttpHeaderField> headers;
+
+        private Builder() {
+            this.message = null;
+            this.depth = 0;
+            this.method = HttpRequestHeader.GET;
+            this.uri = "";
+            this.body = "";
+            this.shouldIgnore = false;
+            this.headers = Collections.emptyList();
+        }
+
+        private Builder(SpiderResourceFound resourceFound) {
+            this.message = resourceFound.getMessage();
+            this.depth = resourceFound.getDepth();
+            this.method = resourceFound.getMethod();
+            this.uri = resourceFound.getUri();
+            this.body = resourceFound.getBody();
+            this.shouldIgnore = resourceFound.isShouldIgnore();
+            this.headers = resourceFound.getHeaders();
+        }
+
+        /**
+         * Sets the message where the resource was found.
+         *
+         * @param message HTTP message where the resource as found (null allowed).
+         * @return the builder.
+         */
+        public Builder setMessage(HttpMessage message) {
+            this.message = message;
+            return this;
+        }
+
+        /**
+         * Sets the spider depth for the resource found.
+         *
+         * @param depth Spider depth for resource.
+         * @return the builder.
+         * @throws IllegalArgumentException if the given parameter is negative.
+         */
+        public Builder setDepth(int depth) {
+            if (depth < 0) {
+                throw new IllegalArgumentException("Parameter depth must not be negative.");
+            }
+            this.depth = depth;
+            return this;
+        }
+
+        /**
+         * Sets the method for the resource found.
+         *
+         * @param method Method for resource found.
+         * @return the builder.
+         * @throws IllegalArgumentException if the given parameter is {@code null}.
+         */
+        public Builder setMethod(String method) {
+            if (method == null) {
+                throw new IllegalArgumentException("Parameter method must not be null.");
+            }
+            this.method = method;
+            return this;
+        }
+
+        /**
+         * Sets the URI for the resource found.
+         *
+         * @param uri URI for resource found.
+         * @return the builder.
+         * @throws IllegalArgumentException if the given parameter is {@code null}.
+         */
+        public Builder setUri(String uri) {
+            if (uri == null) {
+                throw new IllegalArgumentException("Parameter uri must not be null.");
+            }
+            this.uri = uri;
+            return this;
+        }
+
+        /**
+         * Sets the request body for the resource found.
+         *
+         * @param body Body for resource found.
+         * @return the builder.
+         * @throws IllegalArgumentException if the given parameter is {@code null}.
+         */
+        public Builder setBody(String body) {
+            if (body == null) {
+                throw new IllegalArgumentException("Parameter body must not be null.");
+            }
+            this.body = body;
+            return this;
+        }
+
+        /**
+         * Sets a flag whether the resource should be ignored.
+         *
+         * @param shouldIgnore Flag for resource found to be ignored.
+         * @return the builder.
+         */
+        public Builder setShouldIgnore(boolean shouldIgnore) {
+            this.shouldIgnore = shouldIgnore;
+            return this;
+        }
+
+        /**
+         * Sets additional request headers for the resource found. Only valid header fields (i.e.
+         * name not {@code null} and not empty, value not {@code null}) will be added.
+         *
+         * @param headers Additional request headers for resource found.
+         * @return the builder.
+         * @throws IllegalArgumentException if the given parameter is {@code null} or an element is
+         *     {@code null}.
+         */
+        public Builder setHeaders(List<HttpHeaderField> headers) {
+            if (headers == null) {
+                throw new IllegalArgumentException("Parameter headers must not be null.");
+            }
+            if (!headers.isEmpty()) {
+                List<HttpHeaderField> validHeaders = new ArrayList<>();
+                for (HttpHeaderField headerField : headers) {
+                    if (headerField == null) {
+                        throw new IllegalArgumentException("Element of headers must not be null.");
+                    }
+                    if (headerField.getName() != null
+                            && !headerField.getName().trim().isEmpty()
+                            && headerField.getValue() != null) {
+                        validHeaders.add(headerField);
+                    }
+                }
+                this.headers = Collections.unmodifiableList(validHeaders);
+            } else {
+                this.headers = Collections.emptyList();
+            }
+            return this;
+        }
+
+        /**
+         * Builds a new {@code SpiderResourceFound}, with the configurations previously set.
+         *
+         * @return a new {@code SpiderResourceFound}.
+         */
+        public SpiderResourceFound build() {
+            return new SpiderResourceFound(
+                    message, depth, uri, method, body, shouldIgnore, headers);
+        }
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/spider/SpiderControllerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/SpiderControllerUnitTest.java
@@ -1,0 +1,304 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.spider;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.db.RecordHistory;
+import org.parosproxy.paros.db.TableAlert;
+import org.parosproxy.paros.db.TableHistory;
+import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpHeaderField;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.WithConfigsTest;
+import org.zaproxy.zap.extension.spider.ExtensionSpider;
+import org.zaproxy.zap.model.ValueGenerator;
+import org.zaproxy.zap.spider.parser.SpiderResourceFound;
+
+/** Unit test for {@link SpiderController}. */
+class SpiderControllerUnitTest extends WithConfigsTest {
+
+    private Spider spider;
+    private SpiderController spiderController;
+
+    @BeforeAll
+    static void setUpTables() throws Exception {
+        TableHistory tableHistory = mock(TableHistory.class);
+        given(tableHistory.write(anyLong(), anyInt(), any())).willReturn(mock(RecordHistory.class));
+        HistoryReference.setTableHistory(tableHistory);
+        HistoryReference.setTableAlert(mock(TableAlert.class));
+    }
+
+    @AfterAll
+    static void cleanUpTables() {
+        HistoryReference.setTableHistory(null);
+        HistoryReference.setTableAlert(null);
+    }
+
+    @BeforeEach
+    void setUp() {
+        spider = mock(Spider.class);
+
+        given(spider.getSpiderParam()).willReturn(new SpiderParam());
+        given(spider.getModel()).willReturn(Model.getSingleton());
+
+        ExtensionSpider extensionSpider = mock(ExtensionSpider.class);
+        given(extensionSpider.getValueGenerator()).willReturn(mock(ValueGenerator.class));
+        given(spider.getExtensionSpider()).willReturn(extensionSpider);
+
+        spiderController = new SpiderController(spider, Collections.emptyList());
+    }
+
+    @Test
+    void shouldSubmitTasksForDifferentSpiderResources() {
+        // Given
+        List<HttpHeaderField> requestHeaders = new ArrayList<>();
+        requestHeaders.add(new HttpHeaderField("X-Custom-Header-1", "xyz"));
+        // When
+        spiderController.resourceFound(
+                createBasicGetSpiderResourceFound("https://example.com/test.html", 1));
+        spiderController.resourceFound(
+                createBasicGetSpiderResourceFound("https://example.com/test.html/", 1));
+        spiderController.resourceFound(
+                createGetSpiderResourceFoundWithHeaders(
+                        "https://example.com/test.html", 1, false, requestHeaders));
+        spiderController.resourceFound(
+                createBasicPostSpiderResourceFound("https://example.com/test.html", "", 1));
+        spiderController.resourceFound(
+                createBasicPostSpiderResourceFound("https://example.com/test.html", "A=1", 1));
+        spiderController.resourceFound(
+                createBasicPostSpiderResourceFound("https://example.com/test.html", "A=2", 1));
+        spiderController.resourceFound(
+                createPostSpiderResourceFoundWithHeaders(
+                        "https://example.com/test.html", "A=2", 1, false, requestHeaders));
+        // Then
+        verify(spider, times(7)).submitTask(any());
+    }
+
+    @Test
+    void shouldSubmitTasksForDifferentMethods() {
+        // Given
+        SpiderResourceFound getResource =
+                SpiderResourceFound.builder()
+                        .setMethod(HttpRequestHeader.GET)
+                        .setUri("http://test.com")
+                        .build();
+        SpiderResourceFound postResource =
+                SpiderResourceFound.builder()
+                        .setMethod(HttpRequestHeader.POST)
+                        .setUri("http://test.com")
+                        .build();
+        SpiderResourceFound putResource =
+                SpiderResourceFound.builder()
+                        .setMethod(HttpRequestHeader.PUT)
+                        .setUri("http://test.com")
+                        .build();
+        SpiderResourceFound deleteResource =
+                SpiderResourceFound.builder()
+                        .setMethod(HttpRequestHeader.DELETE)
+                        .setUri("http://test.com")
+                        .build();
+        SpiderResourceFound headResource =
+                SpiderResourceFound.builder()
+                        .setMethod(HttpRequestHeader.HEAD)
+                        .setUri("http://test.com")
+                        .build();
+        // When
+        spiderController.resourceFound(getResource);
+        spiderController.resourceFound(postResource);
+        spiderController.resourceFound(putResource);
+        spiderController.resourceFound(deleteResource);
+        spiderController.resourceFound(headResource);
+        // Then
+        verify(spider, times(5)).submitTask(any());
+    }
+
+    @Test
+    void shouldNotSubmitSameGetTaskWithDifferentDepthAndIgnore() {
+        // Given
+        SpiderResourceFound spiderResourceFoundDepth1 =
+                createGetSpiderResourceFoundWithHeaders(
+                        "https://example.com/test.html", 1, false, Collections.emptyList());
+        SpiderResourceFound spiderResourceFoundDepth2Ignore =
+                createGetSpiderResourceFoundWithHeaders(
+                        "https://example.com/test.html", 2, true, Collections.emptyList());
+        // When
+        spiderController.resourceFound(spiderResourceFoundDepth1);
+        spiderController.resourceFound(spiderResourceFoundDepth1);
+        spiderController.resourceFound(spiderResourceFoundDepth2Ignore);
+        // Then
+        verify(spider).submitTask(any());
+    }
+
+    @Test
+    void shouldNotSubmitSamePostTaskWithDifferentDepthAndIgnore() {
+        // Given
+        SpiderResourceFound spiderResourceFoundDepth1 =
+                createPostSpiderResourceFoundWithHeaders(
+                        "https://example.com/test.html", "body", 1, false, Collections.emptyList());
+        SpiderResourceFound spiderResourceFoundDepth2Ignore =
+                createPostSpiderResourceFoundWithHeaders(
+                        "https://example.com/test.html", "body", 2, true, Collections.emptyList());
+        // When
+        spiderController.resourceFound(spiderResourceFoundDepth1);
+        spiderController.resourceFound(spiderResourceFoundDepth1);
+        spiderController.resourceFound(spiderResourceFoundDepth2Ignore);
+        // Then
+        verify(spider).submitTask(any());
+    }
+
+    @Test
+    void shouldNotSubmitSameGetTaskWithDifferentHeaderOrder() {
+        // Given
+        List<HttpHeaderField> requestHeadersOrder1 = new ArrayList<>();
+        requestHeadersOrder1.add(new HttpHeaderField("X-Custom-Header-1", "xyz"));
+        requestHeadersOrder1.add(new HttpHeaderField("X-Custom-Header-2", "123"));
+        List<HttpHeaderField> requestHeadersOrder2 = new ArrayList<>();
+        requestHeadersOrder2.add(new HttpHeaderField("X-Custom-Header-2", "123"));
+        requestHeadersOrder2.add(new HttpHeaderField("X-Custom-Header-1", "xyz"));
+        SpiderResourceFound spiderResourceFound1 =
+                createGetSpiderResourceFoundWithHeaders(
+                        "https://example.com/test.html", 2, false, requestHeadersOrder1);
+        SpiderResourceFound spiderResourceFound2 =
+                createGetSpiderResourceFoundWithHeaders(
+                        "https://example.com/test.html", 2, false, requestHeadersOrder2);
+        // When
+        spiderController.resourceFound(spiderResourceFound1);
+        spiderController.resourceFound(spiderResourceFound2);
+        // Then
+        verify(spider).submitTask(any());
+    }
+
+    @Test
+    void shouldNotSubmitSameGetTaskWithDifferentHeaderWhitespaces() {
+        // Given
+        List<HttpHeaderField> requestHeadersWithoutWS = new ArrayList<>();
+        requestHeadersWithoutWS.add(new HttpHeaderField("X-Custom-Header-1", "xyz"));
+        List<HttpHeaderField> requestHeadersWithWS = new ArrayList<>();
+        requestHeadersWithWS.add(new HttpHeaderField("\tX-Custom-Header-1  ", "\nxyz "));
+        SpiderResourceFound spiderResourceFound1 =
+                createGetSpiderResourceFoundWithHeaders(
+                        "https://example.com/test.html", 2, false, requestHeadersWithoutWS);
+        SpiderResourceFound spiderResourceFound2 =
+                createGetSpiderResourceFoundWithHeaders(
+                        "https://example.com/test.html", 2, false, requestHeadersWithWS);
+        // When
+        spiderController.resourceFound(spiderResourceFound1);
+        spiderController.resourceFound(spiderResourceFound2);
+        // Then
+        verify(spider).submitTask(any());
+    }
+
+    @Test
+    void shouldNotSubmitSameGetTaskWithDifferentHeaderCases() {
+        // Given
+        List<HttpHeaderField> requestHeadersUpperCase = new ArrayList<>();
+        requestHeadersUpperCase.add(new HttpHeaderField("X-CUSTOM-HEADER-1", "XYZ"));
+        List<HttpHeaderField> requestHeadersLowerCase = new ArrayList<>();
+        requestHeadersLowerCase.add(new HttpHeaderField("x-custom-header-1", "xyz"));
+        SpiderResourceFound spiderResourceFound1 =
+                createGetSpiderResourceFoundWithHeaders(
+                        "https://example.com/test.html", 2, false, requestHeadersUpperCase);
+        SpiderResourceFound spiderResourceFound2 =
+                createGetSpiderResourceFoundWithHeaders(
+                        "https://example.com/test.html", 2, false, requestHeadersLowerCase);
+        // When
+        spiderController.resourceFound(spiderResourceFound1);
+        spiderController.resourceFound(spiderResourceFound2);
+        // Then
+        verify(spider).submitTask(any());
+    }
+
+    @Test
+    void shouldNotSubmitSameGetTaskWithDuplicateHeaders() {
+        // Given
+        List<HttpHeaderField> requestHeadersWithoutDuplicates = new ArrayList<>();
+        requestHeadersWithoutDuplicates.add(new HttpHeaderField("X-Custom-Header-1", "xyz"));
+        List<HttpHeaderField> requestHeadersWithDuplicates = new ArrayList<>();
+        requestHeadersWithDuplicates.add(new HttpHeaderField("X-Custom-Header-1", "xyz"));
+        requestHeadersWithDuplicates.add(new HttpHeaderField("X-Custom-Header-1", "xyz"));
+        requestHeadersWithDuplicates.add(new HttpHeaderField("X-Custom-Header-1", "xyz"));
+        SpiderResourceFound spiderResourceFound1 =
+                createGetSpiderResourceFoundWithHeaders(
+                        "https://example.com/test.html", 2, false, requestHeadersWithoutDuplicates);
+        SpiderResourceFound spiderResourceFound2 =
+                createGetSpiderResourceFoundWithHeaders(
+                        "https://example.com/test.html", 2, false, requestHeadersWithDuplicates);
+        // When
+        spiderController.resourceFound(spiderResourceFound1);
+        spiderController.resourceFound(spiderResourceFound2);
+        // Then
+        verify(spider).submitTask(any());
+    }
+
+    private static SpiderResourceFound createBasicGetSpiderResourceFound(String uri, int depth) {
+        return SpiderResourceFound.builder().setDepth(depth).setUri(uri).build();
+    }
+
+    private static SpiderResourceFound createGetSpiderResourceFoundWithHeaders(
+            String uri, int depth, boolean shouldIgnore, List<HttpHeaderField> requestHeaders) {
+        return SpiderResourceFound.builder()
+                .setDepth(depth)
+                .setUri(uri)
+                .setShouldIgnore(shouldIgnore)
+                .setHeaders(requestHeaders)
+                .build();
+    }
+
+    private static SpiderResourceFound createBasicPostSpiderResourceFound(
+            String uri, String body, int depth) {
+        return SpiderResourceFound.builder()
+                .setDepth(depth)
+                .setUri(uri)
+                .setMethod(HttpRequestHeader.POST)
+                .setBody(body)
+                .build();
+    }
+
+    private static SpiderResourceFound createPostSpiderResourceFoundWithHeaders(
+            String uri,
+            String body,
+            int depth,
+            boolean shouldIgnore,
+            List<HttpHeaderField> requestHeaders) {
+        return SpiderResourceFound.builder()
+                .setDepth(depth)
+                .setUri(uri)
+                .setShouldIgnore(shouldIgnore)
+                .setMethod(HttpRequestHeader.POST)
+                .setBody(body)
+                .setHeaders(requestHeaders)
+                .build();
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderParserTestUtils.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderParserTestUtils.java
@@ -28,7 +28,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import net.htmlparser.jericho.Source;
+import org.parosproxy.paros.network.HttpHeaderField;
 import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.zap.spider.SpiderParam;
 import org.zaproxy.zap.testutils.TestUtils;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
@@ -71,7 +73,7 @@ class SpiderParserTestUtils extends TestUtils {
 
     protected static class TestSpiderParserListener implements SpiderParserListener {
 
-        private final List<SpiderResource> resources;
+        private final List<SpiderResourceFound> resources;
         private final List<String> urls;
 
         private TestSpiderParserListener() {
@@ -80,7 +82,7 @@ class SpiderParserTestUtils extends TestUtils {
         }
 
         int getNumberOfUrlsFound() {
-            return resources.size();
+            return urls.size();
         }
 
         List<String> getUrlsFound() {
@@ -91,28 +93,14 @@ class SpiderParserTestUtils extends TestUtils {
             return resources.size();
         }
 
-        List<SpiderResource> getResourcesFound() {
+        List<SpiderResourceFound> getResourcesFound() {
             return resources;
         }
 
         @Override
-        public void resourceURIFound(HttpMessage responseMessage, int depth, String uri) {
-            urls.add(uri);
-            resources.add(uriResource(responseMessage, depth, uri));
-        }
-
-        @Override
-        public void resourceURIFound(
-                HttpMessage responseMessage, int depth, String uri, boolean shouldIgnore) {
-            urls.add(uri);
-            resources.add(uriResource(responseMessage, depth, uri, shouldIgnore));
-        }
-
-        @Override
-        public void resourcePostURIFound(
-                HttpMessage responseMessage, int depth, String uri, String requestBody) {
-            urls.add(uri);
-            resources.add(postResource(responseMessage, depth, uri, requestBody));
+        public void resourceFound(SpiderResourceFound resourceFound) {
+            urls.add(resourceFound.getUri());
+            resources.add(resourceFound);
         }
 
         boolean isResourceFound() {
@@ -120,18 +108,53 @@ class SpiderParserTestUtils extends TestUtils {
         }
     }
 
-    static SpiderResource uriResource(HttpMessage message, int depth, String uri) {
-        return new SpiderResource(message, depth, uri);
+    static SpiderResourceFound uriResource(HttpMessage message, int depth, String uri) {
+        return SpiderResourceFound.builder()
+                .setMessage(message)
+                .setDepth(depth)
+                .setUri(uri)
+                .build();
     }
 
-    static SpiderResource uriResource(
+    static SpiderResourceFound uriResource(
             HttpMessage message, int depth, String uri, boolean shouldIgnore) {
-        return new SpiderResource(message, depth, uri, shouldIgnore);
+        return uriResource(message, depth, uri, shouldIgnore, new ArrayList<>());
     }
 
-    static SpiderResource postResource(
+    static SpiderResourceFound uriResource(
+            HttpMessage message,
+            int depth,
+            String uri,
+            boolean shouldIgnore,
+            List<HttpHeaderField> requestHeaders) {
+        return SpiderResourceFound.builder()
+                .setMessage(message)
+                .setDepth(depth)
+                .setUri(uri)
+                .setShouldIgnore(shouldIgnore)
+                .setHeaders(requestHeaders)
+                .build();
+    }
+
+    static SpiderResourceFound postResource(
             HttpMessage message, int depth, String uri, String requestBody) {
-        return new SpiderResource(message, depth, uri, requestBody);
+        return postResource(message, depth, uri, requestBody, new ArrayList<>());
+    }
+
+    static SpiderResourceFound postResource(
+            HttpMessage message,
+            int depth,
+            String uri,
+            String requestBody,
+            List<HttpHeaderField> requestHeaders) {
+        return SpiderResourceFound.builder()
+                .setMessage(message)
+                .setDepth(depth)
+                .setUri(uri)
+                .setMethod(HttpRequestHeader.POST)
+                .setBody(requestBody)
+                .setHeaders(requestHeaders)
+                .build();
     }
 
     static String params(String... params) {
@@ -156,124 +179,6 @@ class SpiderParserTestUtils extends TestUtils {
                     + URLEncoder.encode(value, StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    static class SpiderResource {
-
-        private final HttpMessage message;
-        private final int depth;
-        private final String uri;
-
-        private final boolean shouldIgnore;
-
-        private final String requestBody;
-
-        private SpiderResource(HttpMessage message, int depth, String uri) {
-            this.message = message;
-            this.depth = depth;
-            this.uri = uri;
-            this.requestBody = null;
-            this.shouldIgnore = false;
-        }
-
-        private SpiderResource(HttpMessage message, int depth, String uri, boolean shouldIgnore) {
-            this.message = message;
-            this.depth = depth;
-            this.uri = uri;
-            this.requestBody = null;
-            this.shouldIgnore = shouldIgnore;
-        }
-
-        private SpiderResource(HttpMessage message, int depth, String uri, String requestBody) {
-            this.message = message;
-            this.depth = depth;
-            this.uri = uri;
-            this.requestBody = requestBody;
-            this.shouldIgnore = false;
-        }
-
-        HttpMessage getMessage() {
-            return message;
-        }
-
-        int getDepth() {
-            return depth;
-        }
-
-        String getUri() {
-            return uri;
-        }
-
-        boolean isShouldIgnore() {
-            return shouldIgnore;
-        }
-
-        String getRequestBody() {
-            return requestBody;
-        }
-
-        @Override
-        public int hashCode() {
-            int result = 31 + depth;
-            result = 31 * result + ((message == null) ? 0 : message.hashCode());
-            result = 31 * result + ((requestBody == null) ? 0 : requestBody.hashCode());
-            result = 31 * result + (shouldIgnore ? 1231 : 1237);
-            result = 31 * result + ((uri == null) ? 0 : uri.hashCode());
-            return result;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj) {
-                return true;
-            }
-            if (obj == null) {
-                return false;
-            }
-            if (getClass() != obj.getClass()) {
-                return false;
-            }
-            SpiderResource other = (SpiderResource) obj;
-            if (depth != other.depth) {
-                return false;
-            }
-            if (message == null) {
-                if (other.message != null) {
-                    return false;
-                }
-            } else if (message != other.message) {
-                return false;
-            }
-            if (requestBody == null) {
-                if (other.requestBody != null) {
-                    return false;
-                }
-            } else if (!requestBody.equals(other.requestBody)) {
-                return false;
-            }
-            if (shouldIgnore != other.shouldIgnore) {
-                return false;
-            }
-            if (uri == null) {
-                if (other.uri != null) {
-                    return false;
-                }
-            } else if (!uri.equals(other.uri)) {
-                return false;
-            }
-            return true;
-        }
-
-        @Override
-        public String toString() {
-            StringBuilder strBuilder = new StringBuilder(250);
-            strBuilder.append("URI=").append(uri);
-            strBuilder.append(", Depth=").append(depth);
-            strBuilder.append(", RequestBody=").append(requestBody);
-            strBuilder.append(", ShouldIgnore=").append(shouldIgnore);
-            strBuilder.append(", Message=").append(message.hashCode());
-            return strBuilder.toString();
         }
     }
 }

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderParserUnitTest.java
@@ -1,0 +1,163 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.spider.parser;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+
+import net.htmlparser.jericho.Source;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMessage;
+
+/** Unit test for {@link SpiderParser}. */
+class SpiderParserUnitTest extends SpiderParserTestUtils {
+
+    @Test
+    void shouldHaveNonNullLogger() {
+        // Given
+        TestSpiderParser testSpiderParser = new TestSpiderParser();
+        // When / Then
+        assertThat(testSpiderParser.getLogger(), is(not(nullValue())));
+    }
+
+    @Test
+    void shouldNotifyListenersOfResourceFound() {
+        // Given
+        TestSpiderParser testSpiderParser = new TestSpiderParser();
+        TestSpiderParserListener listener1 = createTestSpiderParserListener();
+        TestSpiderParserListener listener2 = createTestSpiderParserListener();
+        SpiderResourceFound resourceFound1 = mock(SpiderResourceFound.class);
+        SpiderResourceFound resourceFound2 = mock(SpiderResourceFound.class);
+        // When
+        testSpiderParser.addSpiderParserListener(listener1);
+        testSpiderParser.addSpiderParserListener(listener2);
+        testSpiderParser.notifyListenersResourceFound(resourceFound1);
+        testSpiderParser.notifyListenersResourceFound(resourceFound2);
+        // Then
+        assertThat(listener1.getResourcesFound(), contains(resourceFound1, resourceFound2));
+        assertThat(listener2.getResourcesFound(), contains(resourceFound1, resourceFound2));
+    }
+
+    @Test
+    void shouldNotNotifyRemovedListenerOfResourceFound() {
+        // Given
+        TestSpiderParser testSpiderParser = new TestSpiderParser();
+        TestSpiderParserListener listener1 = createTestSpiderParserListener();
+        testSpiderParser.addSpiderParserListener(listener1);
+        TestSpiderParserListener listener2 = createTestSpiderParserListener();
+        testSpiderParser.addSpiderParserListener(listener2);
+        SpiderResourceFound resourceFound1 = mock(SpiderResourceFound.class);
+        SpiderResourceFound resourceFound2 = mock(SpiderResourceFound.class);
+        // When
+        testSpiderParser.notifyListenersResourceFound(resourceFound1);
+        testSpiderParser.removeSpiderParserListener(listener2);
+        testSpiderParser.notifyListenersResourceFound(resourceFound2);
+        // Then
+        assertThat(listener1.getResourcesFound(), contains(resourceFound1, resourceFound2));
+        assertThat(listener2.getResourcesFound(), contains(resourceFound1));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void shouldNotifyListenersOfUriResourceFound() {
+        // Given
+        TestSpiderParser testSpiderParser = new TestSpiderParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        testSpiderParser.addSpiderParserListener(listener);
+        HttpMessage message = mock(HttpMessage.class);
+        int depth = 42;
+        String uri = "https://example.com";
+        // When
+        testSpiderParser.notifyListenersResourceFound(message, depth, uri);
+        // Then
+        assertThat(listener.getResourcesFound(), contains(uriResource(message, depth, uri)));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void shouldNotifyListenersOfPostResourceFound() {
+        // Given
+        TestSpiderParser testSpiderParser = new TestSpiderParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        testSpiderParser.addSpiderParserListener(listener);
+        HttpMessage message = mock(HttpMessage.class);
+        int depth = 42;
+        String uri = "https://example.com";
+        String body = "body";
+        // When
+        testSpiderParser.notifyListenersPostResourceFound(message, depth, uri, body);
+        // Then
+        assertThat(listener.getResourcesFound(), contains(postResource(message, depth, uri, body)));
+    }
+
+    @Test
+    void shouldNotifyListenersOfProcessedUrl() {
+        // Given
+        TestSpiderParser testSpiderParser = new TestSpiderParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        testSpiderParser.addSpiderParserListener(listener);
+        HttpMessage message = mock(HttpMessage.class);
+        int depth = 42;
+        String baseUrl = "https://example.com/";
+        String localUrl = "/path/";
+        String expectedUri = "https://example.com/path/";
+        // When
+        testSpiderParser.processURL(message, depth, localUrl, baseUrl);
+        // Then
+        assertThat(
+                listener.getResourcesFound(),
+                contains(uriResource(message, depth + 1, expectedUri)));
+    }
+
+    @Test
+    void shouldNotNotifyListenersOfMalformedProcessedUrl() {
+        // Given
+        TestSpiderParser testSpiderParser = new TestSpiderParser();
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        testSpiderParser.addSpiderParserListener(listener);
+        HttpMessage message = mock(HttpMessage.class);
+        int depth = 42;
+        String baseUrl = "/";
+        String localUrl = "/";
+        // When
+        testSpiderParser.processURL(message, depth, localUrl, baseUrl);
+        // Then
+        assertThat(listener.getResourcesFound(), is(empty()));
+    }
+
+    private static class TestSpiderParser extends SpiderParser {
+
+        @Override
+        public boolean parseResource(HttpMessage message, Source source, int depth) {
+            return true;
+        }
+
+        @Override
+        public boolean canParseResource(
+                HttpMessage message, String path, boolean wasAlreadyConsumed) {
+            return true;
+        }
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderResourceFoundUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderResourceFoundUnitTest.java
@@ -1,0 +1,209 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.spider.parser;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.parosproxy.paros.network.HttpHeaderField;
+import org.parosproxy.paros.network.HttpMessage;
+
+/** Unit test for {@link SpiderResourceFound}. */
+class SpiderResourceFoundUnitTest {
+
+    private SpiderResourceFound.Builder builder;
+
+    @BeforeEach
+    void setUp() {
+        builder = SpiderResourceFound.builder();
+    }
+
+    @Test
+    void shouldSetMessage() {
+        // Given
+        HttpMessage message = mock(HttpMessage.class);
+        // When
+        SpiderResourceFound resource = builder.setMessage(message).build();
+        // Then
+        assertThat(resource.getMessage(), is(equalTo(message)));
+    }
+
+    @Test
+    void shouldSetShouldIgnore() {
+        // Given
+        boolean shouldIgnore = true;
+        // When
+        SpiderResourceFound resource = builder.setShouldIgnore(shouldIgnore).build();
+        // Then
+        assertThat(resource.isShouldIgnore(), is(equalTo(shouldIgnore)));
+    }
+
+    @Test
+    void shouldSetUri() {
+        // Given
+        String uri = "uri";
+        // When
+        SpiderResourceFound resource = builder.setUri(uri).build();
+        // Then
+        assertThat(resource.getUri(), is(equalTo(uri)));
+    }
+
+    @Test
+    void shouldThrowExceptionForNullUri() {
+        // Given
+        String uri = null;
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> builder.setUri(uri));
+    }
+
+    @Test
+    void shouldSetDepth() {
+        // Given
+        int depth = 42;
+        // When
+        SpiderResourceFound resource = builder.setDepth(depth).build();
+        // Then
+        assertThat(resource.getDepth(), is(equalTo(depth)));
+    }
+
+    @Test
+    void shouldThrowExceptionForNegativeDepth() {
+        // Given
+        int depth = -99;
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> builder.setDepth(depth));
+    }
+
+    @Test
+    void shouldSetMethod() {
+        // Given
+        String method = "method";
+        // When
+        SpiderResourceFound resource = builder.setMethod(method).build();
+        // Then
+        assertThat(resource.getMethod(), is(equalTo(method)));
+    }
+
+    @Test
+    void shouldThrowExceptionForNullMethod() {
+        // Given
+        String method = null;
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> builder.setMethod(method));
+    }
+
+    @Test
+    void shouldSetBody() {
+        // Given
+        String body = "body";
+        // When
+        SpiderResourceFound resource = builder.setBody(body).build();
+        // Then
+        assertThat(resource.getBody(), is(equalTo(body)));
+    }
+
+    @Test
+    void shouldThrowExceptionForNullBody() {
+        // Given
+        String body = null;
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> builder.setBody(body));
+    }
+
+    @Test
+    void shouldThrowExceptionForNullHeaders() {
+        // Given
+        List<HttpHeaderField> headers = null;
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> builder.setHeaders(headers));
+    }
+
+    @Test
+    void shouldThrowExceptionForNullHeaderField() {
+        // Given
+        List<HttpHeaderField> headers = new ArrayList<>();
+        headers.add(null);
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> builder.setHeaders(headers));
+    }
+
+    @Test
+    void shouldSetHeaders() {
+        // Given
+        HttpHeaderField header1 = new HttpHeaderField("name 1", "value 1");
+        HttpHeaderField header2 = new HttpHeaderField("name 2", "value 2");
+        List<HttpHeaderField> headers = Arrays.asList(header1, header2);
+        // When
+        SpiderResourceFound resource = builder.setHeaders(headers).build();
+        // Then
+        assertThat(resource.getHeaders(), contains(header1, header2));
+    }
+
+    @Test
+    void shouldSetEmptyHeaders() {
+        // Given
+        HttpHeaderField header1 = new HttpHeaderField("name 1", "value 1");
+        HttpHeaderField header2 = new HttpHeaderField("name 2", "value 2");
+        List<HttpHeaderField> headers = Arrays.asList(header1, header2);
+        builder.setHeaders(headers);
+        // When
+        SpiderResourceFound resource = builder.setHeaders(Collections.emptyList()).build();
+        // Then
+        assertThat(resource.getHeaders(), is(empty()));
+    }
+
+    static Stream<Arguments> invalidHeadersProvider() {
+        return Stream.of(
+                arguments(null, "123"),
+                arguments("", "123"),
+                arguments(" ", "123"),
+                arguments("name", null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidHeadersProvider")
+    void shouldSkipInvalidHeaders(String name, String value) {
+        // Given
+        HttpHeaderField header1 = new HttpHeaderField("name 1", "value 1");
+        HttpHeaderField invalidHeader = new HttpHeaderField(name, value);
+        HttpHeaderField header2 = new HttpHeaderField("name 2", "value 2");
+        List<HttpHeaderField> headers = Arrays.asList(header1, invalidHeader, header2);
+        // When
+        SpiderResourceFound resource = builder.setHeaders(headers).build();
+        // Then
+        assertThat(resource.getHeaders(), contains(header1, header2));
+    }
+}

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -168,7 +168,19 @@ val japicmp by tasks.registering(JapicmpTask::class) {
         "org.parosproxy.paros.core.scanner.Variant#setParameters(org.parosproxy.paros.network.HttpMessage,java.util.List)"
         )
 
-    methodExcludes = listOf()
+    methodExcludes = listOf(
+        // Not intended to be used directly by add-ons.
+        "org.zaproxy.zap.spider.parser.SpiderParserListener#resourcePostURIFound(org.parosproxy.paros.network.HttpMessage,int,java.lang.String,java.lang.String)",
+        "org.zaproxy.zap.spider.parser.SpiderParserListener#resourceURIFound(org.parosproxy.paros.network.HttpMessage,int,java.lang.String)",
+        "org.zaproxy.zap.spider.parser.SpiderParserListener#resourceURIFound(org.parosproxy.paros.network.HttpMessage,int,java.lang.String,boolean)",
+        "org.zaproxy.zap.spider.SpiderController#resourcePostURIFound(org.parosproxy.paros.network.HttpMessage,int,java.lang.String,java.lang.String)",
+        "org.zaproxy.zap.spider.SpiderController#resourceURIFound(org.parosproxy.paros.network.HttpMessage,int,java.lang.String,boolean)",
+        "org.zaproxy.zap.spider.SpiderController#resourceURIFound(org.parosproxy.paros.network.HttpMessage,int,java.lang.String)",
+        "org.zaproxy.zap.spider.SpiderTask#SpiderTask(org.zaproxy.zap.spider.Spider,org.apache.commons.httpclient.URI,int,java.lang.String,java.lang.String)",
+        "org.zaproxy.zap.spider.SpiderTask#SpiderTask(org.zaproxy.zap.spider.Spider,org.apache.commons.httpclient.URI,int,java.lang.String)",
+        "org.zaproxy.zap.spider.SpiderTask#SpiderTask(org.zaproxy.zap.spider.Spider,org.apache.commons.httpclient.URI,org.apache.commons.httpclient.URI,int,java.lang.String)",
+        "org.zaproxy.zap.spider.SpiderTask#SpiderTask(org.zaproxy.zap.spider.Spider,org.apache.commons.httpclient.URI,org.apache.commons.httpclient.URI,int,java.lang.String,java.lang.String)"
+    )
 
     richReport {
         destinationDir = file("$buildDir/reports/japicmp/")


### PR DESCRIPTION
- Introduction of a new class 'SpiderResourceFound' storing resource
details used within SpiderParser, SpiderParserListener,
SpiderController, SpiderTask, and SpiderParserTestUtils
- Simplified canonicalization of visited resources (incl. supplied
headers) using one hash set
- Introduction of new unit tests in class
'SpiderParserAdditionalHeadersUnitTest' which create a custom test
spider parser + controller (incl. spider) and cover header-related
handling in the spider controller

Signed-off-by: Vladislav Dexheimer <vladislav.dexheimer@sap.com>