### PR TITLE
Use only zapbot credentials in release workflows

### DIFF
--- a/.github/workflows/handle-release.yml
+++ b/.github/workflows/handle-release.yml
@@ -12,6 +12,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Setup Java 8
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/prepare-release-main-version.yml
+++ b/.github/workflows/prepare-release-main-version.yml
@@ -11,6 +11,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Setup Java
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/release-main-version.yml
+++ b/.github/workflows/release-main-version.yml
@@ -16,13 +16,13 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Setup Java
       uses: actions/setup-java@v1
       with:
         java-version: 11
     - name: Build and Release
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         INSTALL4J_LICENSE: ${{ secrets.INSTALL4J_LICENSE }}
         ZAPBOT_TOKEN: ${{ secrets.ZAPBOT_TOKEN }}
       run: ./gradlew "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m" :zap:createMainRelease

--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -11,12 +11,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Setup Java
       uses: actions/setup-java@v1
       with:
         java-version: 11
     - name: Build and Release
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         ZAPBOT_TOKEN: ${{ secrets.ZAPBOT_TOKEN }}
       run: ./gradlew "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m" :zap:createWeeklyRelease

--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/CreateGitHubRelease.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/CreateGitHubRelease.java
@@ -49,12 +49,12 @@ import org.kohsuke.github.GHFileNotFoundException;
 import org.kohsuke.github.GHRelease;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
+import org.zaproxy.zap.GitHubUser;
 
 /** A task that creates a GitHub release. */
-public class CreateGitHubRelease extends DefaultTask {
+public abstract class CreateGitHubRelease extends DefaultTask {
 
     private final Property<String> repo;
-    private final Property<String> authToken;
     private final Property<String> tag;
     private final Property<String> title;
     private final Property<String> body;
@@ -68,7 +68,6 @@ public class CreateGitHubRelease extends DefaultTask {
     public CreateGitHubRelease() {
         ObjectFactory objects = getProject().getObjects();
         this.repo = objects.property(String.class);
-        this.authToken = objects.property(String.class);
         this.tag = objects.property(String.class);
         this.title = objects.property(String.class);
         this.body = objects.property(String.class);
@@ -89,9 +88,7 @@ public class CreateGitHubRelease extends DefaultTask {
     }
 
     @Input
-    public Property<String> getAuthToken() {
-        return authToken;
-    }
+    public abstract Property<GitHubUser> getUser();
 
     @Input
     public Property<String> getTag() {
@@ -159,7 +156,9 @@ public class CreateGitHubRelease extends DefaultTask {
             throw new IllegalArgumentException("The checksum algorithm must not be empty.");
         }
 
-        GHRepository ghRepo = GitHub.connect("", authToken.get()).getRepository(repo.get());
+        GitHubUser ghUser = getUser().get();
+        GHRepository ghRepo =
+                GitHub.connect(ghUser.getName(), ghUser.getAuthToken()).getRepository(repo.get());
 
         validateTagExists(ghRepo, tag.get());
         validateReleaseDoesNotExist(ghRepo, tag.get());

--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/CreateTagAndGitHubRelease.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/CreateTagAndGitHubRelease.java
@@ -44,9 +44,6 @@ public abstract class CreateTagAndGitHubRelease extends CreateGitHubRelease {
     }
 
     @Input
-    public abstract Property<GitHubUser> getUser();
-
-    @Input
     public abstract Property<String> getTagMessage();
 
     @Override

--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/github-releases.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/github-releases.gradle.kts
@@ -22,7 +22,6 @@ tasks.register<CreateTagAndGitHubRelease>("createWeeklyRelease") {
     val tagName = dateProvider.map { "w$it" }
 
     user.set(ghUser)
-    authToken.set(System.getenv("GITHUB_TOKEN"))
     repo.set(System.getenv("GITHUB_REPOSITORY"))
     tag.set(tagName)
     tagMessage.set(dateProvider.map { "Weekly release $it" })
@@ -97,7 +96,6 @@ tasks.register<CreateMainRelease>("createMainRelease") {
     val tagName = "v${project.version}"
 
     user.set(ghUser)
-    authToken.set(System.getenv("GITHUB_TOKEN"))
     repo.set(System.getenv("GITHUB_REPOSITORY"))
     tag.set(tagName)
     tagMessage.set("Version ${project.version}")


### PR DESCRIPTION
Do not persist default credentials and use only zapbot's ones.