### PR TITLE
Docker: Fix integration tests

### DIFF
--- a/docker/integration_tests/af_context_tests.sh
+++ b/docker/integration_tests/af_context_tests.sh
@@ -24,7 +24,7 @@ do
 	DIFF=$(diff <(sed 's/user>.*;/user>x;/g' $file) <(sed 's/user>.*;/user>x;/g' /zap/wrk/output/$file)) 
 	if [ "$DIFF" != "" ] 
 	then
-	    echo "FAIL: differences:"
+	    echo "ERROR: differences:"
 	    echo "$DIFF"
 		RES=1
 	else

--- a/docker/integration_tests/af_plan_tests.sh
+++ b/docker/integration_tests/af_plan_tests.sh
@@ -23,7 +23,7 @@ do
     
 	if [ "$RET" != 0 ] 
 	then
-	    echo "FAIL"
+	    echo "ERROR"
 		RES=1
 	else
     	echo "PASS"

--- a/docker/integration_tests/baseline_tests.sh
+++ b/docker/integration_tests/baseline_tests.sh
@@ -16,13 +16,13 @@ then
 fi
 if [ "$DIFF" != "" ] 
 then
-    echo "FAIL: differences:"
+    echo "ERROR: differences:"
     echo "$DIFF"
 	RES=1
 else
 	if [ "$RET" -ne 2 ] 
 	then
-    	echo "FAIL: exited with $RET instead of 2"
+    	echo "ERROR: exited with $RET instead of 2"
 		RES=1
 	else
     	echo "PASS"
@@ -43,13 +43,13 @@ then
 fi
 if [ "$DIFF" != "" ] 
 then
-    echo "FAIL: differences:"
+    echo "ERROR: differences:"
     echo "$DIFF"
 	RES=1
 else
 	if [ "$RET" -ne 1 ] 
 	then
-    	echo "FAIL: exited with $RET instead of 1"
+    	echo "ERROR: exited with $RET instead of 1"
 		RES=1
 	else
     	echo "PASS"
@@ -66,13 +66,13 @@ RET=$?
 DIFF=$(diff /zap/wrk/output/baseline3.out /zap/wrk/results/baseline3.out) 
 if [ "$DIFF" != "" ] 
 then
-    echo "FAIL: differences:"
+    echo "ERROR: differences:"
     echo "$DIFF"
 	RES=1
 else
 	if [ "$RET" -ne 1 ] 
 	then
-    	echo "FAIL: exited with $RET instead of 1"
+    	echo "ERROR: exited with $RET instead of 1"
 		RES=1
 	else
     	echo "PASS"
@@ -89,13 +89,13 @@ RET=$?
 DIFF=$(diff /zap/wrk/output/baseline4.out /zap/wrk/results/baseline4.out) 
 if [ "$DIFF" != "" ] 
 then
-    echo "FAIL: differences:"
+    echo "ERROR: differences:"
     echo "$DIFF"
 	RES=1
 else
 	if [ "$RET" -ne 1 ] 
 	then
-    	echo "FAIL: exited with $RET instead of 1"
+    	echo "ERROR: exited with $RET instead of 1"
 		RES=1
 	else
     	echo "PASS"

--- a/docker/integration_tests/results/baseline1.out
+++ b/docker/integration_tests/results/baseline1.out
@@ -1,6 +1,4 @@
 Using the Automation Framework
-Unable to copy yaml file to /zap/wrk/zap.yaml
-Add-on update check complete
 Total of 4 URLs
 PASS: Vulnerable JS Library [10003]
 PASS: Cookie No HttpOnly Flag [10010]

--- a/docker/integration_tests/results/baseline1b.out
+++ b/docker/integration_tests/results/baseline1b.out
@@ -1,6 +1,4 @@
 Using the Automation Framework
-Unable to copy yaml file to /zap/wrk/zap.yaml
-Add-on update check complete
 Total of 4 URLs
 PASS: Vulnerable JS Library [10003]
 PASS: Cookie No HttpOnly Flag [10010]

--- a/docker/integration_tests/results/baseline2.out
+++ b/docker/integration_tests/results/baseline2.out
@@ -1,6 +1,4 @@
 Using the Automation Framework
-Unable to copy yaml file to /zap/wrk/zap.yaml
-Add-on update check complete
 Total of 4 URLs
 PASS: Vulnerable JS Library [10003]
 PASS: Cookie No HttpOnly Flag [10010]

--- a/docker/integration_tests/results/baseline2b.out
+++ b/docker/integration_tests/results/baseline2b.out
@@ -1,6 +1,4 @@
 Using the Automation Framework
-Unable to copy yaml file to /zap/wrk/zap.yaml
-Add-on update check complete
 Total of 4 URLs
 PASS: Vulnerable JS Library [10003]
 PASS: Cookie No HttpOnly Flag [10010]

--- a/docker/integration_tests/results/baseline3.out
+++ b/docker/integration_tests/results/baseline3.out
@@ -1,6 +1,4 @@
 Using the Automation Framework
-Unable to copy yaml file to /zap/wrk/zap.yaml
-Add-on update check complete
 Total of 3 URLs
 PASS: Vulnerable JS Library [10003]
 PASS: Cookie No HttpOnly Flag [10010]

--- a/docker/integration_tests/results/baseline4.out
+++ b/docker/integration_tests/results/baseline4.out
@@ -1,6 +1,4 @@
 Using the Automation Framework
-Unable to copy yaml file to /zap/wrk/zap.yaml
-Add-on update check complete
 Total of 3 URLs
 PASS: Vulnerable JS Library [10003]
 PASS: Cookie No HttpOnly Flag [10010]


### PR DESCRIPTION
The following lines are no longer in the outout:
```
Unable to copy yaml file to /zap/wrk/zap.yaml
Add-on update check complete
```

Also changed "FAIL:" to "ERROR" as this seems to be highlighted by GitHub actions :)
https://github.com/zaproxy/zaproxy/runs/4125812511?check_suite_focus=true

Signed-off-by: Simon Bennetts <psiinon@gmail.com>