### PR TITLE
Deprecate core endpoints related to root CA cert

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/control/ControlOverrides.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/ControlOverrides.java
@@ -113,6 +113,6 @@ public class ControlOverrides {
      * @since 2.12.0
      */
     public List<String> getMandatoryAddOns() {
-        return Arrays.asList("callhome");
+        return Arrays.asList("callhome", "network");
     }
 }

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -1596,6 +1596,7 @@ core.api.view.excludedFromProxy = Gets the regular expressions, applied to URLs,
 core.api.view.sessionLocation = Gets the location of the current session file
 core.api.view.zapHomePath = Gets the path to ZAP's home directory.
 
+core.api.deprecated.network = Use the API endpoints in the 'network' component instead.
 core.api.depreciated.alert = Use the API endpoint with the same name in the 'alert' component instead.
 core.api.depreciated.report = Use the 'generate' API endpoint the 'reports' component instead.
 

--- a/zap/src/main/weekly-add-ons.json
+++ b/zap/src/main/weekly-add-ons.json
@@ -22,6 +22,7 @@
       ":addOns:graphql",
       ":addOns:importurls",
       ":addOns:invoke",
+      ":addOns:network",
       ":addOns:oast",
       ":addOns:onlineMenu",
       ":addOns:openapi",

--- a/zap/src/test/java/org/zaproxy/zap/extension/api/CoreAPIUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/api/CoreAPIUnitTest.java
@@ -1,0 +1,91 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+import net.sf.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.ConnectionParam;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.utils.I18N;
+
+/** Unit test for {@link CoreAPI}. */
+class CoreAPIUnitTest {
+
+    private ApiImplementor networkApi;
+    private CoreAPI coreApi;
+
+    @BeforeEach
+    void setUp() {
+        Model model = mock(Model.class, withSettings().lenient());
+        Model.setSingletonForTesting(model);
+        Constant.messages = mock(I18N.class, withSettings().lenient());
+        networkApi = mock(ApiImplementor.class, withSettings().lenient());
+        given(networkApi.getPrefix()).willReturn("network");
+        API.getInstance().registerApiImplementor(networkApi);
+        coreApi = new CoreAPI(mock(ConnectionParam.class));
+    }
+
+    @AfterEach
+    void cleanUp() {
+        API.getInstance().removeApiImplementor(networkApi);
+        Constant.messages = null;
+    }
+
+    @Test
+    void shouldCallNetworkApiWhenGeneratingRootCaCert() throws Exception {
+        // Given
+        String name = "generateRootCA";
+        JSONObject params = new JSONObject();
+        given(networkApi.handleApiAction(any(), any())).willReturn(ApiResponseElement.OK);
+        // When
+        ApiResponse response = coreApi.handleApiAction(name, params);
+        // Then
+        verify(networkApi).handleApiAction("generateRootCaCert", params);
+        assertThat(response, is(equalTo(ApiResponseElement.OK)));
+    }
+
+    @Test
+    void shouldCallNetworkApiWhenObtainingRootCaCert() throws Exception {
+        // Given
+        String name = "rootcert";
+        JSONObject params = new JSONObject();
+        HttpMessage message = new HttpMessage();
+        given(networkApi.handleApiOther(any(), any(), any())).willReturn(message);
+        // When
+        HttpMessage response = coreApi.handleApiOther(message, name, params);
+        // Then
+        verify(networkApi).handleApiOther(message, "rootCaCert", params);
+        assertThat(response, is(sameInstance(message)));
+    }
+}


### PR DESCRIPTION
Deprecate the core endpoints `generateRootCA` and `rootcert`, use the
network API to serve them instead.
Make network add-on mandatory.

---
WIP pending changes in the add-on.