### PR TITLE
Prepare 2.11.1 release

### DIFF
--- a/LEGALNOTICE.md
+++ b/LEGALNOTICE.md
@@ -60,9 +60,9 @@ and subject to their respective licenses.
 | jfreechart-1.5.3.jar                | LGPL                      |
 | jgrapht-core-0.9.0.jar              | LGPL 2.1                  |
 | json-lib-2.4-jdk15.jar              | MIT + "Good, Not Evil"    |
-| log4j-1.2-api-2.14.1.jar            | Apache 2.0                |
-| log4j-api-2.14.1.jar                | Apache 2.0                |
-| log4j-core-2.14.1.jar               | Apache 2.0                |
+| log4j-1.2-api-2.15.0.jar            | Apache 2.0                |
+| log4j-api-2.15.0.jar                | Apache 2.0                |
+| log4j-core-2.15.0.jar               | Apache 2.0                |
 | rsyntaxtextarea-3.1.3.jar           | BSD-3 clause              |
 | sqlite-jdbc-3.36.0.1.jar            | BSD-2 clause              |
 | - NestedVM                          | Apache 2.0                |

--- a/zap/src/main/add-ons.txt
+++ b/zap/src/main/add-ons.txt
@@ -19,7 +19,7 @@ https://github.com/zaproxy/zap-extensions/releases/download/fuzz-v13.3.0/fuzz-be
 https://github.com/zaproxy/zap-extensions/releases/download/gettingStarted-v13/gettingStarted-release-13.zap 3eea769ec19f28c2ac7e924f5c77dbd1c3c59f40f409a1fcd3bf97cebdfd36ad
 https://github.com/zaproxy/zap-extensions/releases/download/graaljs-v0.2.0/graaljs-alpha-0.2.0.zap 6201ffc802a1d4922a4f2b5ea38f58a7332a5638e3719f4796efba375aa15045
 https://github.com/zaproxy/zap-extensions/releases/download/graphql-v0.6.0/graphql-alpha-0.6.0.zap d3da8c9c0fc346679aa9b099d3f3b2712d45fa68488eb688842291d64570a425
-https://github.com/zaproxy/zap-core-help/releases/download/help-v12/help-release-12.zap 640c2d1e8fce1737673fc7c146d9a3c2c16a69f0c3491e66a8b73fc789e64829
+https://github.com/zaproxy/zap-core-help/releases/download/help-v13/help-release-13.zap fff11e2e2c99a635a599a826fc3fb1bcec250486823e4e39b7ab545b14d5c58c
 https://github.com/zaproxy/zap-hud/releases/download/v0.13.0/hud-beta-0.13.0.zap 06bdf1f9ef0c7f1f55cdd1d5eb9c9ba1a53903b8a3a26224c941d7bb9f18c8ef
 https://github.com/zaproxy/zap-extensions/releases/download/importurls-v8/importurls-beta-8.zap 22d509de7ef01de5ca046614c58a2a83d40180a4c593053735e680ac86e99d87
 https://github.com/zaproxy/zap-extensions/releases/download/invoke-v11/invoke-beta-11.zap 088ed335a7dbe1ad1569fc249e1a395f1957e39598c6d4d648cdc49780cb71fc

--- a/zap/src/main/java/org/parosproxy/paros/Constant.java
+++ b/zap/src/main/java/org/parosproxy/paros/Constant.java
@@ -186,7 +186,7 @@ public final class Constant {
     private static final String VERSION_ELEMENT = "version";
 
     // Accessible for tests
-    static final long VERSION_TAG = 2010000;
+    static final long VERSION_TAG = 20011001;
 
     // Old version numbers - for upgrade
     private static final long V_2_10_0_TAG = 20010000;

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -20,8 +20,8 @@ plugins {
 }
 
 group = "org.zaproxy"
-version = "2.11.0"
-val versionBC = "2.10.0"
+version = "2.11.1"
+val versionBC = "2.11.0"
 
 val versionLangFile = "1"
 val creationDate by extra { project.findProperty("creationDate") ?: LocalDate.now().toString() }
@@ -69,7 +69,7 @@ dependencies {
     api("org.apache.commons:commons-text:1.9")
     api("edu.umass.cs.benchlab:harlib:1.1.3")
     api("javax.help:javahelp:2.0.05")
-    val log4jVersion = "2.14.1"
+    val log4jVersion = "2.15.0"
     api("org.apache.logging.log4j:log4j-api:$log4jVersion")
     api("org.apache.logging.log4j:log4j-1.2-api:$log4jVersion")
     implementation("org.apache.logging.log4j:log4j-core:$log4jVersion")


### PR DESCRIPTION
Update Log4j to latest version, 2.15.0.
Update Help add-on.
Bump ZAP version.