### PR TITLE
Add option for allowing app integration in containers

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/Constant.java
+++ b/zap/src/main/java/org/parosproxy/paros/Constant.java
@@ -111,6 +111,7 @@
 // ZAP: 2020/11/02 Do not backup old Log4j config if already present.
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2021/09/15 Added support for detecting containers
+// ZAP: 2021/09/21 Added support for detecting snapcraft
 package org.parosproxy.paros;
 
 import java.io.File;
@@ -291,6 +292,8 @@ public final class Constant {
     private static final String ZAP_CONTAINER_FILE = "/zap/container";
     private static final String FLATPAK_FILE = "/.flatpak-info";
     public static final String FLATPAK_NAME = "flatpak";
+    private static final String SNAP_FILE = "meta/snap.yaml";
+    public static final String SNAP_NAME = "snapcraft";
 
     //
     // Home dir for ZAP, i.e. where the config file is. Can be set on cmdline, otherwise will be set
@@ -1563,6 +1566,7 @@ public final class Constant {
             // This is created by the Docker files from 2.11
             File containerFile = new File(ZAP_CONTAINER_FILE);
             File flatpakFile = new File(FLATPAK_FILE);
+            File snapFile = new File(SNAP_FILE);
             if (isLinux() && containerFile.exists()) {
                 inContainer = true;
                 try {
@@ -1577,6 +1581,9 @@ public final class Constant {
             } else if (flatpakFile.exists()) {
                 inContainer = true;
                 containerName = FLATPAK_NAME;
+            } else if (snapFile.exists()) {
+                inContainer = true;
+                containerName = SNAP_NAME;
             } else {
                 inContainer = false;
             }

--- a/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsParamView.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsParamView.java
@@ -46,6 +46,7 @@
 // ZAP: 2020/09/29 Add support for dynamic Look and Feel switching (Issue 6201)
 // ZAP: 2020/10/26 Update pop up menus when changing look and feel.
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
+// ZAP: 2021/09/16 Add support for enabling app integration in containers
 package org.parosproxy.paros.extension.option;
 
 import java.awt.Window;
@@ -118,6 +119,7 @@ public class OptionsParamView extends AbstractParam {
     public static final String SHOW_DEV_WARNING = "view.showDevWarning";
     public static final String LOOK_AND_FEEL = "view.lookAndFeel";
     public static final String LOOK_AND_FEEL_CLASS = "view.lookAndFeelClass";
+    public static final String ALLOW_APP_INTEGRATION_IN_CONTAINERS = "view.allowAppsInContainers";
 
     /**
      * The default look and feel: Flat Light.
@@ -175,6 +177,7 @@ public class OptionsParamView extends AbstractParam {
     private boolean scaleImages = true;
     private boolean showDevWarning = true;
     private LookAndFeelInfo lookAndFeelInfo = DEFAULT_LOOK_AND_FEEL;
+    private boolean allowAppIntegrationInContainers;
 
     private boolean confirmRemoveProxyExcludeRegex;
     private boolean confirmRemoveScannerExcludeRegex;
@@ -240,6 +243,8 @@ public class OptionsParamView extends AbstractParam {
                 new LookAndFeelInfo(
                         getString(LOOK_AND_FEEL, DEFAULT_LOOK_AND_FEEL.getName()),
                         getString(LOOK_AND_FEEL_CLASS, DEFAULT_LOOK_AND_FEEL.getClassName()));
+
+        allowAppIntegrationInContainers = getBoolean(ALLOW_APP_INTEGRATION_IN_CONTAINERS, false);
 
         // Special cases - set via static methods
         LargeRequestUtil.setMinContentLength(largeRequestSize);
@@ -514,6 +519,18 @@ public class OptionsParamView extends AbstractParam {
         this.largeResponseSize = largeResponseSize;
         LargeResponseUtil.setMinContentLength(largeResponseSize);
         getConfig().setProperty(LARGE_RESPONSE_SIZE, largeResponseSize);
+    }
+
+    /** @since 2.11.0 */
+    public boolean isAllowAppIntegrationInContainers() {
+        return allowAppIntegrationInContainers;
+    }
+
+    /** @since 2.11.0 */
+    public void setAllowAppIntegrationInContainers(boolean allowAppIntegrationInContainers) {
+        this.allowAppIntegrationInContainers = allowAppIntegrationInContainers;
+        getConfig()
+                .setProperty(ALLOW_APP_INTEGRATION_IN_CONTAINERS, allowAppIntegrationInContainers);
     }
 
     /**

--- a/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsViewPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsViewPanel.java
@@ -38,6 +38,7 @@
 // ZAP: 2020/03/25 Remove hardcoded colour in titled border (Issue 5542).
 // ZAP: 2020/12/03 Add constants for indexes of possible break buttons locations
 // ZAP: 2021/05/14 Remove redundant type arguments and empty statement.
+// ZAP: 2021/09/16 Add support for enabling app integration in containers
 package org.parosproxy.paros.extension.option;
 
 import java.awt.BorderLayout;
@@ -124,6 +125,7 @@ public class OptionsViewPanel extends AbstractParamPanel {
     private JCheckBox chkShowSplashScreen = null;
     private JCheckBox scaleImages = null;
     private JCheckBox showLocalConnectRequestsCheckbox;
+    private JCheckBox allowAppsInContainers = null;
 
     private JComboBox<String> brkPanelViewSelect = null;
     private JComboBox<String> displaySelect = null;
@@ -352,6 +354,19 @@ public class OptionsViewPanel extends AbstractParamPanel {
                     LayoutHelper.getGBC(0, row, 1, 1.0D, new java.awt.Insets(2, 2, 2, 2)));
             panelMisc.add(
                     getShowSplashScreen(),
+                    LayoutHelper.getGBC(1, row, 1, 1.0D, new java.awt.Insets(2, 2, 2, 2)));
+
+            row++;
+            JLabel allowAppIntegrationInContainersLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "view.options.label.allowAppsInContainers"));
+            allowAppIntegrationInContainersLabel.setLabelFor(getAllowAppsInContainers());
+            panelMisc.add(
+                    allowAppIntegrationInContainersLabel,
+                    LayoutHelper.getGBC(0, row, 1, 1.0D, new java.awt.Insets(2, 2, 2, 2)));
+            panelMisc.add(
+                    getAllowAppsInContainers(),
                     LayoutHelper.getGBC(1, row, 1, 1.0D, new java.awt.Insets(2, 2, 2, 2)));
 
             row++;
@@ -723,6 +738,13 @@ public class OptionsViewPanel extends AbstractParamPanel {
         return scaleImages;
     }
 
+    private JCheckBox getAllowAppsInContainers() {
+        if (allowAppsInContainers == null) {
+            allowAppsInContainers = new JCheckBox();
+        }
+        return allowAppsInContainers;
+    }
+
     private JComboBox<LookAndFeelInfoUi> getLookAndFeelSelect() {
         if (lookAndFeel == null) {
             lookAndFeel = new JComboBox<>();
@@ -770,6 +792,8 @@ public class OptionsViewPanel extends AbstractParamPanel {
         selectItem(
                 getLookAndFeelSelect(),
                 item -> item.getLookAndFeelInfo().getName().equals(nameLaf));
+        getAllowAppsInContainers()
+                .setSelected(options.getViewParam().isAllowAppIntegrationInContainers());
     }
 
     private static <T> void selectItem(JComboBox<T> comboBox, Predicate<T> predicate) {
@@ -823,6 +847,8 @@ public class OptionsViewPanel extends AbstractParamPanel {
                 .setLookAndFeelInfo(
                         ((LookAndFeelInfoUi) getLookAndFeelSelect().getSelectedItem())
                                 .getLookAndFeelInfo());
+        options.getViewParam()
+                .setAllowAppIntegrationInContainers(getAllowAppsInContainers().isSelected());
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuOpenUrlInBrowser.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuOpenUrlInBrowser.java
@@ -19,7 +19,9 @@
  */
 package org.zaproxy.zap.extension.stdmenus;
 
+import java.util.List;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.DesktopUtils;
@@ -29,6 +31,7 @@ import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 public class PopupMenuOpenUrlInBrowser extends PopupMenuItemHttpMessageContainer {
 
     private static final long serialVersionUID = 1L;
+    private boolean disabledToolTipSet = false;
 
     /** @param label */
     public PopupMenuOpenUrlInBrowser(String label) {
@@ -41,6 +44,26 @@ public class PopupMenuOpenUrlInBrowser extends PopupMenuItemHttpMessageContainer
             View.getSingleton()
                     .showWarningDialog(Constant.messages.getString("history.browser.warning"));
         }
+    }
+
+    @Override
+    protected boolean isButtonEnabledForSelectedMessages(List<HttpMessage> httpMessages) {
+        if (Constant.isInContainer()
+                && !Model.getSingleton()
+                        .getOptionsParam()
+                        .getViewParam()
+                        .isAllowAppIntegrationInContainers()) {
+            if (!disabledToolTipSet) {
+                this.setToolTipText(Constant.messages.getString("history.browser.disabled"));
+                disabledToolTipSet = true;
+            }
+            return false;
+        }
+        if (disabledToolTipSet) {
+            this.setToolTipText("");
+            disabledToolTipSet = false;
+        }
+        return super.isButtonEnabledForSelectedMessages(httpMessages);
     }
 
     @Override

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -1785,6 +1785,7 @@ help.name = Help Extension
 history.addnote.title                  = Add Note
 history.browser.popup                  = Open URL in System Browser
 history.browser.warning                = Failed to display HTTP message in browser.
+history.browser.disabled               = Displaying HTTP messages in browser is disabled as ZAP appears to be running in a container
 history.delete.popup                   = Delete (from view)
 history.export.messages.popup          = Export Messages to File...
 history.export.messages.select.warning = Select HTTP messages in History panel before export to file.
@@ -3291,6 +3292,7 @@ view.href.type.name.manual = Manual
 view.href.type.name.undefined = Undefined
 
 view.options.label.advancedview             = Activate advanced view
+view.options.label.allowAppsInContainers	= Enable app integration in containers
 view.options.label.askonexit                = Ask for confirmation to save data on exit
 view.options.label.brkPanelView             = Show break buttons:
 view.options.label.brkPanelView.both        = Break panel and toolbar


### PR DESCRIPTION
And use the option for launching the system browser.
If ZAP appears to be running in a container then openning a URL in the system browser will be disabled - a tool tip will explain why.
The new display option can be used to re-enable it - the user could have made some changes which mean this will actually work.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>