### PR TITLE
Remove unused resource message

### DIFF
--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -2823,7 +2823,6 @@ sites.panel.mnemonic	   = s
 sites.panel.title          = Sites
 sites.purge.popup          = Delete
 sites.purge.warning        = Are you sure you want to delete the node(s)?\nThis will delete all of the messages associated with the deleted Site Tree nodes.
-sites.resend.popup         = Open/Resend with Request Editor...
 sites.spider.popup         = Spider...
 sites.showinsites.popup    = Show in Sites Tab
 


### PR DESCRIPTION
The resource message is no longer in use after the removal of the
corresponding class (#7064).