### PR TITLE
Tweak CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: Java CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Only execute CI build on pushes to default branch, to reduce the builds
when the branches are pushed to main repo.