### PR TITLE
Address test failures in newer Java versions

### DIFF
--- a/LEGALNOTICE.md
+++ b/LEGALNOTICE.md
@@ -68,4 +68,4 @@ and subject to their respective licenses.
 | sqlite-jdbc-3.34.0.jar              | BSD-2 clause              |
 | - NestedVM                          | Apache 2.0                |
 | swingx-all-1.6.5-1.jar              | LGPL 2.1                  |
-| xom-1.2.10.jar                      | LGPL                      |
+| xom-1.3.7.jar                       | LGPL                      |

--- a/zap/src/test/java/org/zaproxy/zap/VerifyScriptTemplates.java
+++ b/zap/src/test/java/org/zaproxy/zap/VerifyScriptTemplates.java
@@ -40,11 +40,14 @@ import java.util.List;
 import javax.script.Compilable;
 import javax.script.ScriptEngineManager;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 /** Verifies that the script templates are parsed without errors. */
 public class VerifyScriptTemplates {
 
     @Test
+    @EnabledForJreRange(max = JRE.JAVA_14)
     public void shouldParseJsTemplates() throws Exception {
         // Given
         List<Path> templates = getScriptTemplates(".js");

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -81,7 +81,7 @@ dependencies {
 
     runtimeOnly("commons-jxpath:commons-jxpath:1.3")
     runtimeOnly("commons-logging:commons-logging:1.2")
-    runtimeOnly("com.io7m.xom:xom:1.2.10") {
+    runtimeOnly("xom:xom:1.3.7") {
         setTransitive(false)
     }
 


### PR DESCRIPTION
Do not attempt to verify JavaScript templates when running with newer
Java versions (15+), the Nashorn engine is not present.
Update XOM to latest version, 1.3.7, to address an IllegalAccessError
with Java 16+.