### PR TITLE
Dynamic Docker USER

### DIFF
--- a/docker/Dockerfile-bare
+++ b/docker/Dockerfile-bare
@@ -27,7 +27,8 @@ RUN echo "http://dl-3.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
     chown -R zap:zap /home/zap/.ZAP/
 
 #Change to the zap user so things get done as the right person (apart from copy)
-USER zap
+RUN export userId=$(id -u zap)
+USER $userId
 
 ENV PATH $JAVA_HOME/bin:/zap/:$PATH
 ENV ZAP_PATH /zap/zap.sh

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -41,7 +41,8 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 WORKDIR /zap-src
 
 #Change to the zap user so things get done as the right person (apart from copy)
-USER zap
+RUN export userId=$(id -u zap)
+USER $userId
 
 RUN mkdir /home/zap/.vnc
 
@@ -98,6 +99,5 @@ RUN chown zap:zap /zap/* && \
 
 WORKDIR /zap
 
-RUN export userId=$(id -u zap)
 USER $userId
 HEALTHCHECK --retries=5 --interval=5s CMD zap-cli status

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -98,5 +98,6 @@ RUN chown zap:zap /zap/* && \
 
 WORKDIR /zap
 
-USER zap
+RUN export userId=$(id -u zap)
+USER $userId
 HEALTHCHECK --retries=5 --interval=5s CMD zap-cli status

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -88,7 +88,6 @@ RUN chown zap:zap /zap/* && \
 	chmod a+x /home/zap/.xinitrc
 
 #Change back to zap at the end
-RUN export userId=$(id -u zap)
 USER $userId
 
 HEALTHCHECK --retries=5 --interval=5s CMD zap-cli status

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -87,6 +87,7 @@ RUN chown zap:zap /zap/* && \
 	chmod a+x /home/zap/.xinitrc
 
 #Change back to zap at the end
-USER zap
+RUN export userId=$(id -u zap)
+USER $userId
 
 HEALTHCHECK --retries=5 --interval=5s CMD zap-cli status

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -36,7 +36,8 @@ RUN mkdir /zap && chown zap:zap /zap
 WORKDIR /zap
 
 #Change to the zap user so things get done as the right person (apart from copy)
-USER zap
+RUN export userId=$(id -u zap)
+USER $userId
 
 RUN mkdir /home/zap/.vnc
 

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -88,7 +88,6 @@ RUN chown zap:zap /zap/* CHANGELOG.md && \
 	chmod a+x /home/zap/.xinitrc
 
 #Change back to zap at the end
-RUN export userId=$(id -u zap)
 USER $userId
 
 HEALTHCHECK --retries=5 --interval=5s CMD zap-cli status

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -36,7 +36,8 @@ RUN mkdir /zap && chown zap:zap /zap
 WORKDIR /zap
 
 #Change to the zap user so things get done as the right person (apart from copy)
-USER zap
+RUN export userId=$(id -u zap)
+USER $userId
 
 RUN mkdir /home/zap/.vnc
 

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -87,6 +87,7 @@ RUN chown zap:zap /zap/* CHANGELOG.md && \
 	chmod a+x /home/zap/.xinitrc
 
 #Change back to zap at the end
-USER zap
+RUN export userId=$(id -u zap)
+USER $userId
 
 HEALTHCHECK --retries=5 --interval=5s CMD zap-cli status


### PR DESCRIPTION
By using the ID instead of the name (dynamically) certain systems can perform better root-user checks.

(Followed all the signing steps this time)