### PR TITLE
chore: core pscan: Use parameterized logging messages

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -286,18 +286,16 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
                 getPolicyPanel().getPassiveScanTableModel().addScanner(scanner);
             }
 
-            logger.info("loaded passive scan rule: " + scanner.getName());
+            logger.info("loaded passive scan rule: {}", scanner.getName());
             if (scanner.getPluginId() == -1) {
                 logger.error(
-                        "The passive scan rule \""
-                                + scanner.getName()
-                                + "\" ["
-                                + scanner.getClass().getCanonicalName()
-                                + "] does not have a defined ID.");
+                        "The passive scan rule \"{}\" [{}] does not have a defined ID.",
+                        scanner.getName(),
+                        scanner.getClass().getCanonicalName());
             }
 
         } catch (Exception e) {
-            logger.error("Failed to load passive scanner " + scanner.getName(), e);
+            logger.error("Failed to load passive scan rule {}", scanner.getName(), e);
         }
 
         return added;

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanAPI.java
@@ -174,7 +174,7 @@ public class PassiveScanAPI extends ApiImplementor {
                         extension.setPluginPassiveScannerEnabled(pluginId, enabled);
                     }
                 } catch (NumberFormatException e) {
-                    logger.error("Failed to parse scanner ID: " + e.getMessage(), e);
+                    logger.error("Failed to parse scanner ID: {}", e.getMessage(), e);
                 }
             }
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanParam.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanParam.java
@@ -118,7 +118,7 @@ public class PassiveScanParam extends AbstractParam {
                 }
             }
         } catch (ConversionException e) {
-            logger.error("Error while loading the auto tag scanners: " + e.getMessage(), e);
+            logger.error("Error while loading the auto tag scanners: {}", e.getMessage(), e);
         }
 
         this.confirmRemoveAutoTagScanner = getBoolean(CONFIRM_REMOVE_AUTO_TAG_SCANNER_KEY, true);

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
@@ -172,7 +172,7 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
                     if (shutDown) {
                         return;
                     }
-                    logger.error("Failed to read record " + currentId + " from History table", e);
+                    logger.error("Failed to read record {} from History table", currentId, e);
                 }
 
                 if (href != null
@@ -213,12 +213,10 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
                                         Stats.incCounter("stats.pscan.reqBodyTooBig");
                                         if (logger.isDebugEnabled()) {
                                             logger.debug(
-                                                    "Request to "
-                                                            + msg.getRequestHeader().getURI()
-                                                            + " body size "
-                                                            + msg.getRequestBody().length()
-                                                            + " larger than max configured "
-                                                            + maxBodySize);
+                                                    "Request to {} body size {} larger than max configured {}",
+                                                    msg.getRequestHeader().getURI(),
+                                                    msg.getRequestBody().length(),
+                                                    maxBodySize);
                                         }
                                     }
                                     if (msg.isResponseFromTargetHost()) {
@@ -231,12 +229,10 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
                                             Stats.incCounter("stats.pscan.respBodyTooBig");
                                             if (logger.isDebugEnabled()) {
                                                 logger.debug(
-                                                        "Response from "
-                                                                + msg.getRequestHeader().getURI()
-                                                                + " body size "
-                                                                + msg.getResponseBody().length()
-                                                                + " larger than max configured "
-                                                                + maxBodySize);
+                                                        "Response from {} body size {} larger than max configured {}",
+                                                        msg.getRequestHeader().getURI(),
+                                                        msg.getResponseBody().length(),
+                                                        maxBodySize);
                                             }
                                         }
                                     }
@@ -269,14 +265,11 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
                                                                 + msg.getResponseBody().length();
                                             }
                                             logger.warn(
-                                                    "Passive Scan rule "
-                                                            + currentRuleName
-                                                            + " took "
-                                                            + (timeTaken / 1000)
-                                                            + " seconds to scan "
-                                                            + currentUrl
-                                                            + " "
-                                                            + responseInfo);
+                                                    "Passive Scan rule {} took {} seconds to scan {} {}",
+                                                    currentRuleName,
+                                                    timeTaken / 1000,
+                                                    currentUrl,
+                                                    responseInfo);
                                         }
                                     }
                                 }
