### PR TITLE
Stop using deprecated API endpoint in API UI

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/WebUI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/WebUI.java
@@ -487,7 +487,7 @@ public class WebUI {
                                 + API.API_NONCE_PARAM
                                 + "="
                                 + API.getInstance()
-                                        .getLongLivedNonce("/OTHER/core/other/rootcert/")));
+                                        .getLongLivedNonce("/OTHER/network/other/rootCaCert/")));
         sb.append(Constant.messages.getString("api.home.links.header"));
         if (apiEnabled) {
             sb.append(Constant.messages.getString("api.home.links.api.enabled"));

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -210,7 +210,7 @@ api.home.links.online		= <li><a href="https://www.zaproxy.org/">ZAP Website</a><
 <li><a href="https://groups.google.com/group/zaproxy-develop">ZAP Developer Group</a></li>\
 <li><a href="https://github.com/zaproxy/zaproxy/issues">Report an issue</a></li>
 api.home.cacert	= <h2>HTTPS Warnings Prevention</h2>\
-<p>To avoid HTTPS Warnings <a href="/OTHER/core/other/rootcert{0}">download</a> and \
+<p>To avoid HTTPS Warnings <a href="/OTHER/network/other/rootCaCert{0}">download</a> and \
 <a href="https://www.zaproxy.org/docs/desktop/ui/dialogs/options/dynsslcert/#install" target="_blank">\
  install CA root Certificate</a> in your Mobile device or computer.</p>
 api.home.proxypac			= <h2>Proxy Configuration</h2>\


### PR DESCRIPTION
Call the Network endpoint directly instead of going through the core
endpoint.