### PR TITLE
improve: ci workflow add concurrency grouping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 To cancel in-progress builds when a force push is done and a ci workflow is already running.

Ref:
- https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
- https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>