### PR TITLE
Rely on default branches for weekly add-ons

### DIFF
--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/GradleBuildWithGitRepos.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/GradleBuildWithGitRepos.java
@@ -155,8 +155,11 @@ public class GradleBuildWithGitRepos extends DefaultTask {
                                     if (quiet.get()) {
                                         execArgs.add("-q");
                                     }
-                                    execArgs.add("--branch");
-                                    execArgs.add(repoData.getBranch());
+                                    String branch = repoData.getBranch();
+                                    if (branch != null && !branch.isEmpty()) {
+                                        execArgs.add("--branch");
+                                        execArgs.add(branch);
+                                    }
                                     execArgs.add("--depth");
                                     execArgs.add("1");
                                     execArgs.add(cloneUrl);

--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/internal/BuildData.kt
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/internal/BuildData.kt
@@ -19,4 +19,4 @@
  */
 package org.zaproxy.zap.internal
 
-data class RepoData(val cloneUrl: String, val branch: String, val projects: List<String>)
+data class RepoData(val cloneUrl: String, val branch: String?, val projects: List<String>)

--- a/zap/src/main/weekly-add-ons.json
+++ b/zap/src/main/weekly-add-ons.json
@@ -1,7 +1,6 @@
 [
   {
     "cloneUrl": "https://github.com/zaproxy/zap-extensions.git",
-    "branch": "master",
     "projects": [
       ":addOns:accessControl",
       ":addOns:alertFilters",
@@ -48,13 +47,11 @@
   },
   {
     "cloneUrl": "https://github.com/zaproxy/zap-core-help.git",
-    "branch": "master",
     "projects": [
         ":addOns:help"
     ]
   },
   {
-    "cloneUrl": "https://github.com/zaproxy/zap-hud.git",
-    "branch": "develop"
+    "cloneUrl": "https://github.com/zaproxy/zap-hud.git"
   }
 ]


### PR DESCRIPTION
Do not specify the branch when building the add-ons, use the default
instead.
Update build task accordingly.