### PR TITLE
Action for integration tests

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -1,0 +1,33 @@
+name: Build and Run Integration Tests Docker
+on:
+  workflow_dispatch:
+  schedule:
+    # Every day at the 1am
+    - cron:  '0 1 * * *'
+
+jobs:
+  publish:
+    name: Build, Push and Run Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: zapbot
+          password: ${{ secrets.ZAPBOT_DOCKER_TOKEN }}
+      -
+        name: Build Docker image
+        uses: docker/build-push-action@v2
+        with:
+          load: true
+          context: docker
+          file: docker/Dockerfile-tests
+          tags: |
+            owasp/zap2docker-tests:latest
+          build-args: |
+            WEBSWING_TOKEN=${{ secrets.WEBSWING_TOKEN }}
+      - run: docker push owasp/zap2docker-tests:latest
+      - name: Run tests
+        run: docker run --rm -t owasp/zap2docker-tests:latest wrk/baseline_tests.sh

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2021-08-11
+ - Changed to enable integration tests, inc enabling the AF for the baseline `-c` option if the `--auto` flag is used before it.
+
 ### 2021-07-08
  - Changed to use user's home directory for the Automation Framework files so it will work for any user
 

--- a/docker/integration_tests/baseline_tests.sh
+++ b/docker/integration_tests/baseline_tests.sh
@@ -6,7 +6,7 @@ RES=0
 mkdir /zap/wrk/output
 
 echo "TEST: Baseline test 1 (vs example.com)"
-/zap/zap-baseline.py -t https://www.example.com/ --auto > /zap/wrk/output/baseline1.out
+/zap/zap-baseline.py -t https://www.example.com/ > /zap/wrk/output/baseline1.out
 RET=$?
 DIFF=$(diff /zap/wrk/output/baseline1.out /zap/wrk/results/baseline1.out) 
 if [ "$DIFF" != "" ] 
@@ -26,7 +26,7 @@ fi
 
 echo
 echo "Baseline test 2 (vs example.com with INFO/WARN/FAIL set)"
-/zap/zap-baseline.py -t https://www.example.com/ -c configs/baseline2.conf --auto > /zap/wrk/output/baseline2.out
+/zap/zap-baseline.py -t https://www.example.com/ --auto -c configs/baseline2.conf > /zap/wrk/output/baseline2.out
 RET=$?
 DIFF=$(diff /zap/wrk/output/baseline2.out /zap/wrk/results/baseline2.out) 
 if [ "$DIFF" != "" ] 

--- a/docker/zap-baseline.py
+++ b/docker/zap-baseline.py
@@ -125,10 +125,14 @@ def usage():
     -s
     -T
     -z zap_options
+
+    The following parameters are partially supported. 
+    If you specify the '--auto' flag _before_ using them then the Automation Framework will be used:
+
+    -c config_file    Supports IGNORE, WARN and FAIL. Does not yet support OUTOFSCOPE or custom rule messages.
     
     If any of the next set of parameters are used then the existing code will be used instead:
     
-    -c config_file    partially supported so cannot be enabled just yet
     -u config_url     ditto
     -D secs           need new delay/sleep job
     -i                need to support config files
@@ -173,6 +177,7 @@ def main(argv):
     user = ''
     use_af = True
     af_supported = True
+    af_override = False
 
     pass_count = 0
     warn_count = 0
@@ -200,7 +205,8 @@ def main(argv):
             logging.debug('Target: ' + target)
         elif opt == '-c':
             config_file = arg
-            af_supported = False
+            if not af_override:
+              af_supported = False
         elif opt == '-u':
             config_url = arg
             af_supported = False
@@ -262,6 +268,7 @@ def main(argv):
             af_supported = False
         elif opt == '--auto':
             use_af = True
+            af_override = True
         elif opt == '--autooff':
             use_af = False
 


### PR DESCRIPTION
Creates a new action for running the integrations tests every day (or on demand).
Also pushed the zap2docker-tests image to dockerhub to make retesting easier.
Also changed the baseline scan to work with the `-c` option but only if `--auto` is specified _before_ it. This is really just for our tests but I'll post to the user group about it as well.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>