### PR TITLE
Keep state of only break on scope when resetting

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakPanelToolbarFactory.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakPanelToolbarFactory.java
@@ -536,10 +536,7 @@ public class BreakPanelToolbarFactory {
         isBreakRequest = false;
         isBreakResponse = false;
         isBreakAll = false;
-        setBreakOnJavaScript(true);
-        setBreakOnCssAndFonts(true);
-        setBreakOnMultimedia(true);
-        setOnlyBreakOnScope(breakpointsParams.isInScopeOnly());
+        setShowIgnoreFilesButtons(false);
         countCaughtMessages = 0;
     }
 
@@ -604,7 +601,7 @@ public class BreakPanelToolbarFactory {
             setBreakOnJavaScript(true);
             setBreakOnCssAndFonts(true);
             setBreakOnMultimedia(true);
-            setOnlyBreakOnScope(false);
+            setOnlyBreakOnScope(breakpointsParams.isInScopeOnly());
         }
     }
 


### PR DESCRIPTION
Use the current state for only break on scope when resetting the break
buttons, otherwise it could inadvertently change its state.
Reduce code duplication.

Fix #6437.