### PR TITLE
[BugFix] Added target to spider scanning

### DIFF
--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -403,7 +403,7 @@ def raise_scan_not_started():
 def zap_spider(zap, target):
     if scan_user:
         logging.debug('Spider %s as user %s', target, scan_user['name'])
-        spider_scan_id = zap.spider.scan_as_user(context_id, scan_user['id'])
+        spider_scan_id = zap.spider.scan_as_user(context_id, scan_user['id'],target)
     else:
         logging.debug('Spider %s', target)
         spider_scan_id = zap.spider.scan(target, contextname=context_name)


### PR DESCRIPTION
When scanning a URL using the spider with a user inside a context, the ZAP API throws a error as it is expecting a URL to be provided. This small change passes through that URL to the ZAP API, fixing the issue.