### PR TITLE
Link to zaproxy website for dev IDE guides

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -3,8 +3,8 @@ ZAP is built with [Gradle], the following sections explain how to use it to buil
 The Gradle tasks are expected to be executed with the provided [Gradle Wrapper].
 
 ## IDEs
-The following wiki page provides an in depth guide on how to import, build, and run ZAP (core and add-ons) with commonly used IDEs:
-https://github.com/zaproxy/zaproxy/wiki/Building
+The following page provides in depth guides on how to import, build, and run ZAP (core and add-ons) with commonly used IDEs:
+https://www.zaproxy.org/docs/developer/
 
 ## Run ZAP
 To run ZAP directly from the source run the task `:zap:run`. It will use any add-ons available in the [zap/src/main/dist/plugin/] directory.


### PR DESCRIPTION
Link to website instead of the wiki for IDE guides on how to build/run
ZAP and the add-ons.