### PR TITLE
Fix contexts tests (mostly)

### DIFF
--- a/docker/integration_tests/af_tests.sh
+++ b/docker/integration_tests/af_tests.sh
@@ -33,3 +33,6 @@ done
 
 # Tidy up
 rm ~/.ZAP_D/config.xml
+
+echo "End result: $RES"
+exit $RES

--- a/docker/integration_tests/configs/plans/contexts/basic.context
+++ b/docker/integration_tests/configs/plans/contexts/basic.context
@@ -56,6 +56,8 @@
         <authentication>
             <type>0</type>
             <strategy>EACH_RESP</strategy>
+            <pollurl/>
+            <polldata/>
             <pollfreq>60</pollfreq>
             <pollunits>REQUESTS</pollunits>
         </authentication>

--- a/docker/integration_tests/configs/plans/contexts/session-http.context
+++ b/docker/integration_tests/configs/plans/contexts/session-http.context
@@ -56,6 +56,8 @@
         <authentication>
             <type>0</type>
             <strategy>EACH_RESP</strategy>
+            <pollurl/>
+            <polldata/>
             <pollfreq>60</pollfreq>
             <pollunits>REQUESTS</pollunits>
         </authentication>

--- a/docker/integration_tests/configs/plans/contexts/session-script.context
+++ b/docker/integration_tests/configs/plans/contexts/session-script.context
@@ -56,6 +56,8 @@
         <authentication>
             <type>0</type>
             <strategy>EACH_RESP</strategy>
+            <pollurl/>
+            <polldata/>
             <pollfreq>60</pollfreq>
             <pollunits>REQUESTS</pollunits>
         </authentication>


### PR DESCRIPTION
The tests are actually failing silently :(
https://github.com/zaproxy/zaproxy/runs/4029456493?check_suite_focus=true

This will _mostly_ fix that and make the failure visible.
One test should still fail - I've not looked into that yet as I want to make sure it fails the whole job...

Signed-off-by: Simon Bennetts <psiinon@gmail.com>