### PR TITLE
Use the whole message to get the leaf name

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantCustom.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantCustom.java
@@ -25,7 +25,6 @@ import java.util.regex.Pattern;
 import org.apache.commons.codec.binary.Base64;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.Model;
-import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
@@ -240,13 +239,7 @@ public class VariantCustom implements Variant {
      */
     public String getStandardLeafName(
             String nodeName, HttpMessage msg, List<NameValuePair> params) {
-        return Model.getSingleton()
-                .getSession()
-                .getLeafName(
-                        nodeName,
-                        msg.getRequestHeader().getMethod(),
-                        msg.getRequestHeader().getHeader(HttpHeader.CONTENT_TYPE),
-                        params);
+        return Model.getSingleton().getSession().getLeafName(nodeName, msg, params);
     }
 
     /**

--- a/zap/src/main/java/org/parosproxy/paros/model/Session.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/Session.java
@@ -1654,9 +1654,9 @@ public class Session {
 
     public String getLeafName(
             String nodeName,
-            String method,
-            String contentType,
+            HttpMessage message,
             List<org.parosproxy.paros.core.scanner.NameValuePair> params) {
+        String method = message.getRequestHeader().getMethod();
         StringBuilder sb = new StringBuilder();
         sb.append(method);
         sb.append(":");
@@ -1666,6 +1666,7 @@ public class Session {
                         params, org.parosproxy.paros.core.scanner.NameValuePair.TYPE_QUERY_STRING));
 
         if (method.equalsIgnoreCase(HttpRequestHeader.POST)) {
+            String contentType = message.getRequestHeader().getHeader(HttpHeader.CONTENT_TYPE);
             if (contentType != null && contentType.startsWith("multipart/form-data")) {
                 sb.append("(multipart/form-data)");
             } else {
@@ -1711,11 +1712,7 @@ public class Session {
                             org.parosproxy.paros.core.scanner.NameValuePair.TYPE_POST_DATA));
         }
 
-        return getLeafName(
-                nodeName,
-                msg.getRequestHeader().getMethod(),
-                msg.getRequestHeader().getHeader(HttpHeader.CONTENT_TYPE),
-                params);
+        return getLeafName(nodeName, msg, params);
     }
 
     /**


### PR DESCRIPTION
Provide the whole message when available to get the leaf name, allowing
to use other message components if/when needed without adding/changing
the method.