### PR TITLE
Set background of checkbox tree label

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/view/JCheckBoxTree.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/JCheckBoxTree.java
@@ -167,6 +167,7 @@ public class JCheckBoxTree extends JTree {
             this.setLayout(new BorderLayout());
             checkBox = new JCheckBox();
             altLabel = new JLabel("");
+            altLabel.setOpaque(true);
             add(checkBox, BorderLayout.CENTER);
             add(altLabel, BorderLayout.EAST);
             setOpaque(false);
@@ -188,6 +189,9 @@ public class JCheckBoxTree extends JTree {
             altLabel.setForeground(
                     UIManager.getColor(
                             selected ? "Tree.selectionForeground" : "Tree.textForeground"));
+            altLabel.setBackground(
+                    UIManager.getColor(
+                            selected ? "Tree.selectionBackground" : "Tree.textBackground"));
             CheckedNode cn = nodesCheckingState.get(tp);
             if (cn == null) {
                 checkBox.setVisible(false);


### PR DESCRIPTION
Set the appropriate background to the label to ensure the text is
visible (e.g. when it has the same colour as the tree's background).

Fix #3988.