### PR TITLE
Address some glitches when changing look and feel

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsParamView.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsParamView.java
@@ -44,6 +44,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/02/24 Persist the class of the selected look and feel.
 // ZAP: 2020/09/29 Add support for dynamic Look and Feel switching (Issue 6201)
+// ZAP: 2020/10/26 Update pop up menus when changing look and feel.
 package org.parosproxy.paros.extension.option;
 
 import java.awt.Window;
@@ -627,7 +628,9 @@ public class OptionsParamView extends AbstractParam {
                                         UIManager.setLookAndFeel(lookAndFeelInfo.getClassName());
                                         Arrays.asList(Window.getWindows()).stream()
                                                 .forEach(SwingUtilities::updateComponentTreeUI);
-
+                                        View.getSingleton()
+                                                .getPopupList()
+                                                .forEach(SwingUtilities::updateComponentTreeUI);
                                     } catch (Exception e2) {
                                         LOG.warn(
                                                 "Failed to set the look and feel: "

--- a/zap/src/main/java/org/parosproxy/paros/view/AbstractParamContainerPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/AbstractParamContainerPanel.java
@@ -33,6 +33,8 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/03/24 Remove hardcoded white background on Headline field (part of Issue 5542).
 // ZAP: 2020/08/25 Catch NullPointerException when validating/saving the panel.
+// ZAP: 2020/10/26 Use empty border in the help button, to prevent the look and feel change from
+// resetting it. Also, use the icon from the ExtensionHelp.
 package org.parosproxy.paros.view;
 
 import java.awt.BorderLayout;
@@ -52,6 +54,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.Hashtable;
+import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JPanel;
@@ -1025,11 +1028,8 @@ public class AbstractParamContainerPanel extends JSplitPane {
     private JButton getHelpButton() {
         if (btnHelp == null) {
             btnHelp = new JButton();
-            btnHelp.setBorder(null);
-            btnHelp.setIcon(
-                    new ImageIcon(
-                            AbstractParamContainerPanel.class.getResource(
-                                    "/resource/icon/16/201.png"))); // help icon
+            btnHelp.setBorder(BorderFactory.createEmptyBorder());
+            btnHelp.setIcon(ExtensionHelp.getHelpIcon());
             btnHelp.addActionListener(getShowHelpAction());
             btnHelp.setToolTipText(Constant.messages.getString("menu.help"));
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/help/ExtensionHelp.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/help/ExtensionHelp.java
@@ -465,8 +465,7 @@ public class ExtensionHelp extends ExtensionAdaptor {
     private JButton getHelpButton() {
         if (helpButton == null) {
             helpButton = new JButton();
-            helpButton.setIcon(
-                    new ImageIcon(ExtensionHelp.class.getResource("/resource/icon/16/201.png")));
+            helpButton.setIcon(getHelpIcon());
 
             helpButton.addActionListener(
                     new java.awt.event.ActionListener() {

--- a/zap/src/main/java/org/zaproxy/zap/view/MainToolbarPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/MainToolbarPanel.java
@@ -24,6 +24,7 @@ import java.awt.GridBagConstraints;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import javax.swing.BorderFactory;
+import javax.swing.Box;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -81,13 +82,8 @@ public class MainToolbarPanel extends JPanel {
         gridBagConstraints2.anchor = java.awt.GridBagConstraints.EAST;
         gridBagConstraints2.fill = java.awt.GridBagConstraints.HORIZONTAL;
 
-        JToolBar t1 = new JToolBar();
-        t1.setEnabled(true);
-        t1.setPreferredSize(new java.awt.Dimension(80000, 25));
-        t1.setMaximumSize(new java.awt.Dimension(80000, 25));
-
         add(getToolbar(), gridBagConstraints1);
-        add(t1, gridBagConstraints2);
+        add(Box.createHorizontalGlue(), gridBagConstraints2);
 
         toolbar.add(getModeSelect());
         toolbar.add(getBtnNew());


### PR DESCRIPTION
Update global pop up menus, otherwise some of them could still be shown
with previous look and feel.
Change help button in param panels to have an empty border instead of
null, to prevent the look and feel change from resetting it.
Related to help button (but not UI glitch), use the same help icon
already loaded by the help extension (and in the extension itself).
Replace toolbar used as spacer which could be detached after changing
the look and feel.

Part of #6201.