### PR TITLE
Tidy up tests' setup

### DIFF
--- a/zap/src/test/java/org/parosproxy/paros/model/SessionUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/model/SessionUnitTest.java
@@ -36,10 +36,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.NameValuePair;
 import org.parosproxy.paros.core.scanner.Variant;
@@ -58,7 +56,6 @@ public class SessionUnitTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        WithConfigsTest.setUpConstant();
         factory = new VariantFactory();
         Model model = mock(Model.class);
         given(model.getVariantFactory()).willReturn(factory);
@@ -66,11 +63,6 @@ public class SessionUnitTest {
 
         session = new Session(model);
         given(model.getSession()).willReturn(session);
-    }
-
-    @AfterEach
-    void cleanUp() {
-        Constant.messages = null;
     }
 
     /** Tests related to {@link Context}. */

--- a/zap/src/test/java/org/parosproxy/paros/model/SiteMapUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/model/SiteMapUnitTest.java
@@ -46,7 +46,6 @@ import org.parosproxy.paros.db.TableAlert;
 import org.parosproxy.paros.db.TableHistory;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
-import org.zaproxy.zap.WithConfigsTest;
 import org.zaproxy.zap.extension.ascan.VariantFactory;
 import org.zaproxy.zap.model.StandardParameterParser;
 
