### PR TITLE
Support packaged authenticated scans

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2020-11-24
+ - Add support for authenticated scans.
+
 ### 2020-11-19
  - Add zap_tune function (disable all tags and limit pscan alerts to 10), zap_tuned hook and disable recovery log.
 

--- a/docker/tests/test_zap_hooks.py
+++ b/docker/tests/test_zap_hooks.py
@@ -41,9 +41,15 @@ class TestZapHooks(unittest.TestCase):
 
     def setUp(self):
         zap_common.zap_hooks = None
+        zap_common.context_id = None
+        zap_common.context_name = None
+        zap_common.scan_user = None
 
     def tearDown(self):
         zap_common.zap_hooks = None
+        zap_common.context_id = None
+        zap_common.context_name = None
+        zap_common.scan_user = None
 
     def test_trigger_hook_mismatch_exception(self):
         """ If the hook signature doesn't match the hook the exception bubbles up """
@@ -282,3 +288,20 @@ class TestZapHooks(unittest.TestCase):
 
         hooks.zap_import_context.assert_called_once_with(zap, context_file)
         hooks.zap_import_context_wrap.assert_called_once_with(context_id)
+
+    def test_zap_set_scan_user_triggers_hooks(self):
+        """Hooks are triggered when zap_set_scan_user is called."""
+        hooks = Mock(zap_set_scan_user=Mock(return_value=[]))
+        zap_common.zap_hooks = hooks
+
+        user = "user1"
+        zap_common.context_users = [{'name': user, 'id': '1'}]
+
+        zap = Mock()
+
+        zap_common.zap_set_scan_user(zap, user)
+
+        hooks.zap_set_scan_user.assert_called_once_with(zap, user)
+        hooks.zap_set_scan_user_wrap.assert_called_once_with(None)
+
+        zap_common.context_users = None

--- a/docker/zap-api-scan.py
+++ b/docker/zap-api-scan.py
@@ -109,6 +109,7 @@ def usage():
     print('    -s                short output format - dont show PASSes or example URLs')
     print('    -S                safe mode this will skip the active scan and perform a baseline scan')
     print('    -T                max time in minutes to wait for ZAP to start and the passive scan to run')
+    print('    -U user           username to use for authenticated scans - must be defined in the given context file')
     print('    -O                the hostname to override in the (remote) OpenAPI spec')
     print('    -z zap_options    ZAP command line options e.g. -z "-config aaa=bbb -config ccc=ddd"')
     print('    --hook            path to python file that define your custom hooks')
@@ -149,6 +150,7 @@ def main(argv):
     hook_file = None
     schema = ''
     schema_url = ''
+    user = ''
 
     pass_count = 0
     warn_count = 0
@@ -157,9 +159,10 @@ def main(argv):
     ignore_count = 0
     warn_inprog_count = 0
     fail_inprog_count = 0
+    exception_raised = False
 
     try:
-        opts, args = getopt.getopt(argv, "t:f:c:u:g:m:n:r:J:w:x:l:hdaijSp:sz:P:D:T:IO:", ["hook=", "schema="])
+        opts, args = getopt.getopt(argv, "t:f:c:u:g:m:n:r:J:w:x:l:hdaijSp:sz:P:D:T:IO:U:", ["hook=", "schema="])
     except getopt.GetoptError as exc:
         logging.warning('Invalid option ' + exc.opt + ' : ' + exc.msg)
         usage()
@@ -221,6 +224,8 @@ def main(argv):
             timeout = int(arg)
         elif opt == '-O':
             host_override = arg
+        elif opt == '-U':
+            user = arg
         elif opt == '--hook':
             hook_file = arg
         elif opt == '--schema':
@@ -249,6 +254,11 @@ def main(argv):
                 logging.warning('A file based option has been specified but the directory \'/zap/wrk\' is not mounted ')
                 usage()
                 sys.exit(3)
+
+    if user and not context_file:
+        logging.warning('A context file must be specified (and include the user) if the user option is selected')
+        usage()
+        sys.exit(3)
 
     target_file = ''
     if target.startswith('http://') or target.startswith('https://'):
@@ -383,6 +393,8 @@ def main(argv):
         if context_file:
             # handle the context file, cant use base_dir as it might not have been set up
             zap_import_context(zap, '/zap/wrk/' + os.path.basename(context_file))
+            if (user):
+                zap_set_scan_user(zap, user)
 
         # Enable scripts
         zap.script.load('Alert_on_HTTP_Response_Code_Errors.js', 'httpsender', 'Oracle Nashorn', '/home/zap/.ZAP_D/scripts/scripts/httpsender/Alert_on_HTTP_Response_Code_Errors.js')
@@ -578,20 +590,22 @@ def main(argv):
         # Stop ZAP
         zap.core.shutdown()
 
