### PR TITLE
Variant Tweaks - Clean Code

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantAbstractRPCQuery.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantAbstractRPCQuery.java
@@ -101,55 +101,27 @@ public abstract class VariantAbstractRPCQuery implements Variant {
         listParam.add(param);
     }
 
-    /**
-     * @param beginOffset
-     * @param endOffset
-     * @return
-     */
     public String getToken(int beginOffset, int endOffset) {
         return requestContent.substring(beginOffset, endOffset);
     }
 
-    /** @return */
     @Override
     public List<NameValuePair> getParamList() {
         return params;
     }
 
-    /**
-     * @param msg
-     * @param originalPair
-     * @param name
-     * @param value
-     * @return
-     */
     @Override
     public String setParameter(
             HttpMessage msg, NameValuePair originalPair, String name, String value) {
         return this.setParameter(msg, originalPair, name, value, false);
     }
 
-    /**
-     * @param msg
-     * @param originalPair
-     * @param name
-     * @param value
-     * @return
-     */
     @Override
     public String setEscapedParameter(
             HttpMessage msg, NameValuePair originalPair, String name, String value) {
         return this.setParameter(msg, originalPair, name, value, true);
     }
 
-    /**
-     * @param msg
-     * @param originalPair
-     * @param name
-     * @param value
-     * @param escaped
-     * @return
-     */
     private String setParameter(
             HttpMessage msg,
             NameValuePair originalPair,
@@ -167,7 +139,6 @@ public abstract class VariantAbstractRPCQuery implements Variant {
         return query;
     }
 
-    /** @param requestContent */
     protected void setRequestContent(String requestContent) {
         this.requestContent = requestContent;
         parseContent(requestContent);
@@ -207,26 +178,12 @@ public abstract class VariantAbstractRPCQuery implements Variant {
         return result.toString();
     }
 
-    /**
-     * @param contentType
-     * @return
-     */
     public abstract boolean isValidContentType(String contentType);
 
-    /** @param content */
     public abstract void parseContent(String content);
 
-    /**
-     * @param value
-     * @param toQuote
-     * @return
-     */
     public abstract String getEscapedValue(String value, boolean toQuote);
 
-    /**
-     * @param value
-     * @return
-     */
     public abstract String getUnescapedValue(String value);
 
     /** Inner support class */

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantCookie.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantCookie.java
@@ -109,40 +109,18 @@ public class VariantCookie implements Variant {
         return params;
     }
 
-    /**
-     * @param msg
-     * @param originalPair
-     * @param name
-     * @param value
-     * @return
-     */
     @Override
     public String setParameter(
             HttpMessage msg, NameValuePair originalPair, String name, String value) {
         return setParameter(msg, originalPair, name, value, false);
     }
 
-    /**
-     * @param msg
-     * @param originalPair
-     * @param name
-     * @param value
-     * @return
-     */
     @Override
     public String setEscapedParameter(
             HttpMessage msg, NameValuePair originalPair, String name, String value) {
         return setParameter(msg, originalPair, name, value, true);
     }
 
-    /**
-     * @param msg
-     * @param originalPair
-     * @param name
-     * @param value
-     * @param escaped
-     * @return
-     */
     private String setParameter(
             HttpMessage msg,
             NameValuePair originalPair,

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantDirectWebRemotingQuery.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantDirectWebRemotingQuery.java
@@ -62,26 +62,16 @@ public class VariantDirectWebRemotingQuery extends VariantAbstractRPCQuery {
         return contentType.startsWith(DWR_CONTENT_TYPE);
     }
 
-    /**
-     * @param value
-     * @param toQuote
-     * @return
-     */
     @Override
     public String getEscapedValue(String value, boolean toQuote) {
         return StringEscapeUtils.escapeJava(value);
     }
 
-    /**
-     * @param value
-     * @return
-     */
     @Override
     public String getUnescapedValue(String value) {
         return StringEscapeUtils.unescapeJava(value);
     }
 
-    /** @param content */
     @Override
     public void parseContent(String content) {
         // System.out.println("Getting parameters from ["+content + "]");

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantHeader.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantHeader.java
@@ -133,13 +133,6 @@ public class VariantHeader implements Variant {
         return params;
     }
 
-    /**
-     * @param msg
-     * @param originalPair
-     * @param name
-     * @param value
-     * @return
-     */
     @Override
     public String setParameter(
             HttpMessage msg, NameValuePair originalPair, String name, String value) {
@@ -150,13 +143,6 @@ public class VariantHeader implements Variant {
         return originalPair.getName() + ": " + value;
     }
 
-    /**
-     * @param msg
-     * @param originalPair
-     * @param name
-     * @param value
-     * @return
-     */
     @Override
     public String setEscapedParameter(
             HttpMessage msg, NameValuePair originalPair, String name, String value) {

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantJSONQuery.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantJSONQuery.java
@@ -41,27 +41,17 @@ public class VariantJSONQuery extends VariantAbstractRPCQuery {
         super(NameValuePair.TYPE_JSON);
     }
 
-    /**
-     * @param contentType
-     * @return
-     */
     @Override
     public boolean isValidContentType(String contentType) {
         return contentType.startsWith(JSON_RPC_CONTENT_TYPE);
     }
 
-    /** @param content */
     @Override
     public void parseContent(String content) {
         sr = new SimpleStringReader(content);
         parseObject();
     }
 
-    /**
-     * @param value
-     * @param toQuote
-     * @return
-     */
     @Override
     public String getEscapedValue(String value, boolean toQuote) {
         String result = StringEscapeUtils.escapeJava(value);
@@ -177,7 +167,6 @@ public class VariantJSONQuery extends VariantAbstractRPCQuery {
         }
     }
 
-    /** @param fieldName */
     private void parseValue(String fieldName) {
         int chr = sr.read();
 
@@ -353,7 +342,6 @@ public class VariantJSONQuery extends VariantAbstractRPCQuery {
             next--;
         }
 
-        /** @return */
         public int getPosition() {
             return next;
         }

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantODataFilterQuery.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantODataFilterQuery.java
@@ -50,7 +50,7 @@ import org.parosproxy.paros.network.HttpMessage;
  */
 public class VariantODataFilterQuery implements Variant {
 
-    private static final Logger log = LogManager.getLogger(VariantODataFilterQuery.class);
+    private static final Logger LOG = LogManager.getLogger(VariantODataFilterQuery.class);
 
     // Extract the content of the $filter parameter
     private static final Pattern patternFilterParameters =
@@ -129,7 +129,7 @@ public class VariantODataFilterQuery implements Variant {
             }
 
         } catch (URIException e) {
-            log.error(e.getMessage() + uri, e);
+            LOG.error(e.getMessage() + uri, e);
         }
     }
 
@@ -164,7 +164,7 @@ public class VariantODataFilterQuery implements Variant {
                 msg.getRequestHeader().getURI().setQuery(modifiedQuery);
 
             } catch (URIException | NullPointerException e) {
-                log.error("Exception with the modified query " + modifiedQuery, e);
+                LOG.error("Exception with the modified query " + modifiedQuery, e);
             }
 
             return newfilter;

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantODataIdQuery.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantODataIdQuery.java
@@ -46,7 +46,7 @@ import org.parosproxy.paros.network.HttpMessage;
  */
 public class VariantODataIdQuery implements Variant {
 
-    private static final Logger log = LogManager.getLogger(VariantODataIdQuery.class);
+    private static final Logger LOG = LogManager.getLogger(VariantODataIdQuery.class);
 
     /** In order to identify the unnamed id we add this prefix to the resource name * */
     public static final String RESOURCE_ID_PREFIX = "__ID__";
@@ -153,7 +153,7 @@ public class VariantODataIdQuery implements Variant {
             }
 
         } catch (URIException e) {
-            log.error(e.getMessage() + uri, e);
+            LOG.error(e.getMessage() + uri, e);
         }
     }
 

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantURLPath.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantURLPath.java
@@ -38,10 +38,10 @@ import org.parosproxy.paros.network.HttpMessage;
  */
 public class VariantURLPath implements Variant {
 
-    private final Logger logger = LogManager.getLogger(this.getClass());
+    private final Logger LOGGER = LogManager.getLogger(this.getClass());
+
     private final List<NameValuePair> stringParam = new ArrayList<>();
 
-    /** @param msg */
     @Override
     public void setMessage(HttpMessage msg) {
         /*
@@ -70,32 +70,17 @@ public class VariantURLPath implements Variant {
         }
     }
 
-    /** @return */
     @Override
     public List<NameValuePair> getParamList() {
         return stringParam;
     }
 
-    /**
-     * @param msg
-     * @param originalPair
-     * @param name
-     * @param value
-     * @return
-     */
     @Override
     public String setParameter(
             HttpMessage msg, NameValuePair originalPair, String name, String value) {
         return setParameter(msg, originalPair, name, value, false);
     }
 
-    /**
-     * @param msg
-     * @param originalPair
-     * @param name
-     * @param value
-     * @return
-     */
     @Override
     public String setEscapedParameter(
             HttpMessage msg, NameValuePair originalPair, String name, String value) {
@@ -120,14 +105,6 @@ public class VariantURLPath implements Variant {
         return "";
     }
 
-    /**
-     * @param msg
-     * @param originalPair
-     * @param name
-     * @param value
-     * @param escaped
-     * @return
-     */
     private String setParameter(
             HttpMessage msg,
             NameValuePair originalPair,
@@ -155,7 +132,7 @@ public class VariantURLPath implements Variant {
             }
 
         } catch (URIException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         return value;

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantURLQuery.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantURLQuery.java
@@ -39,7 +39,7 @@ import org.parosproxy.paros.network.HttpMessage;
 
 public class VariantURLQuery extends VariantAbstractQuery {
 
-    private static final Logger log = LogManager.getLogger(VariantURLQuery.class);
+    private static final Logger LOG = LogManager.getLogger(VariantURLQuery.class);
 
     public VariantURLQuery() {
         super();
@@ -82,7 +82,7 @@ public class VariantURLQuery extends VariantAbstractQuery {
             msg.getRequestHeader().getURI().setEscapedQuery(query);
 
         } catch (URIException e) {
-            log.error(e.getMessage() + query, e);
+            LOG.error(e.getMessage() + query, e);
         }
     }
 }

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantUserDefined.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantUserDefined.java
@@ -37,7 +37,7 @@ public class VariantUserDefined implements Variant {
 
     private int[][] injectionPoints = null;
 
-    private static final Logger logger = LogManager.getLogger(VariantUserDefined.class);
+    private static final Logger LOGGER = LogManager.getLogger(VariantUserDefined.class);
 
     public VariantUserDefined() {
         super();
@@ -69,7 +69,7 @@ public class VariantUserDefined implements Variant {
                 if (isInHeader(this.injectionPoints[i]) || isInBody(this.injectionPoints[i])) {
                     list.add(new NameValuePair(NameValuePair.TYPE_UNDEFINED, "", "", i));
                 } else {
-                    logger.warn(
+                    LOGGER.warn(
                             "Invalid injection point: "
                                     + java.util.Arrays.toString(this.injectionPoints[i]));
                 }
@@ -91,7 +91,7 @@ public class VariantUserDefined implements Variant {
             try {
                 msg.getRequestHeader().setMessage(sb.toString());
             } catch (HttpMalformedHeaderException e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         } else {
             String body = msg.getRequestBody().toString();


### PR DESCRIPTION
* VariantCustom
  - Fix "thta" javadoc typo

* VariantURLPath
  - Remove boilerplate javadoc on overridden and private methods
  - Name logger as constant (fullcaps)

* VariantJSONQuery
  - Remove boilerplate javadoc

* VariantHeader
  - Remove boilerplate javadoc

* VariantDirectWebRemotingQuery
  - Remove boilerplate javadoc on overridden methods

* VariantCookie
  - Remove boilerplate javadoc on overridden and private methods

* VariantAbstractRPCQuery()
  - Remove boilerplate javadoc

* VariantODataFilterQuery & VariantODataIdQuery
  - Name logger as constant (fullcaps)

* VariantURLQuery
  - Name logger as constant (fullcaps)

* VariantUserDefined
  - Name logger as constant (fullcaps)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>