### PR TITLE
Baseline - use AF for * OUTOFSCOPE config settings

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to the docker containers will be documented in this file.
 
 ### 2021-08-11
  - Changed to enable integration tests, inc enabling the AF for the baseline `-c` option if the `--auto` flag is used before it.
+ - Added Automation Framework support for * OUTOFSCOPE baseline config file option.
 
 ### 2021-07-08
  - Changed to use user's home directory for the Automation Framework files so it will work for any user

--- a/docker/integration_tests/baseline_tests.sh
+++ b/docker/integration_tests/baseline_tests.sh
@@ -45,7 +45,27 @@ else
 fi
 
 echo
-echo "TEST Baseline 3 (new vs old) - we expect _some_ differences and this will not fail the whole script"
+echo "Baseline test 3 (vs example.com with INFO/WARN/FAIL and OUTOFSCOPE set)"
+/zap/zap-baseline.py -t https://www.example.com/ --auto -c configs/baseline3.conf > /zap/wrk/output/baseline3.out
+RET=$?
+DIFF=$(diff /zap/wrk/output/baseline3.out /zap/wrk/results/baseline3.out) 
+if [ "$DIFF" != "" ] 
+then
+    echo "FAIL: differences:"
+    echo "$DIFF"
+	RES=1
+else
+	if [ "$RET" -ne 1 ] 
+	then
+    	echo "FAIL: exited with $RET instead of 1"
+		RES=1
+	else
+    	echo "PASS"
+    fi
+fi
+
+echo
+echo "TEST Baseline 4 (new vs old) - we expect _some_ differences and this will not fail the whole script"
 /zap/zap-baseline.py -t https://www.example.com/ --autooff > /zap/wrk/output/baseline1-orig.out
 DIFF=$(diff /zap/wrk/output/baseline1.out /zap/wrk/output/baseline1-orig.out) 
 echo "Differences:"

--- a/docker/integration_tests/configs/baseline3.conf
+++ b/docker/integration_tests/configs/baseline3.conf
@@ -1,0 +1,4 @@
+10015	INFO	(Incomplete or No Cache-control and Pragma HTTP Header Set)
+10020	FAIL	(X-Frame-Options Header)
+10050	IGNORE	(Retrieved from Cache)
+*	OUTOFSCOPE	.*/robots\.txt

