### PR TITLE
Guard against extensions' errors

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -42,6 +42,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
+import java.util.function.Function;
 import javax.net.ssl.SSLHandshakeException;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -1627,30 +1628,43 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
      */
     private static String getExtensionsUnsavedResources(
             Collection<AddOn> addOns, Set<Extension> extensions) {
-        List<String> unsavedResources = new ArrayList<>();
+        return getExtensionsMessages(addOns, extensions, Extension::getUnsavedResources);
+    }
+
+    private static String getExtensionsMessages(
+            Collection<AddOn> addOns,
+            Set<Extension> extensions,
+            Function<Extension, List<String>> function) {
+        List<String> messages = new ArrayList<>();
         for (AddOn addOn : addOns) {
-            for (Extension extension : addOn.getLoadedExtensions()) {
-                if (!extension.isEnabled()) {
-                    continue;
-                }
-
-                List<String> resources = extension.getUnsavedResources();
-                if (resources != null) {
-                    unsavedResources.addAll(resources);
-                }
-            }
+            addMessages(addOn.getLoadedExtensions(), function, messages);
         }
-        for (Extension extension : extensions) {
-            if (!extension.isEnabled()) {
-                continue;
-            }
+        addMessages(extensions, function, messages);
+        return wrapEntriesInLiTags(messages);
+    }
 
-            List<String> resources = extension.getUnsavedResources();
-            if (resources != null) {
-                unsavedResources.addAll(resources);
-            }
-        }
-        return wrapEntriesInLiTags(unsavedResources);
+    private static void addMessages(
+            Collection<Extension> extensions,
+            Function<Extension, List<String>> function,
+            List<String> sink) {
+        extensions.stream()
+                .filter(Extension::isEnabled)
+                .map(
+                        e -> {
+                            try {
+                                List<String> messages = function.apply(e);
+                                if (messages != null) {
+                                    return messages;
+                                }
+                            } catch (Throwable ex) {
+                                logger.error(
+                                        "Error while getting messages from {}",
+                                        e.getClass().getCanonicalName(),
+                                        ex);
+                            }
+                            return Collections.<String>emptyList();
+                        })
+                .forEach(sink::addAll);
     }
 
     private static String wrapEntriesInLiTags(List<String> entries) {
@@ -1679,30 +1693,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
      */
     private static String getExtensionsActiveActions(
             Collection<AddOn> addOns, Set<Extension> extensions) {
-        List<String> activeActions = new ArrayList<>();
-        for (AddOn addOn : addOns) {
-            for (Extension extension : addOn.getLoadedExtensions()) {
-                if (!extension.isEnabled()) {
-                    continue;
-                }
-
-                List<String> actions = extension.getActiveActions();
-                if (actions != null) {
-                    activeActions.addAll(actions);
-                }
-            }
-        }
-        for (Extension extension : extensions) {
-            if (!extension.isEnabled()) {
-                continue;
-            }
-
-            List<String> resources = extension.getActiveActions();
-            if (resources != null) {
-                activeActions.addAll(resources);
-            }
-        }
-        return wrapEntriesInLiTags(activeActions);
+        return getExtensionsMessages(addOns, extensions, Extension::getActiveActions);
     }
 
     private void downloadAddOn(AddOn addOn) {

--- a/zap/src/test/java/org/parosproxy/paros/extension/ExtensionLoaderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/extension/ExtensionLoaderUnitTest.java
@@ -19,10 +19,15 @@
  */
 package org.parosproxy.paros.extension;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
@@ -73,5 +78,81 @@ class ExtensionLoaderUnitTest {
         // Then
         inOrder.verify(extension).stop();
         inOrder.verify(extension).destroy();
+    }
+
+    @Test
+    void shouldGetUnsavedResourcesFromExtensions() {
+        // Given
+        Extension extensionA = mock(Extension.class);
+        given(extensionA.getUnsavedResources()).willReturn(Arrays.asList("Resource A"));
+        extensionLoader.addExtension(extensionA);
+        Extension extensionB = mock(Extension.class);
+        given(extensionB.getUnsavedResources()).willReturn(null);
+        extensionLoader.addExtension(extensionB);
+        Extension extensionC = mock(Extension.class);
+        given(extensionC.getUnsavedResources()).willReturn(Arrays.asList("Resource C"));
+        extensionLoader.addExtension(extensionC);
+        // When
+        List<String> resources = extensionLoader.getUnsavedResources();
+        // Then
+        assertThat(resources, contains("Resource A", "Resource C"));
+    }
+
+    @Test
+    void shouldGetUnsavedResourcesFromExtensionsWhileHandlingErrors() {
+        // Given
+        Extension extensionA = mock(Extension.class);
+        given(extensionA.getUnsavedResources()).willAnswer(this::throwThrowable);
+        extensionLoader.addExtension(extensionA);
+        Extension extensionB = mock(Extension.class);
+        given(extensionB.getUnsavedResources()).willReturn(null);
+        extensionLoader.addExtension(extensionB);
+        Extension extensionC = mock(Extension.class);
+        given(extensionC.getUnsavedResources()).willReturn(Arrays.asList("Resource C"));
+        extensionLoader.addExtension(extensionC);
+        // When
+        List<String> resources = extensionLoader.getUnsavedResources();
+        // Then
+        assertThat(resources, contains("Resource C"));
+    }
+
+    @Test
+    void shouldGetActiveActionsFromExtensions() {
+        // Given
+        Extension extensionA = mock(Extension.class);
+        given(extensionA.getActiveActions()).willReturn(Arrays.asList("Action A"));
+        extensionLoader.addExtension(extensionA);
+        Extension extensionB = mock(Extension.class);
+        given(extensionB.getActiveActions()).willReturn(null);
+        extensionLoader.addExtension(extensionB);
+        Extension extensionC = mock(Extension.class);
+        given(extensionC.getActiveActions()).willReturn(Arrays.asList("Action C"));
+        extensionLoader.addExtension(extensionC);
+        // When
+        List<String> resources = extensionLoader.getActiveActions();
+        // Then
+        assertThat(resources, contains("Action A", "Action C"));
+    }
+
+    @Test
+    void shouldGetActiveActionsFromExtensionsWhileHandlingErrors() {
+        // Given
+        Extension extensionA = mock(Extension.class);
+        given(extensionA.getActiveActions()).willAnswer(this::throwThrowable);
+        extensionLoader.addExtension(extensionA);
+        Extension extensionB = mock(Extension.class);
+        given(extensionB.getActiveActions()).willReturn(null);
+        extensionLoader.addExtension(extensionB);
+        Extension extensionC = mock(Extension.class);
+        given(extensionC.getActiveActions()).willReturn(Arrays.asList("Action C"));
+        extensionLoader.addExtension(extensionC);
+        // When
+        List<String> actions = extensionLoader.getActiveActions();
+        // Then
+        assertThat(actions, contains("Action C"));
+    }
+
+    private <T> T throwThrowable(T arg) throws Throwable {
+        throw new Throwable();
     }
 }


### PR DESCRIPTION
Catch `Throwable` when getting unsaved resources and active actions to
ensure that the extensions' errors do not break core functionality (e.g.
exit, uninstall add-on).

Fix #6755.