### PR TITLE
Fix Report Write Failure When Path Contained '#'

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/report/ReportGenerator.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/report/ReportGenerator.java
@@ -31,6 +31,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/08/06 Issue 6084: Added date time to html report.
+// ZAP: 2020/10/29 Issue 6267: Fix bug to allow writing reports with file path containing '#'.
 package org.parosproxy.paros.extension.report;
 
 import java.io.BufferedReader;
@@ -92,7 +93,7 @@ public class ReportGenerator {
             Transformer transformer = tFactory.newTransformer(stylesource);
 
             // Make the transformation and write to the output file
-            StreamResult result = new StreamResult(outFile);
+            StreamResult result = new StreamResult(outFile.getPath());
             transformer.transform(source, result);
 
         } catch (TransformerException e) {
@@ -132,7 +133,7 @@ public class ReportGenerator {
                 transformer.setParameter("datetime", getCurrentDateTimeString());
 
                 DOMSource source = new DOMSource(doc);
-                StreamResult result = new StreamResult(outfile);
+                StreamResult result = new StreamResult(outfile.getPath());
                 transformer.transform(source, result);
 
             } catch (TransformerException
@@ -311,7 +312,7 @@ public class ReportGenerator {
             transformer.setParameter("datetime", getCurrentDateTimeString());
 
             DOMSource source = new DOMSource(doc);
-            StreamResult result = new StreamResult(outfile);
+            StreamResult result = new StreamResult(outfile.getPath());
             transformer.transform(source, result);
 
         } catch (TransformerException

--- a/zap/src/test/java/org/parosproxy/paros/extension/report/ReportGeneratorUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/extension/report/ReportGeneratorUnitTest.java
@@ -72,6 +72,18 @@ public class ReportGeneratorUnitTest extends TestUtils {
     }
 
     @Test
+    public void shouldWriteReportWhenPathContainsHashSymbol(@TempDir Path tempDir)
+            throws Exception {
+        // Given
+        String data = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><data>ZAP</data>" + NEWLINE;
+        Path report = Files.createTempFile(tempDir, "#", "");
+        // When
+        ReportGenerator.stringToHtml(data, identityXsl(), report.toString());
+        // Then
+        assertThat(contents(report), is(equalTo(data)));
+    }
+
+    @Test
     public void shouldUseEmptyArrayForSitesInJsonReportIfNoSitePresent() {
         // Given
         String xmlReport =


### PR DESCRIPTION
- Partially Fixes #6267 (the customreport add-on will be updated next).

Signed-off-by: ricekot <ricekot@gmail.com>