### PR TITLE
Docker: Add AF context integration tests

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -36,3 +36,6 @@ jobs:
       - 
         name: Run baseline tests
         run: docker run --rm -t owasp/zap2docker-tests:latest wrk/baseline_tests.sh
+      - 
+        name: Automation Framework context tests
+        run: docker run --rm -t owasp/zap2docker-tests:latest wrk/af_tests.sh

--- a/docker/integration_tests/af_tests.sh
+++ b/docker/integration_tests/af_tests.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Script for testing the packaged scans when using the Automation Framework
+
+RES=0
+
+mkdir -p /zap/wrk/output
+
+echo "Automation Framework context tests"
+echo
+
+# Automation Framework context tests
+echo "Running the tests..."
+/zap/zap.sh -cmd -script /zap/wrk/configs/scripts/af_context_tests.js -config "dirs=/zap/wrk/configs/scripts"
+
+# Diff the originals with the generated files
+
+cd /zap/wrk/configs/plans/contexts/
+
+for file in *.context
+do
+	echo
+	echo "Context: $file"
+	DIFF=$(diff $file /zap/wrk/output/$file) 
+	if [ "$DIFF" != "" ] 
+	then
+	    echo "FAIL: differences:"
+	    echo "$DIFF"
+		RES=1
+	else
+    	echo "PASS"
+	fi
+done
+
+# Tidy up
+rm ~/.ZAP_D/config.xml

--- a/docker/integration_tests/baseline_tests.sh
+++ b/docker/integration_tests/baseline_tests.sh
@@ -3,7 +3,7 @@
 
 RES=0
 
-mkdir /zap/wrk/output
+mkdir -p /zap/wrk/output
 
 echo "TEST: Baseline test 1 (vs example.com)"
 /zap/zap-baseline.py -t https://www.example.com/ > /zap/wrk/output/baseline1.out

--- a/docker/integration_tests/configs/plans/contexts/basic.context
+++ b/docker/integration_tests/configs/plans/contexts/basic.context
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<configuration>
+    <context>
+        <name>basic.context</name>
+        <desc/>
+        <inscope>true</inscope>
+        <incregexes>https://www.example.com/.*</incregexes>
+        <excregexes>https://www.example.com/logout</excregexes>
+        <excregexes>https://www.example.com/status/.*</excregexes>
+        <tech>
+            <include>Db</include>
+            <include>Db.CouchDB</include>
+            <include>Db.Firebird</include>
+            <include>Db.HypersonicSQL</include>
+            <include>Db.IBM DB2</include>
+            <include>Db.Microsoft Access</include>
+            <include>Db.Microsoft SQL Server</include>
+            <include>Db.MongoDB</include>
+            <include>Db.MySQL</include>
+            <include>Db.Oracle</include>
+            <include>Db.PostgreSQL</include>
+            <include>Db.SAP MaxDB</include>
+            <include>Db.SQLite</include>
+            <include>Db.Sybase</include>
+            <include>Language</include>
+            <include>Language.ASP</include>
+            <include>Language.C</include>
+            <include>Language.JSP/Servlet</include>
+            <include>Language.Java</include>
+            <include>Language.Java.Spring</include>
+            <include>Language.JavaScript</include>
+            <include>Language.PHP</include>
+            <include>Language.Python</include>
+            <include>Language.Ruby</include>
+            <include>Language.XML</include>
+            <include>OS</include>
+            <include>OS.Linux</include>
+            <include>OS.MacOS</include>
+            <include>OS.Windows</include>
+            <include>SCM</include>
+            <include>SCM.Git</include>
+            <include>SCM.SVN</include>
+            <include>WS</include>
+            <include>WS.Apache</include>
+            <include>WS.IIS</include>
+            <include>WS.Tomcat</include>
+        </tech>
+        <urlparser>
+            <class>org.zaproxy.zap.model.StandardParameterParser</class>
+            <config>{"kvps":"&amp;","kvs":"=","struct":[]}</config>
+        </urlparser>
+        <postparser>
+            <class>org.zaproxy.zap.model.StandardParameterParser</class>
+            <config>{"kvps":"&amp;","kvs":"=","struct":[]}</config>
+        </postparser>
+        <authentication>
+            <type>0</type>
+            <strategy>EACH_RESP</strategy>
+            <pollfreq>60</pollfreq>
+            <pollunits>REQUESTS</pollunits>
+        </authentication>
+        <forceduser>-1</forceduser>
+        <session>
+            <type>0</type>
+        </session>
+        <authorization>
+            <type>0</type>
+            <basic>
+                <header/>
+                <body/>
+                <logic>AND</logic>
+                <code>-1</code>
+            </basic>
+        </authorization>
+    </context>
+</configuration>

