### PR TITLE
Encode parameters when replacing in form auth data

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
@@ -157,18 +157,21 @@ public class FormBasedAuthenticationMethodType extends PostBasedAuthenticationMe
         @Override
         protected String replaceParameterValue(
                 String originalString, NameValuePair parameter, String replaceString) {
+            String name = PARAM_ENCODER.apply(parameter.getName());
+            String value = PARAM_ENCODER.apply(parameter.getValue());
+
             String keyValueSeparator =
                     getContext().getPostParamParser().getDefaultKeyValueSeparator();
-            String nameAndSeparator = parameter.getName() + keyValueSeparator;
+            String nameAndSeparator = name + keyValueSeparator;
             // Make sure we handle the case when there's only the parameter name in the POST data
             // instead of
             // parameter name + separator + value (e.g. just 'param1&...' instead of
             // 'param1=...&...')
             if (originalString.contains(nameAndSeparator)) {
                 return originalString.replace(
-                        nameAndSeparator + parameter.getValue(), nameAndSeparator + replaceString);
+                        nameAndSeparator + value, nameAndSeparator + replaceString);
             }
-            return originalString.replace(parameter.getName(), nameAndSeparator + replaceString);
+            return originalString.replace(name, nameAndSeparator + replaceString);
         }
     }
 


### PR DESCRIPTION
The form based auth parameters are handled/shown in decoded form so they
need to be encoded when finding them in the (encoded) auth data, to be
able to inject the username/password tokens properly.

---
Reported in the OWASP ZAP User Group: https://groups.google.com/g/zaproxy-users/c/QEZNSYtswpY/m/17p6jgtwAwAJ