### PR TITLE
Added menu item to directly add base URL to context

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
@@ -65,6 +65,7 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
     private PopupMenuShowInSites popupMenuShowInSites = null;
     private PopupMenuOpenUrlInBrowser popupMenuOpenUrlInBrowser = null;
     private PopupMenuItemContextInclude popupContextIncludeMenu = null;
+    private PopupMenuItemContextSiteInclude popupContextIncludeSiteMenu = null;
     private PopupMenuItemContextExclude popupContextExcludeMenu = null;
     private PopupMenuItemContextDataDriven popupContextDataDrivenMenu = null;
     private PopupMenuCopyUrls popupMenuCopyUrls = null;
@@ -109,36 +110,58 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
             // Be careful when changing the menu indexes (and order above) - its easy to get
             // unexpected
             // results!
-            extensionHook.getHookMenu().addPopupMenuItem(getPopupExcludeFromProxyMenu(0));
-            if (isExtensionActiveScanEnabled) {
-                extensionHook.getHookMenu().addPopupMenuItem(getPopupExcludeFromScanMenu(0));
-            }
-            extensionHook.getHookMenu().addPopupMenuItem(getPopupExcludeFromSpiderMenu(0));
-            extensionHook.getHookMenu().addPopupMenuItem(getPopupContextIncludeMenu(1));
-            extensionHook.getHookMenu().addPopupMenuItem(getPopupContextExcludeMenu(2));
+            int indexMenuItem = 0;
             extensionHook
                     .getHookMenu()
-                    .addPopupMenuItem(getPopupContextDataDrivenMenu(2)); // TODO ??
+                    .addPopupMenuItem(getPopupExcludeFromProxyMenu(indexMenuItem));
+            if (isExtensionActiveScanEnabled) {
+                extensionHook
+                        .getHookMenu()
+                        .addPopupMenuItem(getPopupExcludeFromScanMenu(indexMenuItem));
+            }
+            extensionHook
+                    .getHookMenu()
+                    .addPopupMenuItem(getPopupExcludeFromSpiderMenu(indexMenuItem));
+            extensionHook
+                    .getHookMenu()
+                    .addPopupMenuItem(getPopupContextIncludeMenu(++indexMenuItem));
+            extensionHook
+                    .getHookMenu()
+                    .addPopupMenuItem(getPopupContextIncludeSiteMenu(++indexMenuItem));
+            extensionHook
+                    .getHookMenu()
+                    .addPopupMenuItem(getPopupContextExcludeMenu(++indexMenuItem));
+            extensionHook
+                    .getHookMenu()
+                    .addPopupMenuItem(getPopupContextDataDrivenMenu(indexMenuItem)); // TODO ??
 
             if (isExtensionActiveScanEnabled) {
-                extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuActiveScanCustom(3));
-            }
-
-            if (isExtensionHistoryEnabled) {
-                extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuResendMessage(4));
+                extensionHook
+                        .getHookMenu()
+                        .addPopupMenuItem(getPopupMenuActiveScanCustom(++indexMenuItem));
             }
 
             if (isExtensionHistoryEnabled) {
                 extensionHook
                         .getHookMenu()
-                        .addPopupMenuItem(getPopupMenuShowInHistory(6)); // Both are index 6
+                        .addPopupMenuItem(getPopupMenuResendMessage(++indexMenuItem));
+            }
+            indexMenuItem += 2;
+            if (isExtensionHistoryEnabled) {
+                extensionHook
+                        .getHookMenu()
+                        .addPopupMenuItem(
+                                getPopupMenuShowInHistory(
+                                        indexMenuItem)); // Both are the same index
             }
             extensionHook
                     .getHookMenu()
-                    .addPopupMenuItem(getPopupMenuShowInSites(6)); // on purpose ;)
-            extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuOpenUrlInBrowser(7));
-            extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuCopyUrls(8));
-            // extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuShowResponseInBrowser(7));
+                    .addPopupMenuItem(getPopupMenuShowInSites(indexMenuItem)); // on purpose ;)
+            extensionHook
+                    .getHookMenu()
+                    .addPopupMenuItem(getPopupMenuOpenUrlInBrowser(++indexMenuItem));
+            // extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuShowResponseInBrowser(indexMenuItem));
+            extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuCopyUrls(++indexMenuItem));
 
             extensionHook.getHookMenu().addPopupMenuItem(getPopupContextTreeMenuInScope());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupContextTreeMenuOutScope());
@@ -436,6 +459,14 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
             popupContextIncludeMenu.setParentMenuIndex(menuIndex);
         }
         return popupContextIncludeMenu;
+    }
+
+    private PopupMenuItemContextSiteInclude getPopupContextIncludeSiteMenu(int menuIndex) {
+        if (popupContextIncludeSiteMenu == null) {
+            popupContextIncludeSiteMenu = new PopupMenuItemContextSiteInclude();
+            popupContextIncludeSiteMenu.setParentMenuIndex(menuIndex);
+        }
+        return popupContextIncludeSiteMenu;
     }
 
     private PopupMenuItemContextExclude getPopupContextExcludeMenu(int menuIndex) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuItemContextSiteInclude.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuItemContextSiteInclude.java
