### PR TITLE
Address deprecation with Java 16

### DIFF
--- a/zap/src/main/java/ch/csnc/extension/httpclient/SSLContextManager.java
+++ b/zap/src/main/java/ch/csnc/extension/httpclient/SSLContextManager.java
@@ -276,7 +276,7 @@ public class SSLContextManager {
             throw new KeyStoreException(e.getMessage());
         }
 
-        String dn = x509.getSubjectDN().getName();
+        String dn = x509.getSubjectX500Principal().getName();
 
         log.info("Fingerprint is " + buff.toString().toUpperCase());
 


### PR DESCRIPTION
Use the non-deprecated method to get the subject name from the cert.

Part of #6511.