### PR TITLE
Rely on default JaCoCo version

### DIFF
--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -49,10 +49,6 @@ crowdin {
     }
 }
 
-jacoco {
-    toolVersion = "0.8.6"
-}
-
 tasks.named<JacocoReport>("jacocoTestReport") {
     reports {
         xml.isEnabled = true


### PR DESCRIPTION
Remove the specification of the version, rely on the default which is
already current.