### PR TITLE
Spelling fixes

### DIFF
--- a/zap/src/main/java/ch/csnc/extension/httpclient/SSLContextManager.java
+++ b/zap/src/main/java/ch/csnc/extension/httpclient/SSLContextManager.java
@@ -72,6 +72,11 @@ public class SSLContextManager {
     public static final String SUN_PKCS11_CANONICAL_CLASS_NAME = "sun.security.pkcs11.SunPKCS11";
 
     /** The canonical class name of IBMPKCS11Impl Provider. */
+    public static final String IBM_PKCS11_CANONICAL_CLASS_NAME =
+            "com.ibm.crypto.pkcs11impl.provider.IBMPKCS11Impl";
+
+    /** @deprecated use {link IBM_PKCS11_CANONICAL_CLASS_NAME} */
+    @Deprecated
     public static final String IBM_PKCS11_CONONICAL_CLASS_NAME =
             "com.ibm.crypto.pkcs11impl.provider.IBMPKCS11Impl";
 
@@ -156,7 +161,7 @@ public class SSLContextManager {
                     Class.forName(SUN_PKCS11_CANONICAL_CLASS_NAME);
                     return true;
                 } catch (Throwable ignore) {
-                    Class.forName(IBM_PKCS11_CONONICAL_CLASS_NAME);
+                    Class.forName(IBM_PKCS11_CANONICAL_CLASS_NAME);
                     return true;
                 }
             } else if (type.equals("msks")) {
@@ -391,7 +396,7 @@ public class SSLContextManager {
         } else if (isIbmPKCS11Provider()) {
             pkcs11 =
                     createInstance(
-                            IBM_PKCS11_CONONICAL_CLASS_NAME,
+                            IBM_PKCS11_CANONICAL_CLASS_NAME,
                             BufferedReader.class,
                             new BufferedReader(
                                     new InputStreamReader(configuration.toInpuStream())));
@@ -436,7 +441,7 @@ public class SSLContextManager {
 
     private static boolean isIbmPKCS11Provider() {
         try {
-            Class.forName(IBM_PKCS11_CONONICAL_CLASS_NAME);
+            Class.forName(IBM_PKCS11_CANONICAL_CLASS_NAME);
             return true;
         } catch (Throwable ignore) {
         }

--- a/zap/src/main/java/ch/csnc/extension/httpclient/SSLContextManager.java
+++ b/zap/src/main/java/ch/csnc/extension/httpclient/SSLContextManager.java
@@ -75,10 +75,9 @@ public class SSLContextManager {
     public static final String IBM_PKCS11_CANONICAL_CLASS_NAME =
             "com.ibm.crypto.pkcs11impl.provider.IBMPKCS11Impl";
 
-    /** @deprecated use {link IBM_PKCS11_CANONICAL_CLASS_NAME} */
+    /** @deprecated (2.11.0) Use {@link #IBM_PKCS11_CANONICAL_CLASS_NAME} */
     @Deprecated
-    public static final String IBM_PKCS11_CONONICAL_CLASS_NAME =
-            "com.ibm.crypto.pkcs11impl.provider.IBMPKCS11Impl";
+    public static final String IBM_PKCS11_CONONICAL_CLASS_NAME = IBM_PKCS11_CANONICAL_CLASS_NAME;
 
     /** The name of Sun PKCS#11 Provider. */
     private static final String SUN_PKCS11_PROVIDER_NAME = "SunPKCS11";

--- a/zap/src/main/java/ch/csnc/extension/ui/DriversView.java
+++ b/zap/src/main/java/ch/csnc/extension/ui/DriversView.java
@@ -158,7 +158,7 @@ public class DriversView extends AbstractFrame {
         if (!Model.getSingleton()
                 .getOptionsParam()
                 .getExperimentalFeaturesParam()
-                .isExerimentalSliSupportEnabled()) {
+                .isExperimentalSliSupportEnabled()) {
             slotTextField.setEnabled(false);
         }
 

--- a/zap/src/main/java/ch/csnc/extension/util/OptionsParamExperimentalSliSupport.java
+++ b/zap/src/main/java/ch/csnc/extension/util/OptionsParamExperimentalSliSupport.java
@@ -34,7 +34,13 @@ public class OptionsParamExperimentalSliSupport extends AbstractParam {
         expSliSupportEnabled = getBoolean(EXPERIMENTAL_SLOT_LIST_INDEXES, false);
     }
 
+    /** @deprecated use {link #isExperimentalSliSupportEnabled()} */
+    @Deprecated
     public boolean isExerimentalSliSupportEnabled() {
+        return isExperimentalSliSupportEnabled();
+    }
+
+    public boolean isExperimentalSliSupportEnabled() {
         return expSliSupportEnabled;
     }
 

--- a/zap/src/main/java/ch/csnc/extension/util/OptionsParamExperimentalSliSupport.java
+++ b/zap/src/main/java/ch/csnc/extension/util/OptionsParamExperimentalSliSupport.java
@@ -34,7 +34,7 @@ public class OptionsParamExperimentalSliSupport extends AbstractParam {
         expSliSupportEnabled = getBoolean(EXPERIMENTAL_SLOT_LIST_INDEXES, false);
     }
 
-    /** @deprecated use {link #isExperimentalSliSupportEnabled()} */
+    /** @deprecated (2.11.0) Use {@link #isExperimentalSliSupportEnabled()} */
     @Deprecated
     public boolean isExerimentalSliSupportEnabled() {
         return isExperimentalSliSupportEnabled();

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantAbstractRPCQuery.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantAbstractRPCQuery.java
@@ -184,13 +184,12 @@ public abstract class VariantAbstractRPCQuery implements Variant {
         }
     }
 
-    /** @deprecated use {link #getReadableParameterizedQuery()} */
+    /** @deprecated (2.11.0) Use {@link #getReadableParameterizedQuery()} */
     @Deprecated
     public String getReadableParametrizedQuery() {
         return getReadableParameterizedQuery();
     }
 
-    /** @return */
     public String getReadableParameterizedQuery() {
         StringBuilder result = new StringBuilder();
         int begin = 0;

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantAbstractRPCQuery.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantAbstractRPCQuery.java
@@ -184,8 +184,14 @@ public abstract class VariantAbstractRPCQuery implements Variant {
         }
     }
 
-    /** @return */
+    /** @deprecated use {link #getReadableParameterizedQuery()} */
+    @Deprecated
     public String getReadableParametrizedQuery() {
+        return getReadableParameterizedQuery();
+    }
+
+    /** @return */
+    public String getReadableParameterizedQuery() {
         StringBuilder result = new StringBuilder();
         int begin = 0;
         int end;

--- a/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
@@ -966,7 +966,7 @@ public class OptionsCertificatePanel extends AbstractParamPanel {
                         "The required PKCS#11 provider is not available ("
                                 + SSLContextManager.SUN_PKCS11_CANONICAL_CLASS_NAME
                                 + " or "
-                                + SSLContextManager.IBM_PKCS11_CONONICAL_CLASS_NAME
+                                + SSLContextManager.IBM_PKCS11_CANONICAL_CLASS_NAME
                                 + ").");
                 showErrorMessageSunPkcs11ProviderNotAvailable();
                 return;

--- a/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
@@ -1351,7 +1351,7 @@ public class OptionsCertificatePanel extends AbstractParamPanel {
                 Model.getSingleton()
                         .getOptionsParam()
                         .getExperimentalFeaturesParam()
-                        .isExerimentalSliSupportEnabled());
+                        .isExperimentalSliSupportEnabled());
 
         // actual certificate fields
         certificateTextField.setEnabled(useClientCertificateCheckBox.isSelected());

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpStatusCode.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpStatusCode.java
@@ -120,13 +120,19 @@ public final class HttpStatusCode {
         HTTP_VERSION_NOT_SUPPORTED
     };
 
+    /** @deprecated use {link #isInformational} */
+    @Deprecated
+    public static boolean isInformatinal(int statusCode) {
+        return isInformational(statusCode);
+    }
+
     /**
      * Check if a status code is informational. (100 &le; status &lt; 200)
      *
      * @param statusCode
      * @return true if informational
      */
-    public static boolean isInformatinal(int statusCode) {
+    public static boolean isInformational(int statusCode) {
         if (statusCode >= 100 && statusCode < 200) return true;
         else return false;
     }

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpStatusCode.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpStatusCode.java
@@ -22,6 +22,7 @@
 // ZAP: 2018/07/27 Address JavaDoc warns.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2020/01/22 Fix typo.
 package org.parosproxy.paros.network;
 
 public final class HttpStatusCode {
@@ -76,7 +77,7 @@ public final class HttpStatusCode {
     public static final int GATEWAY_TIMEOUT = 504;
     public static final int HTTP_VERSION_NOT_SUPPORTED = 505;
 
-    /** @deprecated use {link #GATEWAY_TIMEOUT} */
+    /** @deprecated (2.11.0) Use {@link #GATEWAY_TIMEOUT} */
     @Deprecated public static final int GATEWAY_TIEMOUT = 504;
 
     // ZAP: Added code array
@@ -123,7 +124,7 @@ public final class HttpStatusCode {
         HTTP_VERSION_NOT_SUPPORTED
     };
 
-    /** @deprecated use {link #isInformational} */
+    /** @deprecated (2.11.0) Use {@link #isInformational} */
     @Deprecated
     public static boolean isInformatinal(int statusCode) {
         return isInformational(statusCode);

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpStatusCode.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpStatusCode.java
@@ -73,8 +73,11 @@ public final class HttpStatusCode {
     public static final int NOT_IMPLEMENTED = 501;
     public static final int BAD_GATEWAY = 502;
     public static final int SERVICE_UNAVAILABLE = 503;
-    public static final int GATEWAY_TIEMOUT = 504;
+    public static final int GATEWAY_TIMEOUT = 504;
     public static final int HTTP_VERSION_NOT_SUPPORTED = 505;
+
+    /** @deprecated use {link #GATEWAY_TIMEOUT} */
+    @Deprecated public static final int GATEWAY_TIEMOUT = 504;
 
     // ZAP: Added code array
     public static final int[] CODES = {
@@ -116,7 +119,7 @@ public final class HttpStatusCode {
         NOT_IMPLEMENTED,
         BAD_GATEWAY,
         SERVICE_UNAVAILABLE,
-        GATEWAY_TIEMOUT,
+        GATEWAY_TIMEOUT,
         HTTP_VERSION_NOT_SUPPORTED
     };
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanProgressItem.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanProgressItem.java
@@ -57,7 +57,7 @@ public class ScanProgressItem {
         return pluginStats.getPluginName();
     }
 
-    /** @deprecated use {link #getAttackStrengthLabel} */
+    /** @deprecated (2.11.0) Use {@link #getAttackStrengthLabel} */
     @Deprecated
     public String getAttackStrenghtLabel() {
         return getAttackStrengthLabel();

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanProgressItem.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanProgressItem.java
@@ -57,8 +57,14 @@ public class ScanProgressItem {
         return pluginStats.getPluginName();
     }
 
-    /** @return */
+    /** @deprecated use {link #getAttackStrengthLabel} */
+    @Deprecated
     public String getAttackStrenghtLabel() {
+        return getAttackStrengthLabel();
+    }
+
+    /** @return */
+    public String getAttackStrengthLabel() {
         return Constant.messages.getString(
                 "ascan.policy.level." + plugin.getAttackStrength().name().toLowerCase(Locale.ROOT));
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanProgressTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanProgressTableModel.java
@@ -108,7 +108,7 @@ public class ScanProgressTableModel extends AbstractTableModel {
                     return item.getNameLabel();
 
                 case 1:
-                    return item.getAttackStrenghtLabel();
+                    return item.getAttackStrengthLabel();
 
                 case 2:
                     if (item.isCompleted() || item.isRunning() || item.isSkipped()) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -1988,7 +1988,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
             Thread.currentThread().setContextClassLoader(previousContextClassLoader);
         }
 
-        if (script.isRunableStandalone()) {
+        if (script.isRunnableStandalone()) {
             return null;
         }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptWrapper.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptWrapper.java
@@ -296,7 +296,7 @@ public class ScriptWrapper {
         return null;
     }
 
-    /** @deprecated use {link #isRunnableStandalone} */
+    /** @deprecated (2.11.0) Use {@link #isRunnableStandalone} */
     @Deprecated
     public boolean isRunableStandalone() {
         return isRunnableStandalone();

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptWrapper.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptWrapper.java
@@ -296,7 +296,13 @@ public class ScriptWrapper {
         return null;
     }
 
+    /** @deprecated use {link #isRunnableStandalone} */
+    @Deprecated
     public boolean isRunableStandalone() {
+        return isRunnableStandalone();
+    }
+
+    public boolean isRunnableStandalone() {
         return this.getType() != null
                 && ExtensionScript.TYPE_STANDALONE.equals(this.getType().getName());
     }

--- a/zap/src/test/java/ch/csnc/extension/httpclient/SSLContextManagerUnitTest.java
+++ b/zap/src/test/java/ch/csnc/extension/httpclient/SSLContextManagerUnitTest.java
@@ -43,7 +43,7 @@ public class SSLContextManagerUnitTest {
             Class.forName(SSLContextManager.SUN_PKCS11_CANONICAL_CLASS_NAME);
         } catch (ClassNotFoundException e) {
             try {
-                Class.forName(SSLContextManager.IBM_PKCS11_CONONICAL_CLASS_NAME);
+                Class.forName(SSLContextManager.IBM_PKCS11_CANONICAL_CLASS_NAME);
             } catch (ClassNotFoundException e2) {
                 pkcs11ProviderAvailable = false;
             }


### PR DESCRIPTION
Cherry picked the following from #5717:
 - spelling: [API] canonical
 - spelling: [API] experimental
 - spelling: [API] informational
 - spelling: [API] parameterized
 - spelling: [API] runnable
 - spelling: [API] strength
 - spelling: [API] timeout

as they don't require major changes (e.g. class renames) and can be merged sooner.
