### PR TITLE
Dynamically switch to user using ID

### DIFF
--- a/docker/Dockerfile-bare
+++ b/docker/Dockerfile-bare
@@ -27,7 +27,8 @@ RUN echo "http://dl-3.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
     chown -R zap:zap /home/zap/.ZAP/
 
 #Change to the zap user so things get done as the right person (apart from copy)
-USER zap
+RUN export userId=$(id -u zap)
+USER $userId
 
 ENV PATH $JAVA_HOME/bin:/zap/:$PATH
 ENV ZAP_PATH /zap/zap.sh

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -98,5 +98,6 @@ RUN chown zap:zap /zap/* && \
 
 WORKDIR /zap
 
-USER zap
+RUN export userId=$(id -u zap)
+USER $userId
 HEALTHCHECK --retries=5 --interval=5s CMD zap-cli status

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -87,6 +87,7 @@ RUN chown zap:zap /zap/* && \
 	chmod a+x /home/zap/.xinitrc
 
 #Change back to zap at the end
-USER zap
+RUN export userId=$(id -u zap)
+USER $userId
 
 HEALTHCHECK --retries=5 --interval=5s CMD zap-cli status

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -87,6 +87,7 @@ RUN chown zap:zap /zap/* CHANGELOG.md && \
 	chmod a+x /home/zap/.xinitrc
 
 #Change back to zap at the end
-USER zap
+RUN export userId=$(id -u zap)
+USER $userId
 
 HEALTHCHECK --retries=5 --interval=5s CMD zap-cli status


### PR DESCRIPTION
By using a dynamic way you can use the same method for all your Docker files (just ease of use from my side), but by using the ID you can have security software monitoring on your platform whether it's a high privileged account. 

Blocking HP accounts will be as easy as blocking and ID below 1000. Although to enable this all users must be using an ID.