### PR TITLE
Fix unit tests failing randomly due to files not closed by Files.list()

### DIFF
--- a/zap/src/test/java/org/parosproxy/paros/ConstantUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/ConstantUnitTest.java
@@ -33,7 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
+import java.util.stream.Stream;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.core.config.Configurator;
@@ -223,19 +223,17 @@ public class ConstantUnitTest {
     }
 
     private String getNameBackupMalformedConfig() throws IOException {
-        Optional<Path> file =
-                Files.list(zapHomeDir)
-                        .filter(
-                                f -> {
-                                    String name = f.getFileName().toString();
-                                    return name.startsWith("config-") && name.endsWith(".xml.bak");
-                                })
-                        .findFirst();
-
-        if (file.isPresent()) {
-            return file.get().getFileName().toString();
+        try (Stream<Path> files = Files.list(zapHomeDir)) {
+            return files.filter(
+                            f -> {
+                                String name = f.getFileName().toString();
+                                return name.startsWith("config-") && name.endsWith(".xml.bak");
+                            })
+                    .findFirst()
+                    .map(Path::getFileName)
+                    .map(Path::toString)
+                    .orElse(null);
         }
-        return null;
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/control/AddOnInstallerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/AddOnInstallerUnitTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.Constant;
@@ -204,12 +205,12 @@ public class AddOnInstallerUnitTest extends AddOnTestUtils {
 
     private static void assertInstalledLibs(AddOn addOn, String... fileNames) throws IOException {
         Path addOnLibsDir = addOnDataLibsDir(addOn);
-        assertThat(
-                Files.list(addOnLibsDir)
-                        .map(Path::getFileName)
-                        .map(Path::toString)
-                        .collect(Collectors.toList()),
-                containsInAnyOrder(fileNames));
+
+        try (Stream<Path> files = Files.list(addOnLibsDir)) {
+            assertThat(
+                    files.map(Path::getFileName).map(Path::toString).collect(Collectors.toList()),
+                    containsInAnyOrder(fileNames));
+        }
     }
 
     private static String contents(Path file) throws IOException {


### PR DESCRIPTION
Two unit tests might fail when executed on Windows, due to a directory handlers not closed properly before cleanup of test resources. Error messages look like:

```
java.io.IOException: Failed to delete temp directory [TEMP DIR]\junit5272034518084445797. The following paths could not be deleted (see suppressed exceptions for details): , zap-7862358289951850220
	at org.junit.jupiter.engine.extension.TempDirectory$CloseablePath.createIOExceptionWithAttachedFailures(TempDirectory.java:262)
	at org.junit.jupiter.engine.extension.TempDirectory$CloseablePath.close(TempDirectory.java:182)
	[...]
	Suppressed: java.nio.file.DirectoryNotEmptyException: [TEMP DIR]\junit5272034518084445797\zap-7862358289951850220
		at java.base/sun.nio.fs.WindowsFileSystemProvider.implDelete(WindowsFileSystemProvider.java:267)
		at java.base/sun.nio.fs.AbstractFileSystemProvider.delete(AbstractFileSystemProvider.java:105)
		at java.base/java.nio.file.Files.delete(Files.java:1141)
		at org.junit.jupiter.engine.extension.TempDirectory$CloseablePath$1.deleteAndContinue(TempDirectory.java:206)
		at org.junit.jupiter.engine.extension.TempDirectory$CloseablePath$1.postVisitDirectory(TempDirectory.java:201)
		at org.junit.jupiter.engine.extension.TempDirectory$CloseablePath$1.postVisitDirectory(TempDirectory.java:192)
		at java.base/java.nio.file.Files.walkFileTree(Files.java:2742)
		at java.base/java.nio.file.Files.walkFileTree(Files.java:2796)
		at org.junit.jupiter.engine.extension.TempDirectory$CloseablePath.deleteAllFilesAndDirectories(TempDirectory.java:192)
		at org.junit.jupiter.engine.extension.TempDirectory$CloseablePath.close(TempDirectory.java:180)
		... 69 more
```

That's because `java.nio.file.Files.list()` still holds the directory open. The javadoc of Files.list states:

> This method must be used within a try-with-resources statement or similar control structure to ensure that the stream's open directory is closed promptly after the stream's operations have completed.

So I'm moving it to try-with-resources block. 