### PR TITLE
Do not check for null engine in visibility check

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptEngineWrapper.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptEngineWrapper.java
@@ -90,11 +90,6 @@ public abstract class ScriptEngineWrapper {
      * @since 2.8.0
      */
     public boolean isVisible() {
-        // TODO remove the if statement once NullScriptEngineWrapper implements this method.
-        // NullScriptEngineWrapper is not a functional engine.
-        if ("Null".equals(getEngineName())) {
-            return false;
-        }
         return true;
     }
 


### PR DESCRIPTION
The null engine already implements the required method.