### PR TITLE
Docker: change packaged scans to always update all add-on on start

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2021-10-08
+ - Changed the packaged scans to always update all add-ons on start up to avoid a bug in the automation framework breaking plans
+
 ### 2021-10-05
  - Fixed bug which caused the baseline scan to fail if a read-only mapped drive was used.
 

--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -273,6 +273,7 @@ def create_start_options(mode, port, extra_params):
         'zap-x.sh', mode,
         '-port', str(port),
         '-host', '0.0.0.0',
+        '-addonupdate',
         '-config', 'database.recoverylog=false',
         '-config', 'api.disablekey=true',
         '-config', 'api.addrs.addr.name=.*',


### PR DESCRIPTION
This is to avoid a bug in the automation framework breaking plans

Signed-off-by: Simon Bennetts <psiinon@gmail.com>