### PR TITLE
Keep track of inserted tabs

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/view/TabbedPanel2.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/TabbedPanel2.java
@@ -386,6 +386,18 @@ public class TabbedPanel2 extends TabbedPanel {
         addTab(title, icon, c, hideable, visible, index, true);
     }
 
+    @Override
+    public void insertTab(String title, Icon icon, Component component, String tip, int index) {
+        super.insertTab(title, icon, component, tip, index);
+        if (!isPlusTab(icon) && !this.fullTabList.contains(component)) {
+            this.fullTabList.add(component);
+        }
+    }
+
+    private boolean isPlusTab(Icon icon) {
+        return icon == PLUS_ICON;
+    }
+
     /**
      * Adds a tab with the given component.
      *


### PR DESCRIPTION
Change `TabbedPanel2` to track also tabs inserted, not all of them are
added (e.g. Response tab might be inserted when changing the layout of
the Request/Response panels).

Fix #5165.