### PR TITLE
Request Editor: Add shortcut key

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/ManualRequestEditorDialog.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/ManualRequestEditorDialog.java
@@ -40,6 +40,7 @@
 // ZAP: 2020/11/03 Warn when unable to save the message (Issue 4235).
 // ZAP: 2020/11/20 Support Send button in response panel in tab mode
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
+// ZAP: 2021/02/12 Add shortcut key to Send button (Issue 6448).
 package org.parosproxy.paros.extension.manualrequest;
 
 import java.awt.BorderLayout;
@@ -47,6 +48,7 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.HeadlessException;
+import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import javax.net.ssl.SSLException;
@@ -221,9 +223,17 @@ public abstract class ManualRequestEditorDialog extends AbstractFrame implements
             btnSend = new JButton();
             btnSend.setText(Constant.messages.getString("manReq.button.send"));
             btnSend.setEnabled(isSendEnabled);
+            btnSend.setMnemonic(KeyEvent.VK_ENTER);
+            btnSend.setToolTipText(getBtnSendTooltip());
             btnSend.addActionListener(e -> sendButtonTriggered());
         }
         return btnSend;
+    }
+
+    protected static String getBtnSendTooltip() {
+        return !Constant.isMacOsX()
+                ? Constant.messages.getString("manReq.button.send.tooltip")
+                : Constant.messages.getString("manReq.button.send.tooltip.mac");
     }
 
     /** Do not forget to enable the send button again i */

--- a/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/ManualHttpRequestEditorDialog.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/ManualHttpRequestEditorDialog.java
@@ -32,6 +32,7 @@
 // ZAP: 2019/10/04 Add menu icon.
 // ZAP: 2020/11/20 Support Send button in response panel in tab mode
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
+// ZAP: 2021/02/12 Add shortcut key to Send button (Issue 6448).
 package org.parosproxy.paros.extension.manualrequest.http.impl;
 
 import java.awt.BorderLayout;
@@ -669,6 +670,8 @@ public class ManualHttpRequestEditorDialog extends ManualRequestEditorDialog
         private JButton getResponseSendButton() {
             if (responseSendButton == null) {
                 responseSendButton = new JButton(Constant.messages.getString("manReq.button.send"));
+                responseSendButton.setMnemonic(KeyEvent.VK_ENTER);
+                responseSendButton.setToolTipText(getBtnSendTooltip());
                 responseSendButton.addActionListener(
                         e -> {
                             responseSendButton.setEnabled(false);

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -2052,6 +2052,8 @@ log4j.tools.menu.gc         = Run the Garbage Collector
 
 manReq.name = Manual Request Editor Extension
 manReq.button.send             = Send
+manReq.button.send.tooltip = Alt+Enter
+manReq.button.send.tooltip.mac = Control+Option+Return
 manReq.warn.datainvalid = Unable to set the data to the message.
 manReq.checkBox.fixLength      = Update Content Length
 manReq.checkBox.followRedirect = Follow redirect


### PR DESCRIPTION
- ManualRequestEditorDialog > On send button set Mnemonic (Enter), set button tooltip.
- Messages.properties > Add name/value pair to support to tooltip.

Fixes zaproxy/zaproxy#6448

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>