### PR TITLE
Prepare next dev iter on release

### DIFF
--- a/.github/workflows/handle-release.yml
+++ b/.github/workflows/handle-release.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Setup Java 8
       uses: actions/setup-java@v1
       with:

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -21,6 +21,7 @@ spotless {
 
 dependencies {
     implementation("com.github.javaparser:javaparser-core:3.15.21")
+    implementation("com.github.zafarkhaja:java-semver:0.9.0")
     implementation("commons-codec:commons-codec:1.12")
     implementation("com.google.code.gson:gson:2.8.5")
     val jgitVersion = "5.3.1.201904271842-r"

--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/CreatePullRequest.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/CreatePullRequest.java
@@ -1,0 +1,163 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.tasks;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.transport.URIish;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.TaskAction;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
+import org.zaproxy.zap.GitHubRepo;
+import org.zaproxy.zap.GitHubUser;
+
+/** A task that checks for modifications in a git repo, commits, and creates a pull request. */
+public abstract class CreatePullRequest extends DefaultTask {
+
+    private static final String GITHUB_BASE_URL = "https://github.com/";
+
+    private static final String GIT_REMOTE_ORIGIN = "origin";
+
+    private static final String DEFAULT_GIT_BASE_BRANCH_NAME = "main";
+
+    private final Property<String> baseBranchName;
+
+    public CreatePullRequest() {
+        ObjectFactory objects = getProject().getObjects();
+        this.baseBranchName =
+                objects.property(String.class).convention(DEFAULT_GIT_BASE_BRANCH_NAME);
+
+        setGroup("ZAP");
+        setDescription("Creates a pull request with modifications done in a repo.");
+    }
+
+    @Internal
+    public Property<String> getBaseBranchName() {
+        return baseBranchName;
+    }
+
+    @Internal
+    public abstract Property<String> getBranchName();
+
+    @Internal
+    public abstract Property<GitHubUser> getUser();
+
+    @Internal
+    public abstract Property<GitHubRepo> getRepo();
+
+    @Internal
+    public abstract Property<String> getCommitSummary();
+
+    @Internal
+    public abstract Property<String> getCommitDescription();
+
+    @TaskAction
+    public void pullRequest() throws Exception {
+        GitHubRepo ghRepo = getRepo().get();
+        Repository repository =
+                new FileRepositoryBuilder().setGitDir(new File(ghRepo.getDir(), ".git")).build();
+        try (Git git = new Git(repository)) {
+            if (git.status().call().getModified().isEmpty()) {
+                return;
+            }
+
+            GitHubUser ghUser = getUser().get();
+
+            URIish originUri =
+                    new URIish(GITHUB_BASE_URL + ghUser.getName() + "/" + ghRepo.getName());
+            git.remoteSetUrl().setRemoteName(GIT_REMOTE_ORIGIN).setRemoteUri(originUri).call();
+
+            git.checkout()
+                    .setCreateBranch(true)
+                    .setName(getBranchName().get())
+                    .setStartPoint(GIT_REMOTE_ORIGIN + "/" + baseBranchName.get())
+                    .call();
+
+            PersonIdent personIdent = new PersonIdent(ghUser.getName(), ghUser.getEmail());
+            git.commit()
+                    .setAll(true)
+                    .setSign(false)
+                    .setAuthor(personIdent)
+                    .setCommitter(personIdent)
+                    .setMessage(
+                            getCommitSummary().get()
+                                    + "\n\n"
+                                    + getCommitDescription().get()
+                                    + signedOffBy(personIdent))
+                    .call();
+
+            git.push()
+                    .setCredentialsProvider(
+                            new UsernamePasswordCredentialsProvider(
+                                    ghUser.getName(), ghUser.getAuthToken()))
+                    .setForce(true)
+                    .add(getBranchName().get())
+                    .call();
+
+            GHRepository ghRepository =
+                    GitHub.connect(ghUser.getName(), ghUser.getAuthToken())
+                            .getRepository(ghRepo.toString());
+
+            List<GHPullRequest> pulls =
+                    ghRepository
+                            .queryPullRequests()
+                            .base(baseBranchName.get())
+                            .head(ghUser.getName() + ":" + getBranchName().get())
+                            .state(GHIssueState.OPEN)
+                            .list()
+                            .asList();
+            if (pulls.isEmpty()) {
+                createPullRequest(
+                        ghRepository, getCommitSummary().get(), getCommitDescription().get());
+            } else {
+                pulls.get(0).setBody(getCommitDescription().get());
+            }
+        }
+    }
+
+    private static String signedOffBy(PersonIdent personIdent) {
+        return "\n\nSigned-off-by: "
+                + personIdent.getName()
+                + " <"
+                + personIdent.getEmailAddress()
+                + ">";
+    }
+
+    private void createPullRequest(GHRepository ghRepo, String title, String description)
+            throws IOException {
+        ghRepo.createPullRequest(
+                title,
+                getUser().get().getName() + ":" + getBranchName().get(),
+                baseBranchName.get(),
+                description);
+    }
+}

--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/PrepareNextDevIter.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/PrepareNextDevIter.java
@@ -1,0 +1,109 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.tasks;
+
+import com.github.zafarkhaja.semver.Version;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+
+/** A task that prepares the next development iteration of ZAP. */
+public abstract class PrepareNextDevIter extends DefaultTask {
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    public abstract RegularFileProperty getBuildFile();
+
+    @Input
+    public abstract Property<Pattern> getVersionPattern();
+
+    @Input
+    public abstract Property<Pattern> getVersionBcPattern();
+
+    @Input
+    public abstract ListProperty<Pattern> getClearDataPatterns();
+
+    @TaskAction
+    public void prepare() throws Exception {
+        Path updatedBuildFile = updateBuildFile();
+
+        Files.copy(
+                updatedBuildFile,
+                getBuildFile().getAsFile().get().toPath(),
+                StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    private Path updateBuildFile() throws IOException {
+        Path buildFilePath = getBuildFile().getAsFile().get().toPath();
+        String contents = new String(Files.readAllBytes(buildFilePath), StandardCharsets.UTF_8);
+
+        Matcher version = getVersionPattern().get().matcher(contents);
+        if (!version.find()) {
+            throw new BuildException("Version pattern not found.");
+        }
+        String currentVersion = version.group(1);
+        Version newVersion =
+                Version.valueOf(currentVersion)
+                        .incrementMinorVersion()
+                        .setPreReleaseVersion("SNAPSHOT");
+        contents = replace(contents, version, newVersion.toString());
+
+        Matcher versionBc = getVersionBcPattern().get().matcher(contents);
+        if (!versionBc.find()) {
+            throw new BuildException("Version BC pattern not found.");
+        }
+        contents = replace(contents, versionBc, currentVersion);
+
+        for (Pattern clearDataPattern : getClearDataPatterns().get()) {
+            Matcher clearData = clearDataPattern.matcher(contents);
+            if (!clearData.find()) {
+                throw new BuildException("Clear data pattern not found: " + clearDataPattern);
+            }
+            contents = replace(contents, clearData, "");
+        }
+
+        Path updatedBuildFile =
+                getTemporaryDir().toPath().resolve("updated-" + buildFilePath.getFileName());
+        Files.write(updatedBuildFile, contents.getBytes(StandardCharsets.UTF_8));
+
+        return updatedBuildFile;
+    }
+
+    private static String replace(String value, Matcher matcher, String replacement) {
+        return new StringBuilder()
+                .append(value, 0, matcher.start(1))
+                .append(replacement)
+                .append(value, matcher.end(1), value.length())
+                .toString();
+    }
+}


### PR DESCRIPTION
Add tasks to prepare the next development iteration and create a pull
request when the main release is published.
The task will update the versions and clear the `japicmp` exclusions.