### PR TITLE
Baseline config file support phase 1

### DIFF
--- a/docker/Dockerfile-tests
+++ b/docker/Dockerfile-tests
@@ -1,0 +1,24 @@
+# This dockerfile builds a ZAP docker image used for integration tests
+FROM owasp/zap2docker-live
+LABEL maintainer="psiinon@gmail.com"
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+#Change to the zap user so things get done as the right person (apart from copy)
+USER zap
+
+COPY integration_tests /zap/wrk/
+
+# Pick up any local changes
+COPY zap* CHANGELOG.md /zap/
+
+#Copy doesn't respect USER directives so we need to chown and to do that we need to be root
+USER root
+
+RUN chown zap:zap -R /zap/ && \
+	chmod +x /zap/wrk/*.sh
+
+
+WORKDIR /zap
+
+USER zap

--- a/docker/integration_tests/baseline_tests.sh
+++ b/docker/integration_tests/baseline_tests.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Script for testing the packaged scans when using the Automation Framework
+
+RES=0
+
+mkdir /zap/wrk/output
+
+echo "TEST: Baseline test 1 (vs example.com)"
+/zap/zap-baseline.py -t https://www.example.com/ --auto > /zap/wrk/output/baseline1.out
+RET=$?
+DIFF=$(diff /zap/wrk/output/baseline1.out /zap/wrk/results/baseline1.out) 
+if [ "$DIFF" != "" ] 
+then
+    echo "FAIL: differences:"
+    echo "$DIFF"
+	RES=1
+else
+	if [ "$RET" -ne 2 ] 
+	then
+    	echo "FAIL: exited with $RET instead of 2"
+		RES=1
+	else
+    	echo "PASS"
+    fi
+fi
+
+echo
+echo "Baseline test 2 (vs example.com with INFO/WARN/FAIL set)"
+/zap/zap-baseline.py -t https://www.example.com/ -c configs/baseline2.conf --auto > /zap/wrk/output/baseline2.out
+RET=$?
+DIFF=$(diff /zap/wrk/output/baseline2.out /zap/wrk/results/baseline2.out) 
+if [ "$DIFF" != "" ] 
+then
+    echo "FAIL: differences:"
+    echo "$DIFF"
+	RES=1
+else
+	if [ "$RET" -ne 1 ] 
+	then
+    	echo "FAIL: exited with $RET instead of 1"
+		RES=1
+	else
+    	echo "PASS"
+    fi
+fi
+
+echo
+echo "TEST Baseline 3 (new vs old) - we expect _some_ differences and this will not fail the whole script"
+/zap/zap-baseline.py -t https://www.example.com/ --autooff > /zap/wrk/output/baseline1-orig.out
+DIFF=$(diff /zap/wrk/output/baseline1.out /zap/wrk/output/baseline1-orig.out) 
+echo "Differences:"
+echo "$DIFF"
+
+echo "End result: $RES"
+exit $RES

--- a/docker/integration_tests/configs/baseline2.conf
+++ b/docker/integration_tests/configs/baseline2.conf
@@ -1,0 +1,3 @@
+10015	INFO	(Incomplete or No Cache-control and Pragma HTTP Header Set)
+10020	FAIL	(X-Frame-Options Header)
+10050	IGNORE	(Retrieved from Cache)

--- a/docker/integration_tests/results/baseline1.out
+++ b/docker/integration_tests/results/baseline1.out
@@ -1,0 +1,73 @@
+Using the Automation Framework
+Total of 4 URLs
+PASS: Vulnerable JS Library [10003]
+PASS: Cookie No HttpOnly Flag [10010]
+PASS: Cookie Without Secure Flag [10011]
+PASS: Cross-Domain JavaScript Source File Inclusion [10017]
+PASS: Content-Type Header Missing [10019]
+PASS: Information Disclosure - Debug Error Messages [10023]
+PASS: Information Disclosure - Sensitive Information in URL [10024]
+PASS: Information Disclosure - Sensitive Information in HTTP Referrer Header [10025]
+PASS: HTTP Parameter Override [10026]
+PASS: Information Disclosure - Suspicious Comments [10027]
+PASS: Open Redirect [10028]
+PASS: Cookie Poisoning [10029]
+PASS: User Controllable Charset [10030]
+PASS: User Controllable HTML Element Attribute (Potential XSS) [10031]
+PASS: Viewstate [10032]
+PASS: Directory Browsing [10033]
+PASS: Heartbleed OpenSSL Vulnerability (Indicative) [10034]
+PASS: Server Leaks Information via "X-Powered-By" HTTP Response Header Field(s) [10037]
+PASS: X-Backend-Server Header Information Leak [10039]
+PASS: Secure Pages Include Mixed Content [10040]
+PASS: HTTP to HTTPS Insecure Transition in Form Post [10041]
+PASS: HTTPS to HTTP Insecure Transition in Form Post [10042]
+PASS: User Controllable JavaScript Event (XSS) [10043]
+PASS: Big Redirect Detected (Potential Sensitive Information Leak) [10044]
+PASS: X-ChromeLogger-Data (XCOLD) Header Information Leak [10052]
+PASS: Cookie without SameSite Attribute [10054]
+PASS: CSP [10055]
+PASS: X-Debug-Token Information Leak [10056]
+PASS: Username Hash Found [10057]
+PASS: X-AspNet-Version Response Header [10061]
+PASS: PII Disclosure [10062]
+PASS: Timestamp Disclosure [10096]
+PASS: Hash Disclosure [10097]
+PASS: Cross-Domain Misconfiguration [10098]
+PASS: Weak Authentication Method [10105]
+PASS: Reverse Tabnabbing [10108]
+PASS: Modern Web Application [10109]
+PASS: Absence of Anti-CSRF Tokens [10202]
+PASS: Private IP Disclosure [2]
+PASS: Session ID in URL Rewrite [3]
+PASS: Script Passive Scan Rules [50001]
+PASS: Stats Passive Scan Rule [50003]
+PASS: Insecure JSF ViewState [90001]
+PASS: Charset Mismatch [90011]
+PASS: Application Error Disclosure [90022]
+PASS: WSDL File Detection [90030]
+PASS: Loosely Scoped Cookie [90033]
+WARN-NEW: Incomplete or No Cache-control Header Set [10015] x 1 
+	https://www.example.com/ (200 OK)
+WARN-NEW: X-Frame-Options Header Not Set [10020] x 1 
+	https://www.example.com/ (200 OK)
+WARN-NEW: X-Content-Type-Options Header Missing [10021] x 1 
+	https://www.example.com/ (200 OK)
+WARN-NEW: Strict-Transport-Security Header Not Set [10035] x 3 
+	https://www.example.com/ (200 OK)
+	https://www.example.com/robots.txt (404 Not Found)
+	https://www.example.com/sitemap.xml (404 Not Found)
+WARN-NEW: Server Leaks Version Information via "Server" HTTP Response Header Field [10036] x 4 
+	https://www.example.com/ (200 OK)
+	https://www.example.com/ (200 OK)
+	https://www.example.com/robots.txt (404 Not Found)
+	https://www.example.com/sitemap.xml (404 Not Found)
+WARN-NEW: Content Security Policy (CSP) Header Not Set [10038] x 3 
+	https://www.example.com/ (200 OK)
+	https://www.example.com/robots.txt (404 Not Found)
+	https://www.example.com/sitemap.xml (404 Not Found)
+WARN-NEW: Retrieved from Cache [10050] x 3 
+	https://www.example.com/ (200 OK)
+	https://www.example.com/robots.txt (404 Not Found)
+	https://www.example.com/sitemap.xml (404 Not Found)
+FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 7	WARN-INPROG: 0	INFO: 0	IGNORE: 0	PASS: 47

--- a/docker/integration_tests/results/baseline2.out
+++ b/docker/integration_tests/results/baseline2.out
@@ -1,0 +1,73 @@
+Using the Automation Framework
+Total of 4 URLs
+PASS: Vulnerable JS Library [10003]
+PASS: Cookie No HttpOnly Flag [10010]
+PASS: Cookie Without Secure Flag [10011]
+PASS: Cross-Domain JavaScript Source File Inclusion [10017]
+PASS: Content-Type Header Missing [10019]
+PASS: Information Disclosure - Debug Error Messages [10023]
+PASS: Information Disclosure - Sensitive Information in URL [10024]
+PASS: Information Disclosure - Sensitive Information in HTTP Referrer Header [10025]
+PASS: HTTP Parameter Override [10026]
+PASS: Information Disclosure - Suspicious Comments [10027]
+PASS: Open Redirect [10028]
+PASS: Cookie Poisoning [10029]
+PASS: User Controllable Charset [10030]
+PASS: User Controllable HTML Element Attribute (Potential XSS) [10031]
+PASS: Viewstate [10032]
+PASS: Directory Browsing [10033]
+PASS: Heartbleed OpenSSL Vulnerability (Indicative) [10034]
+PASS: Server Leaks Information via "X-Powered-By" HTTP Response Header Field(s) [10037]
+PASS: X-Backend-Server Header Information Leak [10039]
+PASS: Secure Pages Include Mixed Content [10040]
+PASS: HTTP to HTTPS Insecure Transition in Form Post [10041]
+PASS: HTTPS to HTTP Insecure Transition in Form Post [10042]
+PASS: User Controllable JavaScript Event (XSS) [10043]
+PASS: Big Redirect Detected (Potential Sensitive Information Leak) [10044]
+PASS: X-ChromeLogger-Data (XCOLD) Header Information Leak [10052]
+PASS: Cookie without SameSite Attribute [10054]
+PASS: CSP [10055]
+PASS: X-Debug-Token Information Leak [10056]
+PASS: Username Hash Found [10057]
+PASS: X-AspNet-Version Response Header [10061]
+PASS: PII Disclosure [10062]
+PASS: Timestamp Disclosure [10096]
+PASS: Hash Disclosure [10097]
+PASS: Cross-Domain Misconfiguration [10098]
+PASS: Weak Authentication Method [10105]
+PASS: Reverse Tabnabbing [10108]
+PASS: Modern Web Application [10109]
+PASS: Absence of Anti-CSRF Tokens [10202]
+PASS: Private IP Disclosure [2]
+PASS: Session ID in URL Rewrite [3]
+PASS: Script Passive Scan Rules [50001]
+PASS: Stats Passive Scan Rule [50003]
+PASS: Insecure JSF ViewState [90001]
+PASS: Charset Mismatch [90011]
+PASS: Application Error Disclosure [90022]
+PASS: WSDL File Detection [90030]
+PASS: Loosely Scoped Cookie [90033]
+IGNORE: Retrieved from Cache [10050] x 3 
+	https://www.example.com/ (200 OK)
+	https://www.example.com/robots.txt (404 Not Found)
+	https://www.example.com/sitemap.xml (404 Not Found)
+INFO: Incomplete or No Cache-control Header Set [10015] x 1 
+	https://www.example.com/ (200 OK)
+WARN-NEW: X-Content-Type-Options Header Missing [10021] x 1 
+	https://www.example.com/ (200 OK)
+WARN-NEW: Strict-Transport-Security Header Not Set [10035] x 3 
+	https://www.example.com/ (200 OK)
+	https://www.example.com/robots.txt (404 Not Found)
+	https://www.example.com/sitemap.xml (404 Not Found)
+WARN-NEW: Server Leaks Version Information via "Server" HTTP Response Header Field [10036] x 4 
+	https://www.example.com/ (200 OK)
+	https://www.example.com/ (200 OK)
+	https://www.example.com/robots.txt (404 Not Found)
+	https://www.example.com/sitemap.xml (404 Not Found)
+WARN-NEW: Content Security Policy (CSP) Header Not Set [10038] x 3 
+	https://www.example.com/ (200 OK)
+	https://www.example.com/robots.txt (404 Not Found)
+	https://www.example.com/sitemap.xml (404 Not Found)
+FAIL-NEW: X-Frame-Options Header Not Set [10020] x 1 
+	https://www.example.com/ (200 OK)
+FAIL-NEW: 1	FAIL-INPROG: 0	WARN-NEW: 4	WARN-INPROG: 0	INFO: 1	IGNORE: 1	PASS: 47

--- a/docker/zap-baseline.py
+++ b/docker/zap-baseline.py
@@ -127,7 +127,7 @@ def usage():
     
     If any of the next set of parameters are used then the existing code will be used instead:
     
-    -c config_file    plan to support soon, may just need more testing
+    -c config_file    partially supported so cannot be enabled just yet
     -u config_url     ditto
     -D secs           need new delay/sleep job
     -i                need to support config files
@@ -363,7 +363,7 @@ def main(argv):
                     jobs.append(get_af_spiderAjax(target, mins))
                 
                 jobs.append(get_af_pscan_wait(timeout))
-                jobs.append(get_af_output_summary(('Short', 'Long')[detailed_output], summary_file))
+                jobs.append(get_af_output_summary(('Short', 'Long')[detailed_output], summary_file, config_dict))
                 
                 if report_html:
                     jobs.append(get_af_report('traditional-html', base_dir, report_html, 'ZAP Scanning Report', ''))

--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -143,7 +143,7 @@ def trigger_hook(name, *args, **kwargs):
 @hook()
 def load_config(config, config_dict, config_msg, out_of_scope_dict):
     """ Loads the config file specified into:
-    config_dict - a dictionary which maps plugin_ids to levels (IGNORE, WARN, FAIL)
+    config_dict - a dictionary which maps plugin_ids to levels (IGNORE, INFO, WARN, FAIL)
     config_msg - a dictionary which maps plugin_ids to optional user specified descriptions
     out_of_scope_dict - a dictionary which maps plugin_ids to out of scope regexes
     """
@@ -207,7 +207,6 @@ def print_rules(zap, alert_dict, level, config_dict, config_msg, min_level, inc_
     count = 0
     inprog_count = 0
     for key, alert_list in sorted(alert_dict.items()):
-        #if (config_dict.has_key(key) and config_dict[key] == level):
         if inc_rule(config_dict, key, inc_extra):
             user_msg = ''
             if key in config_msg:
@@ -652,10 +651,15 @@ def get_af_report(template, dir, file, title, description):
             'reportDescription': description}
         }
 
-def get_af_output_summary(format, summaryFile):
-    return {
+def get_af_output_summary(format, summaryFile, config_dict):
+    obj = {
         'type': 'outputSummary',
         'parameters': {
             'format': format,
             'summaryFile': summaryFile}
         }
+    rules = []
+    for id, action in config_dict.items():
+        rules.append({'id': int(id), 'action': action})
+    obj['rules'] = rules
+    return obj


### PR DESCRIPTION
Depends on https://github.com/zaproxy/zap-extensions/pull/2989
As per that PR the config file/urls options are not yet enabled as the files are not yet completely supported.

This PR introduces some very simple integration tests for the baseline / AF migration. Some of them will fail as the config file option is disabled.
They also need the changed in the above PR ;)

The tests can be run using:

```
docker build -t owasp/zap2docker-tests -f docker/Dockerfile-tests docker/
docker run --rm -i -t owasp/zap2docker-tests wrk/baseline_tests.sh
```
The tests use www.example.com - I dont know how consistent this will be so this may need to change.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>