### PR TITLE
fix/Dockerfile: Use ARG directive instead of ENV

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2020-12-02
+ - Use `ARG` command (for `DEBIAN_FRONTEND`) instead of `ENV` so that the parameter does not persist after the build process has been completed.
+
 ### 2020-11-27
  - Move logging level of Params from `info` to `debug`, as it can contain sensitive data when authenticated scans are run.
  

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -2,7 +2,7 @@
 FROM ubuntu:20.04
 LABEL maintainer="psiinon@gmail.com"
 
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
 	make \

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -2,7 +2,7 @@
 FROM ubuntu:20.04
 LABEL maintainer="psiinon@gmail.com"
 
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
 	make \
@@ -39,7 +39,7 @@ USER zap
 
 RUN mkdir /home/zap/.vnc
 
-# Download and expand the latest stable release 
+# Download and expand the latest stable release
 RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml | xmlstarlet sel -t -v //url |grep -i Linux | wget -nv --content-disposition -i - -O - | tar zxv && \
 	cp -R ZAP*/* . &&  \
 	rm -R ZAP* && \

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -2,7 +2,7 @@
 FROM ubuntu:20.04
 LABEL maintainer="psiinon@gmail.com"
 
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
 	make \


### PR DESCRIPTION
Since `DEBIAN_FRONTEND` is only used to do `apt-get` installations, use `ARG` command instead of `ENV` so that the parameter does not persist after the build process has been completed.

This could be helpful for those whos running the zap with `docker run -i` as it implies running container interactively.

Signed-off-by: natebwangsut <nate.bwangsut@gmail.com>