### PR TITLE
Remove deprecated Python 3.5 from CI tests

### DIFF
--- a/.github/workflows/test-packaged-scans.yml
+++ b/.github/workflows/test-packaged-scans.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2021-01-19
+ - Python 3.5 is no longer supported.
+
 ### 2020-12-23
  - Update Webswing to download prod version if valid key supplied.
 


### PR DESCRIPTION
## This PR

- deprecates python 3.5 which is now discontinued

## Notes

- consider adding python 3.9 https://www.python.org/downloads/release/python-390/
- Fixes #6407 