### PR TITLE
Docker: fixed issue with automation updates

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2021-11-03
+ - Fixed issue with automation updates by install updates in a separate ZAP inline call.
+
 ### 2021-10-08
  - Changed the packaged scans to always update all add-ons on start up to avoid a bug in the automation framework breaking plans
 

--- a/docker/zap-baseline.py
+++ b/docker/zap-baseline.py
@@ -400,14 +400,17 @@ def main(argv):
                 
                 if os.path.exists('/zap/wrk'):
                     yaml_copy_file = '/zap/wrk/zap.yaml'
-                    if os.access(yaml_copy_file, os.W_OK):
+                    try:
                         # Write the yaml file to the mapped directory, if there is one
                         copyfile(yaml_file, yaml_copy_file)
-                    else:
-                        print('Unable to copy yaml file to ' + yaml_copy_file)
+                    except OSError as err:
+                        logging.warning('Unable to copy yaml file to ' + yaml_copy_file + ' ' + str(err))
  
-            # Run ZAP inline with the yaml file
             try:
+                # Run ZAP inline to update the add-ons
+                run_zap_inline(port, ['-addonupdate', '-silent'])
+                
+                # Run ZAP inline with the yaml file
                 params = ['-autorun', yaml_file]
     
                 add_zap_options(params, zap_options)

--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -273,7 +273,6 @@ def create_start_options(mode, port, extra_params):
         'zap-x.sh', mode,
         '-port', str(port),
         '-host', '0.0.0.0',
-        '-addonupdate',
         '-config', 'database.recoverylog=false',
         '-config', 'api.disablekey=true',
         '-config', 'api.addrs.addr.name=.*',


### PR DESCRIPTION
Also fixed a problem where the yaml file wasnt getting copied.
To test the failing case you can run: 
`docker run -v $(pwd):/zap/wrk:ro --rm -i -t owasp/zap2docker-sbtest zap-baseline.py -t https://www.example.com`

Note the `ro` which prevents the script from writing to /zap/wrk

Signed-off-by: Simon Bennetts <psiinon@gmail.com>