### PR TITLE
Avoid NPE when checking for AuthenticationScriptV2

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
@@ -795,6 +795,11 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
         try {
             AuthenticationScriptV2 authScript =
                     getScriptsExtension().getInterface(script, AuthenticationScriptV2.class);
+            if (authScript == null) {
+                log.debug(
+                        "Script '{}' is not a AuthenticationScriptV2 interface.", script::getName);
+                return null;
+            }
 
             // Some ScriptEngines do not verify if all Interface Methods are contained in the
             // script.


### PR DESCRIPTION
Check if the script is null (i.e. does not implement the interface)
before trying to call its methods.

---
From OWASP ZAP User Group: https://groups.google.com/g/zaproxy-users/c/AIscC48Iu4c