@@ -1,0 +1,49 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.stdmenus;
+
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.view.popup.PopupMenuItemContextInclude;
+
+class PopupMenuItemContextSiteInclude extends PopupMenuItemContextInclude {
+
+    private static final long serialVersionUID = 1L;
+
+    PopupMenuItemContextSiteInclude() {
+        super();
+    }
+
+    @Override
+    public String getParentMenuName() {
+        return Constant.messages.getString("context.includesite.popup");
+    }
+
+    @Override
+    protected ExtensionPopupMenuItem createPopupIncludeInContextMenu() {
+        return new PopupMenuItemIncludeSiteInContext();
+    }
+
+    @Override
+    protected ExtensionPopupMenuItem createPopupIncludeInContextMenu(Context context) {
+        return new PopupMenuItemIncludeSiteInContext(context);
+    }
+}

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuItemIncludeSiteInContext.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuItemIncludeSiteInContext.java
@@ -1,0 +1,55 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.stdmenus;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.db.DatabaseException;
+import org.parosproxy.paros.model.SiteNode;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.view.popup.PopupMenuItemIncludeInContext;
+
+class PopupMenuItemIncludeSiteInContext extends PopupMenuItemIncludeInContext {
+
+    private static final long serialVersionUID = 1L;
+    private static Logger log = LogManager.getLogger(PopupMenuItemIncludeSiteInContext.class);
+
+    PopupMenuItemIncludeSiteInContext() {
+        super();
+    }
+
+    PopupMenuItemIncludeSiteInContext(Context context) {
+        super(context);
+    }
+
+    @Override
+    public String getParentMenuName() {
+        return Constant.messages.getString("context.includesite.popup");
+    }
+
+    @Override
+    protected String createRegex(SiteNode sn) throws DatabaseException {
+        while (sn.getParent().getParent() != null) {
+            sn = sn.getParent();
+        }
+        return super.createRegex(sn);
+    }
+}

--- a/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemIncludeInContext.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemIncludeInContext.java
@@ -63,7 +63,7 @@ public class PopupMenuItemIncludeInContext extends PopupMenuItemSiteNodeContaine
     @Override
     public void performAction(SiteNode sn) {
         try {
-            performAction(sn.getNodeName(), new StructuralSiteNode(sn).getRegexPattern());
+            performAction(sn.getNodeName(), createRegex(sn));
         } catch (DatabaseException e) {
             // Ignore
         }
@@ -101,6 +101,10 @@ public class PopupMenuItemIncludeInContext extends PopupMenuItemSiteNodeContaine
         // Manually create the UI shared contexts so any modifications are done
         // on an UI shared Context, so changes can be undone by pressing Cancel
         View.getSingleton().getSessionDialog().recreateUISharedContexts(session);
+    }
+
+    protected String createRegex(SiteNode sn) throws DatabaseException {
+        return new StructuralSiteNode(sn).getRegexPattern();
     }
 
     @Override

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -1325,6 +1325,7 @@ context.export.urls.menu 		   = Export URLs for Context(s)
 context.flag.popup                 = Flag as Context 
 context.flag.popup.datadriven      = {0} : Data Driven Node
 context.include.popup              = Include in Context
+context.includesite.popup          = Include Site in Context
 context.import.error			   = Failed to import Context:\n{0}
 context.inscope.label              = In Scope
 context.inscope.popup			   = Add to Scope

--- a/zap/src/test/java/org/zaproxy/zap/extension/stdmenu/PopupMenuItemIncludeSiteInContextUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/stdmenu/PopupMenuItemIncludeSiteInContextUnitTest.java
@@ -1,0 +1,72 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.stdmenus;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.db.DatabaseException;
+import org.parosproxy.paros.model.SiteNode;
+import org.zaproxy.zap.utils.I18N;
+
+/** Unit test for {@link PopupMenuItemIncludeSiteInContext}. */
+class PopupMenuItemIncludeSiteInContextUnitTest {
+
+    private PopupMenuItemIncludeSiteInContext popup;
+
+    @BeforeAll
+    static void setupAll() {
+        Constant.messages = mock(I18N.class);
+    }
+
+    @AfterAll
+    static void cleanup() {
+        Constant.messages = null;
+    }
+
+    @BeforeEach
+    void setup() {
+        popup = new PopupMenuItemIncludeSiteInContext();
+    }
+
+    @Test
+    void shouldTraverseParentsUntilHostNodeForRegex() throws DatabaseException {
+        // Given
+        SiteNode sitesNode = mock(SiteNode.class);
+        SiteNode hostNodeNode = mock(SiteNode.class);
+        // Make "root" to return early on regex creation.
+        given(hostNodeNode.isRoot()).willReturn(true);
+        given(hostNodeNode.getParent()).willReturn(sitesNode);
+        SiteNode leafHostNode = mock(SiteNode.class);
+        given(leafHostNode.getParent()).willReturn(hostNodeNode);
+        // When
+        String regex = popup.createRegex(leafHostNode);
+        // Then
+        assertThat(regex, is(equalTo(".*")));
+    }
+}


### PR DESCRIPTION
A MenuItem was added to the History and Sites Panel right-click menus, allowing to directly add the base URL of a request to the specified context.

Fixes #6023 