### PR TITLE
Custom Pages add initial unittests

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/custompages/CustomPage.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/custompages/CustomPage.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.custompages;
 
-import org.apache.commons.lang.Validate;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.utils.EnableableInterface;
@@ -111,21 +110,23 @@ public interface CustomPage extends EnableableInterface {
 
     /** Defines the types supported by the Custom Page package. */
     enum Type {
-        ERROR_500(1, Constant.messages.getString("custompages.type.error")),
-        NOTFOUND_404(2, Constant.messages.getString("custompages.type.notfound")),
-        OK_200(3, Constant.messages.getString("custompages.type.ok")),
+        ERROR_500(1, "custompages.type.error"),
+        NOTFOUND_404(2, "custompages.type.notfound"),
+        OK_200(3, "custompages.type.ok"),
         /**
          * OTHER is intended to provide an option for scan rule scripts for usages that may not yet
          * have been planned.
          */
-        OTHER(4, Constant.messages.getString("custompages.type.other"));
+        OTHER(4, "custompages.type.other");
 
         private final int id;
         private final String name;
+        private final String nameKey;
 
-        Type(int id, String name) {
+        Type(int id, String nameKey) {
             this.id = id;
-            this.name = name;
+            this.name = Constant.messages.getString(nameKey);
+            this.nameKey = nameKey;
         }
 
         /**
@@ -149,6 +150,10 @@ public interface CustomPage extends EnableableInterface {
             return name;
         }
 
+        String getNameKey() {
+            return nameKey;
+        }
+
         /**
          * Gets the custom page type that has the given {@code id}.
          *
@@ -161,8 +166,6 @@ public interface CustomPage extends EnableableInterface {
          * @see #getDefaultType()
          */
         public static Type getCustomPageTypeWithId(int id) {
-            Validate.notNull(id, "Parameter id must not be null.");
-
             for (Type customPageType : values()) {
                 if (customPageType.id == id) {
                     return customPageType;
@@ -176,7 +179,7 @@ public interface CustomPage extends EnableableInterface {
          *
          * @return the default {@code CustomPage.Type}.
          */
-        private static Type getDefaultType() {
+        protected static Type getDefaultType() {
             return ERROR_500;
         }
 
@@ -193,6 +196,9 @@ public interface CustomPage extends EnableableInterface {
 
         @Override
         public String toString() {
+            if (getName() == null) {
+                return name();
+            }
             return getName();
         }
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/custompages/CustomPageMatcherLocation.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/custompages/CustomPageMatcherLocation.java
@@ -19,20 +19,21 @@
  */
 package org.zaproxy.zap.extension.custompages;
 
-import org.apache.commons.lang.Validate;
 import org.parosproxy.paros.Constant;
 
 /** Defines the page matcher locations supported by the Custom Page package. */
 public enum CustomPageMatcherLocation {
-    RESPONSE_CONTENT(1, Constant.messages.getString("custompages.content.location.response")),
-    URL(2, Constant.messages.getString("custompages.content.location.url"));
+    RESPONSE_CONTENT(1, "custompages.content.location.response"),
+    URL(2, "custompages.content.location.url");
 
     private final int id;
     private final String name;
+    private final String nameKey;
 
-    private CustomPageMatcherLocation(int id, String name) {
+    private CustomPageMatcherLocation(int id, String nameKey) {
         this.id = id;
-        this.name = name;
+        this.name = Constant.messages.getString(nameKey);
+        this.nameKey = nameKey;
     }
 
     /**
@@ -50,12 +51,14 @@ public enum CustomPageMatcherLocation {
     /**
      * Gets the name of this custom page page matcher location.
      *
-     * <p>
-     *
      * @return the name of the custom page page matcher location
      */
     public String getName() {
         return name;
+    }
+
+    String getNameKey() {
+        return nameKey;
     }
 
     /**
@@ -70,8 +73,6 @@ public enum CustomPageMatcherLocation {
      * @see #getDefaultLocation()
      */
     public static CustomPageMatcherLocation getCustomPagePageMatcherLocationWithId(int id) {
-        Validate.notNull(id, "Parameter id must not be null or empty.");
-
         for (CustomPageMatcherLocation cpct : values()) {
             if (cpct.getId() == id) {
                 return cpct;
@@ -106,6 +107,9 @@ public enum CustomPageMatcherLocation {
 
     @Override
     public String toString() {
+        if (getName() == null) {
+            return name();
+        }
         return getName();
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/custompages/DefaultCustomPage.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/custompages/DefaultCustomPage.java
@@ -205,6 +205,7 @@ public class DefaultCustomPage extends Enableable implements CustomPage {
         return pattern.matcher(toMatch).find();
     }
 
+    @Override
     public String toString() {
         StringBuilder cp = new StringBuilder();
         cp.append("ContextId: ").append(this.getContextId());

--- a/zap/src/test/java/org/zaproxy/zap/extension/custompages/CustomPageMatcherLocationUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/custompages/CustomPageMatcherLocationUnitTest.java
@@ -1,0 +1,84 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompages;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.Arrays;
+import java.util.Locale;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.utils.I18N;
+
+class CustomPageMatcherLocationUnitTest {
+
+    @BeforeEach
+    public void setup() {
+        Constant.messages = mock(I18N.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2})
+    public void shouldFindLocationByValidId(int id) {
+        // Given/When
+        CustomPageMatcherLocation location =
+                CustomPageMatcherLocation.getCustomPagePageMatcherLocationWithId(id);
+        // Then
+        assertTrue(Arrays.asList(CustomPageMatcherLocation.values()).contains(location));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 15, Integer.MAX_VALUE})
+    public void shouldReturnDefaultLocationForInvalidId(int id) {
+        // Given/When
+        CustomPageMatcherLocation location =
+                CustomPageMatcherLocation.getCustomPagePageMatcherLocationWithId(id);
+        // Then
+        assertEquals(CustomPageMatcherLocation.getDefaultLocation(), location);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 1, 2})
+    public void shouldNotReturnNullOrEmptyStringRepresentation(int id) {
+        // Given/When
+        CustomPageMatcherLocation location =
+                CustomPageMatcherLocation.getCustomPagePageMatcherLocationWithId(id);
+        // Then
+        assertNotNull(location.toString());
+        assertTrue(!location.toString().isEmpty());
+    }
+
+    @Test
+    public void shouldHaveExpectedI18nLocationNames() {
+        // Given
+        I18N i18n = new I18N(Locale.ENGLISH);
+        // When/Then
+        assertEquals("URL", i18n.getString(CustomPageMatcherLocation.URL.getNameKey()));
+        assertEquals(
+                "Response",
+                i18n.getString(CustomPageMatcherLocation.RESPONSE_CONTENT.getNameKey()));
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/custompages/CustomPageUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/custompages/CustomPageUnitTest.java
@@ -1,0 +1,81 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompages;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.Arrays;
+import java.util.Locale;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.utils.I18N;
+
+class CustomPageUnitTest {
+
+    @BeforeEach
+    public void setup() {
+        Constant.messages = mock(I18N.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3})
+    public void shouldFindTypeByValidId(int id) {
+        // Given/When
+        CustomPage.Type type = CustomPage.Type.getCustomPageTypeWithId(id);
+        // Then
+        assertTrue(Arrays.asList(CustomPage.Type.values()).contains(type));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 15, Integer.MAX_VALUE})
+    public void shouldReturnDefaultTypeForInvalidId(int id) {
+        // Given/When
+        CustomPage.Type type = CustomPage.Type.getCustomPageTypeWithId(id);
+        // Then
+        assertEquals(CustomPage.Type.getDefaultType(), type);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 1, 2, 3})
+    public void shouldNotReturnNullOrEmptyStringRepresentation(int id) {
+        // Given/When
+        CustomPage.Type type = CustomPage.Type.getCustomPageTypeWithId(id);
+        // Then
+        assertNotNull(type.toString());
+        assertTrue(!type.toString().isEmpty());
+    }
+
+    @Test
+    public void shouldHaveExpectedI18nTypeNames() {
+        // Given
+        I18N i18n = new I18N(Locale.ENGLISH);
+        // When/Then
+        assertEquals("Error Page", i18n.getString(CustomPage.Type.ERROR_500.getNameKey()));
+        assertEquals("Not Found", i18n.getString(CustomPage.Type.NOTFOUND_404.getNameKey()));
+        assertEquals("Ok", i18n.getString(CustomPage.Type.OK_200.getNameKey()));
+        assertEquals("Other", i18n.getString(CustomPage.Type.OTHER.getNameKey()));
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/custompages/DefaultCustomPageUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/custompages/DefaultCustomPageUnitTest.java
@@ -1,0 +1,155 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompages;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.utils.I18N;
+
+class DefaultCustomPageUnitTest {
+
+    private static final String TEST_MATCH_PATTERN = ".*Something went wrong.*";
+    private static final String BASE64_TEST_PATTERN =
+            new String(
+                    Base64.getEncoder().encode(TEST_MATCH_PATTERN.getBytes(StandardCharsets.UTF_8)),
+                    StandardCharsets.US_ASCII);
+
+    @BeforeEach
+    public void setup() {
+        Constant.messages = mock(I18N.class);
+    }
+
+    @Test
+    public void shouldEncodeCustomPage() {
+        // Given
+        DefaultCustomPage customPage =
+                new DefaultCustomPage(
+                        0,
+                        TEST_MATCH_PATTERN,
+                        CustomPageMatcherLocation.RESPONSE_CONTENT,
+                        true,
+                        CustomPage.Type.ERROR_500,
+                        true);
+        // When
+        String encodedCustomPage = DefaultCustomPage.encode(customPage);
+        // Then
+        assertTrue(encodedCustomPage.equals(BASE64_TEST_PATTERN + ";1;true;1;true;"));
+    }
+
+    @Test
+    public void shouldDecodeCustomPage() {
+        // Given
+        String encodedCustomPage = BASE64_TEST_PATTERN + ";1;true;1;true;";
+        DefaultCustomPage expectedCustomPage =
+                new DefaultCustomPage(
+                        0,
+                        TEST_MATCH_PATTERN,
+                        CustomPageMatcherLocation.RESPONSE_CONTENT,
+                        true,
+                        CustomPage.Type.ERROR_500,
+                        true);
+        // When
+        DefaultCustomPage customPage = DefaultCustomPage.decode(0, encodedCustomPage);
+        // Then
+        assertCustomPagesMatch(expectedCustomPage, customPage);
+    }
+
+    @Test
+    public void shouldDecodeCustomPageWithDefaultTypeIfTypeIdInvalid() {
+        // Given/When
+        DefaultCustomPage actual =
+                DefaultCustomPage.decode(0, BASE64_TEST_PATTERN + ";1;true;5;true;");
+        DefaultCustomPage expected =
+                new DefaultCustomPage(
+                        0,
+                        TEST_MATCH_PATTERN,
+                        CustomPageMatcherLocation.getCustomPagePageMatcherLocationWithId(1),
+                        true,
+                        CustomPage.Type.getDefaultType(),
+                        true);
+        // Then
+        assertCustomPagesMatch(expected, actual);
+    }
+
+    @Test
+    public void shouldDecodeCustomPageWithDefaultMatcherLocationIfMatcherLocationIdInvalid() {
+        // Given/When
+        DefaultCustomPage actual =
+                DefaultCustomPage.decode(0, BASE64_TEST_PATTERN + ";5;true;1;true;");
+        DefaultCustomPage expected =
+                new DefaultCustomPage(
+                        0,
+                        TEST_MATCH_PATTERN,
+                        CustomPageMatcherLocation.getDefaultLocation(),
+                        true,
+                        CustomPage.Type.getCustomPageTypeWithId(1),
+                        true);
+        // Then
+        assertCustomPagesMatch(expected, actual);
+    }
+
+    @Test
+    public void shouldDecodeCustomPageWithIsRegexFalseWhenIsRegexComponentInvalid() {
+        // Given/When
+        DefaultCustomPage actual =
+                DefaultCustomPage.decode(0, BASE64_TEST_PATTERN + ";1;foo;1;true;");
+        DefaultCustomPage expected =
+                new DefaultCustomPage(
+                        0,
+                        TEST_MATCH_PATTERN,
+                        CustomPageMatcherLocation.getCustomPagePageMatcherLocationWithId(1),
+                        false,
+                        CustomPage.Type.getCustomPageTypeWithId(1),
+                        true);
+        // Then
+        assertCustomPagesMatch(expected, actual);
+    }
+
+    @Test
+    public void shouldDecodeCustomPageWithEnabledFalseWhenEnabledComponentInvalid() {
+        // Given/When
+        DefaultCustomPage actual =
+                DefaultCustomPage.decode(0, BASE64_TEST_PATTERN + ";1;true;1;foo;");
+        DefaultCustomPage expected =
+                new DefaultCustomPage(
+                        0,
+                        TEST_MATCH_PATTERN,
+                        CustomPageMatcherLocation.getCustomPagePageMatcherLocationWithId(1),
+                        true,
+                        CustomPage.Type.getCustomPageTypeWithId(1),
+                        false);
+        // Then
+        assertCustomPagesMatch(expected, actual);
+    }
+
+    private void assertCustomPagesMatch(CustomPage expected, CustomPage actual) {
+        assertTrue(actual.getPageMatcher().equals(expected.getPageMatcher()));
+        assertTrue(actual.getPageMatcherLocation().equals(expected.getPageMatcherLocation()));
+        assertTrue(actual.isRegex() == expected.isRegex());
+        assertTrue(actual.getType().equals(expected.getType()));
+        assertTrue(actual.isEnabled() == expected.isEnabled());
+    }
+}


### PR DESCRIPTION
Add UnitTests for new `AbstractPlugin` functionality, `CustomPageMatcherLocation`, `CustomPage.Type`, `DefaultCustomPage`
encode/decode functionality.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>