### PR TITLE
Ensure certificates service is set always

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/dynssl/ExtensionDynSSL.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/dynssl/ExtensionDynSSL.java
@@ -96,6 +96,14 @@ public class ExtensionDynSSL extends ExtensionAdaptor implements CommandLineList
 
     @Override
     public void start() {
+        try {
+            startImpl();
+        } finally {
+            SSLConnector.setSslCertificateService(CachedSslCertifificateServiceImpl.getService());
+        }
+    }
+
+    private void startImpl() {
         final KeyStore rootca = getParams().getRootca();
         if (rootca == null) {
             try {
@@ -114,8 +122,6 @@ public class ExtensionDynSSL extends ExtensionAdaptor implements CommandLineList
         if (isCertExpired(getRootCaCertificate())) {
             warnRootCaCertExpired();
         }
-
-        SSLConnector.setSslCertificateService(CachedSslCertifificateServiceImpl.getService());
     }
 
     public void createNewRootCa()


### PR DESCRIPTION
Change to set the certificates service in a finally block to ensure
it's set always, when starting with clean home it would not be set.

Issue introduced in #6946.

---
Affects live image.