### PR TITLE
fix: HTTP Panels Font setting for dark LaFs (Theme)

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/HttpPanelSyntaxHighlightTextArea.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/HttpPanelSyntaxHighlightTextArea.java
@@ -134,8 +134,7 @@ public abstract class HttpPanelSyntaxHighlightTextArea extends RSyntaxTextArea {
         setCloseMarkupTags(false);
         setClearWhitespaceLinesEnabled(false);
 
-        this.setFont(
-                FontUtils.getFontWithFallback(FontType.workPanels, this.getFont().getFontName()));
+        setFont();
 
         if (DisplayUtils.isDarkLookAndFeel()) {
             darkLaF = true;
@@ -154,9 +153,15 @@ public abstract class HttpPanelSyntaxHighlightTextArea extends RSyntaxTextArea {
                                     .getResourceAsStream(dark ? RESOURCE_DARK : RESOURCE_LIGHT));
 
             theme.apply(this);
+            setFont();
         } catch (IOException e) {
             // Ignore
         }
+    }
+
+    private void setFont() {
+        this.setFont(
+                FontUtils.getFontWithFallback(FontType.workPanels, this.getFont().getFontName()));
     }
 
     @Override


### PR DESCRIPTION
Ensure HTTP Panels have their font set based on ZAP's Display Options after applying the dark theme.

This still doesn't make font changes dynamic, but they are at least applied properly when customized and ZAP starts with a dark LaF.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>