### PR TITLE
Be more lenient when importing a context

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/model/Model.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/Model.java
@@ -49,6 +49,7 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/09/15 Added the VariantFactory
+// ZAP: 2020/10/14 Allow to set a singleton Model for tests.
 package org.parosproxy.paros.model;
 
 import java.io.File;
@@ -220,6 +221,18 @@ public class Model {
         if (model == null) {
             model = new Model();
         }
+    }
+
+    /**
+     * Sets the given {@code Model} as the singleton.
+     *
+     * <p><strong>Note:</strong> Not part of the public API.
+     *
+     * @param testModel the {@code Model} to test with.
+     */
+    public static void setSingletonForTesting(Model testModel) {
+        model = testModel;
+        model.contextDataFactories = new ArrayList<>();
     }
 
     /** @return Returns the db. */

--- a/zap/src/main/java/org/parosproxy/paros/model/Session.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/Session.java
@@ -83,6 +83,7 @@
 // ZAP: 2020/07/31 Tidy up parameter methods
 // ZAP: 2020/08/17 Changed to use the VariantFactory
 // ZAP: 2020/10/01 Remove use of org.jfree.util.Log use normal log4j infrastructure.
+// ZAP: 2020/10/14 Require just the name when importing context.
 package org.parosproxy.paros.model;
 
 import java.awt.EventQueue;
