### PR TITLE
Scripts stats

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
@@ -275,6 +275,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
             if (script == null) {
                 return null;
             }
+            ExtensionScript.recordScriptCalledStats(this.script);
 
             HttpMessage msg = null;
             try {

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptsCache.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptsCache.java
@@ -154,10 +154,12 @@ public class ScriptsCache<T> {
     public void execute(ScriptWrapperAction<T> action) {
         cachedScripts.forEach(
                 e -> {
+                    ScriptWrapper sw = e.getScriptWrapper();
                     try {
-                        action.apply(e.getScriptWrapper(), e.getScript());
+                        ExtensionScript.recordScriptCalledStats(sw);
+                        action.apply(sw, e.getScript());
                     } catch (Exception ex) {
-                        extensionScript.handleScriptException(e.getScriptWrapper(), ex);
+                        extensionScript.handleScriptException(sw, ex);
                     }
                 });
     }

--- a/zap/src/main/java/org/zaproxy/zap/session/ScriptBasedSessionManagementMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/session/ScriptBasedSessionManagementMethodType.java
@@ -185,6 +185,7 @@ public class ScriptBasedSessionManagementMethodType extends SessionManagementMet
             SessionScript sessionScript = getScriptInterface(script);
             if (sessionScript != null) {
                 try {
+                    ExtensionScript.recordScriptCalledStats(script);
                     sessionScript.processMessageToMatchSession(getSessionWrapper(message));
                 } catch (Exception e) {
                     getScriptsExtension().handleScriptException(script, e);


### PR DESCRIPTION
Some add-ons will need to be changed in order to record their script calls. Those that are not using the script cache anyway.
All script failures _should_ be recorded, as long as they use the standard methods for handling failures.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>