### PR TITLE
Do not require scan rules to implement setParent

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/AntiCsrfDetectScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/AntiCsrfDetectScanner.java
@@ -67,7 +67,7 @@ public class AntiCsrfDetectScanner implements PassiveScanner {
         for (AntiCsrfToken token : list) {
             if (this.registerToken(msg.getHistoryRef().getHistoryType())) {
                 if (parent != null) {
-                    parent.addTag(id, ExtensionAntiCSRF.TAG);
+                    parent.addTag(ExtensionAntiCSRF.TAG);
                 }
                 extAntiCSRF.registerAntiCsrfToken(token);
             }

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanData.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanData.java
@@ -44,7 +44,7 @@ import org.zaproxy.zap.users.User;
  * @see PluginPassiveScanner
  * @since 2.9.0
  */
-public final class PassiveScanData {
+public class PassiveScanData {
 
     private static final Logger LOGGER = LogManager.getLogger(PassiveScanData.class);
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
@@ -388,7 +388,25 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
         }
     }
 
+    /**
+     * Adds the given tag to the message being passive scanned.
+     *
+     * @param id not used.
+     * @param tag the name of the tag.
+     * @deprecated (2.11.0) Use {@link #addTag(String)} instead, the id is not used.
+     */
+    @Deprecated
     public void addTag(int id, String tag) {
+        addTag(tag);
+    }
+
+    /**
+     * Adds the given tag to the message being passive scanned.
+     *
+     * @param tag the name of the tag.
+     * @since 2.11.0
+     */
+    public void addTag(String tag) {
         if (shutDown) {
             return;
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
@@ -96,6 +96,16 @@ public abstract class PluginPassiveScanner extends Enableable
         setParent(parent);
     }
 
+    /**
+     * <strong>Note:</strong> This method should no longer need to be overridden, the functionality
+     * provided by the {@code parent} can be obtained directly with {@link #newAlert()} and {@link
+     * #addTag(String)}.
+     */
+    @Override
+    public void setParent(PassiveScanThread parent) {
+        // Nothing to do.
+    }
+
     void clean() {
         parent = null;
         message = null;
@@ -379,6 +389,16 @@ public abstract class PluginPassiveScanner extends Enableable
      */
     public PassiveScanData getHelper() {
         return passiveScanData;
+    }
+
+    /**
+     * Adds the given tag to the message being passive scanned.
+     *
+     * @param tag the name of the tag.
+     * @since 2.11.0
+     */
+    protected void addTag(String tag) {
+        parent.addTag(tag);
     }
 
     /**

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/RegexAutoTagScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/RegexAutoTagScanner.java
@@ -25,7 +25,6 @@ import net.htmlparser.jericho.Source;
 import org.apache.commons.httpclient.URIException;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
-import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.model.SessionStructure;
 import org.zaproxy.zap.utils.Stats;
@@ -56,8 +55,6 @@ public class RegexAutoTagScanner extends PluginPassiveScanner {
 
     private TYPE type = null;
     private String config = null;
-
-    private PassiveScanThread parent = null;
 
     public RegexAutoTagScanner() {
         // Null constructor to prevent error being logged;)
@@ -246,11 +243,6 @@ public class RegexAutoTagScanner extends PluginPassiveScanner {
     }
 
     @Override
-    public void setParent(PassiveScanThread parent) {
-        this.parent = parent;
-    }
-
-    @Override
     public int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
@@ -333,7 +325,7 @@ public class RegexAutoTagScanner extends PluginPassiveScanner {
             if (matcher.groupCount() > 0) {
                 tag = matcher.pattern().matcher(matcher.group()).replaceFirst(tag);
             }
-            parent.addTag(id, tag);
+            addTag(tag);
         }
 
         try {

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
@@ -27,7 +27,6 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
-import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PassiveScript;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.extension.script.ExtensionScript;
@@ -40,9 +39,7 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
     private static final Logger logger = LogManager.getLogger(ScriptsPassiveScanner.class);
 
     private final ScriptsCache<PassiveScript> scripts;
-    private PassiveScanThread parent = null;
 
-    private int currentHRefId;
     private int currentHistoryType;
 
     public ScriptsPassiveScanner() {
@@ -79,7 +76,6 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
             return;
         }
 
-        currentHRefId = id;
         scripts.refreshAndExecute(
                 (sw, script) -> {
                     if (appliesToCurrentHistoryType(sw, script)) {
@@ -194,13 +190,9 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
                 .raise();
     }
 
-    public void addTag(String tag) {
-        this.parent.addTag(currentHRefId, tag);
-    }
-
     @Override
-    public void setParent(PassiveScanThread parent) {
-        this.parent = parent;
+    public void addTag(String tag) {
+        super.addTag(tag);
     }
 
     @Override

--- a/zap/src/test/java/org/zaproxy/zap/extension/pscan/PassiveScanTestHelper.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/pscan/PassiveScanTestHelper.java
@@ -1,0 +1,35 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscan;
+
+import org.parosproxy.paros.network.HttpMessage;
+
+public final class PassiveScanTestHelper {
+
+    private PassiveScanTestHelper() {}
+
+    public static void init(
+            PluginPassiveScanner rule,
+            PassiveScanThread parent,
+            HttpMessage message,
+            PassiveScanData passiveScanData) {
+        rule.init(parent, message, passiveScanData);
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/pscan/PluginPassiveScannerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/pscan/PluginPassiveScannerUnitTest.java
@@ -24,8 +24,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-import net.htmlparser.jericho.Source;
 import org.apache.commons.configuration.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -490,18 +491,22 @@ public class PluginPassiveScannerUnitTest {
         assertThat(configuration.containsKey("pscans.pscanner(3).id"), is(false));
     }
 
+    @Test
+    void shouldCallParentWithTagAdded() {
+        // Given
+        String tag = "tag";
+        PassiveScanThread parent = mock(PassiveScanThread.class);
+        TestPluginPassiveScanner scanner = new TestPluginPassiveScanner();
+        scanner.init(parent, mock(HttpMessage.class), mock(PassiveScanData.class));
+        // When
+        scanner.addTag(tag);
+        // Then
+        verify(parent).addTag(tag);
+    }
+
     private static class TestPluginPassiveScanner extends PluginPassiveScanner {
 
         private static final int PLUGIN_ID = -1;
-
-        @Override
-        public void setParent(PassiveScanThread parent) {}
-
-        @Override
-        public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {}
-
-        @Override
-        public void scanHttpRequestSend(HttpMessage msg, int id) {}
 
         @Override
         public String getName() {

--- a/zap/src/test/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScannerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScannerUnitTest.java
@@ -49,6 +49,8 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.WithConfigsTest;
 import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
+import org.zaproxy.zap.extension.pscan.PassiveScanData;
+import org.zaproxy.zap.extension.pscan.PassiveScanTestHelper;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PassiveScript;
 import org.zaproxy.zap.extension.script.ExtensionScript;
@@ -67,7 +69,6 @@ public class ScriptsPassiveScannerUnitTest extends WithConfigsTest {
     private static final Class<PassiveScript> TARGET_INTERFACE = PassiveScript.class;
 
     private ExtensionScript extensionScript;
-    private PassiveScanThread parent;
     private HttpMessage message;
     private int id;
     private Source source;
@@ -75,7 +76,6 @@ public class ScriptsPassiveScannerUnitTest extends WithConfigsTest {
     @BeforeEach
     void setUp() {
         extensionScript = mock(ExtensionScript.class);
-        parent = mock(PassiveScanThread.class);
         message = mock(HttpMessage.class);
         id = 1;
         source = new Source("");
@@ -117,19 +117,17 @@ public class ScriptsPassiveScannerUnitTest extends WithConfigsTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-    void shouldAddTagsWithParentSet() {
+    void shouldAddTagsWithParent() {
         // Given
         String tag = "Tag";
-        given(extensionScript.<PassiveScript>createScriptsCache(any()))
-                .willReturn(mock(ScriptsCache.class));
+        PassiveScanThread parent = mock(PassiveScanThread.class);
         ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
-        scriptsPassiveScanner.setParent(parent);
-        scriptsPassiveScanner.scanHttpResponseReceive(message, id, source);
+        PassiveScanTestHelper.init(
+                scriptsPassiveScanner, parent, message, mock(PassiveScanData.class));
         // When
         scriptsPassiveScanner.addTag(tag);
         // Then
-        verify(parent).addTag(id, tag);
+        verify(parent).addTag(tag);
     }
 
     @Test


### PR DESCRIPTION
Add implementation in `PluginPassiveScanner` to not require the scan
rules to implement it (most no longer need it), moreover allow to add
tags to the messages with a method in the scan rule itself to not
require the parent (directly) anymore.
Add method to `PassiveScanThread` to add a tag to a message and
deprecate existing one which has an unused parameter.
Change core passive scanners to no longer use the deprecated method.
Allow to extend `PassiveScanData` to ease the tests.