### PR TITLE
Increase memory for Sonar scan

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -31,4 +31,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.ZAPBOT_SONARCLOUD_TOKEN }}
-      run: ./gradlew sonarqube --stacktrace
+      run: ./gradlew -Dorg.gradle.jvmargs=-Xmx4g sonarqube --stacktrace

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("com.diffplug.gradle.spotless")
-    id("org.sonarqube") version "3.0"
+    id("org.sonarqube") version "3.1.1"
     id("com.github.ben-manes.versions") version "0.33.0"
 }
 


### PR DESCRIPTION
The latest scan failed with an OutOfMemoryError.
Update the Gradle plugin to latest version.