### PR TITLE
Add container detection for Docker and Flatpak 

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2021-09-15
+ - Added /zap/container file to make it easier to detect if we are running in a container like docker.
+
 ### 2021-08-11
  - Changed to enable integration tests, inc enabling the AF for the baseline `-c` option if the `--auto` flag is used before it.
  - Added Automation Framework support for * OUTOFSCOPE baseline config file option.

--- a/docker/Dockerfile-bare
+++ b/docker/Dockerfile-bare
@@ -17,6 +17,8 @@ WORKDIR /zap
 COPY --from=builder /zap .
 COPY policies /home/zap/.ZAP/policies/
 
+RUN echo "zap2docker-bare" > /zap/container
+
 RUN echo "http://dl-3.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories &&\
     apk add --update --no-cache bash netcat-openbsd && \
     adduser -h /home/zap -s /bin/bash zap -D zap && \

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -84,6 +84,8 @@ COPY policies /root/.ZAP_D/policies/
 COPY scripts /home/zap/.ZAP_D/scripts/
 COPY .xinitrc /home/zap/
 
+RUN echo "zap2docker-live" > /zap/container
+
 #Copy doesn't respect USER directives so we need to chown and to do that we need to be root
 USER root
 

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -76,6 +76,8 @@ COPY policies /root/.ZAP/policies/
 COPY scripts /home/zap/.ZAP_D/scripts/
 COPY .xinitrc /home/zap/
 
+RUN echo "zap2docker-stable" > /zap/container
+
 #Copy doesn't respect USER directives so we need to chown and to do that we need to be root
 USER root
 

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -76,6 +76,8 @@ COPY policies /root/.ZAP_D/policies/
 COPY scripts /home/zap/.ZAP_D/scripts/
 COPY .xinitrc /home/zap/
 
+RUN echo "zap2docker-weekly" > /zap/container
+
 #Copy doesn't respect USER directives so we need to chown and to do that we need to be root
 USER root
 


### PR DESCRIPTION
The plan is to disable things like browser launch which we know wont work in containers, but this could also be used in telemetry.
Similar changes will be needed for other containers like Flathub and Snap (although we've not been able to update that for 2.10).

Signed-off-by: Simon Bennetts <psiinon@gmail.com>