### PR TITLE
Link to release notes from main GitHub releases

### DIFF
--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/github-releases.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/github-releases.gradle.kts
@@ -101,7 +101,7 @@ tasks.register<CreateMainRelease>("createMainRelease") {
     tagMessage.set("Version ${project.version}")
 
     title.set(tagName)
-    body.set("")
+    body.set("Release notes: https://www.zaproxy.org/docs/desktop/releases/${project.version}/")
     checksumAlgorithm.set("SHA-256")
     draft.set(true)
 


### PR DESCRIPTION
Link to the corresponding website releases page when creating the
GitHub releases.

Fix #7009.