@@ -82,7 +81,6 @@ class SiteMapUnitTest {
         given(tableAlert.getAlertsBySourceHistoryId(anyInt())).willReturn(Collections.emptyList());
         HistoryReference.setTableAlert(tableAlert);
 
-        WithConfigsTest.setUpConstant();
         Model model = mock(Model.class);
 
         Control.initSingletonForTesting(model);

--- a/zap/src/test/java/org/zaproxy/zap/WithConfigsTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/WithConfigsTest.java
@@ -94,7 +94,8 @@ public abstract class WithConfigsTest extends TestUtils {
         extensionLoader = mock(ExtensionLoader.class, withSettings().lenient());
 
         // Init all the things
-        setUpConstant();
+        Constant.getInstance();
+        setUpConstantMessages();
         Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
         Model.getSingleton().getOptionsParam().load(new ZapXmlConfiguration());
     }
@@ -104,8 +105,7 @@ public abstract class WithConfigsTest extends TestUtils {
         Constant.messages = null;
     }
 
-    public static void setUpConstant() {
-        Constant.getInstance();
+    public static void setUpConstantMessages() {
         I18N i18n = Mockito.mock(I18N.class, withSettings().lenient());
         given(i18n.getString(anyString())).willReturn("");
         given(i18n.getString(anyString(), any())).willReturn("");

--- a/zap/src/test/java/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodTypeUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodTypeUnitTest.java
@@ -22,11 +22,8 @@ package org.zaproxy.zap.authentication;
 import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
@@ -39,22 +36,16 @@ import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.WithConfigsTest;
 import org.zaproxy.zap.authentication.AuthenticationMethod.AuthCheckingStrategy;
 import org.zaproxy.zap.authentication.AuthenticationMethod.AuthPollFrequencyUnits;
 import org.zaproxy.zap.authentication.PostBasedAuthenticationMethodType.PostBasedAuthenticationMethod;
-import org.zaproxy.zap.model.Context;
-import org.zaproxy.zap.session.SessionManagementMethod;
-import org.zaproxy.zap.session.WebSession;
 import org.zaproxy.zap.testutils.NanoServerHandler;
-import org.zaproxy.zap.testutils.TestUtils;
 import org.zaproxy.zap.users.AuthenticationState;
 import org.zaproxy.zap.users.User;
 
-public class FormBasedAuthenticationMethodTypeUnitTest extends TestUtils {
+public class FormBasedAuthenticationMethodTypeUnitTest extends WithConfigsTest {
 
     private static final String LOGGED_IN_INDICATOR = "logged in";
     private static final String LOGGED_IN_BODY =
@@ -65,13 +56,9 @@ public class FormBasedAuthenticationMethodTypeUnitTest extends TestUtils {
 
     private AuthenticationMethod method;
     private FormBasedAuthenticationMethodType type;
-    private Context mockedContext;
-    private SessionManagementMethod mockedSessionManagementMethod;
 
     @BeforeEach
     public void setUp() throws Exception {
-
-        WithConfigsTest.setUpConstant();
 
         type = new FormBasedAuthenticationMethodType();
         method = type.createAuthenticationMethod(1);
@@ -80,21 +67,11 @@ public class FormBasedAuthenticationMethodTypeUnitTest extends TestUtils {
         method.setPollFrequency(5);
         method.setLoggedInIndicatorPattern(LOGGED_IN_INDICATOR);
 
-        // Make sure no actual message processing is done
-        mockedSessionManagementMethod = Mockito.mock(SessionManagementMethod.class);
-        doNothing()
-                .when(mockedSessionManagementMethod)
-                .processMessageToMatchSession((HttpMessage) any(), (WebSession) any());
-
-        mockedContext = Mockito.mock(Context.class);
-        when(mockedContext.getSessionManagementMethod()).thenReturn(mockedSessionManagementMethod);
-
         this.startServer();
     }
 
     @AfterEach
-    void cleanUp() {
-        Constant.messages = null;
+    void cleanUpServer() {
         stopServer();
     }
 
@@ -138,7 +115,6 @@ public class FormBasedAuthenticationMethodTypeUnitTest extends TestUtils {
         given(user.getAuthenticationState()).willReturn(new AuthenticationState());
         given(user.getAuthenticationCredentials())
                 .willReturn(new UsernamePasswordAuthenticationCredentials(username, ""));
-        given(user.getContext()).willReturn(mockedContext);
 
         // When/Then
         assertThat(method.isAuthenticated(testMsg, user), is(true));
@@ -182,7 +158,6 @@ public class FormBasedAuthenticationMethodTypeUnitTest extends TestUtils {
         given(user.getAuthenticationState()).willReturn(new AuthenticationState());
         given(user.getAuthenticationCredentials())
                 .willReturn(new UsernamePasswordAuthenticationCredentials("", password));
-        given(user.getContext()).willReturn(mockedContext);
 
         // When/Then
         assertThat(method.isAuthenticated(testMsg, user), is(true));
@@ -223,7 +198,6 @@ public class FormBasedAuthenticationMethodTypeUnitTest extends TestUtils {
         given(user.getAuthenticationState()).willReturn(new AuthenticationState());
         given(user.getAuthenticationCredentials())
                 .willReturn(new UsernamePasswordAuthenticationCredentials(username, ""));
-        given(user.getContext()).willReturn(mockedContext);
 
         // When/Then
         assertThat(method.isAuthenticated(testMsg, user), is(true));

--- a/zap/src/test/java/org/zaproxy/zap/authentication/JsonBasedAuthenticationMethodTypeUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/authentication/JsonBasedAuthenticationMethodTypeUnitTest.java
@@ -22,11 +22,8 @@ package org.zaproxy.zap.authentication;
 import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
@@ -39,21 +36,16 @@ import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.WithConfigsTest;
 import org.zaproxy.zap.authentication.AuthenticationMethod.AuthCheckingStrategy;
 import org.zaproxy.zap.authentication.AuthenticationMethod.AuthPollFrequencyUnits;
 import org.zaproxy.zap.authentication.PostBasedAuthenticationMethodType.PostBasedAuthenticationMethod;
-import org.zaproxy.zap.model.Context;
-import org.zaproxy.zap.session.SessionManagementMethod;
-import org.zaproxy.zap.session.WebSession;
 import org.zaproxy.zap.testutils.NanoServerHandler;
-import org.zaproxy.zap.testutils.TestUtils;
+import org.zaproxy.zap.users.AuthenticationState;
 import org.zaproxy.zap.users.User;
 
-public class JsonBasedAuthenticationMethodTypeUnitTest extends TestUtils {
+public class JsonBasedAuthenticationMethodTypeUnitTest extends WithConfigsTest {
 
     private static final String LOGGED_IN_INDICATOR = "logged in";
     private static final String LOGGED_IN_BODY =
@@ -64,13 +56,9 @@ public class JsonBasedAuthenticationMethodTypeUnitTest extends TestUtils {
 
     private AuthenticationMethod method;
     private JsonBasedAuthenticationMethodType type;
-    private static Context mockedContext;
-    private static SessionManagementMethod mockedSessionManagementMethod;
 
     @BeforeEach
     public void setUp() throws Exception {
-
-        WithConfigsTest.setUpConstant();
 
         type = new JsonBasedAuthenticationMethodType();
         method = type.createAuthenticationMethod(1);
@@ -79,21 +67,11 @@ public class JsonBasedAuthenticationMethodTypeUnitTest extends TestUtils {
         method.setPollFrequency(5);
         method.setLoggedInIndicatorPattern(LOGGED_IN_INDICATOR);
 
-        // Make sure no actual message processing is done
-        mockedSessionManagementMethod = Mockito.mock(SessionManagementMethod.class);
-        doNothing()
-                .when(mockedSessionManagementMethod)
-                .processMessageToMatchSession((HttpMessage) any(), (WebSession) any());
-
-        mockedContext = Mockito.mock(Context.class);
-        when(mockedContext.getSessionManagementMethod()).thenReturn(mockedSessionManagementMethod);
-
         this.startServer();
     }
 
     @AfterEach
-    void cleanUp() {
-        Constant.messages = null;
+    void cleanUpServer() {
         stopServer();
     }
 
@@ -133,10 +111,10 @@ public class JsonBasedAuthenticationMethodTypeUnitTest extends TestUtils {
         method.setPollUrl(pollMsg.getRequestHeader().getURI().toString());
         method.setPollData(pollData);
 
-        User user = spy(new User(0, "user"));
-        user.setAuthenticationCredentials(
-                new UsernamePasswordAuthenticationCredentials(username, ""));
-        doReturn(mockedContext).when(user).getContext();
+        User user = mock(User.class);
+        given(user.getAuthenticationState()).willReturn(new AuthenticationState());
+        given(user.getAuthenticationCredentials())
+                .willReturn(new UsernamePasswordAuthenticationCredentials(username, ""));
 
         // When/Then
         assertThat(method.isAuthenticated(testMsg, user), is(true));
@@ -176,10 +154,10 @@ public class JsonBasedAuthenticationMethodTypeUnitTest extends TestUtils {
         method.setPollUrl(pollMsg.getRequestHeader().getURI().toString());
         method.setPollData(pollData);
 
-        User user = spy(new User(0, "user"));
-        user.setAuthenticationCredentials(
-                new UsernamePasswordAuthenticationCredentials("", password));
-        doReturn(mockedContext).when(user).getContext();
+        User user = mock(User.class);
+        given(user.getAuthenticationState()).willReturn(new AuthenticationState());
+        given(user.getAuthenticationCredentials())
+                .willReturn(new UsernamePasswordAuthenticationCredentials("", password));
 
         // When/Then
         assertThat(method.isAuthenticated(testMsg, user), is(true));
@@ -217,10 +195,10 @@ public class JsonBasedAuthenticationMethodTypeUnitTest extends TestUtils {
         method.setPollUrl(pollMsg.getRequestHeader().getURI().toString());
         method.setPollData(pollData);
 
-        User user = spy(new User(0, "user"));
-        user.setAuthenticationCredentials(
-                new UsernamePasswordAuthenticationCredentials(username, ""));
-        doReturn(mockedContext).when(user).getContext();
+        User user = mock(User.class);
+        given(user.getAuthenticationState()).willReturn(new AuthenticationState());
+        given(user.getAuthenticationCredentials())
+                .willReturn(new UsernamePasswordAuthenticationCredentials(username, ""));
 
         // When/Then
         assertThat(method.isAuthenticated(testMsg, user), is(true));

--- a/zap/src/test/java/org/zaproxy/zap/extension/script/ExtensionScriptUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/script/ExtensionScriptUnitTest.java
@@ -37,7 +37,7 @@ class ExtensionScriptUnitTest {
 
     @BeforeEach
     void setUp() {
-        WithConfigsTest.setUpConstant();
+        WithConfigsTest.setUpConstantMessages();
     }
 
     @AfterEach

--- a/zap/src/test/java/org/zaproxy/zap/model/SessionStructureUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/model/SessionStructureUnitTest.java
@@ -28,10 +28,12 @@ import static org.mockito.Mockito.mock;
 import java.util.List;
 import java.util.stream.Stream;
 import org.apache.commons.httpclient.URI;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Variant;
 import org.parosproxy.paros.model.Model;
@@ -51,7 +53,7 @@ public class SessionStructureUnitTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        WithConfigsTest.setUpConstant();
+        WithConfigsTest.setUpConstantMessages();
         factory = new VariantFactory();
         model = mock(Model.class);
         session = new Session(model);
@@ -59,6 +61,11 @@ public class SessionStructureUnitTest {
         given(model.getVariantFactory()).willReturn(factory);
         Control.initSingletonForTesting(model);
         msg = new HttpMessage();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        Constant.messages = null;
     }
 
     static Stream<String> methodProvider() {


### PR DESCRIPTION
Split initialisation of `Constant#messages` from the `Constant`, not all
tests need both, and was causing older data from the `Constant` to be
used in other tests leading to failures.
Adjusts tests accordingly.
Remove now unnecessary mocks in auth tests.