### PR TITLE
Correct CoreFunctionality init

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/control/CoreFunctionality.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/CoreFunctionality.java
@@ -54,7 +54,7 @@ public final class CoreFunctionality {
     private static List<AbstractPlugin> builtInActiveScanRules;
     private static List<PluginPassiveScanner> builtInPassiveScanRules;
 
-    private CoreFunctionality() {
+    static {
         // Register core event bus publishers asap
         ActiveScanEventPublisher.getPublisher();
         AlertEventPublisher.getPublisher();


### PR DESCRIPTION
Otherwise its not actually called :/

Signed-off-by: Simon Bennetts <psiinon@gmail.com>