### PR TITLE
fix: Disable FlatLaf native decorations on windows

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/GuiBootstrap.java
+++ b/zap/src/main/java/org/zaproxy/zap/GuiBootstrap.java
@@ -334,6 +334,8 @@ public class GuiBootstrap extends ZapBootstrap {
 
         if (Constant.isMacOsX()) {
             OsXGui.setup();
+        } else if (Constant.isWindows()) {
+            UIManager.put("TitlePane.useWindowDecorations", false);
         }
 
         if (setLookAndFeel(System.getProperty("swing.defaultlaf"))) {


### PR DESCRIPTION
Native Decorations were causing various issues for me:
- ZAP wouldn't start maximized.
- Split pane dividers would drift noticeably between starts of ZAP.
- The close button would sometimes be inaccessible.

See: https://github.com/JFormDesigner/FlatLaf/pull/267 for further details.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>