### PR TITLE
Check if Log4j legacy conf backup already exists

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/Constant.java
+++ b/zap/src/main/java/org/parosproxy/paros/Constant.java
@@ -108,6 +108,7 @@
 // ZAP: 2020/09/17 Correct the Syntax Highlighting markoccurrences config key name when upgrading
 // from 2.9 or earlier.
 // ZAP: 2020/10/07 Changes for Log4j 2 migration.
+// ZAP: 2020/11/02 Do not backup old Log4j config if already present.
 package org.parosproxy.paros;
 
 import java.io.File;
@@ -761,11 +762,17 @@ public final class Constant {
 
     private static void backupLegacyLog4jConfig() {
         String fileName = "log4j.properties";
+        Path backupLegacyConfig = Paths.get(zapHome, fileName + ".bak");
+        if (Files.exists(backupLegacyConfig)) {
+            logAndPrintInfo("Ignoring legacy log4j.properties file, backup already exists.");
+            return;
+        }
+
         Path legacyConfig = Paths.get(zapHome, fileName);
         if (Files.exists(legacyConfig)) {
             logAndPrintInfo("Creating backup of legacy log4j.properties file...");
             try {
-                Files.move(legacyConfig, Paths.get(zapHome, fileName + ".bak"));
+                Files.move(legacyConfig, backupLegacyConfig);
             } catch (IOException e) {
                 logAndPrintError("Failed to backup legacy Log4j configuration file:", e);
             }

--- a/zap/src/test/java/org/parosproxy/paros/ConstantUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/ConstantUnitTest.java
@@ -145,6 +145,22 @@ public class ConstantUnitTest {
         assertHomeFile("log4j.properties.bak", log4jContents);
     }
 
+    @Test
+    public void shouldNotBackupLegacyLog4jConfigurationIfBackupExists() throws IOException {
+        // Given
+        Constant.setZapInstall(zapInstallDir.toString());
+        Constant.setZapHome(zapHomeDir.toString());
+        String log4jContents = "log4j.rootLogger...";
+        homeFile("log4j.properties", log4jContents);
+        String log4jContentsBackup = "backup";
+        homeFile("log4j.properties.bak", log4jContentsBackup);
+        // When
+        new Constant();
+        // Then
+        assertHomeFile("log4j.properties", log4jContents);
+        assertHomeFile("log4j.properties.bak", log4jContentsBackup);
+    }
+
     private void assertHomeFile(String name, String contents) throws IOException {
         assertHomeFile(name, is(equalTo(contents)));
     }


### PR DESCRIPTION
Avoid logging an error when the backup already exists, which would
happen after running older and newer ZAP versions using the same home.