### PR TITLE
Add node for URLs ending with a slash

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/model/SiteNode.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/SiteNode.java
@@ -319,10 +319,14 @@ public class SiteNode extends DefaultMutableTreeNode {
         } else if (this.getParent().isRoot()) {
             hierarchicNodeName = this.getNodeName();
         } else {
-            String name =
-                    this.getParent().getHierarchicNodeName(specialNodesAsRegex)
-                            + "/"
-                            + this.getCleanNodeName(specialNodesAsRegex);
+            String nodeName = this.getCleanNodeName(specialNodesAsRegex);
+            String name;
+            if (nodeName.startsWith("/")) {
+                // Leaf nodes ending with a slash have a name of "/"
+                name = this.getParent().getHierarchicNodeName(specialNodesAsRegex) + nodeName;
+            } else {
+                name = this.getParent().getHierarchicNodeName(specialNodesAsRegex) + "/" + nodeName;
+            }
             if (!specialNodesAsRegex) {
                 // Dont cache the non regex version
                 return name;

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
@@ -883,6 +883,10 @@ public class ActiveScanAPI extends ApiImplementor {
         if (useUrl) {
             URI startURI;
             try {
+                if (scanChildren && url.endsWith("/")) {
+                    // Always choose the non leaf node if scanChildren option selected
+                    url = url.substring(0, url.length() - 1);
+                }
                 startURI = new URI(url, true);
             } catch (URIException e) {
                 throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_URL, e);

--- a/zap/src/main/java/org/zaproxy/zap/model/StandardParameterParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/StandardParameterParser.java
@@ -370,6 +370,9 @@ public class StandardParameterParser implements ParameterParser {
             for (int i = 1; i < pathList.length; i++) {
                 list.add(pathList[i]);
             }
+            if (path.endsWith("/")) {
+                list.add("/");
+            }
         }
         if (incStructParams) {
             // Add any structural params (url param) in key order

--- a/zap/src/main/java/org/zaproxy/zap/view/StandardFieldsDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/StandardFieldsDialog.java
@@ -1536,13 +1536,10 @@ public abstract class StandardFieldsDialog extends AbstractDialog {
     private static String getNodeText(SiteNode node) {
         if (node != null && node.getHistoryReference() != null) {
             String url = node.getHistoryReference().getURI().toString();
-            if (node.isLeaf() && url.endsWith("/")) {
-                // String off the slash so we don't match a non leaf
+            if (!node.isLeaf() && url.endsWith("/")) {
+                // Strip off the slash so we don't match a leaf
                 // node with the same name
                 url = url.substring(0, url.length() - 1);
-            } else if (!node.isLeaf() && !url.endsWith("/")) {
-                // Add the slash to show its a non leaf node
-                url = url + "/";
             }
             return url;
         }

--- a/zap/src/test/java/org/parosproxy/paros/model/SiteMapUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/model/SiteMapUnitTest.java
@@ -168,11 +168,11 @@ class SiteMapUnitTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"/", "//", "/a/", "/a/b/"})
+    @ValueSource(strings = {"/a", "//b", "/a/b", "/a/b/c"})
     void shouldFindSiteLeafNodeWithUriIfPresent(String path) {
         // Given
-        String uri = "http://example.com" + path + "file.ext";
-        siteMapWithNodes(uri, "http://example.org" + path + "file.ext");
+        String uri = "http://example.com" + path + "/file.ext";
+        siteMapWithNodes(uri, "http://example.org" + path + "/file.ext");
         // When
         SiteNode node = siteMap.findNode(createUri(uri));
         // Then
@@ -206,15 +206,32 @@ class SiteMapUnitTest {
     @Test
     void shouldFindSiteBranchNodeWithUriIfPresent() {
         // Given
-        String uri = "http://example.com/a/";
+        String uri = "http://example.com/a";
         siteMapWithNodes("http://example.com/a/file.ext", "http://example.org/a/");
         // When
         SiteNode node = siteMap.findNode(createUri(uri));
         // Then
         assertThat(node, is(notNullValue()));
         assertThat(node.getNodeName(), is(equalTo("a")));
-        SiteNode parent = siteMap.findNode(createUri("http://example.com/"));
+        SiteNode parent = siteMap.findNode(createUri("http://example.com"));
         assertThat(node.getParent(), is(equalTo(parent)));
+    }
+
+    @Test
+    void shouldCreateSlashNodeIfUriEndsWithASlash() {
+        // Given
+        String branchUri = "http://example.com/a";
+        String leafUri = "http://example.com/a/";
+        siteMapWithNodes(branchUri, leafUri);
+        // When
+        SiteNode branchNode = siteMap.findNode(createUri(branchUri));
+        SiteNode leafNode = siteMap.findNode(createUri(leafUri));
+        // Then
+        assertThat(branchNode, is(notNullValue()));
+        assertThat(leafNode, is(notNullValue()));
+        assertThat(branchNode.getHierarchicNodeName(), is(equalTo(branchUri)));
+        assertThat(leafNode.getHierarchicNodeName(), is(equalTo(leafUri)));
+        assertThat(leafNode.getParent(), is(equalTo(branchNode)));
     }
 
     private void siteMapWithNodes(String... uris) {

--- a/zap/src/test/java/org/zaproxy/zap/model/SessionStructureUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/model/SessionStructureUnitTest.java
@@ -83,8 +83,8 @@ public class SessionStructureUnitTest {
     public void shouldReturnCorrectNameForNoPathWithSlashNoParams(String method) throws Exception {
         // Given
         msg.getRequestHeader().setMethod(method);
-        String uri = "https://www.example.com";
-        msg.getRequestHeader().setURI(new URI(uri + "/", true));
+        String uri = "https://www.example.com/";
+        msg.getRequestHeader().setURI(new URI(uri, true));
         // When
         String nodeName = SessionStructure.getNodeName(model, msg);
         // Then
@@ -110,8 +110,8 @@ public class SessionStructureUnitTest {
             throws Exception {
         // Given
         msg.getRequestHeader().setMethod(method);
-        String uri = "https://www.example.com";
-        msg.getRequestHeader().setURI(new URI(uri + "/?a=b&c=d", true));
+        String uri = "https://www.example.com/";
+        msg.getRequestHeader().setURI(new URI(uri + "?a=b&c=d", true));
         // When
         String nodeName = SessionStructure.getNodeName(model, msg);
         // Then
@@ -137,8 +137,8 @@ public class SessionStructureUnitTest {
             throws Exception {
         // Given
         msg.getRequestHeader().setMethod(method);
-        String uri = "https://www.example.com/path";
-        msg.getRequestHeader().setURI(new URI(uri + "/", true));
+        String uri = "https://www.example.com/path/";
+        msg.getRequestHeader().setURI(new URI(uri, true));
         // When
         String nodeName = SessionStructure.getNodeName(model, msg);
         // Then
@@ -165,8 +165,8 @@ public class SessionStructureUnitTest {
             throws Exception {
         // Given
         msg.getRequestHeader().setMethod(method);
-        String uri = "https://www.example.com/path";
-        msg.getRequestHeader().setURI(new URI(uri + "/?a=b&c=d", true));
+        String uri = "https://www.example.com/path/";
+        msg.getRequestHeader().setURI(new URI(uri + "?a=b&c=d", true));
         // When
         String nodeName = SessionStructure.getNodeName(model, msg);
         // Then
@@ -202,8 +202,8 @@ public class SessionStructureUnitTest {
     public void shouldReturnCorrectNameForPostNoPathWithSlashNoUrlParams() throws Exception {
         // Given
         msg.getRequestHeader().setMethod(HttpRequestHeader.POST);
-        String uri = "https://www.example.com";
-        msg.getRequestHeader().setURI(new URI(uri + "/", true));
+        String uri = "https://www.example.com/";
+        msg.getRequestHeader().setURI(new URI(uri, true));
         msg.setRequestBody("e=f&g=h");
         // When
         String nodeName = SessionStructure.getNodeName(model, msg);
@@ -228,8 +228,8 @@ public class SessionStructureUnitTest {
     public void shouldReturnCorrectNameForPostNoPathWithSlashWithParams() throws Exception {
         // Given
         msg.getRequestHeader().setMethod(HttpRequestHeader.POST);
-        String uri = "https://www.example.com";
-        msg.getRequestHeader().setURI(new URI(uri + "/?a=b&c=d", true));
+        String uri = "https://www.example.com/";
+        msg.getRequestHeader().setURI(new URI(uri + "?a=b&c=d", true));
         msg.setRequestBody("e=f&g=h");
         // When
         String nodeName = SessionStructure.getNodeName(model, msg);
@@ -254,8 +254,8 @@ public class SessionStructureUnitTest {
     public void shouldReturnCorrectNameForPostWithPathWithSlashNoUrlParams() throws Exception {
         // Given
         msg.getRequestHeader().setMethod(HttpRequestHeader.POST);
-        String uri = "https://www.example.com/path";
-        msg.getRequestHeader().setURI(new URI(uri + "/", true));
+        String uri = "https://www.example.com/path/";
+        msg.getRequestHeader().setURI(new URI(uri, true));
         msg.setRequestBody("e=f&g=h");
         // When
         String nodeName = SessionStructure.getNodeName(model, msg);
@@ -280,8 +280,8 @@ public class SessionStructureUnitTest {
     public void shouldReturnCorrectNameForPostWithPathWithSlashWithParams() throws Exception {
         // Given
         msg.getRequestHeader().setMethod(HttpRequestHeader.POST);
-        String uri = "https://www.example.com/path";
-        msg.getRequestHeader().setURI(new URI(uri + "/?a=b&c=d", true));
+        String uri = "https://www.example.com/path/";
+        msg.getRequestHeader().setURI(new URI(uri + "?a=b&c=d", true));
         msg.setRequestBody("e=f&g=h");
         // When
         String nodeName = SessionStructure.getNodeName(model, msg);
@@ -294,8 +294,8 @@ public class SessionStructureUnitTest {
             throws Exception {
         // Given
         msg.getRequestHeader().setMethod(HttpRequestHeader.POST);
-        String uri = "https://www.example.com/path";
-        msg.getRequestHeader().setURI(new URI(uri + "/?a=b&c=d", true));
+        String uri = "https://www.example.com/path/";
+        msg.getRequestHeader().setURI(new URI(uri + "?a=b&c=d", true));
         msg.setRequestBody("a=b&c=d");
         // When
         String nodeName = SessionStructure.getNodeName(model, msg);


### PR DESCRIPTION
Fix #6297

This allows us to differentiate between https://www.example.com/a and https://www.example.com/a/

The main impact is to the active scanner as this works off the sites tree - if you select the new "/" node then it will have no children and therefore not recurse as most people will want.
So now if you specify a URL with a trailing slash then the slash will be ignored if you specify 'recurse'.

Will require a corresponding change to the Quick Start add-on.

Initially WIP as I need to add some specific tests to make sure we treat nodes with and without a slash differently.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>