### PR TITLE
Update Host header in place

### DIFF
--- a/zap/src/main/java/org/apache/commons/httpclient/HttpMethodBase.java
+++ b/zap/src/main/java/org/apache/commons/httpclient/HttpMethodBase.java
@@ -36,9 +36,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 
@@ -66,6 +68,7 @@ import org.parosproxy.paros.network.HttpHeader;
  *  String, String, String) to preserve the intended request URI.
  *  - Change the way cookie headers are handled when using forced user mode, put all the headers in a single line see ISSUE 1874
  *  - Do not add a User-Agent header by default.
+ *  - Update Host header in place.
  * 
  */
 /**
@@ -116,6 +119,8 @@ import org.parosproxy.paros.network.HttpHeader;
  * @version $Revision: 775455 $ $Date: 2009-05-16 13:28:40 +0100 (Sat, 16 May 2009) $
  */
 public abstract class HttpMethodBase implements HttpMethod {
+
+    private static final String HOST_HEADER = "Host";
 
     // -------------------------------------------------------------- Constants
 
@@ -1492,7 +1497,31 @@ public abstract class HttpMethodBase implements HttpMethod {
             host += (":" + port);
         }
 
-        setRequestHeader("Host", host);
+        if (!getRequestHeaderGroup().containsHeader(HOST_HEADER)) {
+            addRequestHeader(HOST_HEADER, host);
+            return;
+        }
+
+        Header[] hostHeaders = getRequestHeaderGroup().getHeaders(HOST_HEADER);
+        if (hostHeaders.length == 1) {
+            hostHeaders[0].setValue(host);
+            return;
+        }
+
+        List<Header> headers = new ArrayList<>(Arrays.asList(getRequestHeaderGroup().getAllHeaders()));
+        boolean remove = false;
+        for (Iterator<Header> it = headers.iterator(); it.hasNext();) {
+            Header header = it.next();
+            if (HOST_HEADER.equalsIgnoreCase(header.getName())) {
+                if (remove) {
+                    it.remove();
+                } else {
+                    header.setValue(host);
+                    remove = true;
+                }
+            }
+        }
+        getRequestHeaderGroup().setHeaders(headers.toArray(new Header[0]));
     }
 
     /**

--- a/zap/src/test/java/org/apache/commons/httpclient/HttpMethodBaseUnitTest.java
+++ b/zap/src/test/java/org/apache/commons/httpclient/HttpMethodBaseUnitTest.java
@@ -20,16 +20,24 @@
 package org.apache.commons.httpclient;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import java.util.List;
 import java.util.stream.Stream;
+import org.apache.commons.httpclient.protocol.Protocol;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class HttpMethodBaseUnitTest {
+
+    private static final Header EXPECTED_HOST_HEADER = header("Host", "example.com");
 
     @ParameterizedTest
     @MethodSource("cookieHeaderProvider")
@@ -45,5 +53,134 @@ class HttpMethodBaseUnitTest {
                 arguments("has_js=1;JSESSIONID=5DFA94B903A0063839E0440118808875", 2),
                 arguments("has_js=1; JSESSIONID=5DFA94B903A0063839E0440118808875", 2),
                 arguments("has_js=;JSESSIONID=5DFA94B903A0063839E0440118808875", 2));
+    }
+
+    @Test
+    void shouldAddHostHeaderIfNotPresent() throws Exception {
+        // Given
+        HttpMethodBase methodBase = new TestHttpMethodBase();
+        Header headerA = header("A", "Value A");
+        methodBase.addRequestHeader(headerA);
+        HttpConnection conn = connection("example.com", 443);
+        // When
+        methodBase.addHostRequestHeader(null, conn);
+        // Then
+        assertThat(
+                methodBase.getRequestHeaders(), is(arrayContaining(headerA, EXPECTED_HOST_HEADER)));
+    }
+
+    @Test
+    void shouldKeepHostHeaderIfValueMatch() throws Exception {
+        // Given
+        HttpMethodBase methodBase = new TestHttpMethodBase();
+        Header hostHeader = header("Host", "example.com");
+        methodBase.addRequestHeader(hostHeader);
+        Header headerA = header("A", "Value A");
+        methodBase.addRequestHeader(headerA);
+        HttpConnection conn = connection("example.com", 443);
+        // When
+        methodBase.addHostRequestHeader(null, conn);
+        // Then
+        assertThat(
+                methodBase.getRequestHeaders(), is(arrayContaining(EXPECTED_HOST_HEADER, headerA)));
+    }
+
+    @Test
+    void shouldUpdateHostHeaderIfValueMismatch() throws Exception {
+        // Given
+        HttpMethodBase methodBase = new TestHttpMethodBase();
+        methodBase.addRequestHeader(header("Host", "example2.com"));
+        HttpConnection conn = connection("example.com", 443);
+        // When
+        methodBase.addHostRequestHeader(null, conn);
+        // Then
+        assertThat(methodBase.getRequestHeaders(), is(arrayContaining(EXPECTED_HOST_HEADER)));
+    }
+
+    @Test
+    void shouldUpdateHostHeaderInPlace() throws Exception {
+        // Given
+        HttpMethodBase methodBase = new TestHttpMethodBase();
+        Header headerA = header("A", "Value A");
+        methodBase.addRequestHeader(headerA);
+        Header hostHeader = header("Host", "example2.com");
+        methodBase.addRequestHeader(hostHeader);
+        Header headerB = header("B", "Value B");
+        methodBase.addRequestHeader(headerB);
+        HttpConnection conn = connection("example.com", 443);
+        // When
+        methodBase.addHostRequestHeader(null, conn);
+        // Then
+        assertThat(
+                methodBase.getRequestHeaders(),
+                is(arrayContaining(headerA, EXPECTED_HOST_HEADER, headerB)));
+    }
+
+    @Test
+    void shouldKeepOnlyOneHostHeader() throws Exception {
+        // Given
+        HttpMethodBase methodBase = new TestHttpMethodBase();
+        Header headerA = header("A", "Value A");
+        methodBase.addRequestHeader(headerA);
+        Header hostHeader1 = header("Host", "example.com");
+        methodBase.addRequestHeader(hostHeader1);
+        Header headerB = header("B", "Value B");
+        methodBase.addRequestHeader(headerB);
+        Header headerHost2 = header("Host", "Should Remove 1");
+        methodBase.addRequestHeader(headerHost2);
+        Header headerHost3 = header("Host", "Should Remove 2");
+        methodBase.addRequestHeader(headerHost3);
+        HttpConnection conn = connection("example.com", 443);
+        // When
+        methodBase.addHostRequestHeader(null, conn);
+        // Then
+        assertThat(
+                methodBase.getRequestHeaders(),
+                is(arrayContaining(headerA, EXPECTED_HOST_HEADER, headerB)));
+    }
+
+    @Test
+    void shouldUpdateAndKeepOnlyOneHostHeader() throws Exception {
+        // Given
+        HttpMethodBase methodBase = new TestHttpMethodBase();
+        Header headerA = header("A", "Value A");
+        methodBase.addRequestHeader(headerA);
+        Header hostHeader1 = header("Host", "example2.com");
+        methodBase.addRequestHeader(hostHeader1);
+        Header headerB = header("B", "Value B");
+        methodBase.addRequestHeader(headerB);
+        Header headerHost2 = header("Host", "Should Remove 1");
+        methodBase.addRequestHeader(headerHost2);
+        Header headerHost3 = header("Host", "Should Remove 2");
+        methodBase.addRequestHeader(headerHost3);
+        HttpConnection conn = connection("example.com", 443);
+        // When
+        methodBase.addHostRequestHeader(null, conn);
+        // Then
+        assertThat(
+                methodBase.getRequestHeaders(),
+                is(arrayContaining(headerA, EXPECTED_HOST_HEADER, headerB)));
+    }
+
+    private static HttpConnection connection(String host, int port) {
+        HttpConnection connection = mock(HttpConnection.class);
+        given(connection.getHost()).willReturn(host);
+        given(connection.getPort()).willReturn(port);
+        Protocol protocol = mock(Protocol.class);
+        given(protocol.getDefaultPort()).willReturn(port);
+        given(connection.getProtocol()).willReturn(protocol);
+        return connection;
+    }
+
+    private static Header header(String name, String value) {
+        return new Header(name, value);
+    }
+
+    private static class TestHttpMethodBase extends HttpMethodBase {
+
+        @Override
+        public String getName() {
+            return "TEST";
+        }
     }
 }


### PR DESCRIPTION
Keep the Host header in the same place as it was found when updating its
value to match the host of the connection.