### PR TITLE
Tweak panel search and find dialog to be friendly w/ dark LaFs

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/view/FindDialog.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/FindDialog.java
@@ -51,6 +51,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractDialog;
+import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.ZapTextField;
 
 public class FindDialog extends AbstractDialog {
@@ -200,6 +201,7 @@ public class FindDialog extends AbstractDialog {
 
             int length = findText.length();
             if (startPos > -1) {
+                txtComp.setSelectionColor(DisplayUtils.getHighlightColor());
                 txtComp.select(startPos, startPos + length);
                 txtComp.requestFocusInWindow();
                 txtFind.requestFocusInWindow();

--- a/zap/src/main/java/org/zaproxy/zap/view/panelsearch/HighlighterUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/panelsearch/HighlighterUtils.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.view.panelsearch;
 import java.awt.Color;
 import javax.swing.BorderFactory;
 import javax.swing.JComponent;
+import org.zaproxy.zap.utils.DisplayUtils;
 
 public final class HighlighterUtils {
 
@@ -63,7 +64,9 @@ public final class HighlighterUtils {
             ComponentWithTitle componentWithTitle) {
         return highlightTitleWithHtml(
                 componentWithTitle,
-                "<html><div style=' border: 1px solid; border-color: #FFCC00;'>%s</div></html>");
+                "<html><div style=' border: 1px solid; border-color: "
+                        + getHighlightColorHexString()
+                        + ";'>%s</div></html>");
     }
 
     public static void undoHighlightTitleBorderWithHtml(
@@ -75,7 +78,9 @@ public final class HighlighterUtils {
             ComponentWithTitle componentWithTitle) {
         return highlightTitleWithHtml(
                 componentWithTitle,
-                "<html><span style='background-color:#FFCC00;'>%s</span></html>");
+                "<html><span style='background-color:"
+                        + getHighlightColorHexString()
+                        + ";'>%s</span></html>");
     }
 
     public static void undoHighlightTitleBackgroundWithHtml(
@@ -116,5 +121,21 @@ public final class HighlighterUtils {
         // ToDo: We should reset it back to the original border, but that currently does not work.
         // Sometimes the yellow highlight border stays there!
         // component.setBorder(highlightedComponent.get(BORDER));
+    }
+
+    private static String getHighlightColorHexString() {
+        Color hlColor = getHighlightColor();
+        String hex =
+                String.format(
+                        "#%02x%02x%02x", hlColor.getRed(), hlColor.getGreen(), hlColor.getBlue());
+        return hex;
+    }
+
+    public static Color getHighlightColor() {
+        Color hlColor = DEFAULT_HIGHLIGHT_COLOR;
+        if (DisplayUtils.isDarkLookAndFeel()) {
+            hlColor = DisplayUtils.getHighlightColor();
+        }
+        return hlColor;
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/ButtonSearch.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/ButtonSearch.java
@@ -40,7 +40,7 @@ public class ButtonSearch extends AbstractComponentSearch<AbstractButton> {
     @Override
     protected HighlightedComponent highlightInternal(AbstractButton component) {
         return HighlighterUtils.highlightBackground(
-                component, HighlighterUtils.DEFAULT_HIGHLIGHT_COLOR);
+                component, HighlighterUtils.getHighlightColor());
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/ComboBoxElementSearch.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/ComboBoxElementSearch.java
@@ -89,7 +89,7 @@ public class ComboBoxElementSearch extends AbstractComponentSearch<ComboBoxEleme
                             list, value, index, isSelected, cellHasFocus);
             if (highlightedIndexes.contains(index)) {
                 trySetOpaque(item, true);
-                item.setBackground(HighlighterUtils.DEFAULT_HIGHLIGHT_COLOR);
+                item.setBackground(HighlighterUtils.getHighlightColor());
             } else {
                 trySetOpaque(item, false);
                 item.setBackground(null);

--- a/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/ComboBoxSearch.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/ComboBoxSearch.java
@@ -39,7 +39,7 @@ public class ComboBoxSearch extends AbstractComponentSearch<JComboBox<Object>> {
     @Override
     protected HighlightedComponent highlightInternal(JComboBox<Object> component) {
         return HighlighterUtils.highlightBackground(
-                component, HighlighterUtils.DEFAULT_HIGHLIGHT_COLOR);
+                component, HighlighterUtils.getHighlightColor());
     }
 
     @Override
@@ -60,8 +60,7 @@ public class ComboBoxSearch extends AbstractComponentSearch<JComboBox<Object>> {
 
     @Override
     protected HighlightedComponent highlightAsParentInternal(JComboBox<Object> component) {
-        return HighlighterUtils.highlightBorder(
-                component, HighlighterUtils.DEFAULT_HIGHLIGHT_COLOR);
+        return HighlighterUtils.highlightBorder(component, HighlighterUtils.getHighlightColor());
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/JxLabelSearch.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/JxLabelSearch.java
@@ -45,8 +45,8 @@ public class JxLabelSearch extends AbstractComponentSearch<JXLabel> {
         highlightedComponent.put(BACKGROUND_PAINTER, component.getBackgroundPainter());
         component.setBackgroundPainter(
                 new RectanglePainter(
-                        HighlighterUtils.DEFAULT_HIGHLIGHT_COLOR,
-                        HighlighterUtils.DEFAULT_HIGHLIGHT_COLOR));
+                        HighlighterUtils.getHighlightColor(),
+                        HighlighterUtils.getHighlightColor()));
         return highlightedComponent;
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/LabelSearch.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/LabelSearch.java
@@ -39,7 +39,7 @@ public class LabelSearch extends AbstractComponentSearch<JLabel> {
     @Override
     protected HighlightedComponent highlightInternal(JLabel component) {
         return HighlighterUtils.highlightBackground(
-                component, HighlighterUtils.DEFAULT_HIGHLIGHT_COLOR);
+                component, HighlighterUtils.getHighlightColor());
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/SpinnerSearch.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/SpinnerSearch.java
@@ -42,11 +42,11 @@ public class SpinnerSearch extends AbstractComponentSearch<JSpinner> {
         HighlightedComponent highlightedUpAndDownComponent =
                 HighlighterUtils.highlightBackground(
                         new JComponentWithBackground(component),
-                        HighlighterUtils.DEFAULT_HIGHLIGHT_COLOR);
+                        HighlighterUtils.getHighlightColor());
         HighlightedComponent highlightedEditorComponent =
                 HighlighterUtils.highlightBackground(
                         new SpinnerSearchComponentWithBackground(component),
-                        HighlighterUtils.DEFAULT_HIGHLIGHT_COLOR);
+                        HighlighterUtils.getHighlightColor());
 
         highlightedUpAndDownComponent.put(HIGHLIGHTED_EDITOR, highlightedEditorComponent);
         return highlightedUpAndDownComponent;

--- a/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/TabbedPaneSearch.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/TabbedPaneSearch.java
@@ -30,7 +30,9 @@ public class TabbedPaneSearch extends AbstractComponentSearch<JTabbedPane> {
         ArrayList<TabbedPaneElement> elements = new ArrayList<>();
         for (Component childComponent : component.getComponents()) {
             int tabIndex = component.indexOfComponent(childComponent);
-            elements.add(new TabbedPaneElement(childComponent, component, tabIndex));
+            if (tabIndex != -1) {
+                elements.add(new TabbedPaneElement(childComponent, component, tabIndex));
+            }
         }
         return elements.toArray();
     }

--- a/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/TableCellElementSearch.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/TableCellElementSearch.java
@@ -131,7 +131,7 @@ public class TableCellElementSearch extends AbstractComponentSearch<TableCellEle
                                     e.getColumnIdentifier().equals(columnIdentifier)
                                             && e.getValue().equals(value))) {
                 trySetOpaque(item, true);
-                item.setBackground(HighlighterUtils.DEFAULT_HIGHLIGHT_COLOR);
+                item.setBackground(HighlighterUtils.getHighlightColor());
             } else {
                 if (isSelected) {
                     trySetOpaque(item, true);

--- a/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/TableSearch.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/TableSearch.java
@@ -45,8 +45,7 @@ public class TableSearch extends AbstractComponentSearch<JTable> {
 
     @Override
     protected HighlightedComponent highlightAsParentInternal(JTable component) {
-        return HighlighterUtils.highlightBorder(
-                component, HighlighterUtils.DEFAULT_HIGHLIGHT_COLOR);
+        return HighlighterUtils.highlightBorder(component, HighlighterUtils.getHighlightColor());
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/TextFieldSearch.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/TextFieldSearch.java
@@ -34,7 +34,7 @@ public class TextFieldSearch extends AbstractComponentSearch<JTextField> {
     @Override
     protected HighlightedComponent highlightInternal(JTextField component) {
         return HighlighterUtils.highlightBackground(
-                component, HighlighterUtils.DEFAULT_HIGHLIGHT_COLOR);
+                component, HighlighterUtils.getHighlightColor());
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/TreeNodeElementSearch.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/panelsearch/items/TreeNodeElementSearch.java
@@ -122,9 +122,9 @@ public class TreeNodeElementSearch extends AbstractComponentSearch<TreeNodeEleme
 
             if (highlightedNodes.contains(value)) {
                 trySetOpaque(cell, true);
-                cell.setBackground(HighlighterUtils.DEFAULT_HIGHLIGHT_COLOR);
+                cell.setBackground(HighlighterUtils.getHighlightColor());
             } else if (highlightedParentNodes.contains(value)) {
-                trySetBorder(cell, HighlighterUtils.DEFAULT_HIGHLIGHT_COLOR);
+                trySetBorder(cell, HighlighterUtils.getHighlightColor());
             }
 
             return cell;


### PR DESCRIPTION
- HighlighterUtils > Add public getHightlightColor() method which uses DisplayUtils.getHighLightColor() when a dark LaF is in use. (Currently this means a dark orange is used).
  - Have other usages of the public constant highlight color use this method.
- TabbedPaneSearch > Prevent IndexOutOfBoundsException by not adding tab's for which the index is -1 (hidden/disabled).
- FindDialog (CTRL + F) > Set the selection color based on DisplayUtils.getHighlightColor() before selecting the matched string.

Part of zaproxy/zaproxy#5542

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>