### PR TITLE
Add text/yaml to expected media-types

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2021-04-30
+ - Alert_on_Unexpected_Content_Types.js > Added Content-Type text/yaml to the list of expected types.
+
 ### 2021-02-10
  - Check if messages being analyzed by API scan scripts are globally excluded or not.
 

--- a/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
+++ b/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
@@ -21,7 +21,8 @@ var expectedTypes = [
 		"application/xml",
 		"application/x-yaml",
 		"text/x-json",
-		"text/json"
+		"text/json",
+		"text/yaml"
 	]
 
 function sendingRequest(msg, initiator, helper) {


### PR DESCRIPTION
## This PR

- adds `text/yaml` to the list of supported media-types

Fixes #6573