### PR TITLE
Fix scrolling in Sites tab with FlatLaf L&F

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/view/ContextsSitesPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ContextsSitesPanel.java
@@ -110,7 +110,12 @@ public class ContextsSitesPanel extends JPanel {
         public int getScrollableUnitIncrement(
                 Rectangle visibleRect, int orientation, int direction) {
             if (visibleRect.getY() < sitesTree.getBounds().getY()) {
-                return contextsTree.getScrollableUnitIncrement(visibleRect, orientation, direction);
+                int unitIncrement =
+                        contextsTree.getScrollableUnitIncrement(
+                                visibleRect, orientation, direction);
+                if (unitIncrement != 0) {
+                    return unitIncrement;
+                }
             }
             return sitesTree.getScrollableUnitIncrement(visibleRect, orientation, direction);
         }


### PR DESCRIPTION
Check the scrollable unit increment of the Sites tree if the Contexts
tree reports no more increments, it might be that the view is almost in
the Sites tree but not yet in it, which would cause the Contexts tree to
report no more increments while it might still have more for the Sites
tree.

Fix #6520.