### PR TITLE
Use authority form for CONNECT requests

### DIFF
--- a/zap/src/main/java/org/apache/commons/httpclient/URI.java
+++ b/zap/src/main/java/org/apache/commons/httpclient/URI.java
@@ -56,6 +56,7 @@ import org.apache.commons.httpclient.util.EncodingUtil;
  *  - Fix unchecked/rawtypes warnings (required by lint checks).
  *  - Allow to use underscores in hostnames.
  *  - Use neutral Locale when converting to lower case.
+ *  - Allow to create a URI from the authority component.
  */
 /**
  * The interface for the URI(Uniform Resource Identifiers) version of RFC 2396.
@@ -2185,6 +2186,22 @@ public class URI implements Cloneable, Comparable<Object>, Serializable {
         return -1;
     }
 
+    /**
+     * Creates a {@code URI} from the given authority.
+     *
+     * <p><strong>Note:</strong> Not part of the public API.
+     *
+     * @param authority the authority component.
+     * @return the URI.
+     * @throws URIException if an error occurred while parsing the authority.
+     */
+    public static URI fromAuthority(String authority) throws URIException {
+        URI uri = new URI();
+        uri.parseAuthority(authority, true);
+        uri.setURI();
+        uri._uri = authority.toCharArray();
+        return uri;
+    }
 
     /**
      * Parse the authority component.

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpRequestHeader.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpRequestHeader.java
@@ -59,6 +59,7 @@
 // ZAP: 2020/11/10 Add convenience method isCss(), refactor isImage() to use new private method
 // isSpecificType(Pattern).
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
+// ZAP: 2021/05/10 Use authority for CONNECT requests.
 package org.parosproxy.paros.network;
 
 import java.io.UnsupportedEncodingException;
@@ -465,7 +466,7 @@ public class HttpRequestHeader extends HttpHeader {
 
         if (mMethod.equalsIgnoreCase(CONNECT)) {
             parseHostName(sUri);
-            mUri = parseURI(mHostName);
+            mUri = URI.fromAuthority(sUri);
 
         } else {
             mUri = parseURI(sUri);

--- a/zap/src/main/java/org/zaproxy/zap/view/table/DefaultHistoryReferencesTableEntry.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/table/DefaultHistoryReferencesTableEntry.java
@@ -25,7 +25,6 @@ import java.util.Date;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.HistoryReference;
-import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.zap.view.HrefTypeInfo;
 import org.zaproxy.zap.view.table.HistoryReferencesTableModel.Column;
 
@@ -142,9 +141,6 @@ public class DefaultHistoryReferencesTableEntry extends AbstractHistoryReference
         char[] rawHost = historyReference.getURI().getRawHost();
         if (rawHost != null) {
             return new String(rawHost);
-        }
-        if (HttpRequestHeader.CONNECT.equalsIgnoreCase(historyReference.getMethod())) {
-            return historyReference.getURI().toString();
         }
         return null;
     }

--- a/zap/src/test/java/org/apache/commons/httpclient/URIUnitTest.java
+++ b/zap/src/test/java/org/apache/commons/httpclient/URIUnitTest.java
@@ -22,6 +22,7 @@ package org.apache.commons.httpclient;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import org.junit.jupiter.api.Test;
 
@@ -46,5 +47,31 @@ public class URIUnitTest {
         int port = uri.getPort();
         // Then
         assertThat(port, is(equalTo(3001)));
+    }
+
+    @Test
+    void shouldCreateUriFromAuthority() throws Exception {
+        // Given / When
+        URI uri = URI.fromAuthority("www.example.com:8080");
+        // Then
+        assertThat(uri.getScheme(), is(nullValue()));
+        assertThat(uri.getAuthority(), is(equalTo("www.example.com:8080")));
+        assertThat(uri.getHost(), is(equalTo("www.example.com")));
+        assertThat(uri.getPort(), is(equalTo(8080)));
+        assertThat(uri.getPath(), is(nullValue()));
+        assertThat(uri.toString(), is(equalTo("www.example.com:8080")));
+    }
+
+    @Test
+    void shouldCreateUriFromAuthorityWithUnderscoresInHostname() throws Exception {
+        // Given / When
+        URI uri = URI.fromAuthority("hive_test_00.example.com:443");
+        // Then
+        assertThat(uri.getScheme(), is(nullValue()));
+        assertThat(uri.getAuthority(), is(equalTo("hive_test_00.example.com:443")));
+        assertThat(uri.getHost(), is(equalTo("hive_test_00.example.com")));
+        assertThat(uri.getPort(), is(equalTo(443)));
+        assertThat(uri.getPath(), is(nullValue()));
+        assertThat(uri.toString(), is(equalTo("hive_test_00.example.com:443")));
     }
 }

--- a/zap/src/test/java/org/parosproxy/paros/network/HttpRequestHeaderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/network/HttpRequestHeaderUnitTest.java
@@ -70,6 +70,22 @@ public class HttpRequestHeaderUnitTest {
     }
 
     @Test
+    void shouldCreateConnectRequest() throws Exception {
+        // Given
+        String data = "CONNECT example.com:443 HTTP/1.1\\r\\nHost: example.com:443\\r\\n\\r\\n";
+        // When
+        HttpRequestHeader header = new HttpRequestHeader(data);
+        // Then
+        assertThat(header.getMethod(), is(equalTo("CONNECT")));
+        assertThat(header.getHostName(), is(equalTo("example.com")));
+        assertThat(header.getHostPort(), is(equalTo(443)));
+        assertThat(header.getURI().getAuthority(), is(equalTo("example.com:443")));
+        assertThat(header.getURI().getHost(), is(equalTo("example.com")));
+        assertThat(header.getURI().getPort(), is(equalTo(443)));
+        assertThat(header.getURI().toString(), is(equalTo("example.com:443")));
+    }
+
+    @Test
     public void shouldNotBeImageIfItHasNoRequestUri() {
         // Given
         HttpRequestHeader header = new HttpRequestHeader();

--- a/zap/src/test/java/org/zaproxy/zap/view/table/DefaultHistoryReferencesTableEntryUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/view/table/DefaultHistoryReferencesTableEntryUnitTest.java
@@ -49,11 +49,11 @@ class DefaultHistoryReferencesTableEntryUnitTest {
     }
 
     @Test
-    void shouldHaveHostNameForUriWithJustAuthority() {
+    void shouldHaveHostNameForUriWithJustAuthority() throws Exception {
         // Given
         HistoryReference historyReference = mock(HistoryReference.class);
         given(historyReference.getMethod()).willReturn("CONNECT");
-        given(historyReference.getURI()).willReturn(createUri("example.com"));
+        given(historyReference.getURI()).willReturn(URI.fromAuthority("example.com:443"));
         Column[] columns = {Column.HOSTNAME};
         // When
         DefaultHistoryReferencesTableEntry entry =


### PR DESCRIPTION
Allow to create a `URI` with just authority to use with the CONNECT
requests.
Change `HttpRequestHeader` to create the URI with authority when parsing
the CONNECT requests.
Change `DefaultHistoryReferencesTableEntry` to no longer handle CONNECT
requests differently, the host is now properly returned.