### PR TITLE
Make zapbot auth token available to release tasks

### DIFF
--- a/.github/workflows/release-main-version.yml
+++ b/.github/workflows/release-main-version.yml
@@ -19,4 +19,5 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         INSTALL4J_LICENSE: ${{ secrets.INSTALL4J_LICENSE }}
+        ZAPBOT_TOKEN: ${{ secrets.ZAPBOT_TOKEN }}
       run: ./gradlew "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m" :zap:createMainRelease

--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -18,4 +18,5 @@ jobs:
     - name: Build and Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ZAPBOT_TOKEN: ${{ secrets.ZAPBOT_TOKEN }}
       run: ./gradlew "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m" :zap:createWeeklyRelease


### PR DESCRIPTION
Change release workflows to pass the zapbot auth token, required to push
the tags.