### PR TITLE
Upload files to Crowdin on release and manually

### DIFF
--- a/.github/workflows/crowdin-upload-files.yml
+++ b/.github/workflows/crowdin-upload-files.yml
@@ -1,0 +1,19 @@
+name: Crowdin Upload Files
+
+on:
+  workflow_dispatch:
+
+jobs:
+  upload:
+    name: Upload Files
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Upload Files
+      env:
+        CROWDIN_AUTH_TOKEN: ${{ secrets.ZAPBOT_CROWDIN_TOKEN }}
+      run: ./gradlew :zap:crowdinUploadSourceFiles

--- a/.github/workflows/handle-release.yml
+++ b/.github/workflows/handle-release.yml
@@ -20,3 +20,4 @@ jobs:
       run: ./gradlew handleReleaseFromGitHubRef
       env:
         ZAPBOT_TOKEN: ${{ secrets.ZAPBOT_TOKEN }}
+        CROWDIN_AUTH_TOKEN: ${{ secrets.ZAPBOT_CROWDIN_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,6 +15,15 @@ Once published the [Handle Release](https://github.com/zaproxy/zaproxy/actions/w
 will trigger the update of the marketplace with the new release, it will also create a pull request preparing the next
 development iteration.
 
+### Localized Resources
+
+The resources that require localization (e.g. `Messages.properties`, `vulnerabilities.xml`) are uploaded to the OWASP ZAP projects in
+[Crowdin](https://crowdin.com/) when the main release is released, if required (for pre-translation) the resources can be uploaded manually
+at anytime by running the workflow [Crowdin Upload Files](https://github.com/zaproxy/zaproxy/actions/workflows/crowdin-upload-files.yml).
+
+The resulting localized resources are added/updated in the repository periodically (through a workflow in the
+[zap-admin repository](https://github.com/zaproxy/zap-admin/)).
+
 ## Weekly Release
 
 The following steps should be followed to release the weekly:

--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/github-releases.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/github-releases.gradle.kts
@@ -181,6 +181,7 @@ System.getenv("GITHUB_REF")?.let { ref ->
         } else if (targetTag.startsWith("v")) {
             dependsOn(handleMainRelease)
             dependsOn(createPullRequestNextDevIter)
+            dependsOn("crowdinUploadSourceFiles")
         }
     }
 }

--- a/zap/gradle/crowdin.yml
+++ b/zap/gradle/crowdin.yml
@@ -1,0 +1,15 @@
+projects:
+  - id: 9301
+    sources:
+      - dir: "src/main/resources/org/zaproxy/zap/resources"
+        outputDir: "src/main/dist/lang"
+        crowdinPath:
+          dir: "/core"
+          filename: "%file_pathname%"
+        exportPattern:
+          dir: "/zaproxy/core"
+          filename: "%file_name%_%locale_with_underscore%%file_extension%"
+        includes:
+          - pattern: "Messages.properties"
+          - pattern: "vulnerabilities.xml"
+

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     `java-library`
     jacoco
     id("me.champeau.gradle.japicmp")
+    id("org.zaproxy.crowdin") version "0.1.0"
     org.zaproxy.zap.distributions
     org.zaproxy.zap.installers
     org.zaproxy.zap.`github-releases`
@@ -35,6 +36,16 @@ java {
     } else {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+    }
+}
+
+crowdin {
+    credentials {
+        token.set(System.getenv("CROWDIN_AUTH_TOKEN"))
+    }
+
+    configuration {
+        file.set(file("gradle/crowdin.yml"))
     }
 }
 


### PR DESCRIPTION
Change release process to upload the files to Crowdin as part of the
main release.
Add workflow to trigger the upload of the files, to allow to start to
translate the files before the actual release.