--- a/docker/integration_tests/configs/plans/contexts/session-http.context
+++ b/docker/integration_tests/configs/plans/contexts/session-http.context
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<configuration>
+    <context>
+        <name>session-http.context</name>
+        <desc/>
+        <inscope>true</inscope>
+        <incregexes>https://www.example.com/.*</incregexes>
+        <excregexes>https://www.example.com/logout</excregexes>
+        <excregexes>https://www.example.com/status/.*</excregexes>
+        <tech>
+            <include>Db</include>
+            <include>Db.CouchDB</include>
+            <include>Db.Firebird</include>
+            <include>Db.HypersonicSQL</include>
+            <include>Db.IBM DB2</include>
+            <include>Db.Microsoft Access</include>
+            <include>Db.Microsoft SQL Server</include>
+            <include>Db.MongoDB</include>
+            <include>Db.MySQL</include>
+            <include>Db.Oracle</include>
+            <include>Db.PostgreSQL</include>
+            <include>Db.SAP MaxDB</include>
+            <include>Db.SQLite</include>
+            <include>Db.Sybase</include>
+            <include>Language</include>
+            <include>Language.ASP</include>
+            <include>Language.C</include>
+            <include>Language.JSP/Servlet</include>
+            <include>Language.Java</include>
+            <include>Language.Java.Spring</include>
+            <include>Language.JavaScript</include>
+            <include>Language.PHP</include>
+            <include>Language.Python</include>
+            <include>Language.Ruby</include>
+            <include>Language.XML</include>
+            <include>OS</include>
+            <include>OS.Linux</include>
+            <include>OS.MacOS</include>
+            <include>OS.Windows</include>
+            <include>SCM</include>
+            <include>SCM.Git</include>
+            <include>SCM.SVN</include>
+            <include>WS</include>
+            <include>WS.Apache</include>
+            <include>WS.IIS</include>
+            <include>WS.Tomcat</include>
+        </tech>
+        <urlparser>
+            <class>org.zaproxy.zap.model.StandardParameterParser</class>
+            <config>{"kvps":"&amp;","kvs":"=","struct":[]}</config>
+        </urlparser>
+        <postparser>
+            <class>org.zaproxy.zap.model.StandardParameterParser</class>
+            <config>{"kvps":"&amp;","kvs":"=","struct":[]}</config>
+        </postparser>
+        <authentication>
+            <type>0</type>
+            <strategy>EACH_RESP</strategy>
+            <pollfreq>60</pollfreq>
+            <pollunits>REQUESTS</pollunits>
+        </authentication>
+        <forceduser>-1</forceduser>
+        <session>
+            <type>1</type>
+        </session>
+        <authorization>
+            <type>0</type>
+            <basic>
+                <header/>
+                <body/>
+                <logic>AND</logic>
+                <code>-1</code>
+            </basic>
+        </authorization>
+    </context>
+</configuration>

--- a/docker/integration_tests/configs/plans/contexts/session-script.context
+++ b/docker/integration_tests/configs/plans/contexts/session-script.context
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<configuration>
+    <context>
+        <name>session-script.context</name>
+        <desc/>
+        <inscope>true</inscope>
+        <incregexes>https://www.example.com/.*</incregexes>
+        <excregexes>https://www.example.com/logout</excregexes>
+        <excregexes>https://www.example.com/status/.*</excregexes>
+        <tech>
+            <include>Db</include>
+            <include>Db.CouchDB</include>
+            <include>Db.Firebird</include>
+            <include>Db.HypersonicSQL</include>
+            <include>Db.IBM DB2</include>
+            <include>Db.Microsoft Access</include>
+            <include>Db.Microsoft SQL Server</include>
+            <include>Db.MongoDB</include>
+            <include>Db.MySQL</include>
+            <include>Db.Oracle</include>
+            <include>Db.PostgreSQL</include>
+            <include>Db.SAP MaxDB</include>
+            <include>Db.SQLite</include>
+            <include>Db.Sybase</include>
+            <include>Language</include>
+            <include>Language.ASP</include>
+            <include>Language.C</include>
+            <include>Language.JSP/Servlet</include>
+            <include>Language.Java</include>
+            <include>Language.Java.Spring</include>
+            <include>Language.JavaScript</include>
+            <include>Language.PHP</include>
+            <include>Language.Python</include>
+            <include>Language.Ruby</include>
+            <include>Language.XML</include>
+            <include>OS</include>
+            <include>OS.Linux</include>
+            <include>OS.MacOS</include>
+            <include>OS.Windows</include>
+            <include>SCM</include>
+            <include>SCM.Git</include>
+            <include>SCM.SVN</include>
+            <include>WS</include>
+            <include>WS.Apache</include>
+            <include>WS.IIS</include>
+            <include>WS.Tomcat</include>
+        </tech>
+        <urlparser>
+            <class>org.zaproxy.zap.model.StandardParameterParser</class>
+            <config>{"kvps":"&amp;","kvs":"=","struct":[]}</config>
+        </urlparser>
+        <postparser>
+            <class>org.zaproxy.zap.model.StandardParameterParser</class>
+            <config>{"kvps":"&amp;","kvs":"=","struct":[]}</config>
+        </postparser>
+        <authentication>
+            <type>0</type>
+            <strategy>EACH_RESP</strategy>
+            <pollfreq>60</pollfreq>
+            <pollunits>REQUESTS</pollunits>
+        </authentication>
+        <forceduser>-1</forceduser>
+        <session>
+            <type>2</type>
+            <script>
+                <name>session-mgmt-script.js</name>
+                <params>YWFh:QUFB&amp;Y2Nj:Q0ND&amp;YmJi:QkJC&amp;ZGRk:RERE</params>
+            </script>
+        </session>
+        <authorization>
+            <type>0</type>
+            <basic>
+                <header/>
+                <body/>
+                <logic>AND</logic>
+                <code>-1</code>
+            </basic>
+        </authorization>
+    </context>
+</configuration>

