### PR TITLE
Add option to recreate root cert on expired warning

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/dynssl/ExtensionDynSSL.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/dynssl/ExtensionDynSSL.java
@@ -37,6 +37,7 @@ import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
+import javax.swing.JOptionPane;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -44,6 +45,7 @@ import org.bouncycastle.openssl.jcajce.JcaMiscPEMGenerator;
 import org.bouncycastle.util.io.pem.PemWriter;
 import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.CommandLineArgument;
 import org.parosproxy.paros.extension.CommandLineListener;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
@@ -350,7 +352,20 @@ public class ExtensionDynSSL extends ExtensionAdaptor implements CommandLineList
                         cert.getNotAfter().toString(),
                         new Date().toString());
         if (hasView()) {
-            getView().showWarningDialog(warnMsg);
+            if (getView().showConfirmDialog(warnMsg) == JOptionPane.OK_OPTION) {
+                try {
+                    createNewRootCa();
+                    Control.getSingleton()
+                            .getMenuToolsControl()
+                            .options(Constant.messages.getString("dynssl.options.name"));
+                } catch (Exception e) {
+                    logger.error("Failed to create new root CA certificate:", e);
+                    getView()
+                            .showWarningDialog(
+                                    Constant.messages.getString(
+                                            "dynssl.warn.cert.failed", e.getMessage()));
+                }
+            }
         }
         logger.warn(warnMsg);
     }

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -1670,7 +1670,9 @@ dynssl.options.name              = Dynamic SSL Certificates
 dynssl.text.createnow            = Go to options panel and create certificate now.
 dynssl.text.notnow               = Not now, but create certificate later.
 dynssl.text.sslwontwork          = SSL won't work if you haven't created and imported an OWASP ZAP CA root certificate. You can create such a certificate any time in the options menu, so you do not have to create it right now.
-dynssl.warn.cert.expired = ZAPs Root CA certificate has expired as of {0} (now: {1}).\nYou should regenerate it and re-install it in your browsers.
+dynssl.warn.cert.expired = ZAPs Root CA certificate has expired as of {0} (now: {1}).\nYou should regenerate it and re-install it in your browsers.\n\
+Regenerate the certificate and go to the relevant options screen now?
+dynssl.warn.cert.failed			= Failed to create Root CA certificate: {0}
 dynssl.cmdline.certload			= Loads the Root CA certificate from the specified file name
 dynssl.cmdline.certload.done	= Root CA certificate loaded from {0}
 dynssl.cmdline.certfulldump		= Dumps the Root CA full certificate (including the private key) into the specified file name, this is suitable for importing into ZAP


### PR DESCRIPTION
Fixes #6712

New warning dialog (ignore the date - I hacked it to always appear;)

<img width="685" alt="Screenshot 2021-09-14 at 13 55 05" src="https://user-images.githubusercontent.com/1081115/133253702-8baa72cc-b219-4e07-a531-bc556eb23f80.png">

Signed-off-by: Simon Bennetts <psiinon@gmail.com>