### PR TITLE
Allow to use more memory for weekly builds

### DIFF
--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/GradleBuildWithGitRepos.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/GradleBuildWithGitRepos.java
@@ -206,6 +206,7 @@ public class GradleBuildWithGitRepos extends DefaultTask {
 
     private void runGradle(Path repoDir, List<String> args) {
         List<String> execArgs = new ArrayList<>();
+        execArgs.add("-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m");
         if (quiet.get()) {
             execArgs.add("-q");
         }


### PR DESCRIPTION
Increase the max memory allowed when running the build tasks for the
weekly.