### PR TITLE
Do not init extension's view if there's none

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/ExtensionLoader.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/ExtensionLoader.java
@@ -91,6 +91,7 @@
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2021/04/13 Issue 6536: Stop and destroy extensions being removed.
 // ZAP: 2021/08/17 Issue 6755: Extension's errors during shutdown prevent ZAP to exit.
+// ZAP: 2021/10/01 Do not initialise view if there's none when starting a single extension.
 package org.parosproxy.paros.extension;
 
 import java.awt.Component;
@@ -818,7 +819,10 @@ public class ExtensionLoader {
         ext.databaseOpen(model.getDb());
         ext.initModel(model);
         ext.initXML(model.getSession(), model.getOptionsParam());
-        ext.initView(view);
+
+        if (hasView()) {
+            ext.initView(view);
+        }
 
         ExtensionHook extHook = new ExtensionHook(model, view);
         extensionHooks.put(ext, extHook);

--- a/zap/src/test/java/org/parosproxy/paros/extension/ExtensionLoaderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/extension/ExtensionLoaderUnitTest.java
@@ -22,8 +22,10 @@ package org.parosproxy.paros.extension;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
@@ -31,7 +33,9 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
+import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.view.View;
 
 /** Unit test for {@link ExtensionLoader}. */
 class ExtensionLoaderUnitTest {
@@ -43,6 +47,30 @@ class ExtensionLoaderUnitTest {
     void setUp() {
         model = mock(Model.class);
         extensionLoader = new ExtensionLoader(model, null);
+
+        Control.initSingletonForTesting(model, extensionLoader);
+    }
+
+    @Test
+    void shouldNotInitViewWhenStartingExtensionWithoutView() throws Exception {
+        // Given
+        Extension extension = mock(Extension.class);
+        // When
+        extensionLoader.startLifeCycle(extension);
+        // Then
+        verify(extension, times(0)).initView(any());
+    }
+
+    @Test
+    void shouldInitViewWhenStartingExtensionWithView() throws Exception {
+        // Given
+        View view = mock(View.class);
+        extensionLoader = new ExtensionLoader(model, view);
+        Extension extension = mock(Extension.class);
+        // When
+        extensionLoader.startLifeCycle(extension);
+        // Then
+        verify(extension).initView(view);
     }
 
     @Test


### PR DESCRIPTION
Check if there's a view before initialising the view of the extension.

---
Issue reported in the OWASP ZAP User Group: https://groups.google.com/g/zaproxy-users/c/20JJ0w6bRyM/m/p-3Ar4uYAgAJ