### PR TITLE
Add convenience methods for identifying CSS related messages

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/network/HttpRequestHeader.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpRequestHeader.java
@@ -56,6 +56,8 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/12/09 Address deprecation of getHeaders(String) Vector method.
+// ZAP: 2020/11/10 Add convenience method isCss(), refactor isImage() to use new private method
+// isSpecificType(Pattern).
 package org.parosproxy.paros.network;
 
 import java.io.UnsupportedEncodingException;
@@ -119,6 +121,8 @@ public class HttpRequestHeader extends HttpHeader {
             Pattern.compile(
                     "\\A *(OPTIONS|GET|HEAD|POST|PUT|DELETE|TRACE|CONNECT)\\b",
                     Pattern.CASE_INSENSITIVE);
+    private static final Pattern PATTERN_CSS =
+            Pattern.compile("\\.css\\z", Pattern.CASE_INSENSITIVE);
 
     /**
      * The user agent used by {@link #HttpRequestHeader(String, URI, String) default request
@@ -561,6 +565,14 @@ public class HttpRequestHeader extends HttpHeader {
     /** Return if this request header is a image request basing on the path suffix. */
     @Override
     public boolean isImage() {
+        return isSpecificType(patternImage);
+    }
+
+    public boolean isCss() {
+        return isSpecificType(PATTERN_CSS);
+    }
+
+    private boolean isSpecificType(Pattern pattern) {
         if (getURI() == null) {
             return false;
         }
@@ -569,7 +581,7 @@ public class HttpRequestHeader extends HttpHeader {
             // ZAP: prevents a NullPointerException when no path exists
             final String path = getURI().getPath();
             if (path != null) {
-                return (patternImage.matcher(path).find());
+                return (pattern.matcher(path).find());
             }
 
         } catch (URIException e) {

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpResponseHeader.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpResponseHeader.java
@@ -39,6 +39,7 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/12/09 Address deprecation of getHeaders(String) Vector method.
+// ZAP: 2020/11/10 Add convenience method isCss().
 package org.parosproxy.paros.network;
 
 import java.net.HttpCookie;
@@ -93,6 +94,7 @@ public class HttpResponseHeader extends HttpHeader {
     private static final Logger log = Logger.getLogger(HttpResponseHeader.class);
 
     public static final String HTTP_CLIENT_BAD_REQUEST = "HTTP/1.0 400 Bad request" + CRLF + CRLF;
+    private static final String _CONTENT_TYPE_CSS = "css";
     private static final String _CONTENT_TYPE_IMAGE = "image";
     private static final String _CONTENT_TYPE_TEXT = "text";
     private static final String _CONTENT_TYPE_HTML = "html";
@@ -276,6 +278,10 @@ public class HttpResponseHeader extends HttpHeader {
 
     public boolean isJavaScript() {
         return hasContentType(_CONTENT_TYPE_JAVASCRIPT);
+    }
+
+    public boolean isCss() {
+        return hasContentType(_CONTENT_TYPE_CSS);
     }
 
     public static boolean isStatusLine(String data) {

--- a/zap/src/test/java/org/parosproxy/paros/network/HttpResponseHeaderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/network/HttpResponseHeaderUnitTest.java
@@ -23,9 +23,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /** Unit test for {@link HttpResponseHeader}. */
 public class HttpResponseHeaderUnitTest {
@@ -125,5 +129,44 @@ public class HttpResponseHeaderUnitTest {
         // Then
         assertThat(header.getReasonPhrase(), is(equalTo("")));
         assertThat(header.getPrimeHeader(), is(equalTo("HTTP/1.1 200")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "text/html", // Text but not css
+                "image/png", // Not text or css
+                "teXt/hTmL", // Mixed case
+                "text/html; charset=UTF-8", // Expected charset
+                "text/html;charset=UTF-8", // Charset without space
+                "charset=UTF-8; text/html" // Charset first
+            })
+    public void isCssShouldReturnFalseWhenContentTypeDoesNotIndicateCss(String contentType) {
+        // Given
+        HttpResponseHeader hrh = createResponseHeader(contentType);
+        // When / Then
+        assertFalse(hrh.isCss());
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "text/css", // CSS
+                "teXt/cSs", // Mixed case
+                "text/css; charset=UTF-8", // Expected charset
+                "text/css;charset=UTF-8", // Charset without space
+                "charset=UTF-8; text/css" // Charset first
+            })
+    public void isCssShouldReturnTrueWhenContentTypeIndicatesCss(String contentType) {
+        // Given
+        HttpResponseHeader hrh = createResponseHeader(contentType);
+        // When / Then
+        assertTrue(hrh.isCss());
+    }
+
+    private static HttpResponseHeader createResponseHeader(String contentType) {
+        HttpResponseHeader hrh = new HttpResponseHeader();
+        hrh.setHeader(HttpHeader.CONTENT_TYPE, contentType);
+        return hrh;
     }
 }


### PR DESCRIPTION
- HttpRequestHeader > Add `isCss()` method, refactor `isImage()` method, add private `isSpecificyType(Pattern)` method.
- HttpResponseHeader > Add `isCss()` method.

Related to zaproxy/zaproxy#6288

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>