### PR TITLE
Add target to ajaxSpider.scan_as_user call

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2020-12-11
+ - Add `target` parameter to `ajaxSpider.scan_as_user` call. Without it ajaxSpider crawls first included in a context URL and not a target which is set.
+
 ### 2020-12-02
  - Use `ARG` command (for `DEBIAN_FRONTEND`) instead of `ENV` so that the parameter does not persist after the build process has been completed.
 

--- a/docker/tests/test_zap_common.py
+++ b/docker/tests/test_zap_common.py
@@ -281,7 +281,7 @@ class TestZapCommon(unittest.TestCase):
         with patch("time.sleep"):
             zap_common.zap_ajax_spider(zap, target, max_time)
 
-        zap.ajaxSpider.scan_as_user.assert_called_once_with(context_name, user_name)
+        zap.ajaxSpider.scan_as_user.assert_called_once_with(context_name, user_name, target)
 
     def test_zap_active_scan_uses_imported_context(self):
         """Active Scan uses imported context."""

--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -424,7 +424,7 @@ def zap_ajax_spider(zap, target, max_time):
         zap.ajaxSpider.set_option_max_duration(str(max_time))
     if scan_user:
         logging.debug('AjaxSpider %s as user %s', target, scan_user['name'])
-        result = zap.ajaxSpider.scan_as_user(context_name, scan_user['name'])
+        result = zap.ajaxSpider.scan_as_user(context_name, scan_user['name'], target)
     else:
         logging.debug('AjaxSpider %s', target)
         result = zap.ajaxSpider.scan(target, contextname=context_name)


### PR DESCRIPTION
Without this parameter ajaxSpider starts to crawl first included in a context URL and not a target which was set. It isn't an expected behavior. I had API URL configured in the context additionally to an app URL and ajaxSpider crawled only API URL.