--- a/docker/integration_tests/configs/scripts/af_context_tests.js
+++ b/docker/integration_tests/configs/scripts/af_context_tests.js
@@ -1,0 +1,56 @@
+/*
+	A ZAP standalone script for testing Automation Framework (AF) context support.
+	The script loops through a set of context files and for each:
+		* Loads the context file
+		* Create an automation plan based on it
+		* Deletes the context
+		* Runs the plan (which creates the context again)
+		* Exports the context as a file
+		* Deletes the context
+	
+	An external script can then diff the files to make sure the AF has (re)generated then correctly.
+*/
+// Default directories - can be changed for local testing
+var base = '/zap/wrk/configs/plans/contexts'
+var results = '/zap/wrk/output/'
+
+var AutomationPlan = Java.type("org.zaproxy.addon.automation.AutomationPlan");
+var Control = Java.type("org.parosproxy.paros.control.Control");
+var ExtFile = Java.type("java.io.File");
+var File = Java.type("java.io.File");
+var Model = Java.type("org.parosproxy.paros.model.Model");
+
+var dir = new File(base);
+var files = dir.listFiles();
+
+for (var i in files) {
+	// Output the full file name for info
+	print("Loading: " + files[i].getAbsolutePath());
+
+	// Import the context file
+	var context = Model.getSingleton().getSession().importContext(files[i])
+	var contextName = context.getName();
+
+	// Create the plan
+	var plan = new AutomationPlan();
+	plan.getEnv().addContext(context);
+
+	// Register then plan
+	var extAuto = Control.getSingleton().getExtensionLoader().getExtension("ExtensionAutomation");
+	extAuto.registerPlan(plan);
+
+	// Delete the existing context
+	Model.getSingleton().getSession().deleteContext(context)
+
+	// Run the plan, which should recreate the context
+	extAuto.runPlan(plan, true);
+
+	// Export the context - must have the same name as the file
+	context = Model.getSingleton().getSession().getContext(contextName);
+	var outFile = new File(results + contextName);
+	print("Generating: " + outFile.getAbsolutePath());
+	Model.getSingleton().getSession().exportContext(context, outFile)
+
+	// Tidy up
+	Model.getSingleton().getSession().deleteContext(context)
+}

--- a/docker/integration_tests/configs/scripts/session/session-mgmt-script.js
+++ b/docker/integration_tests/configs/scripts/session/session-mgmt-script.js
@@ -1,0 +1,21 @@
+/*
+	Test session management script which does nothing other than expose the right interface
+	and define required and optional parameters ;)
+*/
+
+function extractWebSession(sessionWrapper) {
+}
+    	
+function clearWebSessionIdentifiers(sessionWrapper) {
+}
+    	
+function processMessageToMatchSession(sessionWrapper) {
+}
+
+function getRequiredParamsNames() {
+	return ["aaa", "bbb"];
+}
+
+function getOptionalParamsNames() {
+	return ["ccc", "ddd"];
+}


### PR DESCRIPTION
These work via a ZAP stand alone script which:
* loops through a set of context files (initially just one)
* loads the context
* create an AF plan from the context
* deletes the context
* runs the plan (which should recreate the context)
* exports the context

An external script then diffs the original and resulting context files - they should be the same.

WIP as the tests depend on https://github.com/zaproxy/zap-extensions/pull/3259 - I plan to add more context file to test as well.
Currently the tests fail - that will be fixed in the above PR.
```
Automation Framework context tests

Found Java version 11.0.11
Available memory: 3935 MB
Using JVM args: -Xmx983m
800 [main] INFO  org.parosproxy.paros.Constant - Copying default configuration to /home/zap/.ZAP_D/config.xml
962 [main] INFO  org.parosproxy.paros.Constant - Creating directory /home/zap/.ZAP_D/session
963 [main] INFO  org.parosproxy.paros.Constant - Creating directory /home/zap/.ZAP_D/dirbuster
963 [main] INFO  org.parosproxy.paros.Constant - Creating directory /home/zap/.ZAP_D/fuzzers
963 [main] INFO  org.parosproxy.paros.Constant - Creating directory /home/zap/.ZAP_D/plugin
Loading: /zap/wrk/configs/plans/contexts/basic.context
Generating: /zap/wrk/output/basic.context
Context: basic.context
FAIL: differences:
7a8
>         <incregexes>https://www.example.com/.*</incregexes>
```

Signed-off-by: Simon Bennetts <psiinon@gmail.com>