### PR TITLE
revert: ci workflow concurrency grouping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,6 @@ on:
       - main
   pull_request:
 
-concurrency: 
-  group: ${{ github.head_ref }}
-  cancel-in-progress: true
-
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Until we can find a solution that will work for both PRs and pushes/merges.

https://github.com/zaproxy/zap-extensions/pull/2894

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>