### PR TITLE
Parameterize test in HttpMethodBaseUnitTest

### DIFF
--- a/zap/src/test/java/org/apache/commons/httpclient/HttpMethodBaseUnitTest.java
+++ b/zap/src/test/java/org/apache/commons/httpclient/HttpMethodBaseUnitTest.java
@@ -20,24 +20,22 @@
 package org.apache.commons.httpclient;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.List;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class HttpMethodBaseUnitTest {
 
     @ParameterizedTest
     @MethodSource("cookieHeaderProvider")
-    public void testParseCookieHeader(String cookieHeaderValue, int cookieSize){
-        List<Cookie> cookies =
-                HttpMethodBase.parseCookieHeader("example.com", cookieHeaderValue);
-        assertThat(cookies.size(), is(cookieSize));
+    public void testParseCookieHeader(String cookieHeaderValue, int numberOfCookies) {
+        List<Cookie> cookies = HttpMethodBase.parseCookieHeader("example.com", cookieHeaderValue);
+        assertThat(cookies, hasSize(numberOfCookies));
     }
 
     static Stream<Arguments> cookieHeaderProvider() {
@@ -46,7 +44,6 @@ public class HttpMethodBaseUnitTest {
                 arguments("JSESSIONID=5DFA94B903A0063839E0440118808875", 1),
                 arguments("has_js=1;JSESSIONID=5DFA94B903A0063839E0440118808875", 2),
                 arguments("has_js=1; JSESSIONID=5DFA94B903A0063839E0440118808875", 2),
-                arguments("has_js=;JSESSIONID=5DFA94B903A0063839E0440118808875",2)
-        );
+                arguments("has_js=;JSESSIONID=5DFA94B903A0063839E0440118808875", 2));
     }
 }

--- a/zap/src/test/java/org/apache/commons/httpclient/HttpMethodBaseUnitTest.java
+++ b/zap/src/test/java/org/apache/commons/httpclient/HttpMethodBaseUnitTest.java
@@ -21,40 +21,32 @@ package org.apache.commons.httpclient;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.List;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
 
 public class HttpMethodBaseUnitTest {
 
-    @Test
-    public void testParseCookieHeaderEmpty() {
-        List<Cookie> cookies = HttpMethodBase.parseCookieHeader("example.com", "");
-        assertThat(cookies.size(), is(0));
+    @ParameterizedTest
+    @MethodSource("cookieHeaderProvider")
+    public void testParseCookieHeader(String cookieHeaderValue, int cookieSize){
+        List<Cookie> cookies =
+                HttpMethodBase.parseCookieHeader("example.com", cookieHeaderValue);
+        assertThat(cookies.size(), is(cookieSize));
     }
 
-    @Test
-    public void testParseCookieHeaderWithOneCookie() {
-        List<Cookie> cookies =
-                HttpMethodBase.parseCookieHeader(
-                        "example.com", "JSESSIONID=5DFA94B903A0063839E0440118808875");
-        assertThat(cookies.size(), is(1));
-    }
-
-    @Test
-    public void testParseCookieHeaderWithTwoCookie() {
-        List<Cookie> cookies =
-                HttpMethodBase.parseCookieHeader(
-                        "example.com", "has_js=1;JSESSIONID=5DFA94B903A0063839E0440118808875");
-        assertThat(cookies.size(), is(2));
-        cookies =
-                HttpMethodBase.parseCookieHeader(
-                        "example.com", "has_js=1; JSESSIONID=5DFA94B903A0063839E0440118808875");
-        assertThat(cookies.size(), is(2));
-        // empty value
-        cookies =
-                HttpMethodBase.parseCookieHeader(
-                        "example.com", "has_js=;JSESSIONID=5DFA94B903A0063839E0440118808875");
-        assertThat(cookies.size(), is(2));
+    static Stream<Arguments> cookieHeaderProvider() {
+        return Stream.of(
+                arguments("", 0),
+                arguments("JSESSIONID=5DFA94B903A0063839E0440118808875", 1),
+                arguments("has_js=1;JSESSIONID=5DFA94B903A0063839E0440118808875", 2),
+                arguments("has_js=1; JSESSIONID=5DFA94B903A0063839E0440118808875", 2),
+                arguments("has_js=;JSESSIONID=5DFA94B903A0063839E0440118808875",2)
+        );
     }
 }


### PR DESCRIPTION
Problem:
(1) A test method with many individual assertions stops being executed on the first failed assertion, which prevents the remaining ones' execution.
(2) Classes containing test methods with repeated test code steps, typically, parts that set up test fixtures, generate additional effort in case of test maintenance.

Solution:
Parameterized tests make it possible to run a test multiple times, with different arguments, as individual and independent tests. This way, we could make 3 original tests become 5 independent ones, contributing to test maintenance efforts when needed. In this refactoring, no original assertion value was changed.