### PR TITLE
Update PHP Client API Generator

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/PhpAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/PhpAPIGenerator.java
@@ -269,6 +269,7 @@ public class PhpAPIGenerator extends AbstractAPIGenerator {
             out.write("\n");
             out.write("/**\n");
             out.write(" * This file was automatically generated.\n");
+            out.write(" * @property Zap $zap\n");
             out.write(" */\n");
             out.write("class " + className + " {\n\n");
 


### PR DESCRIPTION
Add `@property Zap $zap` above generated class to explicitly specify magic property `$zap` (and to pass PHPStan tests :^).

Signed-off-by: ricekot <ricekot@gmail.com>