### PR TITLE
Do not update Content-Length in byte models

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/HttpPanelViewModelUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/HttpPanelViewModelUtils.java
@@ -50,6 +50,41 @@ public final class HttpPanelViewModelUtils {
         message.getResponseHeader().setContentLength(message.getResponseBody().length());
     }
 
+    /**
+     * Finds the HTTP header limit, that is the separator ({@code CRLFCRLF}) between the header and
+     * the body.
+     *
+     * @param data the data that contains the header and body.
+     * @return the position after the limit, or {@code -1} if not found.
+     * @since TODO add version
+     */
+    public static int findHeaderLimit(byte[] data) {
+        boolean lastIsCrLf = false;
+        boolean lastIsCr = false;
+        boolean lastIsLf = false;
+
+        for (int i = 0; i < data.length; ++i) {
+            if (!lastIsCr && data[i] == '\r') {
+                lastIsCr = true;
+                lastIsLf = false;
+            } else if (!lastIsLf && data[i] == '\n') {
+                if (lastIsCrLf) {
+                    return i + 1;
+                }
+
+                lastIsCrLf = true;
+                lastIsCr = false;
+                lastIsLf = true;
+            } else {
+                lastIsCr = false;
+                lastIsLf = false;
+                lastIsCrLf = false;
+            }
+        }
+
+        return -1;
+    }
+
     public static byte[] getBodyBytes(HttpHeader header, HttpBody body) {
         if (!isEncoded(header)) {
             return body.getBytes();

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestByteHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestByteHttpPanelViewModel.java
@@ -55,7 +55,7 @@ public class RequestByteHttpPanelViewModel extends AbstractHttpByteHttpPanelView
             return;
         }
 
-        int pos = findHeaderLimit(data);
+        int pos = HttpPanelViewModelUtils.findHeaderLimit(data);
 
         if (pos == -1) {
             logger.warn("Could not Save Header, limit not found. Header: " + new String(data));
@@ -72,34 +72,5 @@ public class RequestByteHttpPanelViewModel extends AbstractHttpByteHttpPanelView
         }
 
         httpMessage.getRequestBody().setBody(ArrayUtils.subarray(data, pos, data.length));
-        HttpPanelViewModelUtils.updateRequestContentLength(httpMessage);
-    }
-
-    private int findHeaderLimit(byte[] data) {
-        boolean lastIsCRLF = false;
-        boolean lastIsCR = false;
-        boolean lastIsLF = false;
-        int pos = -1;
-
-        for (int i = 0; i < data.length; ++i) {
-            if (!lastIsCR && data[i] == '\r') {
-                lastIsCR = true;
-            } else if (!lastIsLF && data[i] == '\n') {
-                if (lastIsCRLF) {
-                    pos = i;
-                    break;
-                }
-
-                lastIsCRLF = true;
-                lastIsCR = false;
-                lastIsLF = false;
-            } else {
-                lastIsCR = false;
-                lastIsLF = false;
-                lastIsCRLF = false;
-            }
-        }
-
-        return pos;
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseByteHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseByteHttpPanelViewModel.java
@@ -56,7 +56,7 @@ public class ResponseByteHttpPanelViewModel extends AbstractHttpByteHttpPanelVie
             return;
         }
 
-        int pos = findHeaderLimit(data);
+        int pos = HttpPanelViewModelUtils.findHeaderLimit(data);
 
         if (pos == -1) {
             logger.warn("Could not Save Header, limit not found. Header: " + new String(data));
@@ -73,34 +73,5 @@ public class ResponseByteHttpPanelViewModel extends AbstractHttpByteHttpPanelVie
         }
 
         httpMessage.getResponseBody().setBody(ArrayUtils.subarray(data, pos, data.length));
