### PR TITLE
improvement: HTTP Panels Font setting for dark LaFs (Theme)

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/HttpPanelSyntaxHighlightTextArea.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/HttpPanelSyntaxHighlightTextArea.java
@@ -134,13 +134,12 @@ public abstract class HttpPanelSyntaxHighlightTextArea extends RSyntaxTextArea {
         setCloseMarkupTags(false);
         setClearWhitespaceLinesEnabled(false);
 
-        setFont();
-
         if (DisplayUtils.isDarkLookAndFeel()) {
             darkLaF = true;
             setLookAndFeel(darkLaF);
         } else {
             darkLaF = false;
+            setFont();
         }
         initHighlighter();
     }


### PR DESCRIPTION
Only set font when needed. During setLookAndFeel for dark LaFs, when instantionating for light LaFs.

Follow-up to: https://github.com/zaproxy/zaproxy/pull/6557

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>