### PR TITLE
Stop and destroy extensions on add-on uninstall

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/Extension.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/Extension.java
@@ -46,6 +46,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/09/12 Add defaults to getAuthor() and getURL().
 // ZAP: 2020/03/09 Default getURL() to null.
+// ZAP: 2021/04/13 Update JavaDoc of stop() and destroy().
 package org.parosproxy.paros.extension;
 
 import java.net.URL;
@@ -127,11 +128,27 @@ public interface Extension {
     /** Start the plugin e.g. if there is a running server. */
     void start();
 
-    /** stop the plugin e.g. if there is a running server. */
+    /**
+     * Stops the extension, e.g. running scans, processes, servers.
+     *
+     * <p>Called when the extension is removed (i.e. corresponding add-on is uninstalled) and when
+     * ZAP shuts down.
+     *
+     * <p>Should be called only by core functionality.
+     *
+     * @see #destroy()
+     */
     void stop();
 
     /**
-     * Plugin cleanup, finalize, etc. when program shutdown. Stop() will be called before shutdown.
+     * Performs final cleanups, free resources.
+     *
+     * <p>Called when the extension is removed (i.e. corresponding add-on is uninstalled) and when
+     * ZAP shuts down.
+     *
+     * <p>Called after {@link #stop() stopping} the extension.
+     *
+     * <p>Should be called only by core functionality.
      */
     void destroy();
 

--- a/zap/src/main/java/org/parosproxy/paros/extension/ExtensionLoader.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/ExtensionLoader.java
@@ -89,6 +89,7 @@
 // ZAP: 2020/05/14 Hook HttpSenderListener when starting single extension.
 // ZAP: 2020/08/27 Added support for plugable variants
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
+// ZAP: 2021/04/13 Issue 6536: Stop and destroy extensions being removed.
 package org.parosproxy.paros.extension;
 
 import java.awt.Component;
@@ -1473,6 +1474,9 @@ public class ExtensionLoader {
     /**
      * Removes the given extension and any components added through its extension hook.
      *
+     * <p>The extension is also {@link Extension#stop() stopped} and {@link Extension#destroy()
+     * destroyed}.
+     *
      * <p><strong>Note:</strong> This method should be called only by bootstrap classes.
      *
      * @param extension the extension to remove.
@@ -1482,6 +1486,12 @@ public class ExtensionLoader {
         extensionList.remove(extension);
         extensionsMap.remove(extension.getClass());
 
+        extension.stop();
+        unhook(extension);
+        extension.destroy();
+    }
+
+    private void unhook(Extension extension) {
         ExtensionHook hook = extensionHooks.remove(extension);
         if (hook == null) {
             logger.error("ExtensionHook not found for: " + extension.getClass().getCanonicalName());

--- a/zap/src/test/java/org/parosproxy/paros/extension/ExtensionLoaderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/extension/ExtensionLoaderUnitTest.java
@@ -1,0 +1,77 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.extension;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.parosproxy.paros.model.Model;
+
+/** Unit test for {@link ExtensionLoader}. */
+class ExtensionLoaderUnitTest {
+
+    private Model model;
+    private ExtensionLoader extensionLoader;
+
+    @BeforeEach
+    void setUp() {
+        model = mock(Model.class);
+        extensionLoader = new ExtensionLoader(model, null);
+    }
+
+    @Test
+    void shouldStopExtensionWhenRemoved() {
+        // Given
+        Extension extension = mock(Extension.class);
+        extensionLoader.addExtension(extension);
+        // When
+        extensionLoader.removeExtension(extension);
+        // Then
+        verify(extension).stop();
+    }
+
+    @Test
+    void shouldDestroyExtensionWhenRemoved() {
+        // Given
+        Extension extension = mock(Extension.class);
+        extensionLoader.addExtension(extension);
+        // When
+        extensionLoader.removeExtension(extension);
+        // Then
+        verify(extension).destroy();
+    }
+
+    @Test
+    void shouldStopBeforeDestroyExtensionWhenRemoved() {
+        // Given
+        Extension extension = mock(Extension.class);
+        extensionLoader.addExtension(extension);
+        InOrder inOrder = inOrder(extension);
+        // When
+        extensionLoader.removeExtension(extension);
+        // Then
+        inOrder.verify(extension).stop();
+        inOrder.verify(extension).destroy();
+    }
+}


### PR DESCRIPTION
Change `ExtensionLoader` to stop and destroy the extension when removed.
Update JavaDoc in `Extension` to be clear that the extension will also
be stopped/destroyed when the add-on is uninstalled, not just when ZAP
shuts down.

Fix #6536.