### PR TITLE
WebSwing - add more flexible ZAP options

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2021-02-01
+ - Allow more flexibility to specify ZAP command line options when using Webswing:
+  - The default options stay as `-host 0.0.0.0 -port 8090` unless
+  - You specify an env var `ZAP_WEBSWING_OPTS` in which case that replaces the defaults
+  - If not then if a `/zap/wrk/owasp_zap_root_ca.key` file exists then this is loaded as the ZAP root cert
+  - If not then if the `/zap/wrk` is writable then ZAP will output the public and private ZAP cert into that directory
+  
 ### 2021-01-19
  - Python 3.5 is no longer supported.
 

--- a/docker/webswing.config
+++ b/docker/webswing.config
@@ -38,7 +38,7 @@
       "javaVersion" : "${java.version}",
       "launcherType" : "Desktop",
       "launcherConfig" : {
-        "args" : "-host 0.0.0.0 -port 8090",
+        "args" : "ZAP_OPTS",
         "mainClass" : "org.zaproxy.zap.ZAP"
       },
       "swingSessionTimeout" : -1,


### PR DESCRIPTION
Will make a PR against the docs on the website, but essentially:

1. The default options `-host 0.0.0.0 -port 8090` havnt changed, unless:
2. You specify an env var `ZAP_WEBSWING_OPTS` in which case those _replace_ the defaults, or
3. A `/zap/wrk/owasp_zap_root_ca.key` file exists, in which case its loaded as the ZAP root cert
4. That file doesnt exist but `/zap/wrk` is writable, in which can ZAP will dump the public and private ZAP cert into that dir

The idea is that if you want to proxy a local browser through ZAP via Webswing then you start the docker container with a directory mapped to `/zap/wrk` - ZAP will output the public and private certs so you can load the public one into your browser and trust for websites.
When you next start the docker container in the same way ZAP will load the cert from the private cert file so you won't have to load it into your browser again.
But if you do want to specify any other ZAP command line options then you can.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>