### PR TITLE
Manual Request response send

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/ManualRequestEditorDialog.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/ManualRequestEditorDialog.java
@@ -38,6 +38,7 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/11/03 Warn when unable to save the message (Issue 4235).
+// ZAP: 2020/11/20 Support Send button in response panel in tab mode
 package org.parosproxy.paros.extension.manualrequest;
 
 import java.awt.BorderLayout;
@@ -45,8 +46,6 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.HeadlessException;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import javax.net.ssl.SSLException;
@@ -80,6 +79,8 @@ public abstract class ManualRequestEditorDialog extends AbstractFrame implements
     private JPanel panelWindow = null;
 
     private JButton btnSend = null;
+
+    private boolean sending = false;
 
     /**
      * Non-abstract classes should call {@link #initialize()} in their constructor.
@@ -164,55 +165,61 @@ public abstract class ManualRequestEditorDialog extends AbstractFrame implements
         getRequestPanel().clearView();
     }
 
+    protected void sendButtonTriggered() {
+        if (sending) {
+            // Can also be triggered by other buttons, eg in the Http Response tab
+            return;
+        }
+        sending = true;
+        try {
+            btnSend.setEnabled(false);
+
+            try {
+                getRequestPanel().saveData();
+            } catch (InvalidMessageDataException e1) {
+                StringBuilder warnMessage = new StringBuilder(150);
+                warnMessage.append(Constant.messages.getString("manReq.warn.datainvalid"));
+                String exceptionMessage = e1.getLocalizedMessage();
+                if (exceptionMessage != null && !exceptionMessage.isEmpty()) {
+                    warnMessage.append('\n').append(exceptionMessage);
+                }
+                View.getSingleton().showWarningDialog(this, warnMessage.toString());
+                btnSend.setEnabled(true);
+                return;
+            }
+
+            Mode mode = Control.getSingleton().getMode();
+            if (mode.equals(Mode.safe)) {
+                // Can happen if the user turns on safe mode with the dialog open
+                View.getSingleton()
+                        .showWarningDialog(
+                                this, Constant.messages.getString("manReq.safe.warning"));
+                btnSend.setEnabled(true);
+                return;
+            } else if (mode.equals(Mode.protect)) {
+                if (!getMessage().isInScope()) {
+                    // In protected mode and not in scope, so fail
+                    View.getSingleton()
+                            .showWarningDialog(
+                                    this, Constant.messages.getString("manReq.outofscope.warning"));
+                    btnSend.setEnabled(true);
+                    return;
+                }
+            }
+
+            btnSendAction();
+
+        } finally {
+            sending = false;
+        }
+    }
+
     protected JButton getBtnSend() {
         if (btnSend == null) {
             btnSend = new JButton();
             btnSend.setText(Constant.messages.getString("manReq.button.send"));
             btnSend.setEnabled(isSendEnabled);
-            btnSend.addActionListener(
-                    new ActionListener() {
-                        @Override
-                        public void actionPerformed(ActionEvent e) {
-                            btnSend.setEnabled(false);
-
-                            try {
-                                getRequestPanel().saveData();
-                            } catch (InvalidMessageDataException e1) {
-                                StringBuilder warnMessage = new StringBuilder(150);
-                                warnMessage.append(
-                                        Constant.messages.getString("manReq.warn.datainvalid"));
-                                String exceptionMessage = e1.getLocalizedMessage();
-                                if (exceptionMessage != null && !exceptionMessage.isEmpty()) {
-                                    warnMessage.append('\n').append(exceptionMessage);
-                                }
-                                View.getSingleton().showWarningDialog(warnMessage.toString());
-                                btnSend.setEnabled(true);
-                                return;
-                            }
-
-                            Mode mode = Control.getSingleton().getMode();
-                            if (mode.equals(Mode.safe)) {
-                                // Can happen if the user turns on safe mode with the dialog open
-                                View.getSingleton()
-                                        .showWarningDialog(
-                                                Constant.messages.getString("manReq.safe.warning"));
-                                btnSend.setEnabled(true);
-                                return;
-                            } else if (mode.equals(Mode.protect)) {
-                                if (!getMessage().isInScope()) {
-                                    // In protected mode and not in scope, so fail
-                                    View.getSingleton()
-                                            .showWarningDialog(
-                                                    Constant.messages.getString(
-                                                            "manReq.outofscope.warning"));
-                                    btnSend.setEnabled(true);
-                                    return;
-                                }
-                            }
-
-                            btnSendAction();
-                        }
-                    });
+            btnSend.addActionListener(e -> sendButtonTriggered());
         }
         return btnSend;
     }
@@ -259,14 +266,20 @@ public abstract class ManualRequestEditorDialog extends AbstractFrame implements
                                                     "network.ssl.error.help",
                                                     Constant.messages.getString(
                                                             "network.ssl.error.help.url")));
-                                    logger.warn(strBuilder.toString());
                                     if (logger.isDebugEnabled()) {
                                         logger.debug(sslEx, sslEx);
                                     }
-                                    View.getSingleton().showWarningDialog(strBuilder.toString());
+                                    View.getSingleton()
+                                            .showWarningDialog(
+                                                    ManualRequestEditorDialog.this,
+                                                    strBuilder.toString());
                                 } catch (Exception e) {
-                                    logger.warn(e.getMessage(), e);
-                                    View.getSingleton().showWarningDialog(e.getMessage());
+                                    if (logger.isDebugEnabled()) {
+                                        logger.debug(e.getMessage(), e);
+                                    }
+                                    View.getSingleton()
+                                            .showWarningDialog(
+                                                    ManualRequestEditorDialog.this, e.getMessage());
                                 } finally {
                                     btnSend.setEnabled(true);
                                 }

--- a/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
@@ -138,6 +138,7 @@ public class HttpPanelSender implements MessageSender {
                                 } else if (!redirectionValidator.isRequestValid()) {
                                     View.getSingleton()
                                             .showWarningDialog(
+                                                    responsePanel,
                                                     Constant.messages.getString(
                                                             "manReq.outofscope.redirection.warning",
                                                             redirectionValidator


### PR DESCRIPTION
Add a Send button to the manual req editor response panel in tab mode and set the parent for the warning dialogs - otherwise on some OSs these are shown against the main tab and the dialog gets hidden.
Also changed some of the logging - I dont think user gui errors need to be logged...

Signed-off-by: Simon Bennetts <psiinon@gmail.com>