-    except IOError as e:
-        if hasattr(e, 'args') and len(e.args) > 1:
-            errno, strerror = e
-            print("ERROR " + str(strerror))
-            logging.warning('I/O error(' + str(errno) + '): ' + str(strerror))
-        else:
-            print("ERROR %s" % e)
-            logging.warning('I/O error: ' + str(e))
-        dump_log_file(cid)
+    except UserInputException as e:
+        exception_raised = True
+        print("ERROR %s" % e)
 
     except (NoUrlsException, ScanNotStartedException):
+        exception_raised = True
+        dump_log_file(cid)
+
+    except IOError as e:
+        exception_raised = True
+        print("ERROR %s" % e)
+        logging.warning('I/O error: ' + str(e))
         dump_log_file(cid)
 
     except:
+        exception_raised = True
         print("ERROR " + str(sys.exc_info()[0]))
         logging.warning('Unexpected error: ' + str(sys.exc_info()[0]))
         dump_log_file(cid)
@@ -601,7 +615,9 @@ def main(argv):
 
     trigger_hook('pre_exit', fail_count, warn_count, pass_count)
 
-    if fail_count > 0:
+    if exception_raised:
+        sys.exit(3)
+    elif fail_count > 0:
         sys.exit(1)
     elif (not ignore_warn) and warn_count > 0:
         sys.exit(2)

--- a/docker/zap-full-scan.py
+++ b/docker/zap-full-scan.py
@@ -97,6 +97,7 @@ def usage():
     print('    -p progress_file  progress file which specifies issues that are being addressed')
     print('    -s                short output format - dont show PASSes or example URLs')
     print('    -T                max time in minutes to wait for ZAP to start and the passive scan to run')
+    print('    -U user           username to use for authenticated scans - must be defined in the given context file')
     print('    -z zap_options    ZAP command line options e.g. -z "-config aaa=bbb -config ccc=ddd"')
     print('    --hook            path to python file that define your custom hooks')
     print('')
@@ -131,6 +132,7 @@ def main(argv):
     timeout = 0
     ignore_warn = False
     hook_file = None
+    user = ''
 
     pass_count = 0
     warn_count = 0
@@ -139,9 +141,10 @@ def main(argv):
     ignore_count = 0
     warn_inprog_count = 0
     fail_inprog_count = 0
+    exception_raised = False
 
     try:
-        opts, args = getopt.getopt(argv, "t:c:u:g:m:n:r:J:w:x:l:hdaijp:sz:P:D:T:I", ["hook="])
+        opts, args = getopt.getopt(argv, "t:c:u:g:m:n:r:J:w:x:l:hdaijp:sz:P:D:T:IU:", ["hook="])
     except getopt.GetoptError as exc:
         logging.warning('Invalid option ' + exc.opt + ' : ' + exc.msg)
         usage()
@@ -201,6 +204,8 @@ def main(argv):
             detailed_output = False
         elif opt == '-T':
             timeout = int(arg)
+        elif opt == '-U':
+            user = arg
         elif opt == '--hook':
             hook_file = arg
 
@@ -227,6 +232,11 @@ def main(argv):
                 logging.warning('A file based option has been specified but the directory \'/zap/wrk\' is not mounted ')
                 usage()
                 sys.exit(3)
+
+    if user and not context_file:
+        logging.warning('A context file must be specified (and include the user) if the user option is selected')
+        usage()
+        sys.exit(3)
 
     # Choose a random 'ephemeral' port and check its available if it wasn't specified with -P option
     if port == 0:
@@ -323,6 +333,8 @@ def main(argv):
         if context_file:
             # handle the context file, cant use base_dir as it might not have been set up
             zap_import_context(zap, '/zap/wrk/' + os.path.basename(context_file))
+            if (user):
+                zap_set_scan_user(zap, user)
 
         zap_access_target(zap, target)
 
@@ -467,20 +479,22 @@ def main(argv):
         # Stop ZAP
         zap.core.shutdown()
 
-    except IOError as e:
-        if hasattr(e, 'args') and len(e.args) > 1:
-            errno, strerror = e
-            print("ERROR " + str(strerror))
-            logging.warning('I/O error(' + str(errno) + '): ' + str(strerror))
-        else:
-            print("ERROR %s" % e)
-            logging.warning('I/O error: ' + str(e))
-        dump_log_file(cid)
+    except UserInputException as e:
+        exception_raised = True
+        print("ERROR %s" % e)
 
     except ScanNotStartedException:
+        exception_raised = True
+        dump_log_file(cid)
+
+    except IOError as e:
+        exception_raised = True
+        print("ERROR %s" % e)
+        logging.warning('I/O error: ' + str(e))
         dump_log_file(cid)
 
     except:
+        exception_raised = True
         print("ERROR " + str(sys.exc_info()[0]))
         logging.warning('Unexpected error: ' + str(sys.exc_info()[0]))
         dump_log_file(cid)
@@ -490,7 +504,9 @@ def main(argv):
 
     trigger_hook('pre_exit', fail_count, warn_count, pass_count)
 
