### PR TITLE
Include the icon in the returned API message

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/API.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/API.java
@@ -397,6 +397,7 @@ public class API {
 
                     msg.setResponseHeader(getDefaultResponseHeader(contentType));
                     msg.getResponseHeader().setContentLength(icon.length);
+                    msg.getResponseBody().setBody(icon);
                     httpOut.write(msg.getResponseHeader());
                     httpOut.write(icon);
                     httpOut.flush();


### PR DESCRIPTION
Set the icon to the returned message as well, callers might just be
using the message returned.