### PR TITLE
Log params at Debug Level

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2020-11-27
+ - Move logging level of Params from `info` to `debug`, as it can contain sensitive data when authenticated scans are run.
+ 
 ### 2020-11-24
  - Add support for authenticated scans.
 

--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -284,7 +284,7 @@ def start_zap(port, extra_zap_params):
 
     params.extend(extra_zap_params)
 
-    logging.info('Params: ' + str(params))
+    logging.debug('Params: ' + str(params))
 
     with open('zap.out', "w") as outfile:
         subprocess.Popen(params, stdout=outfile)
@@ -340,7 +340,7 @@ def start_docker_zap(docker_image, port, extra_zap_params, mount_dir):
 
     params.extend(extra_zap_params)
 
-    logging.info('Params: ' + str(params))
+    logging.debug('Params: ' + str(params))
 
     cid = subprocess.check_output(params).rstrip().decode('utf-8')
     logging.debug('Docker CID: ' + cid)


### PR DESCRIPTION
Hello,

From my point of view, `Params` should be logged at debug level.
Especially because in params, you could have Bearer token (aka sensitive data), and these kind of data should not be logged at info level.

Thanks in advance for your feedback.
Regards