### PR TITLE
Add AWP Identity manager PKCS11 cards (IDEMIA)

### DIFF
--- a/zap/src/main/resources/org/zaproxy/zap/resources/drivers.xml
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/drivers.xml
@@ -19,6 +19,12 @@
 		<slotListIndex>0</slotListIndex>
 	</driver>
 	<driver>
+		<name>AWP Identity Client - Linux</name>
+		<path>/usr/local/AWP/lib/libOcsPKCS11Wrapper.so</path>
+		<slot>0</slot>
+		<slotListIndex>0</slotListIndex>
+	</driver>
+	<driver>
 		<name>Axalto - Windows</name>
 		<path>C:\Program Files\Axalto\Access Client\v5\xltCk.dll</path>
 		<slot>0</slot>


### PR DESCRIPTION
Adding drivers.xml configuration to be able to use AWP Identity Client (IDEMIA) as PKCS11 client certificates provider

Currently tested system:
 * ZAP: 2.10.0
 * OS: Ubuntu 20.04.2 (x86_64)
 * AWP Identity Client: 5.3
 * AWP Middleware: 5.3
 * Hardware Token: Advanced Card Systems, Ltd ACR39U/ACR39T
 * Smartcard: Oberthur Technologies / Cosmo v7.0.1 R2 (also Obertur v8 but don't have it with me to verify exact version)

Note that the checkbox for "Use experimental Slot Api" is needed