@@ -285,14 +278,11 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
                                     return;
                                 }
                                 logger.error(
-                                        "Scanner "
-                                                + scanner.getName()
-                                                + " failed on record "
-                                                + currentId
-                                                + " from History table: "
-                                                + href.getMethod()
-                                                + " "
-                                                + href.getURI(),
+                                        "Scan rule '{}' failed on record {} from History table: {} {}",
+                                        scanner.getName(),
+                                        currentId,
+                                        href.getMethod(),
+                                        href.getURI(),
                                         e);
                             }
                             // Unset in case this is the last one that gets run for a while
@@ -303,13 +293,11 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
                         if (HistoryReference.getTemporaryTypes().contains(href.getHistoryType())) {
                             if (logger.isDebugEnabled()) {
                                 logger.debug(
-                                        "Temporary record " + currentId + " no longer available:",
-                                        e);
+                                        "Temporary record {} no longer available:", currentId, e);
                             }
                         } else {
                             logger.error(
-                                    "Parser failed on record " + currentId + " from History table",
-                                    e);
+                                    "Parser failed on record {} from History table", currentId, e);
                         }
                     }
                     currentUrl = "";
@@ -318,7 +306,7 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
                 if (shutDown) {
                     return;
                 }
-                logger.error("Failed on record " + currentId + " from History table", e);
+                logger.error("Failed on record {} from History table", currentId, e);
             }
             int recordsToScan = getRecordsToScan();
             Stats.setHighwaterMark("stats.pscan.recordsToScan", recordsToScan);
@@ -368,7 +356,7 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
         }
 
         if (currentId != id) {
-            logger.error("Alert id != currentId! " + id + " " + currentId);
+            logger.error("Alert id != currentId! {} {}", id, currentId);
         }
 
         alert.setSource(Alert.Source.PASSIVE);
@@ -387,11 +375,9 @@ public class PassiveScanThread extends Thread implements ProxyListener, SessionC
                 PassiveScanner scanner = this.scannerList.getScanner(alert.getPluginId());
                 if (scanner != null) {
                     logger.info(
-                            "Disabling passive scanner "
-                                    + scanner.getName()
-                                    + " as it has raised more than "
-                                    + this.pscanOptions.getMaxAlertsPerRule()
-                                    + " alerts.");
+                            "Disabling passive scan rule {} as it has raised more than {} alerts.",
+                            scanner.getName(),
+                            this.pscanOptions.getMaxAlertsPerRule());
                     scanner.setEnabled(false);
                 }
             }

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScannerList.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScannerList.java
@@ -64,7 +64,7 @@ public class PassiveScannerList {
 
         for (PassiveScanner scanner : autoTagScanners) {
             if (scannerNames.contains(scanner.getName())) {
-                logger.error("Duplicate passive scanner name: " + scanner.getName());
+                logger.error("Duplicate passive scan rule name: {}", scanner.getName());
             } else {
                 tempScanners.add(scanner);
                 scannerNames.add(scanner.getName());

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
@@ -97,11 +97,9 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
                     && "appliesToHistoryType".equals(e.getCause().getMessage())) {
                 if (logger.isDebugEnabled()) {
                     logger.debug(
-                            "Script [Name="
-                                    + wrapper.getName()
-                                    + ", Engine="
-                                    + wrapper.getEngineName()
-                                    + "]  does not implement the optional method appliesToHistoryType: ",
+                            "Script [Name={}, Engine={}]  does not implement the optional method appliesToHistoryType: ",
+                            wrapper.getName(),
+                            wrapper.getEngineName(),
                             e);
                 }
                 return super.appliesToHistoryType(currentHistoryType);


### PR DESCRIPTION
I started to simply change one of the logged messages to use "scan rule" vs. "scanner" but then sonarlint reminded me that these should all use substitution instead of concatenation, so I decided to tackle it throughout the core pscan extension.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>