### PR TITLE
Avoid setting Request Header Content-length:0 in GET requests 

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/network/HttpRequestHeader.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpRequestHeader.java
@@ -60,6 +60,7 @@
 // isSpecificType(Pattern).
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2021/05/10 Use authority for CONNECT requests.
+// ZAP: 2021/07/16 Issue 6691: Do not add zero Content-Length by default in GET requests
 // ZAP: 2021/07/19 Include SVG in isImage().
 package org.parosproxy.paros.network;
 
@@ -244,11 +245,6 @@ public class HttpRequestHeader extends HttpHeader {
         }
 
         setHeader(ACCEPT_ENCODING, null);
-
-        // ZAP: changed from method to version
-        if (version.equalsIgnoreCase(HTTP11)) {
-            setContentLength(0);
-        }
     }
 
     /**

--- a/zap/src/test/java/org/parosproxy/paros/network/HttpRequestHeaderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/network/HttpRequestHeaderUnitTest.java
@@ -209,6 +209,16 @@ class HttpRequestHeaderUnitTest {
         assertThat(header.getHeaderValues(HttpHeader.COOKIE), hasSize(1));
     }
 
+    @Test
+    void shouldNotHaveContentLengthHeaderByDefault() throws Exception {
+        // Given / When
+        URI uri = new URI("http://example.com", true);
+        HttpRequestHeader header =
+                new HttpRequestHeader(HttpRequestHeader.GET, uri, HttpHeader.HTTP11);
+        // Then
+        assertThat(header.getHeaderValues(HttpHeader.CONTENT_LENGTH), is(empty()));
+    }
+
     private static Stream<Arguments> falseTestCssUrls() {
         return falseTestUrls("css");
     }


### PR DESCRIPTION
Per RFC we should not add Content-Length header for GET,HEAD,TRACE methods. 
https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2

Content-Length is valid only  for POST,PUT, PATCH, DELETE methods.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Method

This addresses https://github.com/zaproxy/zaproxy/issues/6691 and is similar to https://github.com/zaproxy/zaproxy/pull/4593