### PR TITLE
Replace usages of StringBuffer with StringBuilder

### DIFF
--- a/zap/src/main/java/ch/csnc/extension/httpclient/SSLContextManager.java
+++ b/zap/src/main/java/ch/csnc/extension/httpclient/SSLContextManager.java
@@ -266,7 +266,7 @@ public class SSLContextManager {
             return null;
         }
 
-        StringBuffer buff = new StringBuffer();
+        StringBuilder buff = new StringBuilder();
         X509Certificate x509 = (X509Certificate) cert;
 
         try {

--- a/zap/src/main/java/org/apache/commons/httpclient/HttpMethodBase.java
+++ b/zap/src/main/java/org/apache/commons/httpclient/HttpMethodBase.java
@@ -69,6 +69,7 @@ import org.parosproxy.paros.network.HttpHeader;
  *  - Change the way cookie headers are handled when using forced user mode, put all the headers in a single line see ISSUE 1874
  *  - Do not add a User-Agent header by default.
  *  - Update Host header in place.
+ *  - Replace usages of StringBuffer with StringBuilder.
  * 
  */
 /**
@@ -272,7 +273,7 @@ public abstract class HttpMethodBase implements HttpMethod {
      */
     @Override
     public URI getURI() throws URIException {
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
         if (this.httphost != null) {
             buffer.append(this.httphost.getProtocol().getScheme());
             buffer.append("://");
@@ -1659,7 +1660,7 @@ public abstract class HttpMethodBase implements HttpMethod {
         LOG.trace("enter HttpMethodBase.generateRequestLine(HttpConnection, "
             + "String, String, String, String)");
 
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         // Append method name
         buf.append(name);
         buf.append(" ");

--- a/zap/src/main/java/org/apache/commons/httpclient/URI.java
+++ b/zap/src/main/java/org/apache/commons/httpclient/URI.java
@@ -57,6 +57,7 @@ import org.apache.commons.httpclient.util.EncodingUtil;
  *  - Allow to use underscores in hostnames.
  *  - Use neutral Locale when converting to lower case.
  *  - Allow to create a URI from the authority component.
+ *  - Replace usages of StringBuffer with StringBuilder.
  */
 /**
  * The interface for the URI(Uniform Resource Identifiers) version of RFC 2396.
@@ -322,7 +323,7 @@ public class URI implements Cloneable, Comparable<Object>, Serializable {
                String fragment) throws URIException {
 
         // validate and contruct the URI character sequence
-        StringBuffer buff = new StringBuffer();
+        StringBuilder buff = new StringBuilder();
         if (scheme != null) {
             buff.append(scheme);
             buff.append(':');
@@ -2288,7 +2289,7 @@ public class URI implements Cloneable, Comparable<Object>, Serializable {
                 }
             }
             // set a server-based naming authority
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             if (_userinfo != null) { // has_userinfo
                 buf.append(_userinfo);
                 buf.append('@');
@@ -2314,7 +2315,7 @@ public class URI implements Cloneable, Comparable<Object>, Serializable {
      */
     protected void setURI() {
         // set _uri
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         // ^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?
         if (_scheme != null) {
             buf.append(_scheme);
@@ -2940,7 +2941,7 @@ public class URI implements Cloneable, Comparable<Object>, Serializable {
         if (_is_net_path || _is_abs_path) {
             _path = encode(path, allowed_abs_path, charset);
         } else if (_is_rel_path) {
-            StringBuffer buff = new StringBuffer(path.length());
+            StringBuilder buff = new StringBuilder(path.length());
             int at = path.indexOf('/');
             if (at == 0) { // never 0
                 throw new URIException(URIException.PARSING,
@@ -2956,7 +2957,7 @@ public class URI implements Cloneable, Comparable<Object>, Serializable {
             }
             _path = buff.toString().toCharArray();
         } else if (_is_opaque_part) {
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             buf.insert(0, encode(path.substring(0, 1), uric_no_slash, charset));
             buf.insert(1, encode(path.substring(1), uric, charset));
             _opaque = buf.toString().toCharArray();
@@ -2991,7 +2992,7 @@ public class URI implements Cloneable, Comparable<Object>, Serializable {
             if (at != -1) {
                 basePath = base.substring(0, at + 1).toCharArray();
             }
-            StringBuffer buff = new StringBuffer(base.length() 
+            StringBuilder buff = new StringBuilder(base.length() 
                 + relPath.length);
             buff.append((at != -1) ? base.substring(0, at + 1) : "/");
             buff.append(relPath);
@@ -3208,7 +3209,7 @@ public class URI implements Cloneable, Comparable<Object>, Serializable {
         if (_path == null && _query == null) {
             return null;
         }
-        StringBuffer buff = new StringBuffer();
+        StringBuilder buff = new StringBuilder();
         if (_path != null) {
             buff.append(_path);
         }

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpUtil.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpUtil.java
@@ -21,6 +21,7 @@
  */
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2021/09/18 Remove commented code.
 package org.parosproxy.paros.network;
 
 import java.io.InputStream;
@@ -33,14 +34,7 @@ public class HttpUtil {
 
     public static String encodeURI(String uri) throws URISyntaxException {
 
-        // ZAP: FindBugs fix - dont need sb
-        // StringBuffer sb = new StringBuffer();
         String tmp = null;
-
-        // try {
-        //	tmp = URLEncoder.encode(uri, "8859_1");
-        // } catch (UnsupportedEncodingException e) {
-        // }
 
         tmp = uri.replaceAll(" ", "%20");
         tmp = tmp.replaceAll("<", "%3C");

--- a/zap/src/main/java/org/zaproxy/zap/model/DefaultTextHttpMessageLocation.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/DefaultTextHttpMessageLocation.java
@@ -82,7 +82,7 @@ public class DefaultTextHttpMessageLocation implements TextHttpMessageLocation {
 
     @Override
     public String getDescription() {
-        StringBuffer description = new StringBuffer(25);
+        StringBuilder description = new StringBuilder(25);
         switch (location) {
             case REQUEST_HEADER:
             case RESPONSE_HEADER:


### PR DESCRIPTION
This is a minor performance boost by replacing the StringBuffer objects with StringBuilder objects.   
StringBuffer objects are slower since they synchronize on every operation, whereas StringBuilder does not synchronize.    
In all of the instances I am committing, the StringBuffer objects were local to the method and did not require synchronization.
I ran all of the unit tests and they all ran to completion without any test failures.

This is my first pull request to Zaproxy, please excuse any expected actions I did not perform prior to sending this pull request, I will gladly make any changes to fulfill the process to commit code.

Thank you very much,
Larry Diamond