### PR TITLE
Report size for installed add-ons

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
@@ -559,6 +559,7 @@ public class AddOn {
         }
         this.id = extractAddOnId(file.getFileName().toString());
         this.file = file.toFile();
+        this.size = Files.size(file);
         readZapAddOnXmlFile(result.getManifest());
     }
 

--- a/zap/src/test/java/org/zaproxy/zap/control/AddOnUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/AddOnUnitTest.java
@@ -614,6 +614,16 @@ class AddOnUnitTest extends AddOnTestUtils {
     }
 
     @Test
+    void shouldHaveCorrectSize() throws Exception {
+        // Given
+        AddOn addOn = new AddOn(createAddOnFile("addon.zap"));
+        // When
+        long size = addOn.getSize();
+        // Then
+        assertThat(size, is(equalTo(189L)));
+    }
+
+    @Test
     void shouldHaveEmptyBundleByDefault() throws Exception {
         // Given
         Path file = createAddOnFile("addon.zap", "release", "1.0.0");


### PR DESCRIPTION
Initialise the size when creating the add-on from file, instead of
leaving as 0.