### PR TITLE
Integration tests - use new name for 10015

### DIFF
--- a/docker/integration_tests/results/baseline1.out
+++ b/docker/integration_tests/results/baseline1.out
@@ -47,7 +47,7 @@ PASS: Charset Mismatch [90011]
 PASS: Application Error Disclosure [90022]
 PASS: WSDL File Detection [90030]
 PASS: Loosely Scoped Cookie [90033]
-WARN-NEW: Incomplete or No Cache-control Header Set [10015] x 1 
+WARN-NEW: Re-examine Cache-control Directives [10015] x 1 
 	https://www.example.com/ (200 OK)
 WARN-NEW: Missing Anti-clickjacking Header [10020] x 1 
 	https://www.example.com/ (200 OK)

--- a/docker/integration_tests/results/baseline1b.out
+++ b/docker/integration_tests/results/baseline1b.out
@@ -47,7 +47,7 @@ PASS: Charset Mismatch [90011]
 PASS: Application Error Disclosure [90022]
 PASS: WSDL File Detection [90030]
 PASS: Loosely Scoped Cookie [90033]
-WARN-NEW: Incomplete or No Cache-control Header Set [10015] x 1 
+WARN-NEW: Re-examine Cache-control Directives [10015] x 1 
 	https://www.example.com/ (200 OK)
 WARN-NEW: Missing Anti-clickjacking Header [10020] x 1 
 	https://www.example.com/ (200 OK)

--- a/docker/integration_tests/results/baseline2.out
+++ b/docker/integration_tests/results/baseline2.out
@@ -51,7 +51,7 @@ IGNORE: Retrieved from Cache [10050] x 3
 	https://www.example.com/ (200 OK)
 	https://www.example.com/robots.txt (404 Not Found)
 	https://www.example.com/sitemap.xml (404 Not Found)
-INFO: Incomplete or No Cache-control Header Set [10015] x 1 
+INFO: Re-examine Cache-control Directives [10015] x 1 
 	https://www.example.com/ (200 OK)
 WARN-NEW: X-Content-Type-Options Header Missing [10021] x 1 
 	https://www.example.com/ (200 OK)

--- a/docker/integration_tests/results/baseline2b.out
+++ b/docker/integration_tests/results/baseline2b.out
@@ -51,7 +51,7 @@ IGNORE: Retrieved from Cache [10050] x 3
 	https://www.example.com/ (200 OK)
 	https://www.example.com/robots.txt (404 Not Found)
 	https://www.example.com/sitemap.xml (404 Not Found)
-INFO: Incomplete or No Cache-control Header Set [10015] x 1 
+INFO: Re-examine Cache-control Directives [10015] x 1 
 	https://www.example.com/ (200 OK)
 WARN-NEW: X-Content-Type-Options Header Missing [10021] x 1 
 	https://www.example.com/ (200 OK)

--- a/docker/integration_tests/results/baseline3.out
+++ b/docker/integration_tests/results/baseline3.out
@@ -50,7 +50,7 @@ PASS: Loosely Scoped Cookie [90033]
 IGNORE: Retrieved from Cache [10050] x 2 
 	https://www.example.com/ (200 OK)
 	https://www.example.com/sitemap.xml (404 Not Found)
-INFO: Incomplete or No Cache-control Header Set [10015] x 1 
+INFO: Re-examine Cache-control Directives [10015] x 1 
 	https://www.example.com/ (200 OK)
 WARN-NEW: X-Content-Type-Options Header Missing [10021] x 1 Custom X-Content-Type-Options message
 	https://www.example.com/ (200 OK)

--- a/docker/integration_tests/results/baseline4.out
+++ b/docker/integration_tests/results/baseline4.out
@@ -50,7 +50,7 @@ PASS: Loosely Scoped Cookie [90033]
 IGNORE: Retrieved from Cache [10050] x 2 
 	https://www.example.com/ (200 OK)
 	https://www.example.com/sitemap.xml (404 Not Found)
-INFO: Incomplete or No Cache-control Header Set [10015] x 1 
+INFO: Re-examine Cache-control Directives [10015] x 1 
 	https://www.example.com/ (200 OK)
 WARN-NEW: X-Content-Type-Options Header Missing [10021] x 1 Custom X-Content-Type-Options message
 	https://www.example.com/ (200 OK)


### PR DESCRIPTION
Currently failing due to the rule name change: https://github.com/zaproxy/zaproxy/runs/4769703712?check_suite_focus=true

Signed-off-by: Simon Bennetts <psiinon@gmail.com>