### PR TITLE
Check globally excluded URLs in API scan scripts

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2021-02-10
+ - Check if messages being analyzed by API scan scripts are globally excluded or not.
+
 ### 2021-02-01
  - Allow more flexibility to specify ZAP command line options when using Webswing:
   - The default options stay as `-host 0.0.0.0 -port 8090` unless

--- a/docker/scripts/scripts/httpsender/Alert_on_HTTP_Response_Code_Errors.js
+++ b/docker/scripts/scripts/httpsender/Alert_on_HTTP_Response_Code_Errors.js
@@ -2,6 +2,9 @@
 // By default it will raise 'Info' level alerts for Client Errors (4xx) (apart from 404s) and 'Low' Level alerts for Server Errors (5xx)
 // But it can be easily changed.
 
+var Pattern = Java.type("java.util.regex.Pattern")
+var model = Java.type("org.parosproxy.paros.model.Model").getSingleton()
+
 pluginid = 100000	// https://github.com/zaproxy/zaproxy/blob/main/docs/scanners.md
 
 function sendingRequest(msg, initiator, helper) {
@@ -9,7 +12,7 @@ function sendingRequest(msg, initiator, helper) {
 }
 
 function responseReceived(msg, initiator, helper) {
-	if (initiator == 7) { // CHECK_FOR_UPDATES_INITIATOR
+	if (isGloballyExcluded(msg) || initiator == 7) { // CHECK_FOR_UPDATES_INITIATOR
 		// Not of interest.
 		return
 	}
@@ -84,4 +87,15 @@ function responseReceived(msg, initiator, helper) {
 			extensionAlert.alertFound(alert , ref)
 		}
 	}
+}
+
+function isGloballyExcluded(msg) {
+	var url = msg.getRequestHeader().getURI().toString()
+	var regexes = model.getSession().getGlobalExcludeURLRegexs()
+	for (var i in regexes) {
+		if (Pattern.compile(regexes[i], Pattern.CASE_INSENSITIVE).matcher(url).matches()) {
+			return true
+		}
+	}
+	return false
 }

--- a/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
+++ b/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
@@ -2,6 +2,9 @@
 // By default it will raise 'Low' level alerts for content types that are not expected to be returned by APIs.
 // But it can be easily changed.
 
+var Pattern = Java.type("java.util.regex.Pattern")
+var model = Java.type("org.parosproxy.paros.model.Model").getSingleton()
+
 var pluginid = 100001	// https://github.com/zaproxy/zaproxy/blob/main/docs/scanners.md
 
 var extensionAlert = org.parosproxy.paros.control.Control.getSingleton().getExtensionLoader().getExtension(
@@ -26,7 +29,7 @@ function sendingRequest(msg, initiator, helper) {
 }
 
 function responseReceived(msg, initiator, helper) {
-	if (initiator == 7) { // CHECK_FOR_UPDATES_INITIATOR
+	if (isGloballyExcluded(msg) || initiator == 7) { // CHECK_FOR_UPDATES_INITIATOR
 		// Not of interest.
 		return
 	}
@@ -95,4 +98,15 @@ function responseReceived(msg, initiator, helper) {
 			}
 		}
 	}
+}
+
+function isGloballyExcluded(msg) {
+	var url = msg.getRequestHeader().getURI().toString()
+	var regexes = model.getSession().getGlobalExcludeURLRegexs()
+	for (var i in regexes) {
+		if (Pattern.compile(regexes[i], Pattern.CASE_INSENSITIVE).matcher(url).matches()) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Check if the message being scanned in the HTTP Sender scripts used by
Docker API scan are excluded or not.

Fix #6443.