### PR TITLE
Add missing dependency for japicmp

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -39,4 +39,6 @@ dependencies {
         // Just for compilation, not actually used (installers task is replaced).
         implementation("gradle.plugin.install4j.install4j:gradle_plugin:8.0.11")
     implementation("me.champeau.gradle:japicmp-gradle-plugin:0.2.9")
+    // A japicmp dependency being excluded by japicmp-gradle-plugin.
+    implementation("com.google.guava:guava:30.1-jre")
 }


### PR DESCRIPTION
The Gradle Plugin is excluding the dependency of japicmp.
Only one version of Guava is currently on the classpath.