-        HttpPanelViewModelUtils.updateResponseContentLength(httpMessage);
-    }
-
-    private int findHeaderLimit(byte[] data) {
-        boolean lastIsCRLF = false;
-        boolean lastIsCR = false;
-        boolean lastIsLF = false;
-        int pos = -1;
-
-        for (int i = 0; i < data.length; ++i) {
-            if (!lastIsCR && data[i] == '\r') {
-                lastIsCR = true;
-            } else if (!lastIsLF && data[i] == '\n') {
-                if (lastIsCRLF) {
-                    pos = i;
-                    break;
-                }
-
-                lastIsCRLF = true;
-                lastIsCR = false;
-                lastIsLF = false;
-            } else {
-                lastIsCR = false;
-                lastIsLF = false;
-                lastIsCRLF = false;
-            }
-        }
-
-        return pos;
     }
 }

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/ByteHttpPanelViewModelTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/ByteHttpPanelViewModelTest.java
@@ -1,0 +1,181 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.httppanel.view.impl.models.http;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.network.HttpBody;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.httppanel.InvalidMessageDataException;
+import org.zaproxy.zap.utils.I18N;
+
+public abstract class ByteHttpPanelViewModelTest<T1 extends HttpHeader, T2 extends HttpBody> {
+
+    private static final Charset DEFAULT_CHARSET = StandardCharsets.ISO_8859_1;
+
+    private static final String HEADER = "Start Line\r\nHeader1: A\r\nHeader2: B\r\n\r\n";
+    private static final byte[] HEADER_BYTES = HEADER.getBytes(DEFAULT_CHARSET);
+
+    private static final String BODY = "Body\r\n 123\n ABC";
+    private static final byte[] BODY_BYTES = "Body\r\n 123\n ABC".getBytes(DEFAULT_CHARSET);
+    private static final byte[] MESSAGE = (HEADER + BODY).getBytes(DEFAULT_CHARSET);
+    private static final byte[] EMPTY_BODY = new byte[0];
+
+    protected AbstractHttpByteHttpPanelViewModel model;
+
+    protected HttpMessage message;
+    protected T1 header;
+    protected T2 body;
+
+    @BeforeEach
+    void setup() {
+        Constant.messages = mock(I18N.class);
+        model = createModel();
+
+        message = mock(HttpMessage.class);
+        header = mock(getHeaderClass());
+        body = mock(getBodyClass());
+
+        prepareHeader();
+        given(body.getBytes()).willReturn(BODY_BYTES);
+
+        prepareMessage();
+    }
+
+    protected abstract AbstractHttpByteHttpPanelViewModel createModel();
+
+    protected abstract Class<T1> getHeaderClass();
+
+    protected void prepareHeader() {
+        given(header.toString()).willReturn(HEADER);
+    }
+
+    protected abstract void verifyHeader(String header) throws HttpMalformedHeaderException;
+
+    protected abstract void headerThrowsHttpMalformedHeaderException()
+            throws HttpMalformedHeaderException;
+
+    protected abstract Class<T2> getBodyClass();
+
+    protected abstract void prepareMessage();
+
+    @Test
+    void shouldGetEmptyDataFromNullMessage() {
+        // Given
+        model.setMessage(null);
+        // When
+        byte[] data = model.getData();
+        // Then
+        assertThat(data.length, is(equalTo(0)));
+    }
+
+    @Test
+    void shouldGetDataFromHeaderAndBody() {
+        // Given
+        model.setMessage(message);
+        // When
+        byte[] data = model.getData();
+        // Then
+        assertThat(data, is(equalTo(MESSAGE)));
+    }
+
+    @Test
+    void shouldNotSetDataWithNullMessage() {
+        // Given
+        model.setMessage(null);
+        // When / Then
+        assertDoesNotThrow(() -> model.setData(BODY_BYTES));
+    }
+
+    @Test
+    void shouldSetDataIntoHeaderAndBody() throws HttpMalformedHeaderException {
+        // Given
+        model.setMessage(message);
+        String otherHeaderContent = "Other Start Line\r\nHeader1: A\r\nHeader2: B\r\n\r\n";
+        String otherBodyContent = "Other Body\r\n 123\n ABC";
+        byte[] data = (otherHeaderContent + otherBodyContent).getBytes(DEFAULT_CHARSET);
+        // When
+        model.setData(data);
+        // Then
+        verifyHeader(otherHeaderContent);
+        verify(header, times(0)).setContentLength(anyInt());
+        verify(body).setBody(otherBodyContent.getBytes(DEFAULT_CHARSET));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"\r\n", "\r\r", "\n\n"})
+    void shouldThrowExceptionIfHeaderLimitNotFound(String notHeaderLimit)
+            throws HttpMalformedHeaderException {
+        // Given
+        model.setMessage(message);
+        String otherHeaderContent = "Other Start Line\r\nHeader1: A\r\nHeader2: B" + notHeaderLimit;
+        String otherBodyContent = "Other Body\r\n 123\n ABC";
+        byte[] data = (otherHeaderContent + otherBodyContent).getBytes(DEFAULT_CHARSET);
+        // When / Then
+        assertThrows(InvalidMessageDataException.class, () -> model.setData(data));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenSettingMalformedHeader() throws HttpMalformedHeaderException {
+        // Given
+        model.setMessage(message);
+        String otherHeaderContent = "Malformed Header";
+        headerThrowsHttpMalformedHeaderException();
+        String otherBodyContent = "Other Body\r\n 123\n ABC";
+        byte[] data =
+                (otherHeaderContent + "\r\n\r\n" + otherBodyContent).getBytes(DEFAULT_CHARSET);
+        // When / Then
+        assertThrows(InvalidMessageDataException.class, () -> model.setData(data));
+        verify(header, times(0)).setContentLength(anyInt());
+        verify(body, times(0)).setBody(any(byte[].class));
+    }
+
+    @Test
+    void shouldSetDataOnlyIntoHeaderIfBodyEmpty() throws HttpMalformedHeaderException {
+        // Given
+        model.setMessage(message);
+        byte[] data = HEADER_BYTES;
+        // When
+        model.setData(data);
+        // Then
+        verifyHeader(HEADER);
+        verify(header, times(0)).setContentLength(anyInt());
+        verify(body).setBody(EMPTY_BODY);
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/HttpPanelViewModelUtilsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/HttpPanelViewModelUtilsUnitTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.network.HttpBody;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
@@ -96,6 +97,28 @@ class HttpPanelViewModelUtilsUnitTest {
         HttpPanelViewModelUtils.updateResponseContentLength(message);
         // Then
         verify(responseHeader).setContentLength(length);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Header\r\n\r\nBody", "Header\r\n\r\n\r\nBody"})
+    void shouldFindHeaderLimitIfPresent(String value) {
+        // Given
+        byte[] content = value.getBytes(StandardCharsets.US_ASCII);
+        // When
+        int pos = HttpPanelViewModelUtils.findHeaderLimit(content);
+        // Then
+        assertThat(pos, is(equalTo(10)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "Header\r\nBody", "Header\r\rBody", "Header\n\nBody"})
+    void shouldNotFindHeaderLimitIfNotPresent(String value) {
+        // Given
+        byte[] content = value.getBytes(StandardCharsets.US_ASCII);
+        // When
+        int pos = HttpPanelViewModelUtils.findHeaderLimit(content);
+        // Then
+        assertThat(pos, is(equalTo(-1)));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestByteHttpPanelViewModelUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestByteHttpPanelViewModelUnitTest.java
@@ -1,0 +1,74 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.httppanel.view.impl.models.http.request;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.apache.commons.httpclient.URI;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.extension.httppanel.view.impl.models.http.ByteHttpPanelViewModelTest;
+import org.zaproxy.zap.network.HttpRequestBody;
+
+/** Unit test for {@link RequestByteHttpPanelViewModel}. */
+class RequestByteHttpPanelViewModelUnitTest
+        extends ByteHttpPanelViewModelTest<HttpRequestHeader, HttpRequestBody> {
+
+    @Override
+    protected RequestByteHttpPanelViewModel createModel() {
+        return new RequestByteHttpPanelViewModel();
+    }
+
+    @Override
+    protected Class<HttpRequestHeader> getHeaderClass() {
+        return HttpRequestHeader.class;
+    }
+
+    @Override
+    protected void prepareHeader() {
+        given(header.getURI()).willReturn(mock(URI.class));
+        super.prepareHeader();
+    }
+
+    @Override
+    protected void verifyHeader(String header) throws HttpMalformedHeaderException {
+        verify(message).setRequestHeader(header);
+    }
+
+    @Override
+    protected void headerThrowsHttpMalformedHeaderException() throws HttpMalformedHeaderException {
+        willThrow(HttpMalformedHeaderException.class).given(message).setRequestHeader(anyString());
+    }
+
+    @Override
+    protected Class<HttpRequestBody> getBodyClass() {
+        return HttpRequestBody.class;
+    }
+
+    @Override
+    protected void prepareMessage() {
+        given(message.getRequestHeader()).willReturn(header);
+        given(message.getRequestBody()).willReturn(body);
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseByteHttpPanelViewModelUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseByteHttpPanelViewModelUnitTest.java
@@ -1,0 +1,87 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.httppanel.view.impl.models.http.response;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.zaproxy.zap.extension.httppanel.view.impl.models.http.ByteHttpPanelViewModelTest;
+import org.zaproxy.zap.network.HttpResponseBody;
+
+/** Unit test for {@link ResponseByteHttpPanelViewModel}. */
+class ResponseByteHttpPanelViewModelUnitTest
+        extends ByteHttpPanelViewModelTest<HttpResponseHeader, HttpResponseBody> {
+
+    @Override
+    protected ResponseByteHttpPanelViewModel createModel() {
+        return new ResponseByteHttpPanelViewModel();
+    }
+
+    @Override
+    protected Class<HttpResponseHeader> getHeaderClass() {
+        return HttpResponseHeader.class;
+    }
+
+    @Override
+    protected void prepareHeader() {
+        super.prepareHeader();
+        given(header.isEmpty()).willReturn(false);
+    }
+
+    @Override
+    protected void verifyHeader(String header) throws HttpMalformedHeaderException {
+        verify(message).setResponseHeader(header);
+    }
+
+    @Override
+    protected void headerThrowsHttpMalformedHeaderException() throws HttpMalformedHeaderException {
+        willThrow(HttpMalformedHeaderException.class).given(message).setResponseHeader(anyString());
+    }
+
+    @Override
+    protected Class<HttpResponseBody> getBodyClass() {
+        return HttpResponseBody.class;
+    }
+
+    @Override
+    protected void prepareMessage() {
+        given(message.getResponseHeader()).willReturn(header);
+        given(message.getResponseBody()).willReturn(body);
+    }
+
+    @Test
+    void shouldGetEmptyDataWithEmptyHeader() {
+        // Given
+        given(header.isEmpty()).willReturn(true);
+        model.setMessage(message);
+        // When
+        byte[] data = model.getData();
+        // Then
+        assertThat(data.length, is(equalTo(0)));
+    }
+}


### PR DESCRIPTION
The Content-Length is now updated optionally based on the UI option.
Extract method that finds the header limit and correct line feed case.