### PR TITLE
Address exceptions related to parameter parsing

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/model/ParameterParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/ParameterParser.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.model;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.httpclient.URI;
@@ -43,7 +44,8 @@ public interface ParameterParser {
      * <p>The parameters are split using the key value pair separator(s) and each resulting
      * parameter is split into name/value pairs using key value separator(s).
      *
-     * <p>Parameters' names and values are in decoded form.
+     * <p>Parameters' names and values are in decoded form, if not malformed, otherwise the original
+     * name/value. Names and values are never {@code null}.
      *
      * @param msg the message whose parameters will be extracted from
      * @param type the type of parameters to extract
@@ -68,7 +70,8 @@ public interface ParameterParser {
      * <p>The parameters are split using the key value pair separator(s) and each resulting
      * parameter is split into name/value pairs using key value separator(s).
      *
-     * <p>Parameters' names and values are in decoded form.
+     * <p>Parameters' names and values are in decoded form, if not malformed, otherwise the original
+     * name/value. Names and values are never {@code null}.
      *
      * @param parameters the String of parameters to parse, might be {@code null}
      * @return a {@code List} containing the parameters parsed
@@ -77,6 +80,28 @@ public interface ParameterParser {
      * @see #getDefaultKeyValueSeparator()
      */
     List<NameValuePair> parseParameters(String parameters);
+
+    /**
+     * Parses the given {@code parameters} into a list of {@link NameValuePair}.
+     *
+     * <p>The parameters are split using the key value pair separator(s) and each resulting
+     * parameter is split into name/value pairs using key value separator(s).
+     *
+     * <p>Unlike {@link #parseParameters(String)} the parameters' names and values are not decoded.
+     * This allows to rebuild the original string without (re)encoding issues. Values might be
+     * {@code null}, when not present.
+     *
+     * <p>By default returns an empty list.
+     *
+     * @param parameters the String of parameters to parse, might be {@code null}.
+     * @return a {@code List} containing the parameters parsed, never {@code null}.
+     * @since 2.10.0
+     * @see #getDefaultKeyValuePairSeparator()
+     * @see #getDefaultKeyValueSeparator()
+     */
+    default List<NameValuePair> parseRawParameters(String parameters) {
+        return Collections.emptyList();
+    }
 
     List<String> getTreePath(URI uri) throws URIException;
 

--- a/zap/src/main/java/org/zaproxy/zap/model/StandardParameterParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/StandardParameterParser.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -264,6 +265,17 @@ public class StandardParameterParser implements ParameterParser {
 
     @Override
     public List<NameValuePair> parseParameters(String parameters) {
+        return createParameters(
+                parameters,
+                (name, value) -> {
+                    String decodedName = urlDecode(name);
+                    String decodedValue = value != null ? urlDecode(value) : "";
+                    return new DefaultNameValuePair(decodedName, decodedValue);
+                });
+    }
+
+    private List<NameValuePair> createParameters(
+            String parameters, BiFunction<String, String, NameValuePair> nameValuePairFactory) {
         if (parameters == null) {
             return new ArrayList<>(0);
         }
@@ -272,13 +284,9 @@ public class StandardParameterParser implements ParameterParser {
         String[] pairs = getKeyValuePairSeparatorPattern().split(parameters);
         for (String pair : pairs) {
             String[] nameValuePair = getKeyValueSeparatorPattern().split(pair, 2);
-            if (nameValuePair.length == 1) {
-                parametersList.add(new DefaultNameValuePair(urlDecode(nameValuePair[0])));
-            } else {
-                parametersList.add(
-                        new DefaultNameValuePair(
-                                urlDecode(nameValuePair[0]), urlDecode(nameValuePair[1])));
-            }
+            String name = nameValuePair[0];
+            String value = nameValuePair.length == 1 ? null : nameValuePair[1];
+            parametersList.add(nameValuePairFactory.apply(name, value));
         }
         return parametersList;
     }
@@ -286,10 +294,17 @@ public class StandardParameterParser implements ParameterParser {
     private static String urlDecode(String value) {
         try {
             return URLDecoder.decode(value, "UTF-8");
+        } catch (IllegalArgumentException e) {
+            return value;
         } catch (UnsupportedEncodingException ignore) {
             // Shouldn't happen UTF-8 is a standard charset (see java.nio.charset.StandardCharsets)
         }
         return "";
+    }
+
+    @Override
+    public List<NameValuePair> parseRawParameters(String parameters) {
+        return createParameters(parameters, DefaultNameValuePair::new);
     }
 
     @Override

--- a/zap/src/test/java/org/zaproxy/zap/model/StandardParameterParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/model/StandardParameterParserUnitTest.java
@@ -20,9 +20,11 @@
 package org.zaproxy.zap.model;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
@@ -76,6 +78,114 @@ public class StandardParameterParserUnitTest {
         assertEquals(res2.get(2).getValue(), "f");
         assertEquals(res2.get(3).getName(), "d");
         assertEquals(res2.get(3).getValue(), "g");
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenParsingNullString() {
+        // Given / When
+        List<NameValuePair> parameters = spp.parseParameters(null);
+        // Then
+        assertThat(parameters, is(empty()));
+    }
+
+    @Test
+    void shouldReturnEmptyNameValuePairWhenParsingEmptyString() {
+        // Given / When
+        List<NameValuePair> parameters = spp.parseParameters("");
+        // Then
+        assertThat(parameters, hasSize(1));
+        assertThat(parameters.get(0).getName(), is(equalTo("")));
+        assertThat(parameters.get(0).getValue(), is(equalTo("")));
+    }
+
+    @Test
+    void shouldKeepOriginalNameIfMalformedWhenParsing() {
+        // Given / When
+        List<NameValuePair> parameters = spp.parseParameters("%x=1&b=2");
+        // Then
+        assertThat(parameters, hasSize(2));
+        assertThat(parameters.get(0).getName(), is(equalTo("%x")));
+        assertThat(parameters.get(0).getValue(), is(equalTo("1")));
+        assertThat(parameters.get(1).getName(), is(equalTo("b")));
+        assertThat(parameters.get(1).getValue(), is(equalTo("2")));
+    }
+
+    @Test
+    void shouldKeepOriginalValueIfMalformedWhenParsing() {
+        // Given / When
+        List<NameValuePair> parameters = spp.parseParameters("a=%x&b=2");
+        // Then
+        assertThat(parameters, hasSize(2));
+        assertThat(parameters.get(0).getName(), is(equalTo("a")));
+        assertThat(parameters.get(0).getValue(), is(equalTo("%x")));
+        assertThat(parameters.get(1).getName(), is(equalTo("b")));
+        assertThat(parameters.get(1).getValue(), is(equalTo("2")));
+    }
+
+    @Test
+    void shouldParseParametersKeepingEmptyValueWhenAbsent() {
+        // Given / When
+        List<NameValuePair> parameters = spp.parseParameters("a&b");
+        // Then
+        assertThat(parameters, hasSize(2));
+        assertThat(parameters.get(0).getName(), is(equalTo("a")));
+        assertThat(parameters.get(0).getValue(), is(equalTo("")));
+        assertThat(parameters.get(1).getName(), is(equalTo("b")));
+        assertThat(parameters.get(1).getValue(), is(equalTo("")));
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenRawParsingNullString() {
+        // Given / When
+        List<NameValuePair> parameters = spp.parseRawParameters(null);
+        // Then
+        assertThat(parameters, is(empty()));
+    }
+
+    @Test
+    void shouldReturnEmptyNameAndNullValueWhenRawParsingEmptyString() {
+        // Given / When
+        List<NameValuePair> parameters = spp.parseRawParameters("");
+        // Then
+        assertThat(parameters, hasSize(1));
+        assertThat(parameters.get(0).getName(), is(equalTo("")));
+        assertThat(parameters.get(0).getValue(), is(nullValue()));
+    }
+
+    @Test
+    void shouldNotDecodeNameNorValueWhenRawParsing() {
+        // Given / When
+        List<NameValuePair> parameters = spp.parseRawParameters("%x=1&b%25=%20");
+        // Then
+        assertThat(parameters, hasSize(2));
+        assertThat(parameters.get(0).getName(), is(equalTo("%x")));
+        assertThat(parameters.get(0).getValue(), is(equalTo("1")));
+        assertThat(parameters.get(1).getName(), is(equalTo("b%25")));
+        assertThat(parameters.get(1).getValue(), is(equalTo("%20")));
+    }
+
+    @Test
+    void shouldHaveEmptyNamesForMissingNamesWhenRawParsing() {
+        // Given / When
+        List<NameValuePair> parameters = spp.parseRawParameters("=1&=2");
+        // Then
+        assertThat(parameters, hasSize(2));
+        assertThat(parameters.get(0).getName(), is(equalTo("")));
+        assertThat(parameters.get(0).getValue(), is(equalTo("1")));
+        assertThat(parameters.get(1).getName(), is(equalTo("")));
+        assertThat(parameters.get(1).getValue(), is(equalTo("2")));
+    }
+
+    @Test
+    void shouldHaveNullValuesForMissingValuesWhenRawParsing() {
+        // Given / When
+        List<NameValuePair> parameters = spp.parseRawParameters("a&b");
+        // Then
+        assertThat(parameters, hasSize(2));
+        assertThat(parameters.get(0).getName(), is(equalTo("a")));
+        assertThat(parameters.get(0).getValue(), is(nullValue()));
+        assertThat(parameters.get(1).getName(), is(equalTo("b")));
+        assertThat(parameters.get(1).getValue(), is(nullValue()));
     }
 
     @Test

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -161,7 +161,8 @@ val japicmp by tasks.registering(JapicmpTask::class) {
         "org.parosproxy.paros.core.scanner.Variant#getTreePath(org.parosproxy.paros.network.HttpMessage)",
         "org.parosproxy.paros.core.scanner.VariantScript#getLeafName(org.parosproxy.paros.core.scanner.VariantCustom,java.lang.String,org.parosproxy.paros.network.HttpMessage)",
         "org.parosproxy.paros.core.scanner.VariantScript#getTreePath(org.parosproxy.paros.core.scanner.VariantCustom,org.parosproxy.paros.network.HttpMessage)",
-        "org.parosproxy.paros.db.TableAlert#write(int,int,java.lang.String,int,int,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,int,int,int,int,int)"
+        "org.parosproxy.paros.db.TableAlert#write(int,int,java.lang.String,int,int,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,int,int,int,int,int)",
+        "org.zaproxy.zap.model.ParameterParser#parseRawParameters(java.lang.String)"
     )
 
     richReport {


### PR DESCRIPTION
Do not allow null values as the older method didn't allow them, which
was causing exceptions in scan rules, also, catch exception thrown when
decoding name/value, for same reason.
Provide a method that does not decode and allows null values.