-    if fail_count > 0:
+    if exception_raised:
+        sys.exit(3)
+    elif fail_count > 0:
         sys.exit(1)
     elif (not ignore_warn) and warn_count > 0:
         sys.exit(2)

--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -47,6 +47,8 @@ except ImportError:
 class ScanNotStartedException(Exception):
     pass
 
+class UserInputException(Exception):
+    pass
 
 OLD_ZAP_CLIENT_WARNING = '''A newer version of python_owasp_zap_v2.4
  is available. Please run \'pip install -U python_owasp_zap_v2.4\' to update to
@@ -56,6 +58,8 @@ zap_conf_lvls = ["PASS", "IGNORE", "INFO", "WARN", "FAIL"]
 zap_hooks = None
 context_id = None
 context_name = None
+context_users = None
+scan_user = None
 
 def load_custom_hooks(hooks_file=None):
     """ Loads a custom python module which modifies zap scripts behaviour
@@ -66,7 +70,13 @@ def load_custom_hooks(hooks_file=None):
     hooks_file = os.path.expanduser(hooks_file)
 
     if not os.path.exists(hooks_file):
-        logging.debug('Could not find custom hooks file at %s ' % hooks_file)
+        # Check to see if its in the wrk directory
+        hooks_file2 = os.path.expanduser('wrk/' + hooks_file)
+        if os.path.exists(hooks_file2):
+            hooks_file = hooks_file2
+        
+    if not os.path.exists(hooks_file):
+        logging.warning('Could not find custom hooks file at %s ' % os.path.abspath(hooks_file))
         return
 
     loader = SourceFileLoader("zap_hooks", hooks_file)
@@ -391,8 +401,13 @@ def raise_scan_not_started():
 
 @hook(wrap=True)
 def zap_spider(zap, target):
-    logging.debug('Spider ' + target)
-    spider_scan_id = zap.spider.scan(target, contextname=context_name)
+    if scan_user:
+        logging.debug('Spider %s as user %s', target, scan_user['name'])
+        spider_scan_id = zap.spider.scan_as_user(context_id, scan_user['id'])
+    else:
+        logging.debug('Spider %s', target)
+        spider_scan_id = zap.spider.scan(target, contextname=context_name)
+
     if not str(spider_scan_id).isdigit():
         raise_scan_not_started()
     time.sleep(5)
@@ -405,10 +420,14 @@ def zap_spider(zap, target):
 
 @hook(wrap=True)
 def zap_ajax_spider(zap, target, max_time):
-    logging.debug('AjaxSpider ' + target)
     if max_time:
         zap.ajaxSpider.set_option_max_duration(str(max_time))
-    result = zap.ajaxSpider.scan(target, contextname=context_name)
+    if scan_user:
+        logging.debug('AjaxSpider %s as user %s', target, scan_user['name'])
+        result = zap.ajaxSpider.scan_as_user(context_name, scan_user['name'])
+    else:
+        logging.debug('AjaxSpider %s', target)
+        result = zap.ajaxSpider.scan(target, contextname=context_name)
     if result != "OK":
         raise_scan_not_started()
     time.sleep(5)
@@ -421,8 +440,12 @@ def zap_ajax_spider(zap, target, max_time):
 
 @hook(wrap=True)
 def zap_active_scan(zap, target, policy):
-    logging.debug('Active Scan ' + target + ' with policy ' + policy)
-    ascan_scan_id = zap.ascan.scan(target, recurse=True, scanpolicyname=policy, contextid=context_id)
+    if scan_user:
+        logging.debug('Active Scan %s with policy %s as user %s', target, policy, scan_user['name'])
+        ascan_scan_id = zap.ascan.scan_as_user(target, recurse=True, scanpolicyname=policy, contextid=context_id, userid=scan_user['id'])
+    else:
+        logging.debug('Active Scan %s with policy %s', target, policy)
+        ascan_scan_id = zap.ascan.scan(target, recurse=True, scanpolicyname=policy, contextid=context_id)
     if not str(ascan_scan_id).isdigit():
         raise_scan_not_started()
     time.sleep(5)
@@ -536,11 +559,24 @@ def write_report(file_path, report):
 def zap_import_context(zap, context_file):
     global context_id
     global context_name
+    global context_users
     res = context_id = zap.context.import_context(context_file)
     try:
         int(res)
         context_name = zap.context.context_list[-1]
+        context_users = zap.users.users_list(context_id)
+        
     except ValueError:
         context_id = None
         logging.error('Failed to load context file ' + context_file + ' : ' + res)
     return context_id
+
+@hook(wrap=True)
+def zap_set_scan_user(zap, username):
+    global scan_user
+    for usr in context_users:
+        if usr['name'] == username:
+            logging.debug('Found user ' + username)
+            scan_user = usr
+            return
+    raise UserInputException('ZAP failed to find user: {0}'.format(username))


### PR DESCRIPTION
Also tweaked the error handling - no popint in dumping the zap.log if its a user error and made sure the scripts return 3 on any exceptions.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>