### PR TITLE
Remove unnecessary null checks and casts

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
@@ -63,7 +63,6 @@ import org.zaproxy.zap.extension.api.ApiResponseSet;
 import org.zaproxy.zap.extension.api.ApiView;
 import org.zaproxy.zap.extension.users.ExtensionUserManagement;
 import org.zaproxy.zap.model.Context;
-import org.zaproxy.zap.model.GenericScanner2;
 import org.zaproxy.zap.model.SessionStructure;
 import org.zaproxy.zap.model.StructuralNode;
 import org.zaproxy.zap.model.Target;
@@ -389,8 +388,7 @@ public class ActiveScanAPI extends ApiImplementor {
                     getActiveScan(params).stopScan();
                     break;
                 case ACTION_REMOVE_SCAN:
-                    GenericScanner2 activeScan =
-                            controller.removeScan(params.getInt(PARAM_SCAN_ID));
+                    ActiveScan activeScan = controller.removeScan(params.getInt(PARAM_SCAN_ID));
                     if (activeScan == null) {
                         throw new ApiException(ApiException.Type.DOES_NOT_EXIST, PARAM_SCAN_ID);
                     }
@@ -757,7 +755,7 @@ public class ActiveScanAPI extends ApiImplementor {
     private ActiveScan getActiveScan(JSONObject params) throws ApiException {
         int id = getParam(params, PARAM_SCAN_ID, -1);
 
-        GenericScanner2 activeScan = null;
+        ActiveScan activeScan = null;
 
         if (id == -1) {
             activeScan = controller.getLastScan();
@@ -769,7 +767,7 @@ public class ActiveScanAPI extends ApiImplementor {
             throw new ApiException(ApiException.Type.DOES_NOT_EXIST, PARAM_SCAN_ID);
         }
 
-        return (ActiveScan) activeScan;
+        return activeScan;
     }
 
     private void setScannersEnabled(ScanPolicy policy, String[] ids, boolean enabled)
@@ -962,12 +960,10 @@ public class ActiveScanAPI extends ApiImplementor {
             case VIEW_STATUS:
                 activeScan = getActiveScan(params);
                 int progress = 0;
-                if (activeScan != null) {
-                    if (activeScan.isStopped()) {
-                        progress = 100;
-                    } else {
-                        progress = activeScan.getProgress();
-                    }
+                if (activeScan.isStopped()) {
+                    progress = 100;
+                } else {
+                    progress = activeScan.getProgress();
                 }
                 result = new ApiResponseElement(name, String.valueOf(progress));
                 break;
@@ -988,61 +984,56 @@ public class ActiveScanAPI extends ApiImplementor {
             case VIEW_SCAN_PROGRESS:
                 resultList = new ApiResponseList(name);
                 activeScan = getActiveScan(params);
-                if (activeScan != null) {
-                    for (HostProcess hp : activeScan.getHostProcesses()) {
-                        ApiResponseList hpList = new ApiResponseList("HostProcess");
-                        resultList.addItem(new ApiResponseElement("id", hp.getHostAndPort()));
+                for (HostProcess hp : activeScan.getHostProcesses()) {
+                    ApiResponseList hpList = new ApiResponseList("HostProcess");
+                    resultList.addItem(new ApiResponseElement("id", hp.getHostAndPort()));
 
-                        for (Plugin plugin : hp.getCompleted()) {
-                            long timeTaken =
-                                    plugin.getTimeFinished().getTime()
-                                            - plugin.getTimeStarted().getTime();
-                            int reqs = hp.getPluginRequestCount(plugin.getId());
-                            int alertCount = hp.getPluginStats(plugin.getId()).getAlertCount();
-                            hpList.addItem(
-                                    createPluginProgressEntry(
-                                            plugin,
-                                            getStatus(hp, plugin, "Complete"),
-                                            timeTaken,
-                                            reqs,
-                                            alertCount));
-                        }
-
-                        for (Plugin plugin : hp.getRunning()) {
-                            int pc = hp.getTestCurrentCount(plugin) * 100 / hp.getTestTotalCount();
-                            // Make sure not return 100 (or more) if still running...
-                            // That might happen if more nodes are being scanned that the ones
-                            // enumerated at the beginning.
-                            if (pc >= 100) {
-                                pc = 99;
-                            }
-                            long timeTaken =
-                                    new Date().getTime() - plugin.getTimeStarted().getTime();
-                            int reqs = hp.getPluginRequestCount(plugin.getId());
-                            int alertCount = hp.getPluginStats(plugin.getId()).getAlertCount();
-                            hpList.addItem(
-                                    createPluginProgressEntry(
-                                            plugin, pc + "%", timeTaken, reqs, alertCount));
-                        }
-
-                        for (Plugin plugin : hp.getPending()) {
-                            hpList.addItem(
-                                    createPluginProgressEntry(
-                                            plugin, getStatus(hp, plugin, "Pending"), 0, 0, 0));
-                        }
-                        resultList.addItem(hpList);
+                    for (Plugin plugin : hp.getCompleted()) {
+                        long timeTaken =
+                                plugin.getTimeFinished().getTime()
+                                        - plugin.getTimeStarted().getTime();
+                        int reqs = hp.getPluginRequestCount(plugin.getId());
+                        int alertCount = hp.getPluginStats(plugin.getId()).getAlertCount();
+                        hpList.addItem(
+                                createPluginProgressEntry(
+                                        plugin,
+                                        getStatus(hp, plugin, "Complete"),
+                                        timeTaken,
+                                        reqs,
+                                        alertCount));
                     }
+
+                    for (Plugin plugin : hp.getRunning()) {
+                        int pc = hp.getTestCurrentCount(plugin) * 100 / hp.getTestTotalCount();
+                        // Make sure not return 100 (or more) if still running...
+                        // That might happen if more nodes are being scanned that the ones
+                        // enumerated at the beginning.
+                        if (pc >= 100) {
+                            pc = 99;
+                        }
+                        long timeTaken = new Date().getTime() - plugin.getTimeStarted().getTime();
+                        int reqs = hp.getPluginRequestCount(plugin.getId());
+                        int alertCount = hp.getPluginStats(plugin.getId()).getAlertCount();
+                        hpList.addItem(
+                                createPluginProgressEntry(
+                                        plugin, pc + "%", timeTaken, reqs, alertCount));
+                    }
+
+                    for (Plugin plugin : hp.getPending()) {
+                        hpList.addItem(
+                                createPluginProgressEntry(
+                                        plugin, getStatus(hp, plugin, "Pending"), 0, 0, 0));
+                    }
+                    resultList.addItem(hpList);
                 }
                 result = resultList;
                 break;
             case VIEW_MESSAGES_IDS:
                 resultList = new ApiResponseList(name);
                 activeScan = getActiveScan(params);
-                if (activeScan != null) {
-                    synchronized (activeScan.getMessagesIds()) {
-                        for (Integer id : activeScan.getMessagesIds()) {
-                            resultList.addItem(new ApiResponseElement("id", id.toString()));
-                        }
+                synchronized (activeScan.getMessagesIds()) {
+                    for (Integer id : activeScan.getMessagesIds()) {
+                        resultList.addItem(new ApiResponseElement("id", id.toString()));
                     }
                 }
                 result = resultList;
@@ -1050,11 +1041,9 @@ public class ActiveScanAPI extends ApiImplementor {
             case VIEW_ALERTS_IDS:
                 resultList = new ApiResponseList(name);
                 activeScan = getActiveScan(params);
-                if (activeScan != null) {
-                    synchronized (activeScan.getAlertsIds()) {
-                        for (Integer id : activeScan.getAlertsIds()) {
-                            resultList.addItem(new ApiResponseElement("id", id.toString()));
-                        }
+                synchronized (activeScan.getAlertsIds()) {
+                    for (Integer id : activeScan.getAlertsIds()) {
+                        resultList.addItem(new ApiResponseElement("id", id.toString()));
                     }
                 }
                 result = resultList;

--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderAPI.java
@@ -52,7 +52,6 @@ import org.zaproxy.zap.extension.api.ApiResponseSet;
 import org.zaproxy.zap.extension.api.ApiView;
 import org.zaproxy.zap.extension.users.ExtensionUserManagement;
 import org.zaproxy.zap.model.Context;
-import org.zaproxy.zap.model.GenericScanner2;
 import org.zaproxy.zap.model.SessionStructure;
 import org.zaproxy.zap.model.StructuralNode;
 import org.zaproxy.zap.model.Target;
@@ -217,7 +216,7 @@ public class SpiderAPI extends ApiImplementor {
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
         log.debug("Request for handleApiAction: " + name + " (params: " + params.toString() + ")");
-        GenericScanner2 scan;
+        SpiderScan scan;
         int maxChildren = -1;
         Context context = null;
 
@@ -447,8 +446,8 @@ public class SpiderAPI extends ApiImplementor {
      * @throws ApiException if there's no scan with the given scan ID
      * @see #PARAM_SCAN_ID
      */
-    private GenericScanner2 getSpiderScan(JSONObject params) throws ApiException {
-        GenericScanner2 spiderScan;
+    private SpiderScan getSpiderScan(JSONObject params) throws ApiException {
+        SpiderScan spiderScan;
         int id = getParam(params, PARAM_SCAN_ID, -1);
         if (id == -1) {
             spiderScan = extension.getLastScan();
@@ -596,29 +595,25 @@ public class SpiderAPI extends ApiImplementor {
     public ApiResponse handleApiView(String name, JSONObject params) throws ApiException {
         ApiResponse result;
         if (VIEW_STATUS.equals(name)) {
-            SpiderScan scan = (SpiderScan) this.getSpiderScan(params);
+            SpiderScan scan = this.getSpiderScan(params);
             int progress = 0;
-            if (scan != null) {
-                if (scan.isStopped()) {
-                    progress = 100;
-                } else {
-                    progress = scan.getProgress();
-                }
+            if (scan.isStopped()) {
+                progress = 100;
+            } else {
+                progress = scan.getProgress();
             }
             result = new ApiResponseElement(name, Integer.toString(progress));
         } else if (VIEW_RESULTS.equals(name)) {
             result = new ApiResponseList(name);
-            SpiderScan scan = (SpiderScan) this.getSpiderScan(params);
-            if (scan != null) {
-                synchronized (scan.getResults()) {
-                    for (String s : scan.getResults()) {
-                        ((ApiResponseList) result).addItem(new ApiResponseElement("url", s));
-                    }
+            SpiderScan scan = this.getSpiderScan(params);
+            synchronized (scan.getResults()) {
+                for (String s : scan.getResults()) {
+                    ((ApiResponseList) result).addItem(new ApiResponseElement("url", s));
                 }
             }
         } else if (VIEW_FULL_RESULTS.equals(name)) {
             ApiResponseList resultUrls = new ApiResponseList(name);
-            SpiderScan scan = (SpiderScan) this.getSpiderScan(params);
+            SpiderScan scan = this.getSpiderScan(params);
             ApiResponseList resultList = new ApiResponseList("urlsInScope");
             synchronized (scan.getResourcesFound()) {
                 for (SpiderResource sr : scan.getResourcesFound()) {
@@ -654,8 +649,7 @@ public class SpiderAPI extends ApiImplementor {
             }
         } else if (VIEW_SCANS.equals(name)) {
             ApiResponseList resultList = new ApiResponseList(name);
-            for (GenericScanner2 scan : extension.getAllScans()) {
-                SpiderScan spiderScan = (SpiderScan) scan;
+            for (SpiderScan spiderScan : extension.getAllScans()) {
                 Map<String, String> map = new HashMap<>();
                 map.put("id", Integer.toString(spiderScan.getScanId()));
                 map.put("progress", Integer.toString(spiderScan.getProgress()));
@@ -698,11 +692,9 @@ public class SpiderAPI extends ApiImplementor {
             result = resultUrls;
         } else if (VIEW_ADDED_NODES.equals(name)) {
             result = new ApiResponseList(name);
-            SpiderScan scan = (SpiderScan) this.getSpiderScan(params);
-            if (scan != null) {
-                for (String s : scan.getAddedNodesTableModel().getAddedNodes()) {
-                    ((ApiResponseList) result).addItem(new ApiResponseElement("url", s));
-                }
+            SpiderScan scan = this.getSpiderScan(params);
+            for (String s : scan.getAddedNodesTableModel().getAddedNodes()) {
+                ((ApiResponseList) result).addItem(new ApiResponseElement("url", s));
             }
         } else if (VIEW_DOMAINS_ALWAYS_IN_SCOPE.equals(name)
                 || VIEW_OPTION_DOMAINS_ALWAYS_IN_SCOPE.equals(name)) {


### PR DESCRIPTION
Remove the null checks done after obtaining the scan in spider and
active scan APIs, the null check is already being done earlier.
Use the type of the scan instead of the generic type to void castings.