### PR TITLE
Set env var when building add-ons for releases

### DIFF
--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/GradleBuildWithGitRepos.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/GradleBuildWithGitRepos.java
@@ -214,6 +214,7 @@ public class GradleBuildWithGitRepos extends DefaultTask {
         getProject()
                 .exec(
                         spec -> {
+                            spec.environment("ZAP_RELEASE", "1");
                             spec.setWorkingDir(repoDir);
                             spec.setExecutable(gradleWrapper());
                             spec.args(execArgs);


### PR DESCRIPTION
Set env var (`ZAP_RELEASE`) when building the add-ons, to allow them
to be configured as needed.