### PR TITLE
chore: Upgrade Log4j to 2.17.0

### DIFF
--- a/LEGALNOTICE.md
+++ b/LEGALNOTICE.md
@@ -60,9 +60,9 @@ and subject to their respective licenses.
 | jfreechart-1.5.3.jar                | LGPL                      |
 | jgrapht-core-0.9.0.jar              | LGPL 2.1                  |
 | json-lib-2.4-jdk15.jar              | MIT + "Good, Not Evil"    |
-| log4j-1.2-api-2.16.0.jar            | Apache 2.0                |
-| log4j-api-2.16.0.jar                | Apache 2.0                |
-| log4j-core-2.16.0.jar               | Apache 2.0                |
+| log4j-1.2-api-2.17.0.jar            | Apache 2.0                |
+| log4j-api-2.17.0.jar                | Apache 2.0                |
+| log4j-core-2.17.0.jar               | Apache 2.0                |
 | rsyntaxtextarea-3.1.4.jar           | BSD-3 clause              |
 | sqlite-jdbc-3.36.0.3.jar            | BSD-2 clause              |
 | - NestedVM                          | Apache 2.0                |

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     api("org.apache.commons:commons-text:1.9")
     api("edu.umass.cs.benchlab:harlib:1.1.3")
     api("javax.help:javahelp:2.0.05")
-    val log4jVersion = "2.16.0"
+    val log4jVersion = "2.17.0"
     api("org.apache.logging.log4j:log4j-api:$log4jVersion")
     api("org.apache.logging.log4j:log4j-1.2-api:$log4jVersion")
     implementation("org.apache.logging.log4j:log4j-core:$log4jVersion")


### PR DESCRIPTION
Updated build file and LEGALNOTICE.

Related to zaproxy/zaproxy#6980

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>