### PR TITLE
Use Content-Type charset in HTTP body text views

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestBodyStringHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestBodyStringHttpPanelViewModel.java
@@ -38,6 +38,6 @@ public class RequestBodyStringHttpPanelViewModel extends AbstractHttpStringHttpP
             return;
         }
 
-        httpMessage.getRequestBody().setBody(data);
+        httpMessage.setRequestBody(data);
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModel.java
@@ -64,6 +64,6 @@ public class RequestStringHttpPanelViewModel extends AbstractHttpStringHttpPanel
         if (parts.length > 1) {
             body = data.substring(parts[0].length() + 2);
         }
-        httpMessage.getRequestBody().setBody(body);
+        httpMessage.setRequestBody(body);
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseBodyStringHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseBodyStringHttpPanelViewModel.java
@@ -38,6 +38,6 @@ public class ResponseBodyStringHttpPanelViewModel extends AbstractHttpStringHttp
             return;
         }
 
-        httpMessage.getResponseBody().setBody(data);
+        httpMessage.setResponseBody(data);
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseStringHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseStringHttpPanelViewModel.java
@@ -64,6 +64,6 @@ public class ResponseStringHttpPanelViewModel extends AbstractHttpStringHttpPane
         if (parts.length > 1) {
             body = data.substring(parts[0].length() + 2);
         }
-        httpMessage.getResponseBody().setBody(body);
+        httpMessage.setResponseBody(body);
     }
 }

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/BodyStringHttpPanelViewModelTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/BodyStringHttpPanelViewModelTest.java
@@ -67,6 +67,8 @@ public abstract class BodyStringHttpPanelViewModelTest<T1 extends HttpHeader, T2
 
     protected abstract void prepareMessage();
 
+    protected abstract void verifyBodySet(HttpMessage message, String body);
+
     @Test
     void shouldGetEmptyDataFromNullMessage() {
         // Given
@@ -104,7 +106,7 @@ public abstract class BodyStringHttpPanelViewModelTest<T1 extends HttpHeader, T2
         // When
         model.setData(otherBodyContent);
         // Then
-        verify(body).setBody(otherBodyContent);
+        verifyBodySet(message, otherBodyContent);
         verify(header, times(0)).setContentLength(anyInt());
     }
 }

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/StringHttpPanelViewModelTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/StringHttpPanelViewModelTest.java
@@ -26,7 +26,6 @@ import static org.hamcrest.Matchers.isEmptyString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -88,6 +87,10 @@ public abstract class StringHttpPanelViewModelTest<T1 extends HttpHeader, T2 ext
 
     protected abstract void prepareMessage();
 
+    protected abstract void verifyBodySet(HttpMessage message, String body);
+
+    protected abstract void verifyBodyNotSet(HttpMessage message);
+
     @Test
     void shouldGetEmptyDataFromNullMessage() {
         // Given
@@ -129,7 +132,7 @@ public abstract class StringHttpPanelViewModelTest<T1 extends HttpHeader, T2 ext
         // Then
         verifyHeader(otherHeaderContent);
         verify(header, times(0)).setContentLength(anyInt());
-        verify(body).setBody(otherBodyContent);
+        verifyBodySet(message, otherBodyContent);
     }
 
     @Test
@@ -144,7 +147,7 @@ public abstract class StringHttpPanelViewModelTest<T1 extends HttpHeader, T2 ext
         // When / Then
         assertThrows(InvalidMessageDataException.class, () -> model.setData(data));
         verify(header, times(0)).setContentLength(anyInt());
-        verify(body, times(0)).setBody(anyString());
+        verifyBodyNotSet(message);
     }
 
     @Test
@@ -158,6 +161,6 @@ public abstract class StringHttpPanelViewModelTest<T1 extends HttpHeader, T2 ext
         // Then
         verifyHeader(HEADER);
         verify(header, times(0)).setContentLength(anyInt());
-        verify(body).setBody("");
+        verifyBodySet(message, "");
     }
 }

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestBodyStringHttpPanelViewModelUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestBodyStringHttpPanelViewModelUnitTest.java
@@ -20,7 +20,9 @@
 package org.zaproxy.zap.extension.httppanel.view.impl.models.http.request;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
+import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.BodyStringHttpPanelViewModelTest;
 import org.zaproxy.zap.network.HttpRequestBody;
@@ -48,5 +50,10 @@ class RequestBodyStringHttpPanelViewModelUnitTest
     protected void prepareMessage() {
         given(message.getRequestHeader()).willReturn(header);
         given(message.getRequestBody()).willReturn(body);
+    }
+
+    @Override
+    protected void verifyBodySet(HttpMessage message, String body) {
+        verify(message).setRequestBody(body);
     }
 }

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModelUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModelUnitTest.java
@@ -23,10 +23,12 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import org.apache.commons.httpclient.URI;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.StringHttpPanelViewModelTest;
 import org.zaproxy.zap.network.HttpRequestBody;
@@ -70,5 +72,15 @@ class RequestStringHttpPanelViewModelUnitTest
     protected void prepareMessage() {
         given(message.getRequestHeader()).willReturn(header);
         given(message.getRequestBody()).willReturn(body);
+    }
+
+    @Override
+    protected void verifyBodySet(HttpMessage message, String body) {
+        verify(message).setRequestBody(body);
+    }
+
+    @Override
+    protected void verifyBodyNotSet(HttpMessage message) {
+        verify(message, times(0)).setRequestBody(anyString());
     }
 }

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseBodyStringHttpPanelViewModelUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseBodyStringHttpPanelViewModelUnitTest.java
@@ -20,7 +20,9 @@
 package org.zaproxy.zap.extension.httppanel.view.impl.models.http.response;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
+import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.BodyStringHttpPanelViewModelTest;
 import org.zaproxy.zap.network.HttpResponseBody;
@@ -48,5 +50,10 @@ class ResponseBodyStringHttpPanelViewModelUnitTest
     protected void prepareMessage() {
         given(message.getResponseHeader()).willReturn(header);
         given(message.getResponseBody()).willReturn(body);
+    }
+
+    @Override
+    protected void verifyBodySet(HttpMessage message, String body) {
+        verify(message).setResponseBody(body);
     }
 }

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseStringHttpPanelViewModelUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseStringHttpPanelViewModelUnitTest.java
@@ -24,10 +24,12 @@ import static org.hamcrest.Matchers.isEmptyString;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.StringHttpPanelViewModelTest;
 import org.zaproxy.zap.network.HttpResponseBody;
@@ -82,5 +84,15 @@ class ResponseStringHttpPanelViewModelUnitTest
         String data = model.getData();
         // Then
         assertThat(data, isEmptyString());
+    }
+
+    @Override
+    protected void verifyBodySet(HttpMessage message, String body) {
+        verify(message).setResponseBody(body);
+    }
+
+    @Override
+    protected void verifyBodyNotSet(HttpMessage message) {
+        verify(message, times(0)).setResponseBody(anyString());
     }
 }


### PR DESCRIPTION
Set the request/response body through the `HttpMessage` to take into
account the charset defined in the Content-Type header.

Part of #6656.