### PR TITLE
Update RSyntaxTextArea and FlatLaf

### DIFF
--- a/LEGALNOTICE.md
+++ b/LEGALNOTICE.md
@@ -49,7 +49,7 @@ and subject to their respective licenses.
 | commons-text-1.9.jar                | Apache 2.0                |
 | commons-validator-1.7.jar           | Apache 2.0                |
 | ezmorph-1.0.6.jar                   | Apache 2.0                |
-| flatlaf-1.6.4.jar                   | Apache 2.0                |
+| flatlaf-1.6.5.jar                   | Apache 2.0                |
 | harlib-1.1.3.jar                    | Apache 2.0                |
 | hsqldb-2.5.2.jar                    | BSD                       |
 | ice4j-3.0-24-g34c2ce5.jar           | Apache 2.0                |
@@ -63,7 +63,7 @@ and subject to their respective licenses.
 | log4j-1.2-api-2.14.1.jar            | Apache 2.0                |
 | log4j-api-2.14.1.jar                | Apache 2.0                |
 | log4j-core-2.14.1.jar               | Apache 2.0                |
-| rsyntaxtextarea-3.1.3.jar           | BSD-3 clause              |
+| rsyntaxtextarea-3.1.4.jar           | BSD-3 clause              |
 | sqlite-jdbc-3.36.0.3.jar            | BSD-2 clause              |
 | - NestedVM                          | Apache 2.0                |
 | swingx-all-1.6.5-1.jar              | LGPL 2.1                  |

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/lexers/WwwFormTokenMaker.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/lexers/WwwFormTokenMaker.java
@@ -432,6 +432,7 @@ public class WwwFormTokenMaker extends AbstractJFlexTokenMaker {
      *
      * @throws java.io.IOException if the reader could not be closed.
      */
+    @Override
     public final void yyclose() throws java.io.IOException {
         // indicate end of file
         zzAtEOF = true;

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -56,7 +56,7 @@ tasks.named<JacocoReport>("jacocoTestReport") {
 }
 
 dependencies {
-    api("com.fifesoft:rsyntaxtextarea:3.1.3")
+    api("com.fifesoft:rsyntaxtextarea:3.1.4")
     api("com.github.zafarkhaja:java-semver:0.9.0")
     api("commons-beanutils:commons-beanutils:1.9.4")
     api("commons-codec:commons-codec:1.15")
@@ -92,7 +92,7 @@ dependencies {
     implementation("org.jitsi:ice4j:3.0-24-g34c2ce5") {
         setTransitive(false)
     }
-    implementation("com.formdev:flatlaf:1.6.4")
+    implementation("com.formdev:flatlaf:1.6.5")
 
     runtimeOnly("commons-jxpath:commons-jxpath:1.3")
     runtimeOnly("commons-logging:commons-logging:1.2")


### PR DESCRIPTION
Update RSyntaxTextArea to 3.1.4.
Update `JFlexToRstaTokenMaker` to also add the override annotation to
the method `yyclose`.
Update `WwwFormTokenMaker` accordingly.
Update FlatLaf to 1.6.5.