### PR TITLE
Address random test failures

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/session/ScriptBasedSessionManagementMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/session/ScriptBasedSessionManagementMethodType.java
@@ -689,6 +689,17 @@ public class ScriptBasedSessionManagementMethodType extends SessionManagementMet
         return extensionScript;
     }
 
+    /**
+     * Sets the {@code ExtensionScript}.
+     *
+     * <p><strong>Note:</strong> Not part of the public API.
+     *
+     * @param extension the script extension.
+     */
+    public static void setExtensionScript(ExtensionScript extension) {
+        extensionScript = extension;
+    }
+
     private static SessionScript getScriptInterface(ScriptWrapper script) {
         try {
             return getScriptsExtension().getInterface(script, SessionScript.class);

--- a/zap/src/test/java/org/zaproxy/zap/extension/sessions/ExtensionSessionManagementUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/sessions/ExtensionSessionManagementUnitTest.java
@@ -33,6 +33,7 @@ import org.zaproxy.zap.WithConfigsTest;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.session.CookieBasedSessionManagementMethodType.CookieBasedSessionManagementMethod;
 import org.zaproxy.zap.session.HttpAuthSessionManagementMethodType.HttpAuthSessionManagementMethod;
+import org.zaproxy.zap.session.ScriptBasedSessionManagementMethodType;
 import org.zaproxy.zap.session.ScriptBasedSessionManagementMethodType.ScriptBasedSessionManagementMethod;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
@@ -42,6 +43,7 @@ public class ExtensionSessionManagementUnitTest extends WithConfigsTest {
 
     @BeforeEach
     public void setUp() throws Exception {
+        ScriptBasedSessionManagementMethodType.setExtensionScript(null);
         extSessMgmt = new ExtensionSessionManagement();
         extSessMgmt.hook(mock(ExtensionHook.class));
     }

--- a/zap/src/test/java/org/zaproxy/zap/utils/PausableScheduledThreadPoolExecutorUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/PausableScheduledThreadPoolExecutorUnitTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class PausableScheduledThreadPoolExecutorUnitTest {
 
     private static final int BULK_TASK_COUNT = 5;
-    private static final long DELAY_MS = 150;
+    private static final long DELAY_MS = 300;
 
     private PausableScheduledThreadPoolExecutor executor;
 


### PR DESCRIPTION
Change `ExtensionSessionManagementUnitTest` to reset the state of the
`ScriptBasedSessionManagementMethodType` by setting the script extension
to null (none), it could be already initialised by other test causing
them to fail (trying to register the script type again).
Change `PausableScheduledThreadPoolExecutorUnitTest` to run the tasks
with more delay to give more time for the tasks to execute in case of
slowdowns.