### PR TITLE
Added `_token` to possible CSRF input names

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/AntiCsrfParam.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/AntiCsrfParam.java
@@ -59,7 +59,8 @@ public class AntiCsrfParam extends AbstractParam {
         "_csrf",
         "_csrfSecret",
         "__csrf_magic",
-        "CSRF"
+        "CSRF",
+        "_token"
     };
 
     private List<AntiCsrfParamToken> tokens = null;


### PR DESCRIPTION
A commonly used framework, Laravel, uses the name `_token` for it's CSRF token fields in a form.

Source: https://laravel.com/docs/8.x/csrf#preventing-csrf-requests