### PR TITLE
Add action to build live docker release

### DIFF
--- a/.github/workflows/release-live-docker.yml
+++ b/.github/workflows/release-live-docker.yml
@@ -1,0 +1,31 @@
+name: Release Live Docker
+on:
+  workflow_dispatch:
+  schedule:
+    # Every day at the start of the day
+    - cron:  '0 0 * * *'
+
+jobs:
+  publish:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: zapbot
+          password: ${{ secrets.ZAPBOT_DOCKER_TOKEN }}
+      -
+        name: Build Docker image
+        uses: docker/build-push-action@v2
+        with:
+          load: true
+          context: docker
+          file: docker/Dockerfile-live
+          tags: |
+            owasp/zap2docker-live:latest
+          build-args: |
+            WEBSWING_TOKEN=${{ secrets.WEBSWING_TOKEN }}
+      - run: docker push owasp/zap2docker-live:latest


### PR DESCRIPTION
Looks like the dockerhub option to build automatically in now only available to teams and pro accounts :(

Signed-off-by: Simon Bennetts <psiinon@gmail.com>