### PR TITLE
Do not recompile the scripts if not changed

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/control/Control.java
+++ b/zap/src/main/java/org/parosproxy/paros/control/Control.java
@@ -81,6 +81,7 @@
 // ZAP: 2019/12/16 Log path of new session.
 // ZAP: 2019/12/13 Enable prompting/suggesting a new port when there's a proxy port conflict (Issue
 // 2016).
+// ZAP: 2020/11/23 Allow to initialise the singleton with an ExtensionLoader for tests.
 package org.parosproxy.paros.control;
 
 import java.awt.Desktop;
@@ -94,6 +95,7 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.db.DatabaseException;
+import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SessionListener;
@@ -375,6 +377,19 @@ public class Control extends AbstractControl implements SessionListener {
     // ZAP: Added method to allow for testing when a model is required
     public static void initSingletonForTesting(Model model) {
         control = new Control(model, null);
+    }
+
+    /**
+     * Initialises the {@code Control} singleton with the given data.
+     *
+     * <p><strong>Note:</strong> Not part of the public API.
+     *
+     * @param model the {@code Model} to test with.
+     * @param extensionLoader the {@code ExtensionLoader} to test with.
+     */
+    public static void initSingletonForTesting(Model model, ExtensionLoader extensionLoader) {
+        initSingletonForTesting(model);
+        control.loader = extensionLoader;
     }
 
     public void runCommandLine() throws Exception {

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/HostProcess.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/HostProcess.java
@@ -94,7 +94,7 @@
 // ZAP: 2020/09/23 Add functionality for custom error pages handling (Issue 9).
 // ZAP: 2020/10/19 Tweak JavaDoc and init startNodes in the constructor.
 // ZAP: 2020/06/30 Fix bug that makes zap test same request twice (Issue 6043).
-
+// ZAP: 2020/11/23 Expose getScannerParam() for tests.
 package org.parosproxy.paros.core.scanner;
 
 import java.io.IOException;
@@ -1155,7 +1155,14 @@ public class HostProcess implements Runnable {
         return kb;
     }
 
-    protected ScannerParam getScannerParam() {
+    /**
+     * Gets the scanner parameters.
+     *
+     * <p><strong>Note:</strong> Not part of the public API.
+     *
+     * @return the scanner parameters.
+     */
+    public ScannerParam getScannerParam() {
         return scannerParam;
     }
 

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantCustom.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantCustom.java
@@ -76,6 +76,19 @@ public class VariantCustom implements Variant {
     }
 
     /**
+     * Constructs a {@code VariantCustom} with the given values.
+     *
+     * @param wrapper the script wrapper.
+     * @param script the script.
+     * @param extension the script extension.
+     */
+    public VariantCustom(ScriptWrapper wrapper, VariantScript script, ExtensionScript extension) {
+        this.wrapper = wrapper;
+        this.script = script;
+        this.extension = extension;
+    }
+
+    /**
      * Set the current message that this Variant has to scan
      *
      * @param msg the message object (remember Response is not set)

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.pscan.scanner;
 
 import java.lang.reflect.UndeclaredThrowableException;
-import java.util.List;
 import net.htmlparser.jericho.Source;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -32,30 +31,40 @@ import org.zaproxy.zap.extension.pscan.PassiveScript;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
+import org.zaproxy.zap.extension.script.ScriptsCache;
+import org.zaproxy.zap.extension.script.ScriptsCache.Configuration;
 
 public class ScriptsPassiveScanner extends PluginPassiveScanner {
 
     private static final Logger logger = Logger.getLogger(ScriptsPassiveScanner.class);
 
-    private ExtensionScript extension = null;
+    private final ScriptsCache<PassiveScript> scripts;
     private PassiveScanThread parent = null;
 
     private int currentHRefId;
     private int currentHistoryType;
 
-    public ScriptsPassiveScanner() {}
+    public ScriptsPassiveScanner() {
+        ExtensionScript extension =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
+        scripts =
+                extension != null
+                        ? extension.createScriptsCache(
+                                Configuration.<PassiveScript>builder()
+                                        .setScriptType(ExtensionPassiveScan.SCRIPT_TYPE_PASSIVE)
+                                        .setTargetInterface(PassiveScript.class)
+                                        .setInterfaceErrorMessageProvider(
+                                                sw ->
+                                                        Constant.messages.getString(
+                                                                "pscan.scripts.interface.passive.error",
+                                                                sw.getName()))
+                                        .build())
+                        : null;
+    }
 
     @Override
     public String getName() {
         return Constant.messages.getString("pscan.scripts.passivescanner.title");
-    }
-
-    private ExtensionScript getExtension() {
-        if (extension == null) {
-            extension =
-                    Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
-        }
-        return extension;
     }
 
     @Override
@@ -65,34 +74,17 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-        if (this.getExtension() != null) {
-            currentHRefId = id;
-            List<ScriptWrapper> scripts =
-                    extension.getScripts(ExtensionPassiveScan.SCRIPT_TYPE_PASSIVE);
-            for (ScriptWrapper script : scripts) {
-                try {
-                    if (script.isEnabled()) {
-                        PassiveScript s = extension.getInterface(script, PassiveScript.class);
-
-                        if (s != null) {
-                            if (appliesToCurrentHistoryType(script, s)) {
-                                s.scan(this, msg, source);
-                            }
-
-                        } else {
-                            extension.handleFailedScriptInterface(
-                                    script,
-                                    Constant.messages.getString(
-                                            "pscan.scripts.interface.passive.error",
-                                            script.getName()));
-                        }
-                    }
-
-                } catch (Exception e) {
-                    extension.handleScriptException(script, e);
-                }
-            }
+        if (scripts == null) {
+            return;
         }
+
+        currentHRefId = id;
+        scripts.refreshAndExecute(
+                (sw, script) -> {
+                    if (appliesToCurrentHistoryType(sw, script)) {
+                        script.scan(this, msg, source);
+                    }
+                });
     }
 
     private boolean appliesToCurrentHistoryType(ScriptWrapper wrapper, PassiveScript ps) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -66,6 +66,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.control.ExtensionFactory;
+import org.zaproxy.zap.extension.script.ScriptsCache.Configuration;
 
 public class ExtensionScript extends ExtensionAdaptor implements CommandLineListener {
 
@@ -1932,6 +1933,18 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 
     public void removeScriptUI() {
         this.scriptUI = null;
+    }
+
+    /**
+     * Creates a scripts cache.
+     *
+     * @param <T> the target interface.
+     * @param config the cache configuration
+     * @return the scripts cache.
+     * @since TODO add version
+     */
+    public <T> ScriptsCache<T> createScriptsCache(Configuration<T> config) {
+        return new ScriptsCache<>(this, config);
     }
 
     /**

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptWrapper.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptWrapper.java
@@ -60,6 +60,7 @@ public class ScriptWrapper {
     private Exception lastException = null;
     private Writer writer = null;
     private Charset charset = ExtensionScript.DEFAULT_CHARSET;
+    private int modCount;
 
     public ScriptWrapper() {}
 
@@ -193,7 +194,20 @@ public class ScriptWrapper {
         if (!contents.equals(this.contents)) {
             this.contents = contents;
             this.changed = true;
+            this.modCount++;
         }
+    }
+
+    /**
+     * Gets the mod count.
+     *
+     * <p>The value is different each time the contents of the script change.
+     *
+     * @return the mod count.
+     * @since TODO add version
+     */
+    public int getModCount() {
+        return modCount;
     }
 
     public String getLastOutput() {

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptsCache.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptsCache.java
@@ -1,0 +1,442 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.script;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A collection of cached scripts.
+ *
+ * @since TODO add version
+ * @see ExtensionScript#createScriptsCache(Configuration)
+ */
+public class ScriptsCache<T> {
+
+    private final ExtensionScript extensionScript;
+    private final Configuration<T> config;
+    private final InterfaceProvider<T> interfaceProvider;
+    private final Map<ScriptWrapper, CachedScript<T>> cache;
+
+    private List<CachedScript<T>> cachedScripts;
+
+    ScriptsCache(ExtensionScript extensionScript, Configuration<T> config) {
+        this.extensionScript = extensionScript;
+        this.config = config;
+        this.interfaceProvider =
+                config.getInterfaceProvider() == null
+                        ? createDefaultInterfaceProvider()
+                        : config.getInterfaceProvider();
+        this.cache = Collections.synchronizedMap(new HashMap<>());
+        this.cachedScripts = Collections.emptyList();
+    }
+
+    private InterfaceProvider<T> createDefaultInterfaceProvider() {
+        return (scriptWrapper, targetInterface) -> {
+            T script = extensionScript.getInterface(scriptWrapper, targetInterface);
+            if (script == null) {
+                extensionScript.handleFailedScriptInterface(
+                        scriptWrapper,
+                        config.getInterfaceErrorMessageProvider().getErrorMessage(scriptWrapper));
+            }
+            return script;
+        };
+    }
+
+    /**
+     * Refreshes the cache.
+     *
+     * <p>Any scripts that are now disabled are removed, scripts that were changed are recreated.
+     *
+     * <p>Should be called when the scripts can be safely refreshed, for example, if a script needs
+     * to be initialised before usage the cache should not be refreshed while it's being used.
+     */
+    public void refresh() {
+        synchronized (cache) {
+            List<ScriptWrapper> latestScripts = extensionScript.getScripts(config.getScriptType());
+            cache.keySet().retainAll(latestScripts);
+            List<CachedScript<T>> latestCachedScripts = new ArrayList<>();
+            latestScripts.forEach(
+                    scriptWrapper -> refreshScriptImpl(scriptWrapper, latestCachedScripts));
+
+            cachedScripts = Collections.unmodifiableList(latestCachedScripts);
+        }
+    }
+
+    private void refreshScriptImpl(
+            ScriptWrapper scriptWrapper, List<CachedScript<T>> latestCachedScripts) {
+        CachedScript<T> cachedScript = cache.computeIfAbsent(scriptWrapper, CachedScript::new);
+        if (!cachedScript.isEnabled()) {
+            cachedScript.setScript(null);
+            return;
+        }
+
+        if (!cachedScript.hasChanged()) {
+            latestCachedScripts.add(cachedScript);
+            return;
+        }
+
+        cachedScript.setScript(null);
+        try {
+            T script = interfaceProvider.getInterface(scriptWrapper, config.getTargetInterface());
+            if (script != null) {
+                cachedScript.setScript(script);
+                latestCachedScripts.add(cachedScript);
+            }
+        } catch (Exception e) {
+            extensionScript.handleScriptException(scriptWrapper, e);
+        }
+    }
+
+    /**
+     * Executes the given action on all cached scripts.
+     *
+     * <p>Exceptions thrown during the execution of the action are handled by the {@code
+     * ExtensionScript}.
+     *
+     * @param action the action to be executed on each cached script.
+     * @see ExtensionScript#handleScriptException(ScriptWrapper, Exception)
+     */
+    public void execute(ScriptAction<T> action) {
+        cachedScripts.forEach(
+                e -> {
+                    try {
+                        action.apply(e.getScript());
+                    } catch (Exception ex) {
+                        extensionScript.handleScriptException(e.getScriptWrapper(), ex);
+                    }
+                });
+    }
+
+    /**
+     * Convenience method that refreshes the cached scripts and executes the given action.
+     *
+     * @param action the action applied to each cached script.
+     * @see #refresh()
+     * @see #execute(ScriptAction)
+     */
+    public void refreshAndExecute(ScriptAction<T> action) {
+        refresh();
+        execute(action);
+    }
+
+    /**
+     * Executes the given action on all cached scripts.
+     *
+     * <p>Includes the corresponding script wrapper of each script.
+     *
+     * <p>Exceptions thrown during the execution of the action are handled by the {@code
+     * ExtensionScript}.
+     *
+     * @param action the action to be executed on each cached script.
+     * @see ExtensionScript#handleScriptException(ScriptWrapper, Exception)
+     */
+    public void execute(ScriptWrapperAction<T> action) {
+        cachedScripts.forEach(
+                e -> {
+                    try {
+                        action.apply(e.getScriptWrapper(), e.getScript());
+                    } catch (Exception ex) {
+                        extensionScript.handleScriptException(e.getScriptWrapper(), ex);
+                    }
+                });
+    }
+
+    /**
+     * Convenience method that refreshes the cached scripts and executes the given action.
+     *
+     * @param action the action applied to each cached script.
+     * @see #refresh()
+     * @see #execute(ScriptWrapperAction)
+     */
+    public void refreshAndExecute(ScriptWrapperAction<T> action) {
+        refresh();
+        execute(action);
+    }
+
+    /**
+     * Gets the cached scripts.
+     *
+     * @return an unmodifiable list containing the cached scripts.
+     */
+    public List<CachedScript<T>> getCachedScripts() {
+        return cachedScripts;
+    }
+
+    /**
+     * A cached script, the interface and the corresponding script wrapper.
+     *
+     * @param <T> the type of the interface.
+     */
+    public static class CachedScript<T> {
+
+        private final ScriptWrapper scriptWrapper;
+        private int currentModCount;
+        private T script;
+
+        CachedScript(ScriptWrapper scriptWrapper) {
+            this.scriptWrapper = scriptWrapper;
+            this.currentModCount = scriptWrapper.getModCount();
+        }
+
+        /**
+         * Gets the script wrapper.
+         *
+         * @return the script wrapper, never {@code null}.
+         */
+        public ScriptWrapper getScriptWrapper() {
+            return scriptWrapper;
+        }
+
+        /**
+         * The script, through the interface.
+         *
+         * @return the script, never {@code null} for users of the collection.
+         */
+        public T getScript() {
+            return script;
+        }
+
+        void setScript(T script) {
+            this.script = script;
+        }
+
+        boolean hasChanged() {
+            if (script == null) {
+                return true;
+            }
+
+            int previousModCount = currentModCount;
+            currentModCount = scriptWrapper.getModCount();
+            return previousModCount != currentModCount;
+        }
+
+        boolean isEnabled() {
+            return scriptWrapper.isEnabled();
+        }
+    }
+
+    /**
+     * The configuration of the {@link ScriptsCache}.
+     *
+     * @param <T> the target type of the scripts.
+     */
+    public static class Configuration<T> {
+
+        private final String scriptType;
+        private final Class<T> targetInterface;
+        private final InterfaceProvider<T> interfaceProvider;
+        private final InterfaceErrorMessageProvider interfaceErrorMessageProvider;
+
+        private Configuration(
+                String scriptType,
+                Class<T> targetInterface,
+                InterfaceProvider<T> interfaceProvider,
+                InterfaceErrorMessageProvider interfaceErrorMessageProvider) {
+            this.scriptType = scriptType;
+            this.targetInterface = targetInterface;
+            this.interfaceProvider = interfaceProvider;
+            this.interfaceErrorMessageProvider = interfaceErrorMessageProvider;
+        }
+
+        public String getScriptType() {
+            return scriptType;
+        }
+
+        public Class<T> getTargetInterface() {
+            return targetInterface;
+        }
+
+        public InterfaceProvider<T> getInterfaceProvider() {
+            return interfaceProvider;
+        }
+
+        public InterfaceErrorMessageProvider getInterfaceErrorMessageProvider() {
+            return interfaceErrorMessageProvider;
+        }
+
+        /**
+         * Returns a new configuration builder.
+         *
+         * @param <T1> the target type of the scripts.
+         * @return the configuration builder.
+         */
+        public static <T1> Builder<T1> builder() {
+            return new Builder<>();
+        }
+
+        /**
+         * A builder of configurations.
+         *
+         * @see #build()
+         */
+        public static class Builder<T> {
+
+            private String scriptType;
+            private Class<T> targetInterface;
+            private InterfaceProvider<T> interfaceProvider;
+            private InterfaceErrorMessageProvider interfaceErrorMessageProvider;
+
+            private Builder() {}
+
+            /**
+             * Sets the script type.
+             *
+             * @param scriptType the script type.
+             * @return this, for chaining.
+             */
+            public Builder<T> setScriptType(String scriptType) {
+                this.scriptType = scriptType;
+                return this;
+            }
+
+            /**
+             * Sets the target interface.
+             *
+             * @param targetInterface the target interface.
+             * @return this, for chaining.
+             */
+            public Builder<T> setTargetInterface(Class<T> targetInterface) {
+                this.targetInterface = targetInterface;
+                return this;
+            }
+
+            /**
+             * Sets the provider of interfaces.
+             *
+             * @param interfaceProvider the provider of interfaces.
+             * @return this, for chaining.
+             */
+            public Builder<T> setInterfaceProvider(InterfaceProvider<T> interfaceProvider) {
+                this.interfaceProvider = interfaceProvider;
+                return this;
+            }
+
+            /**
+             * Sets the provider of error messages.
+             *
+             * @param interfaceErrorMessageProvider the provider of error messages.
+             * @return this, for chaining.
+             */
+            public Builder<T> setInterfaceErrorMessageProvider(
+                    InterfaceErrorMessageProvider interfaceErrorMessageProvider) {
+                this.interfaceErrorMessageProvider = interfaceErrorMessageProvider;
+                return this;
+            }
+
+            /**
+             * Builds the configuration from the specified data.
+             *
+             * @return the build configuration.
+             * @throws IllegalStateException if the script type or the target interface is not set.
+             *     Or, the interface error message provider is set at the same time as the interface
+             *     provider. The error message provider is not used when using an interface
+             *     provider.
+             */
+            public final Configuration<T> build() {
+                if (scriptType == null || scriptType.isEmpty()) {
+                    throw new IllegalStateException("The script type must be set.");
+                }
+                if (targetInterface == null) {
+                    throw new IllegalStateException("The target interface must be set.");
+                }
+
+                if (interfaceProvider != null && interfaceErrorMessageProvider != null) {
+                    throw new IllegalStateException(
+                            "The interface error message provider must not be set if using an interface provider.");
+                }
+
+                return new Configuration<>(
+                        scriptType,
+                        targetInterface,
+                        interfaceProvider,
+                        interfaceErrorMessageProvider);
+            }
+        }
+    }
+
+    /**
+     * An action applied on a script, through the interface.
+     *
+     * @param <T> the type of the interface.
+     */
+    public interface ScriptAction<T> {
+        /**
+         * Applies the action on the given script.
+         *
+         * @param script the script.
+         * @throws Exception if an error occurred while applying the action to the script.
+         */
+        void apply(T script) throws Exception;
+    }
+
+    /**
+     * An action applied on a script, through the interface.
+     *
+     * <p>For convenience the corresponding wrapper is also provided.
+     *
+     * @param <T> the type of the interface.
+     */
+    public interface ScriptWrapperAction<T> {
+        /**
+         * Applies the action on the given script.
+         *
+         * @param wrapper the corresponding script wrapper.
+         * @param script the script.
+         * @throws Exception if an error occurred while applying the action to the script.
+         */
+        void apply(ScriptWrapper wrapper, T script) throws Exception;
+    }
+
+    /**
+     * A provider of interfaces from scripts.
+     *
+     * @param <T> the type of the interface.
+     */
+    public interface InterfaceProvider<T> {
+        /**
+         * Gets the given interface from the given script wrapper.
+         *
+         * @param scriptWrapper the script wrapper.
+         * @param targetInterface the target interface.
+         * @return the interface or {@code null} if the script does not implement it.
+         * @throws Exception if an error occurred while creating the interface.
+         */
+        T getInterface(ScriptWrapper scriptWrapper, Class<T> targetInterface) throws Exception;
+    }
+
+    /**
+     * A provider of error messages, that indicates that a script wrapper does not implement the
+     * target interface.
+     */
+    public interface InterfaceErrorMessageProvider {
+        /**
+         * Gets the error message that indicates that the script wrapper does not implement the
+         * interface.
+         *
+         * @param scriptWrapper the script wrapper that does not implement the interface.
+         * @return the error message.
+         */
+        String getErrorMessage(ScriptWrapper scriptWrapper);
+    }
+}

--- a/zap/src/test/java/org/parosproxy/paros/model/SessionUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/model/SessionUnitTest.java
@@ -38,8 +38,10 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.httpclient.URI;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.NameValuePair;
 import org.parosproxy.paros.core.scanner.Variant;
@@ -67,6 +69,11 @@ public class SessionUnitTest {
 
         session = new Session(model);
         given(model.getSession()).willReturn(session);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        Constant.messages = null;
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/WithConfigsTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/WithConfigsTest.java
@@ -31,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -57,6 +58,9 @@ public abstract class WithConfigsTest extends TestUtils {
 
     /** The mocked {@code Model}. */
     protected Model model;
+
+    /** The mocked {@code ExtensionLoader}. */
+    protected ExtensionLoader extensionLoader;
 
     private static String zapInstallDir;
     private static String zapHomeDir;
@@ -87,14 +91,17 @@ public abstract class WithConfigsTest extends TestUtils {
         model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         Model.setSingletonForTesting(model);
 
-        ExtensionLoader extLoader = Mockito.mock(ExtensionLoader.class);
-        Control control = Mockito.mock(Control.class, withSettings().lenient());
-        Mockito.when(control.getExtensionLoader()).thenReturn(extLoader);
+        extensionLoader = mock(ExtensionLoader.class, withSettings().lenient());
 
         // Init all the things
         setUpConstant();
-        Control.initSingletonForTesting(Model.getSingleton());
+        Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
         Model.getSingleton().getOptionsParam().load(new ZapXmlConfiguration());
+    }
+
+    @AfterEach
+    void cleanUp() {
+        Constant.messages = null;
     }
 
     public static void setUpConstant() {

--- a/zap/src/test/java/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodTypeUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodTypeUnitTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.WithConfigsTest;
 import org.zaproxy.zap.authentication.AuthenticationMethod.AuthCheckingStrategy;
@@ -91,7 +92,8 @@ public class FormBasedAuthenticationMethodTypeUnitTest extends TestUtils {
     }
 
     @AfterEach
-    public void shutDownServer() throws Exception {
+    void cleanUp() {
+        Constant.messages = null;
         stopServer();
     }
 

--- a/zap/src/test/java/org/zaproxy/zap/authentication/JsonBasedAuthenticationMethodTypeUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/authentication/JsonBasedAuthenticationMethodTypeUnitTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.WithConfigsTest;
 import org.zaproxy.zap.authentication.AuthenticationMethod.AuthCheckingStrategy;
@@ -91,7 +92,8 @@ public class JsonBasedAuthenticationMethodTypeUnitTest extends TestUtils {
     }
 
     @AfterEach
-    public void shutDownServer() throws Exception {
+    void cleanUp() {
+        Constant.messages = null;
         stopServer();
     }
 

--- a/zap/src/test/java/org/zaproxy/zap/extension/api/ApiGeneratorUtilsTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/api/ApiGeneratorUtilsTest.java
@@ -48,6 +48,7 @@ public class ApiGeneratorUtilsTest extends WithConfigsTest {
 
     @BeforeEach
     public void loadCoreApis() throws Exception {
+        Control.initSingletonForTesting(Model.getSingleton());
         ExtensionHook hook =
                 new ExtensionHook(Model.getSingleton(), null) {
                     @Override

--- a/zap/src/test/java/org/zaproxy/zap/extension/ascan/ScriptsActiveScannerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/ascan/ScriptsActiveScannerUnitTest.java
@@ -1,0 +1,448 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascan;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Locale;
+import javax.script.ScriptException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.core.scanner.HostProcess;
+import org.parosproxy.paros.core.scanner.NameValuePair;
+import org.parosproxy.paros.core.scanner.ScannerParam;
+import org.parosproxy.paros.core.scanner.Variant;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.WithConfigsTest;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+import org.zaproxy.zap.extension.script.ScriptsCache;
+import org.zaproxy.zap.extension.script.ScriptsCache.CachedScript;
+import org.zaproxy.zap.extension.script.ScriptsCache.Configuration;
+import org.zaproxy.zap.utils.I18N;
+
+/** Unit test for {@link ScriptsActiveScanner}. */
+public class ScriptsActiveScannerUnitTest extends WithConfigsTest {
+
+    private static final String SCRIPT_TYPE = ExtensionActiveScan.SCRIPT_TYPE_ACTIVE;
+    private static final Class<ActiveScript> TARGET_INTERFACE_CACHE = ActiveScript.class;
+
+    private ExtensionScript extensionScript;
+    private HostProcess parent;
+    private HttpMessage message;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        extensionScript = mock(ExtensionScript.class);
+        parent = mock(HostProcess.class);
+        message = new HttpMessage(new HttpRequestHeader("GET / HTTP/1.1"));
+
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+    }
+
+    @Test
+    void shouldSkipIfExtensionScriptIsNull() {
+        // Given
+        Constant.messages = new I18N(Locale.ENGLISH);
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(null);
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        // When
+        scriptsActiveScanner.init(message, parent);
+        // Then
+        verify(parent).pluginSkipped(scriptsActiveScanner, "no scripts enabled");
+    }
+
+    @Test
+    void shouldSkipIfNoActiveScripts() {
+        // Given
+        Constant.messages = new I18N(Locale.ENGLISH);
+        given(extensionScript.getScripts(SCRIPT_TYPE)).willReturn(asList());
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        // When
+        scriptsActiveScanner.init(message, parent);
+        // Then
+        verify(parent).pluginSkipped(scriptsActiveScanner, "no scripts enabled");
+    }
+
+    @Test
+    void shouldSkipIfNoEnabledActiveScripts() {
+        // Given
+        Constant.messages = new I18N(Locale.ENGLISH);
+        given(extensionScript.getScripts(SCRIPT_TYPE))
+                .willReturn(asList(mock(ScriptWrapper.class)));
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        // When
+        scriptsActiveScanner.init(message, parent);
+        // Then
+        verify(parent).pluginSkipped(scriptsActiveScanner, "no scripts enabled");
+    }
+
+    @Test
+    void shouldHaveAName() {
+        // Given
+        Constant.messages = new I18N(Locale.ENGLISH);
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        // When
+        String name = scriptsActiveScanner.getName();
+        // Then
+        assertThat(name, is(equalTo("Script Active Scan Rules")));
+    }
+
+    @Test
+    void shouldHaveSpecificPluginId() {
+        // Given
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        // When
+        int pluginId = scriptsActiveScanner.getId();
+        // Then
+        assertThat(pluginId, is(equalTo(50000)));
+    }
+
+    @Test
+    void shouldHaveSpecificCategory() {
+        // Given
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        // When
+        int category = scriptsActiveScanner.getCategory();
+        // Then
+        assertThat(category, is(equalTo(Category.MISC)));
+    }
+
+    @Test
+    void shouldHaveNoDependencies() {
+        // Given
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        // When
+        String[] dependencies = scriptsActiveScanner.getDependency();
+        // Then
+        assertThat(dependencies, is(nullValue()));
+    }
+
+    @Test
+    void shouldScanNodesWithActiveScript2() throws Exception {
+        // Given
+        ActiveScript2 script1 = mock(ActiveScript2.class);
+        ScriptWrapper scriptWrapper1 = createScriptWrapper(script1, ActiveScript2.class);
+        ActiveScript2 script2 = mock(ActiveScript2.class);
+        ScriptWrapper scriptWrapper2 = createScriptWrapper(script2, ActiveScript2.class);
+        given(extensionScript.getScripts(SCRIPT_TYPE))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        VariantFactory variantFactory = mock(VariantFactory.class);
+        given(variantFactory.createVariants(any(), any())).willReturn(asList(mock(Variant.class)));
+        given(model.getVariantFactory()).willReturn(variantFactory);
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        scriptsActiveScanner.init(message, parent);
+        // When
+        scriptsActiveScanner.scan();
+        // Then
+        verify(script1, times(1)).scanNode(scriptsActiveScanner, message);
+        verify(script2, times(1)).scanNode(scriptsActiveScanner, message);
+    }
+
+    @Test
+    void shouldNotCallScanNodeOnDisabledActiveScript2() throws Exception {
+        // Given
+        ScriptWrapper scriptWrapper1 = mock(ScriptWrapper.class);
+        given(scriptWrapper1.isEnabled()).willReturn(false);
+        ActiveScript2 script2 = mock(ActiveScript2.class);
+        ScriptWrapper scriptWrapper2 = createScriptWrapper(script2, ActiveScript2.class);
+        given(extensionScript.getScripts(SCRIPT_TYPE))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        VariantFactory variantFactory = mock(VariantFactory.class);
+        given(variantFactory.createVariants(any(), any())).willReturn(asList(mock(Variant.class)));
+        given(model.getVariantFactory()).willReturn(variantFactory);
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        scriptsActiveScanner.init(message, parent);
+        // When
+        scriptsActiveScanner.scan();
+        // Then
+        verify(extensionScript, times(0)).getInterface(scriptWrapper1, ActiveScript2.class);
+        verify(script2, times(1)).scanNode(scriptsActiveScanner, message);
+    }
+
+    @Test
+    void shouldHandleExceptionsThrownByActiveScript2() throws Exception {
+        // Given
+        ActiveScript2 script1 = mock(ActiveScript2.class);
+        ScriptException exception = mock(ScriptException.class);
+        doThrow(exception).when(script1).scanNode(any(), any());
+        ScriptWrapper scriptWrapper1 = createScriptWrapper(script1, ActiveScript2.class);
+        ActiveScript2 script2 = mock(ActiveScript2.class);
+        ScriptWrapper scriptWrapper2 = createScriptWrapper(script2, ActiveScript2.class);
+        given(extensionScript.getScripts(SCRIPT_TYPE))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        VariantFactory variantFactory = mock(VariantFactory.class);
+        given(variantFactory.createVariants(any(), any())).willReturn(asList(mock(Variant.class)));
+        given(model.getVariantFactory()).willReturn(variantFactory);
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        scriptsActiveScanner.init(message, parent);
+        // When
+        scriptsActiveScanner.scan();
+        // Then
+        verify(script1, times(1)).scanNode(scriptsActiveScanner, message);
+        verify(extensionScript, times(1)).handleScriptException(scriptWrapper1, exception);
+        verify(script2, times(1)).scanNode(scriptsActiveScanner, message);
+    }
+
+    @Test
+    void shouldStopScanningNodesWithActiveScript2WhenScanStopped() throws Exception {
+        // Given
+        ActiveScript2 script1 = mock(ActiveScript2.class);
+        doAnswer(stopScan()).when(script1).scanNode(any(), any());
+        ScriptWrapper scriptWrapper1 = createScriptWrapper(script1, ActiveScript2.class);
+        ScriptWrapper scriptWrapper2 = mock(ScriptWrapper.class);
+        given(extensionScript.getScripts(SCRIPT_TYPE))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        scriptsActiveScanner.init(message, parent);
+        // When
+        scriptsActiveScanner.scan();
+        // Then
+        verify(script1, times(1)).scanNode(scriptsActiveScanner, message);
+        verify(extensionScript, times(0)).getInterface(scriptWrapper2, ActiveScript2.class);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldCreateScriptsCacheWithExpectedConfiguration() throws Exception {
+        // Given
+        ActiveScript script = mock(ActiveScript.class);
+        ScriptWrapper scriptWrapper = createScriptWrapper(script, ActiveScript.class);
+        given(extensionScript.getScripts(SCRIPT_TYPE)).willReturn(asList(scriptWrapper));
+        VariantFactory variantFactory = mock(VariantFactory.class);
+        given(variantFactory.createVariants(any(), any())).willReturn(asList(mock(Variant.class)));
+        given(model.getVariantFactory()).willReturn(variantFactory);
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        scriptsActiveScanner.init(message, parent);
+        // When
+        scriptsActiveScanner.scan();
+        // Then
+        ArgumentCaptor<Configuration<ActiveScript>> argumentCaptor =
+                ArgumentCaptor.forClass(Configuration.class);
+        verify(extensionScript).createScriptsCache(argumentCaptor.capture());
+        Configuration<ActiveScript> configuration = argumentCaptor.getValue();
+        assertThat(configuration.getScriptType(), is(equalTo(SCRIPT_TYPE)));
+        assertThat(configuration.getTargetInterface(), is(equalTo(TARGET_INTERFACE_CACHE)));
+        assertThat(configuration.getInterfaceProvider(), is(not(nullValue())));
+        assertThat(configuration.getInterfaceErrorMessageProvider(), is(nullValue()));
+    }
+
+    @Test
+    void shouldFailScriptsThatDoNotImplementNeitherActiveScript2NorActiveScript() {
+        // Given
+        ScriptWrapper scriptWrapper = mock(ScriptWrapper.class);
+        given(scriptWrapper.isEnabled()).willReturn(true);
+        given(extensionScript.getScripts(SCRIPT_TYPE)).willReturn(asList(scriptWrapper));
+        VariantFactory variantFactory = mock(VariantFactory.class);
+        given(variantFactory.createVariants(any(), any())).willReturn(asList(mock(Variant.class)));
+        given(model.getVariantFactory()).willReturn(variantFactory);
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        scriptsActiveScanner.init(message, parent);
+        given(extensionScript.<ActiveScript>createScriptsCache(any()))
+                .willAnswer(
+                        e -> {
+                            Configuration<ActiveScript> configuration = e.getArgument(0);
+                            configuration
+                                    .getInterfaceProvider()
+                                    .getInterface(scriptWrapper, ActiveScript.class);
+                            return null;
+                        });
+        // When
+        scriptsActiveScanner.scan();
+        // Then
+        verify(extensionScript).handleFailedScriptInterface(eq(scriptWrapper), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldScanParamsWithActiveScript() throws Exception {
+        // Given
+        ActiveScript script1 = mock(ActiveScript.class);
+        ScriptWrapper scriptWrapper1 = createScriptWrapper(script1, ActiveScript.class);
+        ActiveScript script2 = mock(ActiveScript.class);
+        ScriptWrapper scriptWrapper2 = createScriptWrapper(script2, ActiveScript.class);
+        given(extensionScript.getScripts(SCRIPT_TYPE))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        ScriptsCache<ActiveScript> scriptsCache =
+                createScriptsCache(
+                        createCachedScript(script1, scriptWrapper1),
+                        createCachedScript(script2, scriptWrapper2));
+        given(extensionScript.<ActiveScript>createScriptsCache(any())).willReturn(scriptsCache);
+        given(parent.getScannerParam()).willReturn(mock(ScannerParam.class));
+        String name1 = "Name1";
+        String value1 = "Value1";
+        NameValuePair param1 = param(name1, value1);
+        String name2 = "Name2";
+        String value2 = "Value2";
+        NameValuePair param2 = param(name2, value2);
+        Variant variant = mock(Variant.class);
+        given(variant.getParamList()).willReturn(asList(param1, param2));
+        VariantFactory variantFactory = mock(VariantFactory.class);
+        given(variantFactory.createVariants(any(), any())).willReturn(asList(variant));
+        given(model.getVariantFactory()).willReturn(variantFactory);
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        scriptsActiveScanner.init(message, parent);
+        // When
+        scriptsActiveScanner.scan();
+        // Then
+        verify(scriptsCache, times(2)).refresh();
+        verify(scriptsCache, times(2)).getCachedScripts();
+        verify(script1, times(1)).scan(scriptsActiveScanner, message, name1, value1);
+        verify(script1, times(1)).scan(scriptsActiveScanner, message, name2, value2);
+        verify(script2, times(1)).scan(scriptsActiveScanner, message, name1, value1);
+        verify(script2, times(1)).scan(scriptsActiveScanner, message, name2, value2);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldStopScanningParamsWithActiveScriptWhenScanStopped() throws Exception {
+        // Given
+        ActiveScript script1 = mock(ActiveScript.class);
+        doAnswer(stopScan()).when(script1).scan(any(), any(), any(), any());
+        ScriptWrapper scriptWrapper1 = createScriptWrapper(script1, ActiveScript.class);
+        ActiveScript script2 = mock(ActiveScript.class);
+        ScriptWrapper scriptWrapper2 = createScriptWrapper(script2, ActiveScript.class);
+        given(extensionScript.getScripts(SCRIPT_TYPE))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        ScriptsCache<ActiveScript> scriptsCache =
+                createScriptsCache(
+                        createCachedScript(script1, scriptWrapper1),
+                        createCachedScript(script2, scriptWrapper2));
+        given(extensionScript.<ActiveScript>createScriptsCache(any())).willReturn(scriptsCache);
+        given(parent.getScannerParam()).willReturn(mock(ScannerParam.class));
+        String name1 = "Name1";
+        String value1 = "Value1";
+        NameValuePair param1 = param(name1, value1);
+        String name2 = "Name2";
+        String value2 = "Value2";
+        NameValuePair param2 = param(name2, value2);
+        Variant variant = mock(Variant.class);
+        given(variant.getParamList()).willReturn(asList(param1, param2));
+        VariantFactory variantFactory = mock(VariantFactory.class);
+        given(variantFactory.createVariants(any(), any())).willReturn(asList(variant));
+        given(model.getVariantFactory()).willReturn(variantFactory);
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        scriptsActiveScanner.init(message, parent);
+        // When
+        scriptsActiveScanner.scan();
+        // Then
+        verify(scriptsCache, times(1)).refresh();
+        verify(scriptsCache, times(1)).getCachedScripts();
+        verify(script1, times(1)).scan(scriptsActiveScanner, message, name1, value1);
+        verify(script1, times(0)).scan(scriptsActiveScanner, message, name2, value2);
+        verify(script2, times(0)).scan(any(), any(), any(), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldHandleExceptionsThrownByActiveScript() throws Exception {
+        // Given
+        ActiveScript script1 = mock(ActiveScript.class);
+        ScriptWrapper scriptWrapper1 = createScriptWrapper(script1, ActiveScript.class);
+        ActiveScript script2 = mock(ActiveScript.class);
+        ScriptWrapper scriptWrapper2 = createScriptWrapper(script2, ActiveScript.class);
+        given(extensionScript.getScripts(SCRIPT_TYPE))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        ScriptsCache<ActiveScript> scriptsCache =
+                createScriptsCache(
+                        createCachedScript(script1, scriptWrapper1),
+                        createCachedScript(script2, scriptWrapper2));
+        given(extensionScript.<ActiveScript>createScriptsCache(any())).willReturn(scriptsCache);
+        given(parent.getScannerParam()).willReturn(mock(ScannerParam.class));
+        String name1 = "Name1";
+        String value1 = "Value1";
+        NameValuePair param1 = param(name1, value1);
+        ScriptException exception = mock(ScriptException.class);
+        doThrow(exception).when(script1).scan(any(), any(), eq(name1), eq(value1));
+        String name2 = "Name2";
+        String value2 = "Value2";
+        NameValuePair param2 = param(name2, value2);
+        Variant variant = mock(Variant.class);
+        given(variant.getParamList()).willReturn(asList(param1, param2));
+        VariantFactory variantFactory = mock(VariantFactory.class);
+        given(variantFactory.createVariants(any(), any())).willReturn(asList(variant));
+        given(model.getVariantFactory()).willReturn(variantFactory);
+        ScriptsActiveScanner scriptsActiveScanner = new ScriptsActiveScanner();
+        scriptsActiveScanner.init(message, parent);
+        // When
+        scriptsActiveScanner.scan();
+        // Then
+        verify(scriptsCache, times(2)).refresh();
+        verify(scriptsCache, times(2)).getCachedScripts();
+        verify(script1, times(1)).scan(scriptsActiveScanner, message, name1, value1);
+        verify(extensionScript, times(1)).handleScriptException(scriptWrapper1, exception);
+        verify(script2, times(1)).scan(scriptsActiveScanner, message, name1, value1);
+        verify(script2, times(1)).scan(scriptsActiveScanner, message, name2, value2);
+    }
+
+    private <T> ScriptWrapper createScriptWrapper(T script, Class<T> scriptClass) throws Exception {
+        ScriptWrapper scriptWrapper = mock(ScriptWrapper.class);
+        given(scriptWrapper.isEnabled()).willReturn(true);
+        given(extensionScript.getInterface(scriptWrapper, scriptClass)).willReturn(script);
+        return scriptWrapper;
+    }
+
+    private Answer<Void> stopScan() {
+        return e -> {
+            given(parent.isStop()).willReturn(true);
+            return null;
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> CachedScript<T> createCachedScript(T script, ScriptWrapper scriptWrapper) {
+        CachedScript<T> cachedScript = mock(CachedScript.class);
+        given(cachedScript.getScript()).willReturn(script);
+        given(cachedScript.getScriptWrapper()).willReturn(scriptWrapper);
+        return cachedScript;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> ScriptsCache<T> createScriptsCache(CachedScript<T>... cachedScripts) {
+        ScriptsCache<T> scriptsCache = mock(ScriptsCache.class);
+        given(scriptsCache.getCachedScripts()).willReturn(asList(cachedScripts));
+        return scriptsCache;
+    }
+
+    private static NameValuePair param(String name, String value) {
+        NameValuePair nvp = mock(NameValuePair.class);
+        given(nvp.getName()).willReturn(name);
+        given(nvp.getValue()).willReturn(value);
+        return nvp;
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/forceduser/ExtensionForcedUserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/forceduser/ExtensionForcedUserUnitTest.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.extension.forceduser;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -28,7 +29,6 @@ import org.apache.commons.configuration.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.control.Control;
 import org.zaproxy.zap.WithConfigsTest;
 import org.zaproxy.zap.extension.users.ExtensionUserManagement;
 import org.zaproxy.zap.model.Context;
@@ -38,15 +38,11 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
 /** Unit test for {@link ExtensionForcedUser}. */
 class ExtensionForcedUserUnitTest extends WithConfigsTest {
 
-    private ExtensionUserManagement extensionUserManagement;
-
     private ExtensionForcedUser extensionForcedUser;
 
     @BeforeEach
     void setup() {
         Constant.messages = mock(I18N.class);
-        extensionUserManagement = new ExtensionUserManagement();
-        Control.getSingleton().getExtensionLoader().addExtension(extensionUserManagement);
 
         extensionForcedUser = new ExtensionForcedUser();
     }
@@ -65,6 +61,8 @@ class ExtensionForcedUserUnitTest extends WithConfigsTest {
     @Test
     void shouldNotImportContextWithUnknownForcedUser() {
         // Given
+        given(extensionLoader.getExtension(ExtensionUserManagement.class))
+                .willReturn(new ExtensionUserManagement());
         Context context = mock(Context.class);
         Configuration config = new ZapXmlConfiguration();
         config.setProperty("context.forceduser", Integer.MIN_VALUE);

--- a/zap/src/test/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScannerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScannerUnitTest.java
@@ -1,0 +1,300 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscan.scanner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.UndeclaredThrowableException;
+import java.util.Locale;
+import net.htmlparser.jericho.Source;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.WithConfigsTest;
+import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
+import org.zaproxy.zap.extension.pscan.PassiveScanThread;
+import org.zaproxy.zap.extension.pscan.PassiveScript;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+import org.zaproxy.zap.extension.script.ScriptsCache;
+import org.zaproxy.zap.extension.script.ScriptsCache.CachedScript;
+import org.zaproxy.zap.extension.script.ScriptsCache.Configuration;
+import org.zaproxy.zap.extension.script.ScriptsCache.InterfaceErrorMessageProvider;
+import org.zaproxy.zap.extension.script.ScriptsCache.ScriptWrapperAction;
+import org.zaproxy.zap.utils.I18N;
+
+/** Unit test for {@link ScriptsPassiveScanner}. */
+public class ScriptsPassiveScannerUnitTest extends WithConfigsTest {
+
+    private static final String SCRIPT_TYPE = ExtensionPassiveScan.SCRIPT_TYPE_PASSIVE;
+    private static final Class<PassiveScript> TARGET_INTERFACE = PassiveScript.class;
+
+    private ExtensionScript extensionScript;
+    private PassiveScanThread parent;
+    private HttpMessage message;
+    private int id;
+    private Source source;
+
+    @BeforeEach
+    void setUp() {
+        extensionScript = mock(ExtensionScript.class);
+        parent = mock(PassiveScanThread.class);
+        message = mock(HttpMessage.class);
+        id = 1;
+        source = new Source("");
+
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(extensionScript);
+    }
+
+    @Test
+    void shouldNotThrowIfExtensionScriptIsNull() {
+        // Given
+        given(extensionLoader.getExtension(ExtensionScript.class)).willReturn(null);
+        // When / Then
+        ScriptsPassiveScanner scriptsPassiveScanner =
+                assertDoesNotThrow(ScriptsPassiveScanner::new);
+        assertDoesNotThrow(() -> scriptsPassiveScanner.scanHttpRequestSend(message, id));
+        assertDoesNotThrow(
+                () -> scriptsPassiveScanner.scanHttpResponseReceive(message, id, source));
+    }
+
+    @Test
+    void shouldHaveAName() {
+        // Given
+        Constant.messages = new I18N(Locale.ENGLISH);
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        // When
+        String name = scriptsPassiveScanner.getName();
+        // Then
+        assertThat(name, is(equalTo("Script Passive Scan Rules")));
+    }
+
+    @Test
+    void shouldHaveSpecificPluginId() {
+        // Given
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        // When
+        int pluginId = scriptsPassiveScanner.getPluginId();
+        // Then
+        assertThat(pluginId, is(equalTo(50001)));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldAddTagsWithParentSet() {
+        // Given
+        String tag = "Tag";
+        given(extensionScript.<PassiveScript>createScriptsCache(any()))
+                .willReturn(mock(ScriptsCache.class));
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        scriptsPassiveScanner.setParent(parent);
+        scriptsPassiveScanner.scanHttpResponseReceive(message, id, source);
+        // When
+        scriptsPassiveScanner.addTag(tag);
+        // Then
+        verify(parent).addTag(id, tag);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenAddingTagWithoutParent() {
+        // Given
+        String tag = "Tag";
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        // When / Then
+        assertThrows(NullPointerException.class, () -> scriptsPassiveScanner.addTag(tag));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0, 1, 2, 3, 10, 100})
+    void shouldApplyToAllHistoryTypes(int historyType) {
+        // Given
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        // When
+        boolean applies = scriptsPassiveScanner.appliesToHistoryType(historyType);
+        // Then
+        assertThat(applies, is(equalTo(true)));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldCreateScriptsCacheWithExpectedConfiguration() {
+        // Given / When
+        new ScriptsPassiveScanner();
+        // Then
+        ArgumentCaptor<Configuration<PassiveScript>> argumentCaptor =
+                ArgumentCaptor.forClass(Configuration.class);
+        verify(extensionScript).createScriptsCache(argumentCaptor.capture());
+        Configuration<PassiveScript> configuration = argumentCaptor.getValue();
+        assertThat(configuration.getScriptType(), is(equalTo(SCRIPT_TYPE)));
+        assertThat(configuration.getTargetInterface(), is(equalTo(TARGET_INTERFACE)));
+        InterfaceErrorMessageProvider errorMessageProvider =
+                configuration.getInterfaceErrorMessageProvider();
+        assertThat(errorMessageProvider, is(not(nullValue())));
+        ScriptWrapper scriptWrapper = mock(ScriptWrapper.class);
+        given(scriptWrapper.getName()).willReturn("Name");
+        assertThat(errorMessageProvider.getErrorMessage(scriptWrapper), is(not(nullValue())));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldRefreshScriptsAndCallScan() throws Exception {
+        // Given
+        PassiveScript script = mock(TARGET_INTERFACE);
+        given(script.appliesToHistoryType(anyInt())).willReturn(true);
+        ScriptsCache<PassiveScript> scriptsCache = createScriptsCache(createCachedScript(script));
+        given(extensionScript.<PassiveScript>createScriptsCache(any())).willReturn(scriptsCache);
+        int historyType = 5;
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        scriptsPassiveScanner.appliesToHistoryType(historyType);
+        // When
+        scriptsPassiveScanner.scanHttpResponseReceive(message, id, source);
+        // Then
+        verify(scriptsCache, times(1)).refreshAndExecute(any(ScriptWrapperAction.class));
+        verify(script, times(1)).appliesToHistoryType(historyType);
+        ArgumentCaptor<ScriptsPassiveScanner> argumentCaptor =
+                ArgumentCaptor.forClass(ScriptsPassiveScanner.class);
+        verify(script, times(1)).scan(argumentCaptor.capture(), eq(message), eq(source));
+        assertThat(argumentCaptor.getValue(), is(sameInstance(scriptsPassiveScanner)));
+    }
+
+    @Test
+    void shouldNotCallScanIfScriptDoesNotApplyToHistoryType() throws Exception {
+        // Given
+        PassiveScript script = mock(TARGET_INTERFACE);
+        given(script.appliesToHistoryType(anyInt())).willReturn(false);
+        ScriptsCache<PassiveScript> scriptsCache = createScriptsCache(createCachedScript(script));
+        given(extensionScript.<PassiveScript>createScriptsCache(any())).willReturn(scriptsCache);
+        int historyType = 5;
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        scriptsPassiveScanner.appliesToHistoryType(historyType);
+        // When
+        scriptsPassiveScanner.scanHttpResponseReceive(message, id, source);
+        // Then
+        verify(script, times(1)).appliesToHistoryType(historyType);
+        verify(script, times(0)).scan(any(), any(), any());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10, 15})
+    void shouldHandleScriptsThatDoNotImplementAppliesToHistoryType(int historyType)
+            throws Exception {
+        // Given
+        PassiveScript script = mock(TARGET_INTERFACE);
+        NoSuchMethodException cause = mock(NoSuchMethodException.class);
+        given(cause.getMessage()).willReturn("appliesToHistoryType");
+        UndeclaredThrowableException exception = mock(UndeclaredThrowableException.class);
+        given(exception.getCause()).willReturn(cause);
+        given(script.appliesToHistoryType(anyInt())).willThrow(exception);
+        ScriptsCache<PassiveScript> scriptsCache = createScriptsCache(createCachedScript(script));
+        given(extensionScript.<PassiveScript>createScriptsCache(any())).willReturn(scriptsCache);
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        scriptsPassiveScanner.appliesToHistoryType(historyType);
+        // When
+        scriptsPassiveScanner.scanHttpResponseReceive(message, id, source);
+        // Then
+        verify(script, times(1)).appliesToHistoryType(historyType);
+        verify(script, times(1)).scan(any(), any(), any());
+    }
+
+    @Test
+    void shouldPropagateExceptionThrownByAppliesToHistoryTypeIfNotCausedByMissingMethod()
+            throws Exception {
+        // Given
+        PassiveScript script = mock(TARGET_INTERFACE);
+        NoSuchMethodException cause = mock(NoSuchMethodException.class);
+        given(cause.getMessage()).willReturn("other method");
+        UndeclaredThrowableException exception = mock(UndeclaredThrowableException.class);
+        given(exception.getCause()).willReturn(cause);
+        given(script.appliesToHistoryType(anyInt())).willThrow(exception);
+        ScriptsCache<PassiveScript> scriptsCache = createScriptsCache(createCachedScript(script));
+        given(extensionScript.<PassiveScript>createScriptsCache(any())).willReturn(scriptsCache);
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        int historyType = 5;
+        scriptsPassiveScanner.appliesToHistoryType(historyType);
+        // When
+        scriptsPassiveScanner.scanHttpResponseReceive(message, id, source);
+        // Then
+        verify(script, times(1)).appliesToHistoryType(historyType);
+        verify(script, times(0)).scan(any(), any(), any());
+    }
+
+    @Test
+    void shouldPropagateExceptionThrownByAppliesToHistoryTypeIfNotNoSuchMethodException()
+            throws Exception {
+        // Given
+        PassiveScript script = mock(TARGET_INTERFACE);
+        UndeclaredThrowableException exception = mock(UndeclaredThrowableException.class);
+        given(script.appliesToHistoryType(anyInt())).willThrow(exception);
+        ScriptsCache<PassiveScript> scriptsCache = createScriptsCache(createCachedScript(script));
+        given(extensionScript.<PassiveScript>createScriptsCache(any())).willReturn(scriptsCache);
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        int historyType = 5;
+        scriptsPassiveScanner.appliesToHistoryType(historyType);
+        // When
+        scriptsPassiveScanner.scanHttpResponseReceive(message, id, source);
+        // Then
+        verify(script, times(1)).appliesToHistoryType(historyType);
+        verify(script, times(0)).scan(any(), any(), any());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> CachedScript<T> createCachedScript(T script) {
+        CachedScript<T> cachedScript = mock(CachedScript.class);
+        given(cachedScript.getScript()).willReturn(script);
+        return cachedScript;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> ScriptsCache<T> createScriptsCache(CachedScript<T> cachedScript) {
+        ScriptsCache<T> scriptsCache = mock(ScriptsCache.class);
+        Answer<Void> answer =
+                invocation -> {
+                    ScriptWrapperAction<T> action =
+                            (ScriptWrapperAction<T>) invocation.getArguments()[0];
+                    try {
+                        action.apply(cachedScript.getScriptWrapper(), cachedScript.getScript());
+                    } catch (Throwable ignore) {
+                    }
+                    return null;
+                };
+        doAnswer(answer).when(scriptsCache).refreshAndExecute(any(ScriptWrapperAction.class));
+        return scriptsCache;
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/script/ExtensionScriptUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/script/ExtensionScriptUnitTest.java
@@ -1,0 +1,61 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.script;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.WithConfigsTest;
+import org.zaproxy.zap.extension.script.ScriptsCache.Configuration;
+
+/** Unit test for {@link ExtensionScript}. */
+class ExtensionScriptUnitTest {
+
+    @BeforeEach
+    void setUp() {
+        WithConfigsTest.setUpConstant();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        Constant.messages = null;
+    }
+
+    @Test
+    void shouldCreateScriptsCache() {
+        // Given
+        ExtensionScript extensionScript = new ExtensionScript();
+        @SuppressWarnings("unchecked")
+        Configuration<Script> configuration = mock(Configuration.class);
+        // When
+        ScriptsCache<Script> scriptsCache = extensionScript.createScriptsCache(configuration);
+        // Then
+        assertThat(scriptsCache, is(not(nullValue())));
+    }
+
+    private interface Script {}
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/script/HttpSenderScriptListenerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/script/HttpSenderScriptListenerUnitTest.java
@@ -1,0 +1,158 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.script;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.zap.WithConfigsTest;
+import org.zaproxy.zap.extension.script.ScriptsCache.Configuration;
+import org.zaproxy.zap.extension.script.ScriptsCache.InterfaceErrorMessageProvider;
+import org.zaproxy.zap.extension.script.ScriptsCache.ScriptAction;
+
+/** Unit test for {@link HttpSenderScriptListener}. */
+class HttpSenderScriptListenerUnitTest extends WithConfigsTest {
+
+    private static final String SCRIPT_TYPE = ExtensionScript.TYPE_HTTP_SENDER;
+    private static final Class<HttpSenderScript> TARGET_INTERFACE = HttpSenderScript.class;
+
+    private ExtensionScript extensionScript;
+    private HttpMessage message;
+    private int initiator;
+    private HttpSender sender;
+
+    @BeforeEach
+    void setUp() {
+        extensionScript = mock(ExtensionScript.class);
+        message = mock(HttpMessage.class);
+        initiator = HttpSender.MANUAL_REQUEST_INITIATOR;
+        sender = mock(HttpSender.class);
+    }
+
+    @Test
+    void shouldThrowExceptionIfExtensionScriptIsNull() {
+        // Given
+        ExtensionScript extensionScript = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class, () -> new HttpSenderScriptListener(extensionScript));
+    }
+
+    @Test
+    void shouldHaveHighestListenerOrder() {
+        // Given
+        HttpSenderScriptListener httpSenderScriptListener =
+                new HttpSenderScriptListener(extensionScript);
+        // When
+        int listenerOrder = httpSenderScriptListener.getListenerOrder();
+        // Then
+        assertThat(listenerOrder, is(equalTo(Integer.MAX_VALUE)));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldCreateScriptsCacheWithExpectedConfiguration() {
+        // Given / When
+        new HttpSenderScriptListener(extensionScript);
+        // Then
+        ArgumentCaptor<Configuration<HttpSenderScript>> argumentCaptor =
+                ArgumentCaptor.forClass(Configuration.class);
+        verify(extensionScript).createScriptsCache(argumentCaptor.capture());
+        Configuration<HttpSenderScript> configuration = argumentCaptor.getValue();
+        assertThat(configuration.getScriptType(), is(equalTo(SCRIPT_TYPE)));
+        assertThat(configuration.getTargetInterface(), is(equalTo(TARGET_INTERFACE)));
+        InterfaceErrorMessageProvider errorMessageProvider =
+                configuration.getInterfaceErrorMessageProvider();
+        assertThat(errorMessageProvider, is(not(nullValue())));
+        assertThat(errorMessageProvider.getErrorMessage(null), is(not(nullValue())));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldRefreshScriptsAndCallOnHttpRequestSend() throws Exception {
+        // Given
+        HttpSenderScript script = mock(TARGET_INTERFACE);
+        ScriptsCache<HttpSenderScript> scriptsCache = createScriptsCache(script);
+        given(extensionScript.<HttpSenderScript>createScriptsCache(any())).willReturn(scriptsCache);
+        HttpSenderScriptListener httpSenderScriptListener =
+                new HttpSenderScriptListener(extensionScript);
+        // When
+        httpSenderScriptListener.onHttpRequestSend(message, initiator, sender);
+        // Then
+        verify(scriptsCache, times(1)).refresh();
+        verify(scriptsCache, times(1)).execute(any(ScriptAction.class));
+        ArgumentCaptor<HttpSenderScriptHelper> argumentCaptor =
+                ArgumentCaptor.forClass(HttpSenderScriptHelper.class);
+        verify(script, times(1))
+                .sendingRequest(eq(message), eq(initiator), argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getHttpSender(), is(equalTo(sender)));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldCallOnHttpResponseReceive() throws Exception {
+        // Given
+        HttpSenderScript script = mock(TARGET_INTERFACE);
+        ScriptsCache<HttpSenderScript> scriptsCache = createScriptsCache(script);
+        given(extensionScript.<HttpSenderScript>createScriptsCache(any())).willReturn(scriptsCache);
+        HttpSenderScriptListener httpSenderScriptListener =
+                new HttpSenderScriptListener(extensionScript);
+        // When
+        httpSenderScriptListener.onHttpResponseReceive(message, initiator, sender);
+        // Then
+        verify(scriptsCache, times(0)).refresh();
+        verify(scriptsCache, times(1)).execute(any(ScriptAction.class));
+        ArgumentCaptor<HttpSenderScriptHelper> argumentCaptor =
+                ArgumentCaptor.forClass(HttpSenderScriptHelper.class);
+        verify(script, times(1))
+                .responseReceived(eq(message), eq(initiator), argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getHttpSender(), is(equalTo(sender)));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> ScriptsCache<T> createScriptsCache(T script) {
+        ScriptsCache<T> scriptsCache = mock(ScriptsCache.class);
+        Answer<Void> answer =
+                invocation -> {
+                    ScriptAction<T> action = (ScriptAction<T>) invocation.getArguments()[0];
+                    action.apply(script);
+                    return null;
+                };
+        doAnswer(answer).when(scriptsCache).execute(any(ScriptAction.class));
+        return scriptsCache;
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/script/ProxyListenerScriptUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/script/ProxyListenerScriptUnitTest.java
@@ -1,0 +1,232 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.script;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+import javax.script.ScriptException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.parosproxy.paros.extension.history.ProxyListenerLog;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.WithConfigsTest;
+import org.zaproxy.zap.extension.script.ScriptsCache.CachedScript;
+import org.zaproxy.zap.extension.script.ScriptsCache.Configuration;
+import org.zaproxy.zap.extension.script.ScriptsCache.InterfaceErrorMessageProvider;
+
+/** Unit test for {@link ProxyListenerScript}. */
+class ProxyListenerScriptUnitTest extends WithConfigsTest {
+
+    private static final String SCRIPT_TYPE = ExtensionScript.TYPE_PROXY;
+    private static final Class<ProxyScript> TARGET_INTERFACE = ProxyScript.class;
+
+    private ExtensionScript extensionScript;
+    private HttpMessage message;
+
+    @BeforeEach
+    void setUp() {
+        extensionScript = mock(ExtensionScript.class);
+    }
+
+    @Test
+    void shouldThrowExceptionIfExtensionScriptIsNull() {
+        // Given
+        ExtensionScript extensionScript = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> new ProxyListenerScript(extensionScript));
+    }
+
+    @Test
+    void shouldHaveListenerOrderLowerThanProxyListenerOrder() {
+        // Given
+        ProxyListenerScript proxyListenerScript = new ProxyListenerScript(extensionScript);
+        // When
+        int listenerOrder = proxyListenerScript.getArrangeableListenerOrder();
+        // Then
+        assertThat(listenerOrder, is(lessThan(ProxyListenerLog.PROXY_LISTENER_ORDER)));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldCreateScriptsCacheWithExpectedConfiguration() {
+        // Given / When
+        new ProxyListenerScript(extensionScript);
+        // Then
+        ArgumentCaptor<Configuration<ProxyScript>> argumentCaptor =
+                ArgumentCaptor.forClass(Configuration.class);
+        verify(extensionScript).createScriptsCache(argumentCaptor.capture());
+        Configuration<ProxyScript> configuration = argumentCaptor.getValue();
+        assertThat(configuration.getScriptType(), is(equalTo(SCRIPT_TYPE)));
+        assertThat(configuration.getTargetInterface(), is(equalTo(TARGET_INTERFACE)));
+        InterfaceErrorMessageProvider errorMessageProvider =
+                configuration.getInterfaceErrorMessageProvider();
+        assertThat(errorMessageProvider, is(not(nullValue())));
+        assertThat(errorMessageProvider.getErrorMessage(null), is(not(nullValue())));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldRefreshScriptsAndCallOnHttpRequestSend() throws Exception {
+        // Given
+        ProxyScript script = mock(TARGET_INTERFACE);
+        CachedScript<ProxyScript> cachedScript = createCachedScript(script);
+        ScriptsCache<ProxyScript> scriptsCache = createScriptsCache(cachedScript);
+        given(extensionScript.<ProxyScript>createScriptsCache(any())).willReturn(scriptsCache);
+        ProxyListenerScript proxyListenerScript = new ProxyListenerScript(extensionScript);
+        // When
+        boolean forwardMessage = proxyListenerScript.onHttpRequestSend(message);
+        // Then
+        assertThat(forwardMessage, is(equalTo(true)));
+        verify(scriptsCache, times(1)).refresh();
+        verify(scriptsCache, times(1)).getCachedScripts();
+        verify(script, times(1)).proxyRequest(message);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldHandleExceptionsThrownByScriptsOnHttpRequestSend() throws Exception {
+        // Given
+        ProxyScript script = mock(TARGET_INTERFACE);
+        Exception exception = mock(ScriptException.class);
+        given(script.proxyRequest(any())).willThrow(exception);
+        ScriptWrapper scriptWrapper = mock(ScriptWrapper.class);
+        CachedScript<ProxyScript> cachedScript = createCachedScript(script, scriptWrapper);
+        ScriptsCache<ProxyScript> scriptsCache = createScriptsCache(cachedScript);
+        given(extensionScript.<ProxyScript>createScriptsCache(any())).willReturn(scriptsCache);
+        ProxyListenerScript proxyListenerScript = new ProxyListenerScript(extensionScript);
+        // When
+        boolean forwardMessage = proxyListenerScript.onHttpRequestSend(message);
+        // Then
+        assertThat(forwardMessage, is(equalTo(true)));
+        verify(extensionScript, times(1)).handleScriptException(scriptWrapper, exception);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldDropMessageOnHttpRequestSend() throws Exception {
+        // Given
+        ProxyScript script1 = mock(TARGET_INTERFACE);
+        given(script1.proxyRequest(any())).willReturn(true);
+        CachedScript<ProxyScript> cachedScript1 = createCachedScript(script1);
+        ProxyScript script2 = mock(TARGET_INTERFACE);
+        CachedScript<ProxyScript> cachedScript2 = createCachedScript(script2);
+        ScriptsCache<ProxyScript> scriptsCache = createScriptsCache(cachedScript1, cachedScript2);
+        given(extensionScript.<ProxyScript>createScriptsCache(any())).willReturn(scriptsCache);
+        ProxyListenerScript proxyListenerScript = new ProxyListenerScript(extensionScript);
+        // When
+        boolean forwardMessage = proxyListenerScript.onHttpRequestSend(message);
+        // Then
+        assertThat(forwardMessage, is(equalTo(false)));
+        verify(script1, times(1)).proxyRequest(message);
+        verify(script2, times(0)).proxyRequest(message);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldCallOnHttpResponseReceive() throws Exception {
+        // Given
+        ProxyScript script = mock(TARGET_INTERFACE);
+        CachedScript<ProxyScript> cachedScript = createCachedScript(script);
+        ScriptsCache<ProxyScript> scriptsCache = createScriptsCache(cachedScript);
+        given(extensionScript.<ProxyScript>createScriptsCache(any())).willReturn(scriptsCache);
+        ProxyListenerScript proxyListenerScript = new ProxyListenerScript(extensionScript);
+        // When
+        boolean forwardMessage = proxyListenerScript.onHttpResponseReceive(message);
+        // Then
+        assertThat(forwardMessage, is(equalTo(true)));
+        verify(scriptsCache, times(0)).refresh();
+        verify(scriptsCache, times(1)).getCachedScripts();
+        verify(script, times(1)).proxyResponse(message);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldHandleExceptionsThrownByScriptsOnHttpResponseReceive() throws Exception {
+        // Given
+        ProxyScript script = mock(TARGET_INTERFACE);
+        Exception exception = mock(ScriptException.class);
+        given(script.proxyResponse(any())).willThrow(exception);
+        ScriptWrapper scriptWrapper = mock(ScriptWrapper.class);
+        CachedScript<ProxyScript> cachedScript = createCachedScript(script, scriptWrapper);
+        ScriptsCache<ProxyScript> scriptsCache = createScriptsCache(cachedScript);
+        given(extensionScript.<ProxyScript>createScriptsCache(any())).willReturn(scriptsCache);
+        ProxyListenerScript proxyListenerScript = new ProxyListenerScript(extensionScript);
+        // When
+        boolean forwardMessage = proxyListenerScript.onHttpResponseReceive(message);
+        // Then
+        assertThat(forwardMessage, is(equalTo(true)));
+        verify(extensionScript, times(1)).handleScriptException(scriptWrapper, exception);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldDropMessageOnHttpResponseReceive() throws Exception {
+        // Given
+        ProxyScript script1 = mock(TARGET_INTERFACE);
+        given(script1.proxyResponse(any())).willReturn(true);
+        CachedScript<ProxyScript> cachedScript1 = createCachedScript(script1);
+        ProxyScript script2 = mock(TARGET_INTERFACE);
+        CachedScript<ProxyScript> cachedScript2 = createCachedScript(script2);
+        ScriptsCache<ProxyScript> scriptsCache = createScriptsCache(cachedScript1, cachedScript2);
+        given(extensionScript.<ProxyScript>createScriptsCache(any())).willReturn(scriptsCache);
+        ProxyListenerScript proxyListenerScript = new ProxyListenerScript(extensionScript);
+        // When
+        boolean forwardMessage = proxyListenerScript.onHttpResponseReceive(message);
+        // Then
+        assertThat(forwardMessage, is(equalTo(false)));
+        verify(script1, times(1)).proxyResponse(message);
+        verify(script2, times(0)).proxyResponse(message);
+    }
+
+    private static <T> CachedScript<T> createCachedScript(T script) {
+        return createCachedScript(script, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> CachedScript<T> createCachedScript(T script, ScriptWrapper scriptWrapper) {
+        CachedScript<T> cachedScript = mock(CachedScript.class, withSettings().lenient());
+        given(cachedScript.getScript()).willReturn(script);
+        if (scriptWrapper != null) {
+            given(cachedScript.getScriptWrapper()).willReturn(scriptWrapper);
+        }
+        return cachedScript;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> ScriptsCache<T> createScriptsCache(CachedScript<T>... cachedScripts) {
+        ScriptsCache<T> scriptsCache = mock(ScriptsCache.class);
+        given(scriptsCache.getCachedScripts()).willReturn(asList(cachedScripts));
+        return scriptsCache;
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/script/ScriptWrapperUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/script/ScriptWrapperUnitTest.java
@@ -1,0 +1,67 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.script;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit test for {@link ScriptWrapper}. */
+class ScriptWrapperUnitTest {
+
+    @Test
+    void shouldSetContents() {
+        // Given
+        String contents = "Abc";
+        ScriptWrapper scriptWrapper = new ScriptWrapper();
+        // When
+        scriptWrapper.setContents(contents);
+        // Then
+        assertThat(scriptWrapper.getContents(), is(equalTo(contents)));
+    }
+
+    @Test
+    void shouldIncreaseModCountIfContentsChanged() {
+        // Given
+        String contents = "Abc";
+        ScriptWrapper scriptWrapper = new ScriptWrapper();
+        int oldModCount = scriptWrapper.getModCount();
+        // When
+        scriptWrapper.setContents(contents);
+        // Then
+        assertThat(scriptWrapper.getModCount(), is(not(equalTo(oldModCount))));
+    }
+
+    @Test
+    void shouldNotIncreaseModCountIfContentsNotChanged() {
+        // Given
+        String contents = "Abc";
+        ScriptWrapper scriptWrapper = new ScriptWrapper();
+        scriptWrapper.setContents(contents);
+        int oldModCount = scriptWrapper.getModCount();
+        // When
+        scriptWrapper.setContents(contents);
+        // Then
+        assertThat(scriptWrapper.getModCount(), is(equalTo(oldModCount)));
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/script/ScriptsCacheUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/script/ScriptsCacheUnitTest.java
@@ -1,0 +1,486 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.script;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.script.ScriptException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.zaproxy.zap.extension.script.ScriptsCache.CachedScript;
+import org.zaproxy.zap.extension.script.ScriptsCache.Configuration;
+import org.zaproxy.zap.extension.script.ScriptsCache.InterfaceErrorMessageProvider;
+import org.zaproxy.zap.extension.script.ScriptsCache.InterfaceProvider;
+import org.zaproxy.zap.utils.Pair;
+
+/** Unit test for {@link ScriptsCache}. */
+class ScriptsCacheUnitTest {
+
+    private ExtensionScript extensionScript;
+    private String scriptType;
+    private Class<Script> targetInterface;
+    private String interfaceErrorMessage;
+
+    private ScriptsCache<Script> scriptsCache;
+
+    @BeforeEach
+    void setUp() {
+        extensionScript = mock(ExtensionScript.class);
+        scriptType = "ScriptType";
+        targetInterface = Script.class;
+        interfaceErrorMessage = "Script does not implement the interface.";
+
+        scriptsCache =
+                new ScriptsCache<>(
+                        extensionScript,
+                        Configuration.<Script>builder()
+                                .setScriptType(scriptType)
+                                .setTargetInterface(targetInterface)
+                                .setInterfaceErrorMessageProvider(sw -> interfaceErrorMessage)
+                                .build());
+    }
+
+    @Test
+    void shouldHaveNoCachedScriptsIfNotRefreshed() {
+        // Given / When
+        List<CachedScript<Script>> cachedScripts = scriptsCache.getCachedScripts();
+        // Then
+        assertThat(cachedScripts, is(empty()));
+        verifyNoInteractions(extensionScript);
+    }
+
+    @Test
+    void shouldNotCacheDisabledScripts() throws Exception {
+        // Given
+        ScriptWrapper scriptWrapper1 = mockScriptWrapper(mock(Script.class));
+        given(scriptWrapper1.isEnabled()).willReturn(false);
+        ScriptWrapper scriptWrapper2 = mockScriptWrapper(mock(Script.class));
+        given(scriptWrapper2.isEnabled()).willReturn(false);
+        given(extensionScript.getScripts(scriptType))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        // When
+        scriptsCache.refresh();
+        // Then
+        List<CachedScript<Script>> cachedScripts = scriptsCache.getCachedScripts();
+        assertThat(cachedScripts, hasSize(0));
+        verify(extensionScript, times(1)).getScripts(scriptType);
+        verifyNoMoreInteractions(extensionScript);
+    }
+
+    @Test
+    void shouldCacheEnabledScripts() throws Exception {
+        // Given
+        Script script1 = mock(Script.class);
+        ScriptWrapper scriptWrapper1 = mockScriptWrapper(script1);
+        Script script2 = mock(Script.class);
+        ScriptWrapper scriptWrapper2 = mockScriptWrapper(script2);
+        given(extensionScript.getScripts(scriptType))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        // When
+        scriptsCache.refresh();
+        // Then
+        List<CachedScript<Script>> cachedScripts = scriptsCache.getCachedScripts();
+        assertThat(cachedScripts, hasSize(2));
+        assertCachedScript(cachedScripts.get(0), scriptWrapper1, script1);
+        assertCachedScript(cachedScripts.get(1), scriptWrapper2, script2);
+        verify(extensionScript, times(1)).getScripts(scriptType);
+        verify(extensionScript, times(1)).getInterface(scriptWrapper1, targetInterface);
+        verify(extensionScript, times(1)).getInterface(scriptWrapper2, targetInterface);
+        verifyNoMoreInteractions(extensionScript);
+    }
+
+    @Test
+    void shouldCacheEnabledScriptsAndIgnoreDisabledScriptsWhenRefreshing() throws Exception {
+        // Given
+        Script script1 = mock(Script.class);
+        ScriptWrapper scriptWrapper1 = mockScriptWrapper(script1);
+        given(scriptWrapper1.isEnabled()).willReturn(false);
+        Script script2 = mock(Script.class);
+        ScriptWrapper scriptWrapper2 = mockScriptWrapper(script2);
+        given(extensionScript.getScripts(scriptType))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        // When
+        scriptsCache.refresh();
+        // Then
+        List<CachedScript<Script>> cachedScripts = scriptsCache.getCachedScripts();
+        assertThat(cachedScripts, hasSize(1));
+        assertCachedScript(cachedScripts.get(0), scriptWrapper2, script2);
+        verify(extensionScript, times(1)).getScripts(scriptType);
+        verify(extensionScript, times(1)).getInterface(scriptWrapper2, targetInterface);
+        verifyNoMoreInteractions(extensionScript);
+    }
+
+    @Test
+    void shouldNotCacheScriptsNoLongerEnabledWhenRefreshing() throws Exception {
+        // Given
+        Script script1 = mock(Script.class);
+        ScriptWrapper scriptWrapper1 = mockScriptWrapper(script1);
+        Script script2 = mock(Script.class);
+        ScriptWrapper scriptWrapper2 = mockScriptWrapper(script2);
+        given(extensionScript.getScripts(scriptType))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        // When
+        scriptsCache.refresh();
+        given(scriptWrapper1.isEnabled()).willReturn(false);
+        scriptsCache.refresh();
+        // Then
+        List<CachedScript<Script>> cachedScripts = scriptsCache.getCachedScripts();
+        assertThat(cachedScripts, hasSize(1));
+        assertCachedScript(cachedScripts.get(0), scriptWrapper2, script2);
+        verify(extensionScript, times(2)).getScripts(scriptType);
+        verify(extensionScript, times(1)).getInterface(scriptWrapper1, targetInterface);
+        verify(extensionScript, times(1)).getInterface(scriptWrapper2, targetInterface);
+        verifyNoMoreInteractions(extensionScript);
+    }
+
+    @Test
+    void shouldRefreshCachedScriptIfChanged() throws Exception {
+        // Given
+        Script script1 = mock(Script.class);
+        ScriptWrapper scriptWrapper1 = mockScriptWrapper(script1);
+        Script script2 = mock(Script.class);
+        ScriptWrapper scriptWrapper2 = mockScriptWrapper(script2);
+        given(extensionScript.getScripts(scriptType))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        // When
+        scriptsCache.refresh();
+        given(scriptWrapper2.getModCount()).willReturn(1);
+        Script refreshedScript = mock(Script.class);
+        given(extensionScript.getInterface(scriptWrapper2, targetInterface))
+                .willReturn(refreshedScript);
+        scriptsCache.refresh();
+        // Then
+        List<CachedScript<Script>> cachedScripts = scriptsCache.getCachedScripts();
+        assertThat(cachedScripts, hasSize(2));
+        assertCachedScript(cachedScripts.get(0), scriptWrapper1, script1);
+        assertCachedScript(cachedScripts.get(1), scriptWrapper2, refreshedScript);
+        verify(extensionScript, times(2)).getScripts(scriptType);
+        verify(extensionScript, times(1)).getInterface(scriptWrapper1, targetInterface);
+        verify(extensionScript, times(2)).getInterface(scriptWrapper2, targetInterface);
+        verifyNoMoreInteractions(extensionScript);
+    }
+
+    @Test
+    void shouldNotCacheScriptsThatDoNotImplementInterface() throws Exception {
+        // Given
+        Script script1 = mock(Script.class);
+        ScriptWrapper scriptWrapper1 = mockScriptWrapper(script1);
+        Script script2 = mock(Script.class);
+        ScriptWrapper scriptWrapper2 = mockScriptWrapper(script2);
+        given(extensionScript.getInterface(scriptWrapper2, targetInterface)).willReturn(null);
+        given(extensionScript.getScripts(scriptType))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        // When
+        scriptsCache.refresh();
+        // Then
+        List<CachedScript<Script>> cachedScripts = scriptsCache.getCachedScripts();
+        assertThat(cachedScripts, hasSize(1));
+        assertCachedScript(cachedScripts.get(0), scriptWrapper1, script1);
+        verify(extensionScript, times(1)).getScripts(scriptType);
+        verify(extensionScript, times(1)).getInterface(scriptWrapper1, targetInterface);
+        verify(extensionScript, times(1)).getInterface(scriptWrapper2, targetInterface);
+        verify(extensionScript, times(1))
+                .handleFailedScriptInterface(scriptWrapper2, interfaceErrorMessage);
+        verifyNoMoreInteractions(extensionScript);
+    }
+
+    @Test
+    void shouldNotCacheScriptsThatHaveErrors() throws Exception {
+        // Given
+        Script script1 = mock(Script.class);
+        ScriptWrapper scriptWrapper1 = mockScriptWrapper(script1);
+        Script script2 = mock(Script.class);
+        ScriptWrapper scriptWrapper2 = mockScriptWrapper(script2);
+        ScriptException scriptException = mock(ScriptException.class);
+        given(extensionScript.getInterface(scriptWrapper2, targetInterface))
+                .willThrow(scriptException);
+        given(extensionScript.getScripts(scriptType))
+                .willReturn(asList(scriptWrapper1, scriptWrapper2));
+        // When
+        scriptsCache.refresh();
+        // Then
+        List<CachedScript<Script>> cachedScripts = scriptsCache.getCachedScripts();
+        assertThat(cachedScripts, hasSize(1));
+        assertCachedScript(cachedScripts.get(0), scriptWrapper1, script1);
+        verify(extensionScript, times(1)).getScripts(scriptType);
+        verify(extensionScript, times(1)).getInterface(scriptWrapper1, targetInterface);
+        verify(extensionScript, times(1)).getInterface(scriptWrapper2, targetInterface);
+        verify(extensionScript, times(1)).handleScriptException(scriptWrapper2, scriptException);
+        verifyNoMoreInteractions(extensionScript);
+    }
+
+    @Test
+    void shouldExecuteCachedScripts() throws Exception {
+        // Given
+        Script script = mock(Script.class);
+        ScriptWrapper scriptWrapper = mockScriptWrapper(script);
+        given(extensionScript.getScripts(scriptType)).willReturn(asList(scriptWrapper));
+        scriptsCache.refresh();
+        List<Script> scriptsExecuted = new ArrayList<>();
+        // When
+        scriptsCache.execute(e -> scriptsExecuted.add(e));
+        // Then
+        assertThat(scriptsExecuted, hasSize(1));
+        assertThat(scriptsExecuted.get(0), is(sameInstance(script)));
+    }
+
+    @Test
+    void shouldHandleScriptExceptionWhenExecutingCachedScripts() throws Exception {
+        // Given
+        Script script = mock(Script.class);
+        ScriptWrapper scriptWrapper = mockScriptWrapper(script);
+        given(extensionScript.getScripts(scriptType)).willReturn(asList(scriptWrapper));
+        scriptsCache.refresh();
+        ScriptException exception = new ScriptException("");
+        List<Script> scriptsExecuted = new ArrayList<>();
+        // When
+        scriptsCache.execute(
+                e -> {
+                    scriptsExecuted.add(e);
+                    throw exception;
+                });
+        // Then
+        assertThat(scriptsExecuted, hasSize(1));
+        assertThat(scriptsExecuted.get(0), is(sameInstance(script)));
+        verify(extensionScript, times(1)).handleScriptException(scriptWrapper, exception);
+    }
+
+    @Test
+    void shouldRefreshAndExecuteCachedScripts() throws Exception {
+        // Given
+        Script script = mock(Script.class);
+        ScriptWrapper scriptWrapper = mockScriptWrapper(script);
+        given(extensionScript.getScripts(scriptType)).willReturn(asList(scriptWrapper));
+        List<Script> scriptsExecuted = new ArrayList<>();
+        // When
+        scriptsCache.refreshAndExecute(e -> scriptsExecuted.add(e));
+        // Then
+        assertThat(scriptsExecuted, hasSize(1));
+        assertThat(scriptsExecuted.get(0), is(sameInstance(script)));
+    }
+
+    @Test
+    void shouldHandleScriptExceptionWhenRefreshAndExecutingCachedScripts() throws Exception {
+        // Given
+        Script script = mock(Script.class);
+        ScriptWrapper scriptWrapper = mockScriptWrapper(script);
+        given(extensionScript.getScripts(scriptType)).willReturn(asList(scriptWrapper));
+        scriptsCache.refresh();
+        ScriptException exception = new ScriptException("");
+        List<Script> scriptsExecuted = new ArrayList<>();
+        // When
+        scriptsCache.refreshAndExecute(
+                e -> {
+                    scriptsExecuted.add(e);
+                    throw exception;
+                });
+        // Then
+        assertThat(scriptsExecuted, hasSize(1));
+        assertThat(scriptsExecuted.get(0), is(sameInstance(script)));
+        verify(extensionScript, times(1)).handleScriptException(scriptWrapper, exception);
+    }
+
+    @Test
+    void shouldRefreshAndExecuteWithScriptWrapperAndCachedScripts() throws Exception {
+        // Given
+        Script script = mock(Script.class);
+        ScriptWrapper scriptWrapper = mockScriptWrapper(script);
+        given(extensionScript.getScripts(scriptType)).willReturn(asList(scriptWrapper));
+        List<Pair<ScriptWrapper, Script>> scriptsExecuted = new ArrayList<>();
+        // When / When
+        scriptsCache.refreshAndExecute((sw, s) -> scriptsExecuted.add(new Pair<>(sw, s)));
+        // Then
+        assertThat(scriptsExecuted, hasSize(1));
+        assertThat(scriptsExecuted.get(0).first, is(sameInstance(scriptWrapper)));
+        assertThat(scriptsExecuted.get(0).second, is(sameInstance(script)));
+    }
+
+    @Test
+    void shouldHandleScriptExceptionWhenRefreshAndExecutingWithScriptWrapperAndCachedScripts()
+            throws Exception {
+        // Given
+        Script script = mock(Script.class);
+        ScriptWrapper scriptWrapper = mockScriptWrapper(script);
+        given(extensionScript.getScripts(scriptType)).willReturn(asList(scriptWrapper));
+        scriptsCache.refresh();
+        ScriptException exception = new ScriptException("");
+        List<Pair<ScriptWrapper, Script>> scriptsExecuted = new ArrayList<>();
+        // When
+        scriptsCache.refreshAndExecute(
+                (sw, s) -> {
+                    scriptsExecuted.add(new Pair<>(sw, s));
+                    throw exception;
+                });
+        // Then
+        assertThat(scriptsExecuted, hasSize(1));
+        assertThat(scriptsExecuted.get(0).first, is(sameInstance(scriptWrapper)));
+        assertThat(scriptsExecuted.get(0).second, is(sameInstance(script)));
+        verify(extensionScript, times(1)).handleScriptException(scriptWrapper, exception);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldUseInterfaceProvider() throws Exception {
+        // Given
+        InterfaceProvider<Script> interfaceProvider = mock(InterfaceProvider.class);
+        scriptsCache =
+                new ScriptsCache<>(
+                        extensionScript,
+                        Configuration.<Script>builder()
+                                .setScriptType(scriptType)
+                                .setTargetInterface(targetInterface)
+                                .setInterfaceProvider(interfaceProvider)
+                                .build());
+        ScriptWrapper scriptWrapper = mockScriptWrapper(mock(Script.class));
+        given(extensionScript.getScripts(scriptType)).willReturn(asList(scriptWrapper));
+        // When
+        scriptsCache.refresh();
+        // Then
+        verify(interfaceProvider, times(1)).getInterface(scriptWrapper, Script.class);
+    }
+
+    @Nested
+    static class ConfigurationUnitTest {
+
+        private static final String SCRIPT_TYPE = "ScriptType";
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        public void shouldThrowExceptionWhenBuildingWithoutScriptType(String scriptType) {
+            // Given
+            Configuration.Builder<Script> builder =
+                    Configuration.<Script>builder().setScriptType(scriptType);
+            // When
+            IllegalStateException e = assertThrows(IllegalStateException.class, builder::build);
+            // Then
+            assertThat(e.getMessage(), containsString("script type"));
+        }
+
+        @Test
+        public void shouldThrowExceptionWhenBuildingWithoutTargetInterface() {
+            // Given
+            Configuration.Builder<Script> builder =
+                    Configuration.<Script>builder().setScriptType(SCRIPT_TYPE);
+            builder.setTargetInterface(null);
+            // When
+            IllegalStateException e = assertThrows(IllegalStateException.class, builder::build);
+            // Then
+            assertThat(e.getMessage(), containsString("target interface"));
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        public void
+                shouldThrowExceptionWhenBuildingWithTargetInterfaceProviderAndErrorMessageProvider() {
+            // Given
+            Configuration.Builder<Script> builder =
+                    Configuration.<Script>builder()
+                            .setScriptType(SCRIPT_TYPE)
+                            .setTargetInterface(Script.class);
+            builder.setInterfaceProvider(mock(InterfaceProvider.class));
+            builder.setInterfaceErrorMessageProvider(mock(InterfaceErrorMessageProvider.class));
+            // When
+            IllegalStateException e = assertThrows(IllegalStateException.class, builder::build);
+            // Then
+            assertThat(
+                    e.getMessage(),
+                    allOf(
+                            containsString("interface error message provider"),
+                            containsString("interface provider")));
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        public void shouldBuildWithInterfaceProvider() {
+            // Given
+            InterfaceProvider<Script> interfaceProvider = mock(InterfaceProvider.class);
+            Configuration.Builder<Script> builder =
+                    Configuration.<Script>builder()
+                            .setScriptType(SCRIPT_TYPE)
+                            .setTargetInterface(Script.class)
+                            .setInterfaceProvider(interfaceProvider);
+            // When
+            Configuration<Script> configuration = builder.build();
+            // Then
+            assertThat(configuration.getScriptType(), is(equalTo(SCRIPT_TYPE)));
+            assertThat(configuration.getTargetInterface(), is(equalTo(Script.class)));
+            assertThat(configuration.getInterfaceProvider(), is(equalTo(interfaceProvider)));
+            assertThat(configuration.getInterfaceErrorMessageProvider(), is(nullValue()));
+        }
+
+        @Test
+        public void shouldBuildWithInterfaceErrorMessageProvider() {
+            // Given
+            InterfaceErrorMessageProvider interfaceErrorMessageProvider =
+                    mock(InterfaceErrorMessageProvider.class);
+            Configuration.Builder<Script> builder =
+                    Configuration.<Script>builder()
+                            .setScriptType(SCRIPT_TYPE)
+                            .setTargetInterface(Script.class)
+                            .setInterfaceErrorMessageProvider(interfaceErrorMessageProvider);
+            // When
+            Configuration<Script> configuration = builder.build();
+            // Then
+            assertThat(configuration.getScriptType(), is(equalTo(SCRIPT_TYPE)));
+            assertThat(configuration.getTargetInterface(), is(equalTo(Script.class)));
+            assertThat(
+                    configuration.getInterfaceErrorMessageProvider(),
+                    is(equalTo(interfaceErrorMessageProvider)));
+            assertThat(configuration.getInterfaceProvider(), is(nullValue()));
+        }
+    }
+
+    private ScriptWrapper mockScriptWrapper(Script script) throws Exception {
+        ScriptWrapper scriptWrapper = mock(ScriptWrapper.class);
+        given(scriptWrapper.isEnabled()).willReturn(true);
+        given(scriptWrapper.getModCount()).willReturn(0);
+        given(extensionScript.getInterface(scriptWrapper, targetInterface)).willReturn(script);
+        return scriptWrapper;
+    }
+
+    private static void assertCachedScript(
+            CachedScript<Script> cachedScript, ScriptWrapper scriptWrapper, Script script) {
+        assertThat(cachedScript.getScriptWrapper(), is(sameInstance(scriptWrapper)));
+        assertThat(cachedScript.getScript(), is(sameInstance(script)));
+    }
+
+    private interface Script {}
+}


### PR DESCRIPTION
Add `ScriptsCache` which caches scripts of a given type and interface
until they are disabled or the contents changed.

Cache scripts in:
 - `VariantFactory`, for Sites tree usage;
 - `ScriptsActiveScanner`;
 - `ScriptsPassiveScanner`;
 - `HttpSenderScriptListener`;
 - `ProxyListenerScript`.

Fix #6010.