@@ -1490,7 +1491,7 @@ public class Session {
         Context c = createContext(name);
 
         c.setDescription(config.getString(Context.CONTEXT_CONFIG_DESC));
-        c.setInScope(config.getBoolean(Context.CONTEXT_CONFIG_INSCOPE));
+        c.setInScope(config.getBoolean(Context.CONTEXT_CONFIG_INSCOPE, false));
         for (Object obj : config.getList(Context.CONTEXT_CONFIG_INC_REGEXES)) {
             c.addIncludeInContextRegex(obj.toString());
         }
@@ -1512,6 +1513,9 @@ public class Session {
             // Can happen due to a bug in 2.4.0 where is was saved using the wrong name :(
             urlParserClass = config.getString(Context.CONTEXT_CONFIG_URLPARSER);
         }
+        if (urlParserClass == null) {
+            urlParserClass = StandardParameterParser.class.getCanonicalName();
+        }
         Class<?> cl = ExtensionFactory.getAddOnLoader().loadClass(urlParserClass);
         if (cl == null) {
             throw new ConfigurationException(
@@ -1529,6 +1533,9 @@ public class Session {
             // Can happen due to a bug in 2.4.0 where is was saved using the wrong name :(
             postParserClass = config.getString(urlParserClass);
             postParserConfig = config.getString(Context.CONTEXT_CONFIG_URLPARSER_CONFIG);
+        }
+        if (postParserClass == null) {
+            postParserClass = StandardParameterParser.class.getCanonicalName();
         }
         cl = ExtensionFactory.getAddOnLoader().loadClass(postParserClass);
         if (cl == null) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/authorization/ExtensionAuthorization.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authorization/ExtensionAuthorization.java
@@ -49,6 +49,9 @@ public class ExtensionAuthorization extends ExtensionAdaptor
     /** The NAME of the extension. */
     public static final String NAME = "ExtensionAuthorization";
 
+    /** The ID that indicates that there's no authorization method. */
+    private static final int NO_AUTH_METHOD = -1;
+
     /** The map of context panels. */
     private Map<Integer, ContextAuthorizationPanel> contextPanelsMap = new HashMap<>();
 
@@ -162,11 +165,15 @@ public class ExtensionAuthorization extends ExtensionAdaptor
 
     @Override
     public void importContextData(Context ctx, Configuration config) throws ConfigurationException {
-        int type = config.getInt(AuthorizationDetectionMethod.CONTEXT_CONFIG_AUTH_TYPE);
+        int type =
+                config.getInt(
+                        AuthorizationDetectionMethod.CONTEXT_CONFIG_AUTH_TYPE, NO_AUTH_METHOD);
         switch (type) {
             case BasicAuthorizationDetectionMethod.METHOD_UNIQUE_ID:
                 ctx.setAuthorizationDetectionMethod(new BasicAuthorizationDetectionMethod(config));
                 break;
+            default:
+                log.warn("No authorization detection method found for ID: " + type);
         }
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
@@ -82,6 +82,9 @@ public class ExtensionForcedUser extends ExtensionAdaptor
     /** The NAME of the extension. */
     public static final String NAME = "ExtensionForcedUser";
 
+    /** The ID that indicates that there's no forced user. */
+    private static final int NO_FORCED_USER = -1;
+
     /** The Constant log. */
     private static final Logger log = Logger.getLogger(ExtensionForcedUser.class);
 
@@ -409,16 +412,17 @@ public class ExtensionForcedUser extends ExtensionAdaptor
         if (user != null) {
             config.setProperty("context.forceduser", user.getId());
         } else {
-            config.setProperty("context.forceduser", -1);
+            config.setProperty("context.forceduser", NO_FORCED_USER);
         }
     }
 
     @Override
     public void importContextData(Context ctx, Configuration config) {
-        int id = config.getInt("context.forceduser");
-        if (id >= 0) {
-            this.setForcedUser(ctx.getId(), id);
+        int id = config.getInt("context.forceduser", NO_FORCED_USER);
+        if (id == NO_FORCED_USER) {
+            return;
         }
+        this.setForcedUser(ctx.getId(), id);
     }
 
     /** No database tables used, so all supported */

--- a/zap/src/main/java/org/zaproxy/zap/model/StandardParameterParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/StandardParameterParser.java
@@ -46,6 +46,9 @@ public class StandardParameterParser implements ParameterParser {
     private static final String CONFIG_KV_SEPARATORS = "kvs";
     private static final String CONFIG_STRUCTURAL_PARAMS = "struct";
 
+    private static final String DEFAULT_KV_PAIR_SEPARATOR = "&";
+    private static final String DEFAULT_KV_SEPARATOR = "=";
+
     private Context context;
     private Pattern keyValuePairSeparatorPattern;
     private Pattern keyValueSeparatorPattern;
@@ -63,7 +66,7 @@ public class StandardParameterParser implements ParameterParser {
     }
 
     public StandardParameterParser() {
-        this("&", "=");
+        this(DEFAULT_KV_PAIR_SEPARATOR, DEFAULT_KV_SEPARATOR);
     }
 
     private Pattern getKeyValuePairSeparatorPattern() {
@@ -76,6 +79,13 @@ public class StandardParameterParser implements ParameterParser {
 
     @Override
     public void init(String config) {
+        if (config == null || config.isEmpty()) {
+            setKeyValuePairSeparators(DEFAULT_KV_PAIR_SEPARATOR);
+            setKeyValueSeparators(DEFAULT_KV_SEPARATOR);
+            structuralParameters.clear();
+            return;
+        }
+
         try {
             JSONObject json = JSONObject.fromObject(config);
             this.setKeyValuePairSeparators(json.getString(CONFIG_KV_PAIR_SEPARATORS));
@@ -205,8 +215,7 @@ public class StandardParameterParser implements ParameterParser {
         if (this.keyValuePairSeparators != null && this.keyValuePairSeparators.length() > 0) {
             return this.keyValuePairSeparators.substring(0, 1);
         }
-        // The default
-        return "&";
+        return DEFAULT_KV_PAIR_SEPARATOR;
     }
 
     @Override
@@ -214,8 +223,7 @@ public class StandardParameterParser implements ParameterParser {
         if (this.keyValueSeparators != null && this.keyValueSeparators.length() > 0) {
             return this.keyValueSeparators.substring(0, 1);
         }
-        // The default
-        return "=";
+        return DEFAULT_KV_SEPARATOR;
     }
 
     public List<String> getStructuralParameters() {

--- a/zap/src/test/java/org/zaproxy/zap/WithConfigsTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/WithConfigsTest.java
@@ -22,6 +22,8 @@ package org.zaproxy.zap;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
 
 import java.io.InputStream;
@@ -53,6 +55,9 @@ public abstract class WithConfigsTest extends TestUtils {
      */
     @TempDir protected static Path tempDir;
 
+    /** The mocked {@code Model}. */
+    protected Model model;
+
     private static String zapInstallDir;
     private static String zapHomeDir;
 
@@ -78,6 +83,9 @@ public abstract class WithConfigsTest extends TestUtils {
     public void setUpZap() throws Exception {
         Constant.setZapInstall(zapInstallDir);
         Constant.setZapHome(zapHomeDir);
+
+        model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+        Model.setSingletonForTesting(model);
 
         ExtensionLoader extLoader = Mockito.mock(ExtensionLoader.class);
         Control control = Mockito.mock(Control.class, withSettings().lenient());

--- a/zap/src/test/java/org/zaproxy/zap/extension/authentication/ExtensionAuthenticationUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/authentication/ExtensionAuthenticationUnitTest.java
@@ -1,0 +1,66 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.authentication;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link ExtensionAuthentication}. */
+class ExtensionAuthenticationUnitTest {
+
+    private ExtensionAuthentication extensionAuthentication;
+
+    @BeforeEach
+    void setup() {
+        extensionAuthentication = new ExtensionAuthentication();
+    }
+
+    @Test
+    void shouldImportContextWithNoAuthenticationMethod() throws ConfigurationException {
+        // Given
+        Context context = mock(Context.class);
+        Configuration config = new ZapXmlConfiguration();
+        // When
+        extensionAuthentication.importContextData(context, config);
+        // Then
+        verify(context, times(0)).setAuthenticationMethod(any());
+    }
+
+    @Test
+    void shouldImportContextWithUnknownAuthenticationMethod() throws ConfigurationException {
+        // Given
+        Context context = mock(Context.class);
+        Configuration config = new ZapXmlConfiguration();
+        config.setProperty("context.authentication.type", Integer.MIN_VALUE);
+        // When
+        extensionAuthentication.importContextData(context, config);
+        // Then
+        verify(context, times(0)).setAuthenticationMethod(any());
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/authorization/ExtensionAuthorizationUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/authorization/ExtensionAuthorizationUnitTest.java
@@ -1,0 +1,67 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.authorization;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link ExtensionAuthorization}. */
+class ExtensionAuthorizationUnitTest {
+
+    private ExtensionAuthorization extensionAuthorization;
+
+    @BeforeEach
+    void setup() {
+        extensionAuthorization = new ExtensionAuthorization();
+    }
+
+    @Test
+    void shouldImportContextWithNoAuthorizationDetectionMethod() throws ConfigurationException {
+        // Given
+        Context context = mock(Context.class);
+        Configuration config = new ZapXmlConfiguration();
+        // When
+        extensionAuthorization.importContextData(context, config);
+        // Then
+        verify(context, times(0)).setAuthorizationDetectionMethod(any());
+    }
+
+    @Test
+    void shouldImportContextWithUnknownAuthorizationDetectionMethod()
+            throws ConfigurationException {
+        // Given
+        Context context = mock(Context.class);
+        Configuration config = new ZapXmlConfiguration();
+        config.setProperty("context.authorization.type", Integer.MIN_VALUE);
+        // When
+        extensionAuthorization.importContextData(context, config);
+        // Then
+        verify(context, times(0)).setAuthorizationDetectionMethod(any());
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/forceduser/ExtensionForcedUserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/forceduser/ExtensionForcedUserUnitTest.java
@@ -1,0 +1,76 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.forceduser;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.apache.commons.configuration.Configuration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.zaproxy.zap.WithConfigsTest;
+import org.zaproxy.zap.extension.users.ExtensionUserManagement;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.utils.I18N;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link ExtensionForcedUser}. */
+class ExtensionForcedUserUnitTest extends WithConfigsTest {
+
+    private ExtensionUserManagement extensionUserManagement;
+
+    private ExtensionForcedUser extensionForcedUser;
+
+    @BeforeEach
+    void setup() {
+        Constant.messages = mock(I18N.class);
+        extensionUserManagement = new ExtensionUserManagement();
+        Control.getSingleton().getExtensionLoader().addExtension(extensionUserManagement);
+
+        extensionForcedUser = new ExtensionForcedUser();
+    }
+
+    @Test
+    void shouldImportContextWithNoForcedUser() {
+        // Given
+        Context context = mock(Context.class);
+        Configuration config = new ZapXmlConfiguration();
+        // When
+        extensionForcedUser.importContextData(context, config);
+        // Then
+        verify(context, times(0)).getId();
+    }
+
+    @Test
+    void shouldNotImportContextWithUnknownForcedUser() {
+        // Given
+        Context context = mock(Context.class);
+        Configuration config = new ZapXmlConfiguration();
+        config.setProperty("context.forceduser", Integer.MIN_VALUE);
+        // When / Then
+        assertThrows(
+                IllegalStateException.class,
+                () -> extensionForcedUser.importContextData(context, config));
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/model/StandardParameterParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/model/StandardParameterParserUnitTest.java
@@ -19,9 +19,14 @@
  */
 package org.zaproxy.zap.model;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -29,6 +34,8 @@ import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 /** Unit test for {@link StandardParameterParser}. */
 public class StandardParameterParserUnitTest {
@@ -127,6 +134,22 @@ public class StandardParameterParserUnitTest {
         assertEquals(res2.get(0).getValue(), "b&c");
         assertEquals(res2.get(1).getName(), "b");
         assertEquals(res2.get(1).getValue(), "c");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldInitWithNullAndEmptyConfig(String config) {
+        // Given
+        StandardParameterParser parser = new StandardParameterParser("A", "B");
+        parser.setStructuralParameters(Arrays.asList("C", "D"));
+        // When
+        parser.init(config);
+        // Then
+        assertThat(parser.getKeyValuePairSeparators(), is(equalTo("&")));
+        assertThat(parser.getDefaultKeyValuePairSeparator(), is(equalTo("&")));
+        assertThat(parser.getKeyValueSeparators(), is(equalTo("=")));
+        assertThat(parser.getDefaultKeyValueSeparator(), is(equalTo("=")));
+        assertThat(parser.getStructuralParameters(), hasSize(0));
     }
 
     /**


### PR DESCRIPTION
Just require the name when importing a context, preventing exceptions if
the optional fields are not present.

Part of #6206.