### PR TITLE
Set parent of warning messages in param dialogue

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/view/AbstractParamDialog.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/AbstractParamDialog.java
@@ -38,6 +38,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/08/25 Move NullPointerException log to AbstractParamContainerPanel.
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
+// ZAP: 2022/02/08 Set the dialogue as parent of the warning messages.
 package org.parosproxy.paros.view;
 
 import java.awt.Component;
@@ -226,6 +227,7 @@ public class AbstractParamDialog extends AbstractDialog {
                                 }
                                 View.getSingleton()
                                         .showWarningDialog(
+                                                AbstractParamDialog.this,
                                                 Constant.messages.getString(
                                                         "options.dialog.save.error",
                                                         ex.getMessage()));


### PR DESCRIPTION
Use the dialogue itself as parent of the validation warning messages so
they can be properly placed when shown.