### PR TITLE
Use up-to-date add-ons in Docker images

### DIFF
--- a/docker/Dockerfile-bare
+++ b/docker/Dockerfile-bare
@@ -1,14 +1,19 @@
 # This dockerfile builds the zap stable release
-FROM alpine as builder
+FROM openjdk:8-jdk-alpine AS builder
 
 WORKDIR /zap
 
-RUN apk add --no-cache curl wget xmlstarlet unzip
+RUN apk add --no-cache wget xmlstarlet bash
 
-# Download and expand the latest stable release 
-RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml | xmlstarlet sel -t -v //url |grep -i Linux | wget --content-disposition -i - -O - | tar zxv && \
-    mv ZAP*/* . &&  \
-    rm -R ZAP* 
+# Download and expand the latest stable release
+RUN wget -qO- https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml | xmlstarlet sel -t -v //url |grep -i Linux | wget --content-disposition -i - -O - | tar zxv && \
+	mv ZAP*/* . && \
+	rm -R ZAP*
+
+# Update add-ons
+RUN ./zap.sh -cmd -silent -addonupdate
+# Copy them to installation directory
+RUN cp /root/.ZAP/plugin/*.zap plugin/
 
 FROM openjdk:8-jdk-alpine
 LABEL maintainer="psiinon@gmail.com"

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -1,4 +1,20 @@
 # This dockerfile builds the zap stable release
+FROM openjdk:8-jdk-alpine AS builder
+
+WORKDIR /zap
+
+RUN apk add --no-cache wget xmlstarlet bash
+
+# Download and expand the latest stable release
+RUN wget -qO- https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml | xmlstarlet sel -t -v //url |grep -i Linux | wget --content-disposition -i - -O - | tar zxv && \
+	mv ZAP*/* . && \
+	rm -R ZAP*
+
+# Update add-ons
+RUN ./zap.sh -cmd -silent -addonupdate
+# Copy them to installation directory
+RUN cp /root/.ZAP/plugin/*.zap plugin/
+
 FROM ubuntu:20.04
 LABEL maintainer="psiinon@gmail.com"
 
@@ -42,12 +58,8 @@ RUN mkdir /home/zap/.vnc
 
 ENV WEBSWING_VERSION 21.1.5
 
-# Download and expand the latest stable release
-RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml | xmlstarlet sel -t -v //url |grep -i Linux | wget -nv --content-disposition -i - -O - | tar zxv && \
-	cp -R ZAP*/* . &&  \
-	rm -R ZAP* && \
-	# Setup Webswing
-	if [ -z "$WEBSWING_URL" ] ; \
+# Setup Webswing
+RUN if [ -z "$WEBSWING_URL" ] ; \
 	then curl -s -L  "https://storage.googleapis.com/builds.webswing.org/releases/webswing-examples-eval-${WEBSWING_VERSION}-distribution.zip" > webswing.zip; \
 	else curl -s -L  "$WEBSWING_URL-${WEBSWING_VERSION}-distribution.zip" > webswing.zip; fi && \
 	unzip webswing.zip && \
@@ -55,6 +67,9 @@ RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersio
 	mv webswing-* webswing && \
 	# Remove Webswing bundled examples
 	rm -Rf webswing/apps/
+
+# Copy stable release
+COPY --from=builder /zap .
 
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64/
 ENV PATH $JAVA_HOME/bin:/zap/:$PATH


### PR DESCRIPTION
Change stable and bare build files to update the add-ons, to always
include the latest versions.

Fix #6669.