### PR TITLE
Remove unnecessary todo

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/option/OptionsLocalePanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/option/OptionsLocalePanel.java
@@ -167,10 +167,4 @@ public class OptionsLocalePanel extends AbstractParamPanel {
             options.getViewParam().setLocale(selectedLocale.getLocale());
         }
     }
-
-    @Override
-    public String getHelpIndex() {
-        // TODO no help page?
-        return "ui.dialogs.options.locale";
-    }
 }


### PR DESCRIPTION
The dialogue that allows to select the locale does not show/have any
help button (the method is not actually called by the dialogue).