--- a/docker/integration_tests/results/baseline3.out
+++ b/docker/integration_tests/results/baseline3.out
@@ -1,0 +1,69 @@
+Using the Automation Framework
+Total of 3 URLs
+PASS: Vulnerable JS Library [10003]
+PASS: Cookie No HttpOnly Flag [10010]
+PASS: Cookie Without Secure Flag [10011]
+PASS: Cross-Domain JavaScript Source File Inclusion [10017]
+PASS: Content-Type Header Missing [10019]
+PASS: Information Disclosure - Debug Error Messages [10023]
+PASS: Information Disclosure - Sensitive Information in URL [10024]
+PASS: Information Disclosure - Sensitive Information in HTTP Referrer Header [10025]
+PASS: HTTP Parameter Override [10026]
+PASS: Information Disclosure - Suspicious Comments [10027]
+PASS: Open Redirect [10028]
+PASS: Cookie Poisoning [10029]
+PASS: User Controllable Charset [10030]
+PASS: User Controllable HTML Element Attribute (Potential XSS) [10031]
+PASS: Viewstate [10032]
+PASS: Directory Browsing [10033]
+PASS: Heartbleed OpenSSL Vulnerability (Indicative) [10034]
+PASS: Server Leaks Information via "X-Powered-By" HTTP Response Header Field(s) [10037]
+PASS: X-Backend-Server Header Information Leak [10039]
+PASS: Secure Pages Include Mixed Content [10040]
+PASS: HTTP to HTTPS Insecure Transition in Form Post [10041]
+PASS: HTTPS to HTTP Insecure Transition in Form Post [10042]
+PASS: User Controllable JavaScript Event (XSS) [10043]
+PASS: Big Redirect Detected (Potential Sensitive Information Leak) [10044]
+PASS: X-ChromeLogger-Data (XCOLD) Header Information Leak [10052]
+PASS: Cookie without SameSite Attribute [10054]
+PASS: CSP [10055]
+PASS: X-Debug-Token Information Leak [10056]
+PASS: Username Hash Found [10057]
+PASS: X-AspNet-Version Response Header [10061]
+PASS: PII Disclosure [10062]
+PASS: Timestamp Disclosure [10096]
+PASS: Hash Disclosure [10097]
+PASS: Cross-Domain Misconfiguration [10098]
+PASS: Weak Authentication Method [10105]
+PASS: Reverse Tabnabbing [10108]
+PASS: Modern Web Application [10109]
+PASS: Absence of Anti-CSRF Tokens [10202]
+PASS: Private IP Disclosure [2]
+PASS: Session ID in URL Rewrite [3]
+PASS: Script Passive Scan Rules [50001]
+PASS: Stats Passive Scan Rule [50003]
+PASS: Insecure JSF ViewState [90001]
+PASS: Charset Mismatch [90011]
+PASS: Application Error Disclosure [90022]
+PASS: WSDL File Detection [90030]
+PASS: Loosely Scoped Cookie [90033]
+IGNORE: Retrieved from Cache [10050] x 2 
+	https://www.example.com/ (200 OK)
+	https://www.example.com/sitemap.xml (404 Not Found)
+INFO: Incomplete or No Cache-control Header Set [10015] x 1 
+	https://www.example.com/ (200 OK)
+WARN-NEW: X-Content-Type-Options Header Missing [10021] x 1 
+	https://www.example.com/ (200 OK)
+WARN-NEW: Strict-Transport-Security Header Not Set [10035] x 2 
+	https://www.example.com/ (200 OK)
+	https://www.example.com/sitemap.xml (404 Not Found)
+WARN-NEW: Server Leaks Version Information via "Server" HTTP Response Header Field [10036] x 3 
+	https://www.example.com/ (200 OK)
+	https://www.example.com/ (200 OK)
+	https://www.example.com/sitemap.xml (404 Not Found)
+WARN-NEW: Content Security Policy (CSP) Header Not Set [10038] x 2 
+	https://www.example.com/ (200 OK)
+	https://www.example.com/sitemap.xml (404 Not Found)
+FAIL-NEW: X-Frame-Options Header Not Set [10020] x 1 
+	https://www.example.com/ (200 OK)
+FAIL-NEW: 1	FAIL-INPROG: 0	WARN-NEW: 4	WARN-INPROG: 0	INFO: 1	IGNORE: 1	PASS: 47

--- a/docker/zap-baseline.py
+++ b/docker/zap-baseline.py
@@ -129,7 +129,7 @@ def usage():
     The following parameters are partially supported. 
     If you specify the '--auto' flag _before_ using them then the Automation Framework will be used:
 
-    -c config_file    Supports IGNORE, WARN and FAIL. Does not yet support OUTOFSCOPE or custom rule messages.
+    -c config_file    Supports IGNORE, WARN and FAIL and * OUTOFSCOPE. Does not yet support plugin specific OUTOFSCOPE or custom rule messages.
     
     If any of the next set of parameters are used then the existing code will be used instead:
     
@@ -357,7 +357,7 @@ def main(argv):
                         target = t2
                         top_levels.append(target)
                
-                yaml.dump(get_af_env(top_levels, debug), yf)
+                yaml.dump(get_af_env(top_levels, out_of_scope_dict, debug), yf)
                 
                 addons = ['pscanrulesBeta']
                 if zap_alpha:

--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -589,12 +589,19 @@ def zap_set_scan_user(zap, username):
             return
     raise UserInputException('ZAP failed to find user: {0}'.format(username))
 
-def get_af_env(targets, debug):
+def get_af_env(targets, out_of_scope_dict, debug):
+    exclude = []
+    # '*' rules apply to all scan rules so can just be added to the context exclusions
+    if '*' in out_of_scope_dict:
+        for rule in out_of_scope_dict['*']:
+            exclude.append(rule.pattern)
+    
     return {
             'env': {
                 'contexts': [{
                     'name': 'baseline',
-                    'urls': targets
+                    'urls': targets,
+                    'excludePaths': exclude
                     }],
                 'parameters': {
                     'failOnError': True,


### PR DESCRIPTION
Adds * OUTOFSCOPE regexes to the context excludePaths
The plugin specific ones will take more work and probably AF job changes ;)
And this change does include a new integration test :D

Signed-off-by: Simon Bennetts <psiinon@gmail.com>