### PR TITLE
Restore active scanning everything in scope

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/model/StructuralSiteNode.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/StructuralSiteNode.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.model;
 
 import java.util.Iterator;
+import java.util.Objects;
 import org.apache.commons.httpclient.URI;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.model.HistoryReference;
@@ -30,8 +31,15 @@ public class StructuralSiteNode implements StructuralNode {
     private SiteNode node;
     private StructuralNode parent = null;
 
+    /**
+     * Constructs a {@code StructuralSiteNode} with the given node.
+     *
+     * @param node the node to wrap.
+     * @throws NullPointerException (since TODO add version) if the given {@code node} is {@code
+     *     null}.
+     */
     public StructuralSiteNode(SiteNode node) {
-        this.node = node;
+        this.node = Objects.requireNonNull(node);
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/model/Target.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/Target.java
@@ -144,8 +144,19 @@ public class Target {
         return maxDepth;
     }
 
+    /**
+     * Sets the given node as the start node.
+     *
+     * <p>Start nodes previously set are discarded.
+     *
+     * <p><strong>Note:</strong> The call to this method as no effect if the node is {@code null}.
+     *
+     * @param startNode the start node.
+     */
     public void setStartNode(SiteNode startNode) {
-        setStartNode(new StructuralSiteNode(startNode));
+        if (startNode != null) {
+            setStartNode(new StructuralSiteNode(startNode));
+        }
     }
 
     /**

--- a/zap/src/test/java/org/zaproxy/zap/model/StructuralSiteNodeUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/model/StructuralSiteNodeUnitTest.java
@@ -1,0 +1,47 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.model;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.model.SiteNode;
+
+/** Unit test for {@link StructuralSiteNode}. */
+class StructuralSiteNodeUnitTest {
+
+    @Test
+    void shouldNotAllowToConstructWithNullNode() {
+        // Given
+        SiteNode node = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> new StructuralSiteNode(node));
+    }
+
+    @Test
+    void shouldConstructWithNonNullNode() {
+        // Given
+        SiteNode node = mock(SiteNode.class);
+        // When / Then
+        assertDoesNotThrow(() -> new StructuralSiteNode(node));
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/model/TargetUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/model/TargetUnitTest.java
@@ -1,0 +1,54 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.model.SiteNode;
+
+/** Unit test for {@link Target}. */
+class TargetUnitTest {
+
+    @Test
+    void shouldNotSetNullSiteNodeWhenConstructing() {
+        // Given
+        SiteNode startNode = null;
+        // When
+        Target target = new Target(startNode, null, true, true);
+        // Then
+        assertThat(target.getStartNode(), is(nullValue()));
+        assertThat(target.getStartNodes(), is(nullValue()));
+    }
+
+    @Test
+    void shouldNotSetNullStartSiteNode() {
+        // Given
+        SiteNode siteNode = null;
+        Target target = new Target();
+        // When
+        target.setStartNode(siteNode);
+        // Then
+        assertThat(target.getStartNode(), is(nullValue()));
+        assertThat(target.getStartNodes(), is(nullValue()));
+    }
+}


### PR DESCRIPTION
Do not create a `Target` with invalid start node (i.e. null node), just
ignore it (has no special meaning).
Prevent constructing a `StructuralSiteNode` with a null node, to fail
early as possible.

Fix #6102.