### PR TITLE
CustomPages: Add core isSuccess Method(s)

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -678,11 +678,32 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
     }
 
     /**
-     * Tells whether or not the response has a status code between 400 and 499 (inclusive). Falls
-     * back to check {@code CustomPage.Type.NOTFOUND_404} and {@code
-     * Analyser#isFileExist(HttpMessage)}. Checks if the message matches {@code
-     * CustomPage.Type.OK_200} or {@code CustomPage.Type.ERROR_500} first, in case the user is
-     * trying to override something.
+     * Tells whether or not the response has a status code between 200 and 299 (inclusive), or
+     * {@code CustomPage.Type.OK_200} and {@code Analyser#isFileExist(HttpMessage)}. Checks if the
+     * message matches {@code CustomPage.Type.NOTFOUND_404} or {@code CustomPage.Type.ERROR_500}
+     * first, in case the user is trying to override something.
+     *
+     * @param msg the message that will be checked
+     * @return {@code true} if the message matches, {@code false} otherwise
+     * @since TODO Add version
+     * @see {@code Analyser#isFileExist(HttpMessage)}
+     */
+    public boolean isSuccess(HttpMessage msg) {
+        if (isCustomPage(msg, CustomPage.Type.NOTFOUND_404)
+                || isCustomPage(msg, CustomPage.Type.ERROR_500)) {
+            return false;
+        }
+        if (isCustomPage(msg, CustomPage.Type.OK_200) || parent.getAnalyser().isFileExist(msg)) {
+            return true;
+        }
+        return HttpStatusCode.isSuccess(msg.getResponseHeader().getStatusCode());
+    }
+
+    /**
+     * Tells whether or not the response has a status code between 400 and 499 (inclusive), or
+     * {@code CustomPage.Type.NOTFOUND_404} and {@code Analyser#isFileExist(HttpMessage)}. Checks if
+     * the message matches {@code CustomPage.Type.OK_200} or {@code CustomPage.Type.ERROR_500}
+     * first, in case the user is trying to override something.
      *
      * @param msg the message that will be checked
      * @return {@code true} if the message matches, {@code false} otherwise
@@ -702,8 +723,8 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
     }
 
     /**
-     * Tells whether or not the response has a status code between 500 and 599 (inclusive). Falls
-     * back to check {@code CustomPage.Type.EROOR_500}. Checks if the message matches {@code
+     * Tells whether or not the response has a status code between 500 and 599 (inclusive), or
+     * {@code CustomPage.Type.EROOR_500}. Checks if the message matches {@code
      * CustomPage.Type.OK_200} or {@code CustomPage.Type.NOTFOUND_404} first, in case the user is
      * trying to override something.
      *

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanData.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanData.java
@@ -247,8 +247,29 @@ public final class PassiveScanData {
     }
 
     /**
-     * Tells whether or not the response has a status code between 400 and 499 (inclusive). Falls
-     * back to check {@code CustomPage.Type.NOTFOUND_404}. Checks if the message matches {@code
+     * Tells whether or not the response has a status code between 200 and 299 (inclusive), or
+     * {@code CustomPage.Type.OK_200}. Checks if the message matches {@code
+     * CustomPage.Type.NOTFOUND_404} or {@code CusotmPage.Type.ERROR_500} first, in case the user is
+     * trying to override something.
+     *
+     * @param msg the message that will be checked
+     * @return {@code true} if the message matches, {@code false} otherwise
+     * @since TODO Add version
+     */
+    public boolean isSuccess(HttpMessage msg) {
+        if (isCustomPage(msg, CustomPage.Type.NOTFOUND_404)
+                || isCustomPage(msg, CustomPage.Type.ERROR_500)) {
+            return false;
+        }
+        if (isCustomPage(msg, CustomPage.Type.OK_200)) {
+            return true;
+        }
+        return HttpStatusCode.isSuccess(msg.getResponseHeader().getStatusCode());
+    }
+
+    /**
+     * Tells whether or not the response has a status code between 400 and 499 (inclusive), or
+     * {@code CustomPage.Type.NOTFOUND_404}. Checks if the message matches {@code
      * CustomPage.Type.OK_200} or {@code CusotmPage.Type.ERROR_500} first, in case the user is
      * trying to override something.
      *
@@ -268,8 +289,8 @@ public final class PassiveScanData {
     }
 
     /**
-     * Tells whether or not the response has a status code between 500 and 599 (inclusive). Falls
-     * back to check {@code CustomPage.Type.EROOR_500}. Checks if the message matches {@code
+     * Tells whether or not the response has a status code between 500 and 599 (inclusive), or
+     * {@code CustomPage.Type.EROOR_500}. Checks if the message matches {@code
      * CustomPage.Type.OK_200} or {@code CustomPage.Type.NOTFOUND_404} first, in case the user is
      * trying to override something.
      *

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/AbstractPluginUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/AbstractPluginUnitTest.java
@@ -1604,6 +1604,127 @@ public class AbstractPluginUnitTest extends PluginTestUtils {
     }
 
     @Test
+    public void isSuccessShouldReturnTrueIfCustomPage200Matches() {
+        // Given
+        CustomPage.Type type = CustomPage.Type.OK_200;
+        HttpMessage message = new HttpMessage();
+        message.getResponseHeader().setStatusCode(302);
+        given(parent.isCustomPage(message, CustomPage.Type.NOTFOUND_404)).willReturn(false);
+        given(parent.isCustomPage(message, CustomPage.Type.ERROR_500)).willReturn(false);
+        given(parent.isCustomPage(message, type)).willReturn(true);
+        given(analyser.isFileExist(message)).willReturn(false);
+        plugin.init(message, parent);
+        // When
+        boolean result = plugin.isSuccess(message);
+        // Then
+        assertThat(result, is(equalTo(true)));
+        verify(parent).isCustomPage(message, CustomPage.Type.NOTFOUND_404);
+        verify(parent).isCustomPage(message, CustomPage.Type.ERROR_500);
+        verify(parent).isCustomPage(message, type);
+    }
+
+    @Test
+    public void isSuccessShouldReturnTrueIfStatusCodeMatches() {
+        // Given
+        CustomPage.Type type = CustomPage.Type.NOTFOUND_404;
+        HttpMessage message = new HttpMessage();
+        message.getResponseHeader().setStatusCode(204);
+        plugin.init(message, parent);
+        given(parent.isCustomPage(message, CustomPage.Type.NOTFOUND_404)).willReturn(false);
+        given(parent.isCustomPage(message, CustomPage.Type.ERROR_500)).willReturn(false);
+        given(parent.isCustomPage(message, type)).willReturn(false);
+        given(parent.getAnalyser()).willReturn(analyser);
+        given(parent.getAnalyser().isFileExist(message)).willReturn(false);
+        // When
+        boolean result = plugin.isSuccess(message);
+        // Then
+        assertThat(result, is(equalTo(true)));
+        verify(parent).isCustomPage(message, CustomPage.Type.NOTFOUND_404);
+        verify(parent).isCustomPage(message, CustomPage.Type.ERROR_500);
+        verify(parent).isCustomPage(message, type);
+    }
+
+    @Test
+    public void
+            isSuccessShouldReturnTrueIfNoStatusCodeNorCustomPageMatchesButAnalyserIndicates200() {
+        // Given
+        CustomPage.Type type = CustomPage.Type.NOTFOUND_404;
+        HttpMessage message = new HttpMessage();
+        message.getResponseHeader().setStatusCode(302);
+        given(parent.isCustomPage(message, CustomPage.Type.NOTFOUND_404)).willReturn(false);
+        given(parent.isCustomPage(message, CustomPage.Type.ERROR_500)).willReturn(false);
+        given(parent.isCustomPage(message, type)).willReturn(false);
+        given(parent.getAnalyser()).willReturn(analyser);
+        given(parent.getAnalyser().isFileExist(message)).willReturn(true);
+        plugin.init(message, parent);
+        // When
+        boolean result = plugin.isSuccess(message);
+        // Then
+        assertThat(result, is(equalTo(true)));
+        verify(parent).isCustomPage(message, CustomPage.Type.NOTFOUND_404);
+        verify(parent).isCustomPage(message, CustomPage.Type.ERROR_500);
+        verify(parent).isCustomPage(message, type);
+    }
+
+    @Test
+    public void
+            isSuccessShouldReturnFalseIfNoStatusCodeNorCustomPageMatchesAndAnalyserIndicates404() {
+        // Given
+        CustomPage.Type type = CustomPage.Type.OK_200;
+        HttpMessage message = new HttpMessage();
+        message.getResponseHeader().setStatusCode(302);
+        given(parent.isCustomPage(message, CustomPage.Type.NOTFOUND_404)).willReturn(false);
+        given(parent.isCustomPage(message, CustomPage.Type.ERROR_500)).willReturn(false);
+        given(parent.isCustomPage(message, type)).willReturn(false);
+        given(parent.getAnalyser()).willReturn(analyser);
+        given(parent.getAnalyser().isFileExist(message)).willReturn(false);
+        plugin.init(message, parent);
+        // When
+        boolean result = plugin.isSuccess(message);
+        // Then
+        assertThat(result, is(equalTo(false)));
+        verify(parent).isCustomPage(message, CustomPage.Type.NOTFOUND_404);
+        verify(parent).isCustomPage(message, CustomPage.Type.ERROR_500);
+        verify(parent).isCustomPage(message, type);
+    }
+
+    @Test
+    public void isSuccessShouldReturnFalseIfCustomPage404Matches() {
+        // Given
+        CustomPage.Type type = CustomPage.Type.NOTFOUND_404;
+        HttpMessage message = new HttpMessage();
+        message.getResponseHeader().setStatusCode(200);
+        given(parent.isCustomPage(message, type)).willReturn(true);
+        given(parent.isCustomPage(message, CustomPage.Type.ERROR_500)).willReturn(false);
+        given(parent.getAnalyser()).willReturn(analyser);
+        plugin.init(message, parent);
+        // When
+        boolean result = plugin.isSuccess(message);
+        // Then
+        assertThat(result, is(equalTo(false)));
+        verify(parent).isCustomPage(message, CustomPage.Type.NOTFOUND_404);
+    }
+
+    @Test
+    public void isSuccessShouldReturnFalseIfCustomPage500Matches() {
+        // Given
+        CustomPage.Type type = CustomPage.Type.NOTFOUND_404;
+        HttpMessage message = new HttpMessage();
+        message.getResponseHeader().setStatusCode(200);
+        given(parent.isCustomPage(message, type)).willReturn(false);
+        given(parent.isCustomPage(message, CustomPage.Type.ERROR_500)).willReturn(true);
+        given(parent.getAnalyser()).willReturn(analyser);
+        given(parent.getAnalyser().isFileExist(message)).willReturn(true);
+        plugin.init(message, parent);
+        // When
+        boolean result = plugin.isSuccess(message);
+        // Then
+        assertThat(result, is(equalTo(false)));
+        verify(parent).isCustomPage(message, CustomPage.Type.NOTFOUND_404);
+        verify(parent).isCustomPage(message, CustomPage.Type.ERROR_500);
+    }
+
+    @Test
     public void isClientErrorShouldReturnTrueIfCustomPage404Matches() {
         // Given
         CustomPage.Type type = CustomPage.Type.NOTFOUND_404;


### PR DESCRIPTION
- Add `isSuccess(HttpMessage)` in `AbstractPlugin` and `PassiveScanData`.
- Add Unit Tests for the new method.
- Tweak javadoc for `isClientError(HttpMessage)` and `isServerError(HttpMessage)` in both classes as well.

Related to zaproxy/zaproxy#9