### PR TITLE
Fix Stats Concurrent access bug

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/utils/Statistics.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/Statistics.java
@@ -23,10 +23,11 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class Statistics {
 
-    private Map<String, Long> stats = new HashMap<>();
+    private Map<String, Long> stats = new ConcurrentHashMap<>();
 
     public void incCounter(String key) {
         incCounter(key, 1);


### PR DESCRIPTION
Doesnt happen often, but it has been spotted:
```
216792 [ZAP-WS-Listener (remote) 'example.org:443 (#1)'] ERROR
org.zaproxy.zap.utils.Stats - null
java.util.ConcurrentModificationException: null
        at java.util.HashMap.compute(HashMap.java:1229) ~[?:?]
        at org.zaproxy.zap.utils.Statistics.incCounter(Statistics.java:36)
~[main/:?]
        at org.zaproxy.zap.utils.Statistics.incCounter(Statistics.java:32)
~[main/:?]
        at
org.zaproxy.zap.extension.stats.InMemoryStats.counterInc(InMemoryStats.java:58)
~[main/:?]
        at org.zaproxy.zap.utils.Stats.incCounter(Stats.java:48) [main/:?]
        at
org.zaproxy.zap.extension.websocket.WebSocketProxy.notifyMessageObservers(WebSocketProxy.java:762)
[websocket-25.0.0.zap:?]
        at
org.zaproxy.zap.extension.websocket.WebSocketProxy.processRead(WebSocketProxy.java:621)
[websocket-25.0.0.zap:?]
        at
org.zaproxy.zap.extension.websocket.WebSocketListener.run(WebSocketListener.java:79)
[websocket-25.0.0.zap:?]
        at
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[?:?]
        at
java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[?:?]
        at java.lang.Thread.run(Thread.java:829) [?:?]
```

Signed-off-by: Simon Bennetts <psiinon@gmail.com>