### PR TITLE
chore: Update gradle to 7.2

### DIFF
--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/JFlexGenerator.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/JFlexGenerator.java
@@ -92,14 +92,15 @@ public class JFlexGenerator extends SourceTask {
         ExecResult result =
                 getProject()
                         .javaexec(
-                                spec ->
-                                        spec.setClasspath(classpath)
-                                                .setMain("jflex.Main")
-                                                .args(args)
-                                                .setStandardOutput(System.out)
-                                                .setErrorOutput(System.err)
-                                                .setWorkingDir(
-                                                        getWorkingDir(source.getFile(), relPath)));
+                                spec -> {
+                                    spec.getMainClass().set("jflex.Main");
+                                    spec.setClasspath(classpath)
+                                            .args(args)
+                                            .setStandardOutput(System.out)
+                                            .setErrorOutput(System.err)
+                                            .setWorkingDir(
+                                                    getWorkingDir(source.getFile(), relPath));
+                                });
 
         result.assertNormalExitValue();
     }

--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/installers.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/installers.gradle.kts
@@ -103,7 +103,8 @@ val prepareWin64InstallerData by tasks.registering(Sync::class) {
     }
 }
 
-if (JavaVersion.current() >= JavaVersion.VERSION_11) {
+val java11OrHigher = JavaVersion.current() >= JavaVersion.VERSION_11
+if (java11OrHigher) {
 
     val installers by tasks.registering(Install4jTask::class) {
         group = "Distribution"
@@ -166,7 +167,9 @@ if (JavaVersion.current() >= JavaVersion.VERSION_11) {
 
         install4jHomeDirValidated = true
     }
-} else {
+}
+
+if (!java11OrHigher) {
     tasks.register("installers") {
         group = "Distribution"
         description = "Creates the Linux and Windows installers."

--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/test.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/test.gradle.kts
@@ -15,8 +15,8 @@ tasks.register("testAll") {
     dependsOn(tasks.withType<Test>())
 }
 
-val java: JavaPluginConvention
-    get() = the<JavaPluginConvention>()
+val java: JavaPluginExtension
+    get() = the<JavaPluginExtension>()
 
 fun setupTest(name: String, addToCheck: Boolean = true): TaskProvider<Test> {
     val nameTest = "test$name"
@@ -43,8 +43,8 @@ fun setupTest(name: String, addToCheck: Boolean = true): TaskProvider<Test> {
         shouldRunAfter(tasks.test)
 
         reports {
-            html.destination = file("${html.destination.parent}/$nameLowerCase")
-            junitXml.destination = file("${junitXml.destination.parent}/$nameLowerCase")
+            html.outputLocation.set(file("${html.outputLocation.get().asFile.parent}/$nameLowerCase"))
+            junitXml.outputLocation.set(file("${junitXml.outputLocation.get().asFile.parent}/$nameLowerCase"))
         }
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=13bf8d3cf8eeeb5770d19741a59bde9bd966dd78d17f1bbad787a05ef19d1c2d
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionSha256Sum=a8da5b02437a60819cad23e10fc7e9cf32bcb57029d9cb277e26eeff76ce014b
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Per https://docs.gradle.org/current/userguide/gradle_wrapper.html via
`./gradlew wrapper --gradle-version 7.2 --distribution-type all
--gradle-distribution-sha256-sum=a8da5b02437a60819cad23e10fc7e9cf32bcb57029d9cb277e26eeff76ce014b`

`./gradlew assemble --scan --warning-mode all` does indicate a few deprecations, which I've started to address.

If this one is acceptable I'll do hud, fuzzdb-offensive, community-scripts, and zap-extensions as well.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>