### PR TITLE
Root Cert Download from Main API Page

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -1388,7 +1388,8 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                     String response = sw.toString();
                     msg.setResponseHeader(
                             API.getDefaultResponseHeader(
-                                    "application/pkix-cert;", response.length()));
+                                            "application/pkix-cert;", response.length())
+                                    + "Content-Disposition: attachment; filename=\"ZAPCACert.cer\"\r\n");
 
                     msg.setResponseBody(response);
                 } catch (Exception e) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/WebUI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/WebUI.java
@@ -480,6 +480,14 @@ public class WebUI {
                                 + "="
                                 + API.getInstance()
                                         .getLongLivedNonce("/OTHER/core/other/proxy.pac/")));
+        sb.append(
+                Constant.messages.getString(
+                        "api.home.cacert",
+                        "/?"
+                                + API.API_NONCE_PARAM
+                                + "="
+                                + API.getInstance()
+                                        .getLongLivedNonce("/OTHER/core/other/rootcert/")));
         sb.append(Constant.messages.getString("api.home.links.header"));
         if (apiEnabled) {
             sb.append(Constant.messages.getString("api.home.links.api.enabled"));

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -194,6 +194,10 @@ api.home.links.online		= <li><a href="https://www.zaproxy.org/">ZAP Website</a><
 <li><a href="https://groups.google.com/group/zaproxy-users">ZAP User Group</a></li>\
 <li><a href="https://groups.google.com/group/zaproxy-develop">ZAP Developer Group</a></li>\
 <li><a href="https://github.com/zaproxy/zaproxy/issues">Report an issue</a></li>
+api.home.cacert	= <h2>HTTPS Warnings Prevention</h2>\
+<p>To avoid HTTPS Warnings <a href="/OTHER/core/other/rootcert{0}">download</a> and \
+<a href="https://www.zaproxy.org/docs/desktop/ui/dialogs/options/dynsslcert/#install" target="_blank">\
+ install CA root Certificate</a> in your Mobile device or computer.</p>
 api.home.proxypac			= <h2>Proxy Configuration</h2>\
 <p>To use ZAP effectively it is recommended that you configure your browser to proxy via ZAP.</p><p></p>\
 <p>The easiest way to do this is to launch your browser from ZAP via the "Quick Start / Manual Explore" panel - it will be configured to proxy via ZAP and ignore any certificate warnings.<br>\


### PR DESCRIPTION
- To facilitate Mobile security testing using ZAP by allowing download of the CA certificate directly from the API home page.

See https://github.com/zaproxy/zaproxy/pull/6022 for original.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>