### PR TITLE
Correct anti-csrf form generation

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRF.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRF.java
@@ -35,6 +35,7 @@ import java.util.TreeSet;
 import net.htmlparser.jericho.Element;
 import net.htmlparser.jericho.HTMLElementName;
 import net.htmlparser.jericho.Source;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -496,17 +497,18 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
         sb.append("<html>\n");
         sb.append("<body>\n");
         sb.append("<h3>");
-        sb.append(requestUri);
+        String uriEscaped = StringEscapeUtils.escapeHtml(requestUri);
+        sb.append(uriEscaped);
         sb.append("</h3>");
-        sb.append("<form id=\"f1\" method=\"POST\" action=\"").append(requestUri).append("\">\n");
+        sb.append("<form id=\"f1\" method=\"POST\" action=\"").append(uriEscaped).append("\">\n");
         sb.append("<table>\n");
 
         TreeSet<HtmlParameter> params = msg.getFormParams();
         Iterator<HtmlParameter> iter = params.iterator();
         while (iter.hasNext()) {
             HtmlParameter htmlParam = iter.next();
-            String name = URLDecoder.decode(htmlParam.getName(), "UTF-8");
-            String value = URLDecoder.decode(htmlParam.getValue(), "UTF-8");
+            String name = StringEscapeUtils.escapeHtml(urlDecode(htmlParam.getName()));
+            String value = StringEscapeUtils.escapeHtml(urlDecode(htmlParam.getValue()));
             sb.append("<tr><td>\n");
             sb.append(name);
             sb.append("<td>");
@@ -525,6 +527,15 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
         sb.append("</html>\n");
 
         return sb.toString();
+    }
+
+    private static String urlDecode(String value) {
+        try {
+            return URLDecoder.decode(value, "UTF-8");
+        } catch (UnsupportedEncodingException ignore) {
+            // Shouldn't happen UTF-8 is a standard Charset (see java.nio.charset.StandardCharsets)
+        }
+        return value;
     }
 
     static interface HistoryReferenceFactory {


### PR DESCRIPTION
Escape URI and parameters' names/values when generating the HTML form.

Fix #6121.