### PR TITLE
Detect WebSocket upgrade messages having multiple Connection directives

### DIFF
--- a/zap/src/test/java/org/parosproxy/paros/network/HttpMessageUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/network/HttpMessageUnitTest.java
@@ -335,6 +335,78 @@ public class HttpMessageUnitTest {
         verify(body).setContentEncodings(Collections.emptyList());
     }
 
+    @Test
+    public void
+            shouldBeWebSocketUpgradeIfRequestConnectionHeaderContainsUpgradeAndUpgradeHeaderEqualsWebsocket()
+                    throws Exception {
+        // Given
+        HttpMessage message =
+                new HttpMessage(
+                        new HttpRequestHeader(
+                                "GET / HTTP/1.1\r\nConnection: keep-alive, Upgrade\r\nUpgrade: websocket"));
+        // When
+        boolean webSocketUpgrade = message.isWebSocketUpgrade();
+        // Then
+        assertThat(webSocketUpgrade, is(equalTo(true)));
+    }
+
+    @Test
+    public void
+            shouldBeWebSocketUpgradeIfResponseConnectionHeaderEqualsUpgradeAndUpgradeHeaderEqualsWebsocket()
+                    throws Exception {
+        // Given
+        HttpMessage message = new HttpMessage();
+        message.setResponseHeader(
+                new HttpResponseHeader(
+                        "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: websocket"));
+        // When
+        boolean webSocketUpgrade = message.isWebSocketUpgrade();
+        // Then
+        assertThat(webSocketUpgrade, is(equalTo(true)));
+    }
+
+    @Test
+    public void
+            shouldBeWebSocketUpgradeIfResponseConnectionHeaderContainsUpgradeAndUpgradeHeaderEqualsWebsocket()
+                    throws Exception {
+        // Given
+        HttpMessage message = new HttpMessage();
+        message.setResponseHeader(
+                new HttpResponseHeader(
+                        "HTTP/1.1 101 Switching Protocols\r\nConnection: keep-alive, Upgrade\r\nUpgrade: websocket"));
+        // When
+        boolean webSocketUpgrade = message.isWebSocketUpgrade();
+        // Then
+        assertThat(webSocketUpgrade, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldNotBeWebSocketUpgradeIfResponseConnectionHeaderMissUpgradeValue()
+            throws Exception {
+        // Given
+        HttpMessage message = new HttpMessage();
+        message.setResponseHeader(
+                new HttpResponseHeader(
+                        "HTTP/1.1 101 Switching Protocols\r\nConnection: keep-alive\r\nUpgrade: websocket"));
+        // When
+        boolean webSocketUpgrade = message.isWebSocketUpgrade();
+        // Then
+        assertThat(webSocketUpgrade, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotBeWebSocketUpgradeIfResponseMissUpgradeHeader() throws Exception {
+        // Given
+        HttpMessage message = new HttpMessage();
+        message.setResponseHeader(
+                new HttpResponseHeader(
+                        "HTTP/1.1 101 Switching Protocols\r\nConnection: keep-alive, Upgrade"));
+        // When
+        boolean webSocketUpgrade = message.isWebSocketUpgrade();
+        // Then
+        assertThat(webSocketUpgrade, is(equalTo(false)));
+    }
+
     private static HttpMessage newHttpMessage() throws Exception {
         HttpMessage message =
                 new HttpMessage(


### PR DESCRIPTION
`HttpMessage.isWebSocketUpgrade()` does not recognize WebSocket upgrade message when the _Connection_ header has multiple values. 

Connection header is allowed to have a comma-separated list of HTTP headers, i.e. `Connection: keep-alive, Upgrade`, and not just a single `Connection: Upgrade` keyword. 

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection 

> any comma-separated list of HTTP headers

or https://tools.ietf.org/html/rfc6455: 

> The request MUST contain a |Connection| header field whose value MUST **include** the Upgrade token. 

Also, request messages could be considered WebSocket upgrade messages also, similarly to `isEventStream()` method checking both request and response headers. 