### PR TITLE
chore: Update flatlaf dependency

### DIFF
--- a/LEGALNOTICE.md
+++ b/LEGALNOTICE.md
@@ -49,7 +49,7 @@ and subject to their respective licenses.
 | commons-text-1.9.jar                | Apache 2.0                |
 | commons-validator-1.7.jar           | Apache 2.0                |
 | ezmorph-1.0.6.jar                   | Apache 2.0                |
-| flatlaf-1.6.5.jar                   | Apache 2.0                |
+| flatlaf-2.0.1.jar                   | Apache 2.0                |
 | harlib-1.1.3.jar                    | Apache 2.0                |
 | hsqldb-2.5.2.jar                    | BSD                       |
 | ice4j-3.0-24-g34c2ce5.jar           | Apache 2.0                |

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -92,7 +92,7 @@ dependencies {
     implementation("org.jitsi:ice4j:3.0-24-g34c2ce5") {
         setTransitive(false)
     }
-    implementation("com.formdev:flatlaf:1.6.5")
+    implementation("com.formdev:flatlaf:2.0.1")
 
     runtimeOnly("commons-jxpath:commons-jxpath:1.3")
     runtimeOnly("commons-logging:commons-logging:1.2")


### PR DESCRIPTION
Update to flatlaf 2.0.1
https://github.com/JFormDesigner/FlatLaf/releases/tag/2.0.1

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>