### PR TITLE
Fix exception when checking for breakpoints

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakpointMessageHandler2.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakpointMessageHandler2.java
@@ -212,7 +212,7 @@ public class BreakpointMessageHandler2 {
 
     protected boolean isSkipOnIgnoreRules(
             Message aMessage, boolean isRequest, boolean onlyIfInScope) {
-        if (enabledIgnoreRules.isEmpty()) {
+        if (enabledIgnoreRules == null || enabledIgnoreRules.isEmpty()) {
             // No Ignoring rules
             return false;
         }

--- a/zap/src/test/java/org/zaproxy/zap/extension/brk/BreakpointMessageHandler2UnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/brk/BreakpointMessageHandler2UnitTest.java
@@ -23,6 +23,7 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -124,6 +125,24 @@ public class BreakpointMessageHandler2UnitTest {
         boolean breakpoint = breakpointMessageHandler.isBreakpoint(message, request, false);
         // Then
         assertThat(breakpoint, is(equalTo(true)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"true", "false"})
+    void shouldNotFailWithoutIgnoreRules(boolean request) {
+        // Given
+        Message message = mock(Message.class);
+        given(message.isInScope()).willReturn(false);
+        boolean onlyIfInScope = true;
+        breakpointMessageHandler.setEnabledIgnoreRules(null);
+        // When
+        boolean breakpoint =
+                assertDoesNotThrow(
+                        () ->
+                                breakpointMessageHandler.isBreakpoint(
+                                        message, request, onlyIfInScope));
+        // Then
+        assertThat(breakpoint, is(equalTo(false)));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Check if the ignore rules are defined before using them.

Related to zaproxy/zap-extensions#2659.