### PR TITLE
Add reports to core release

### DIFF
--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/distributions.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/distributions.gradle.kts
@@ -112,6 +112,7 @@ tasks.register<Zip>("distCore") {
             "plugnhack",
             "pscanrules",
             "quickstart",
+            "reports",
             "reveal",
             "saverawmessage",
             "tips")


### PR DESCRIPTION
Otherwise the Quick Start add-on will fail to load.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>