### PR TITLE
Passive Scan stats

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
@@ -246,6 +246,14 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
                                     if (scanned) {
                                         long timeTaken =
                                                 System.currentTimeMillis() - currentRuleStartTime;
+                                        if (scanner instanceof PluginPassiveScanner) {
+                                            PluginPassiveScanner pps =
+                                                    (PluginPassiveScanner) scanner;
+                                            Stats.incCounter(
+                                                    "stats.pscan." + pps.getPluginId() + ".time",
+                                                    timeTaken);
+                                        }
+                                        // TODO remove at some point
                                         Stats.incCounter(
                                                 "stats.pscan." + currentRuleName, timeTaken);
                                         if (timeTaken > 5000) {
@@ -312,12 +320,14 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
                 }
                 logger.error("Failed on record " + currentId + " from History table", e);
             }
+            int recordsToScan = getRecordsToScan();
+            Stats.setHighwaterMark("stats.pscan.recordsToScan", recordsToScan);
             if (View.isInitialised()) {
                 Control.getSingleton()
                         .getExtensionLoader()
                         .getExtension(ExtensionPassiveScan.class)
                         .getScanStatus()
-                        .setScanCount(getRecordsToScan());
+                        .setScanCount(recordsToScan);
             }
         }
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
@@ -35,6 +35,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.extension.alert.ExampleAlertProvider;
 import org.zaproxy.zap.utils.Enableable;
+import org.zaproxy.zap.utils.Stats;
 
 public abstract class PluginPassiveScanner extends Enableable
         implements PassiveScanner, ExampleAlertProvider {
@@ -584,6 +585,7 @@ public abstract class PluginPassiveScanner extends Enableable
         /** Raises the alert with specified data. */
         public void raise() {
             plugin.parent.raiseAlert(message.getHistoryRef().getHistoryId(), build());
+            Stats.incCounter("stats.pscan." + plugin.getPluginId() + ".alerts");
         }
     }
 }


### PR DESCRIPTION
Record the number of alerts each rule raises and use the ID for the times - the stats with the names will be removed in a future release.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>