### PR TITLE
Deprecate and disable proxy related code

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/CommandLine.java
+++ b/zap/src/main/java/org/parosproxy/paros/CommandLine.java
@@ -48,6 +48,7 @@
 // ZAP: 2019/10/09 Issue 5619: Ensure -configfile maintains key order
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2021/05/14 Remove redundant type arguments.
+// ZAP: 2022/02/09 No longer parse host/port and deprecate related code.
 package org.parosproxy.paros;
 
 import java.io.File;
@@ -79,8 +80,11 @@ public class CommandLine {
     public static final String HELP2 = "-h";
     public static final String DIR = "-dir";
     public static final String VERSION = "-version";
-    public static final String PORT = "-port";
-    public static final String HOST = "-host";
+    /** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
+    @Deprecated public static final String PORT = "-port";
+    /** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
+    @Deprecated public static final String HOST = "-host";
+
     public static final String CMD = "-cmd";
     public static final String INSTALL_DIR = "-installdir";
     public static final String CONFIG = "-config";
@@ -122,8 +126,6 @@ public class CommandLine {
     private boolean lowMem = false;
     private boolean experimentalDb = false;
     private boolean silent = false;
-    private int port = -1;
-    private String host = null;
     private String[] args;
     private final Map<String, String> configs = new LinkedHashMap<>();
     private final Hashtable<String, String> keywords = new Hashtable<>();
@@ -386,14 +388,6 @@ public class CommandLine {
             Constant.setZapInstall(keywords.get(INSTALL_DIR));
             result = true;
 
-        } else if (checkPair(args, HOST, i)) {
-            this.host = keywords.get(HOST);
-            result = true;
-
-        } else if (checkPair(args, PORT, i)) {
-            this.port = Integer.parseInt(keywords.get(PORT));
-            result = true;
-
         } else if (checkPair(args, CONFIG, i)) {
             String pair = keywords.get(CONFIG);
             if (pair != null && pair.indexOf("=") > 0) {
@@ -494,12 +488,16 @@ public class CommandLine {
         return this.displaySupportInfo;
     }
 
+    /** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
+    @Deprecated
     public int getPort() {
-        return this.port;
+        return -1;
     }
 
+    /** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
+    @Deprecated
     public String getHost() {
-        return host;
+        return null;
     }
 
     /**

--- a/zap/src/main/java/org/parosproxy/paros/control/Control.java
+++ b/zap/src/main/java/org/parosproxy/paros/control/Control.java
@@ -86,6 +86,7 @@
 // ZAP: 2021/05/14 Remove empty statement.
 // ZAP: 2021/09/13 Added setExitStatus.
 // ZAP: 2021/11/08 Validate if mandatory add-ons are present.
+// ZAP: 2022/02/09 No longer manage the proxy, deprecate related code.
 package org.parosproxy.paros.control;
 
 import java.awt.Desktop;
@@ -125,7 +126,6 @@ public class Control extends AbstractControl implements SessionListener {
     private static Logger log = LogManager.getLogger(Control.class);
 
     private static Control control = null;
-    private Proxy proxy = null;
     private MenuFileControl menuFileControl = null;
     private MenuToolsControl menuToolsControl = null;
     private SessionListener lastCallback = null;
@@ -142,7 +142,7 @@ public class Control extends AbstractControl implements SessionListener {
         super(null, null);
     }
 
-    private boolean init(ControlOverrides overrides, boolean startProxy) {
+    private boolean init(ControlOverrides overrides) {
         AddOnLoader addOnLoader =
                 ExtensionFactory.getAddOnLoader(
                         model.getOptionsParam().getCheckForUpdatesParam().getAddonDirectories());
@@ -168,14 +168,6 @@ public class Control extends AbstractControl implements SessionListener {
         // Load extensions first as message bundles are loaded as a side effect
         loadExtension();
 
-        // ZAP: Start proxy even if no view
-        Proxy proxy = getProxy(overrides);
-        proxy.setIgnoreList(model.getOptionsParam().getGlobalExcludeURLParam().getTokensNames());
-        getExtensionLoader().hookProxyListener(proxy);
-        getExtensionLoader().hookOverrideMessageProxyListener(proxy);
-        getExtensionLoader().hookPersistentConnectionListener(proxy);
-        getExtensionLoader().hookConnectRequestProxyListeners(proxy);
-
         if (hasView()) {
             // ZAP: Add site map listeners
             getExtensionLoader().hookSiteMapListener(view.getSiteTreePanel());
@@ -183,12 +175,6 @@ public class Control extends AbstractControl implements SessionListener {
 
         model.postInit();
 
-        if (startProxy) {
-            proxy.setShouldPrompt(true);
-            boolean started = proxy.startServer();
-            proxy.setShouldPrompt(false);
-            return started;
-        }
         return false;
     }
 
@@ -196,16 +182,15 @@ public class Control extends AbstractControl implements SessionListener {
         return view != null;
     }
 
+    /** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
+    @Deprecated
     public Proxy getProxy() {
         return this.getProxy(null);
     }
-
+    /** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
+    @Deprecated
     public Proxy getProxy(ControlOverrides overrides) {
-        if (proxy == null) {
-            proxy = new Proxy(model, overrides);
-        }
-
-        return proxy;
+        return new Proxy(model, overrides);
     }
 
     @Override
@@ -237,7 +222,6 @@ public class Control extends AbstractControl implements SessionListener {
                 view.getResponsePanel().saveConfig(model.getOptionsParam().getConfig());
             }
 
-            getProxy(null).stopServer();
             super.shutdown(compact);
         } finally {
             // Ensure all extensions' config changes done during shutdown are saved.
@@ -409,17 +393,21 @@ public class Control extends AbstractControl implements SessionListener {
 
     public static boolean initSingletonWithView(ControlOverrides overrides) {
         control = new Control(Model.getSingleton(), View.getSingleton());
-        return control.init(overrides, true);
+        return control.init(overrides);
     }
 
     public static boolean initSingletonWithoutView(ControlOverrides overrides) {
         control = new Control(Model.getSingleton(), null);
-        return control.init(overrides, true);
+        return control.init(overrides);
     }
 
+    /**
+     * @deprecated (2.12.0) Use {@link #initSingletonWithoutView(ControlOverrides)} instead. It will
+     *     be removed in a future release.
+     */
+    @Deprecated
     public static void initSingletonWithoutViewAndProxy(ControlOverrides overrides) {
-        control = new Control(Model.getSingleton(), null);
-        control.init(overrides, false);
+        initSingletonWithoutView(overrides);
     }
 
     // ZAP: Added method to allow for testing
@@ -478,16 +466,12 @@ public class Control extends AbstractControl implements SessionListener {
     }
 
     /**
-     * Creates a new session and resets session related data in other components (e.g. proxy
-     * excluded URLs).
+     * Creates a new session.
      *
      * @return the newly created session.
      */
     private Session createNewSession() {
-        Session session = model.newSession();
-        getProxy()
-                .setIgnoreList(model.getOptionsParam().getGlobalExcludeURLParam().getTokensNames());
-        return session;
+        return model.newSession();
     }
 
     public void runCommandLineOpenSession(String fileName) throws Exception {
@@ -501,9 +485,12 @@ public class Control extends AbstractControl implements SessionListener {
         control.getExtensionLoader().sessionChangedAllPlugin(session);
     }
 
-    public void setExcludeFromProxyUrls(List<String> urls) {
-        this.getProxy(null).setIgnoreList(urls);
-    }
+    /**
+     * @deprecated (2.12.0) The proxy is no longer managed by Control. It will be removed in a
+     *     future release.
+     */
+    @Deprecated
+    public void setExcludeFromProxyUrls(List<String> urls) {}
 
     public void openSession(final File file, final SessionListener callback) {
         log.info("Open Session");

--- a/zap/src/main/java/org/parosproxy/paros/control/MenuToolsControl.java
+++ b/zap/src/main/java/org/parosproxy/paros/control/MenuToolsControl.java
@@ -27,6 +27,7 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
+// ZAP: 2022/02/09 Remove proxy related code.
 package org.parosproxy.paros.control;
 
 import javax.swing.JOptionPane;
@@ -84,9 +85,6 @@ public class MenuToolsControl {
             control.getExtensionLoader().optionsChangedAllPlugin(model.getOptionsParam());
 
             view.getMainFrame().applyViewOptions();
-
-            control.getProxy().stopServer();
-            control.getProxy().startServer();
         }
     }
 }

--- a/zap/src/main/java/org/parosproxy/paros/control/Proxy.java
+++ b/zap/src/main/java/org/parosproxy/paros/control/Proxy.java
@@ -36,22 +36,23 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/09/17 Remove irrelevant conditional in stopServer().
 // ZAP: 2019/12/13 Save the proxy port if it had to be selected during startup (Issue 2016).
+// ZAP: 2022/02/09 Deprecate the class.
 package org.parosproxy.paros.control;
 
 import java.util.List;
-import org.parosproxy.paros.core.proxy.CacheProcessingItem;
 import org.parosproxy.paros.core.proxy.ConnectRequestProxyListener;
 import org.parosproxy.paros.core.proxy.OverrideMessageProxyListener;
 import org.parosproxy.paros.core.proxy.ProxyListener;
-import org.parosproxy.paros.core.proxy.ProxyServer;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.PersistentConnectionListener;
 import org.zaproxy.zap.control.ControlOverrides;
 
+/** @deprecated (2.12.0) No longer used/needed by core. Use the network add-on instead. */
+@Deprecated
 public class Proxy {
 
     private Model model = null;
-    private ProxyServer proxyServer = null;
+    private org.parosproxy.paros.core.proxy.ProxyServer proxyServer = null;
     private boolean reverseProxy = false;
     private String reverseProxyHost = "";
     private ControlOverrides overrides = null;
@@ -61,7 +62,7 @@ public class Proxy {
         this.model = model;
         this.overrides = overrides;
 
-        proxyServer = new ProxyServer();
+        proxyServer = new org.parosproxy.paros.core.proxy.ProxyServer();
         proxyServer.setEnableApi(true);
     }
 
@@ -206,7 +207,7 @@ public class Proxy {
         }
     }
 
-    public void addCacheProcessingList(CacheProcessingItem item) {
+    public void addCacheProcessingList(org.parosproxy.paros.core.proxy.CacheProcessingItem item) {
         if (proxyServer != null) {
             proxyServer.addCacheProcessingList(item);
         }

--- a/zap/src/main/java/org/parosproxy/paros/core/proxy/CacheProcessingItem.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/proxy/CacheProcessingItem.java
@@ -25,6 +25,8 @@ package org.parosproxy.paros.core.proxy;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.network.HttpMessage;
 
+/** @deprecated (2.12.0) */
+@Deprecated
 public class CacheProcessingItem {
 
     public CacheProcessingItem(HistoryReference ref, HttpMessage msg) {

--- a/zap/src/main/java/org/parosproxy/paros/core/proxy/CustomStreamsSocket.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/proxy/CustomStreamsSocket.java
@@ -28,6 +28,8 @@ import java.net.SocketAddress;
 import java.net.SocketException;
 import java.nio.channels.SocketChannel;
 
+/** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
+@Deprecated
 public class CustomStreamsSocket extends Socket {
 
     private final Socket delegate;

--- a/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyParam.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyParam.java
@@ -43,6 +43,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/02/08 Use isEmpty where applicable.
+// ZAP: 2022/02/09 Deprecate the class.
 package org.parosproxy.paros.core.proxy;
 
 import java.net.InetAddress;
@@ -55,7 +56,11 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.common.AbstractParam;
 import org.parosproxy.paros.network.SSLConnector;
 
-/** @author simon */
+/**
+ * @author simon
+ * @deprecated (2.12.0) Use the network add-on instead.
+ */
+@Deprecated
 public class ProxyParam extends AbstractParam {
 
     //	private static final String PROXY = "proxy";
@@ -183,8 +188,6 @@ public class ProxyParam extends AbstractParam {
             return;
         }
         this.proxyIp = proxyIp.trim();
-        getConfig().setProperty(PROXY_IP, this.proxyIp);
-        determineProxyIpAnyLocalAddress();
     }
 
     public int getProxyPort() {
@@ -193,7 +196,6 @@ public class ProxyParam extends AbstractParam {
 
     public void setProxyPort(int proxyPort) {
         this.proxyPort = proxyPort;
-        getConfig().setProperty(PROXY_PORT, Integer.toString(this.proxyPort));
     }
 
     public String getReverseProxyIp() {

--- a/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyServer.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyServer.java
@@ -41,6 +41,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/12/13 Handle proxy port conflict at startup (issue 2016).
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
+// ZAP: 2022/02/09 Deprecate the class.
 package org.parosproxy.paros.core.proxy;
 
 import java.io.IOException;
@@ -66,6 +67,8 @@ import org.parosproxy.paros.network.HttpUtil;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.PersistentConnectionListener;
 
+/** @deprecated (2.12.0) Use the network add-on instead. */
+@Deprecated
 public class ProxyServer implements Runnable {
 
     protected Thread thread = null;

--- a/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyThread.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyThread.java
@@ -86,6 +86,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2020/12/09 Rely on the content encodings from the body to decode.
+// ZAP: 2022/02/09 Deprecate the class.
 package org.parosproxy.paros.core.proxy;
 
 import java.io.BufferedInputStream;
@@ -128,6 +129,8 @@ import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.network.HttpRequestBody;
 import org.zaproxy.zap.network.HttpRequestConfig;
 
+/** @deprecated No longer used/needed. It will be removed in a future release. */
+@Deprecated
 public class ProxyThread implements Runnable {
 
     //	private static final int		BUFFEREDSTREAM_SIZE = 4096;

--- a/zap/src/main/java/org/parosproxy/paros/extension/ExtensionLoader.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/ExtensionLoader.java
@@ -92,6 +92,7 @@
 // ZAP: 2021/04/13 Issue 6536: Stop and destroy extensions being removed.
 // ZAP: 2021/08/17 Issue 6755: Extension's errors during shutdown prevent ZAP to exit.
 // ZAP: 2021/10/01 Do not initialise view if there's none when starting a single extension.
+// ZAP: 2022/02/09 Deprecate code related to core proxy, remove code no longer needed.
 package org.parosproxy.paros.extension;
 
 import java.awt.Component;
@@ -115,13 +116,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.common.AbstractParam;
-import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.control.Control.Mode;
-import org.parosproxy.paros.control.Proxy;
 import org.parosproxy.paros.core.proxy.ConnectRequestProxyListener;
 import org.parosproxy.paros.core.proxy.OverrideMessageProxyListener;
 import org.parosproxy.paros.core.proxy.ProxyListener;
-import org.parosproxy.paros.core.proxy.ProxyServer;
 import org.parosproxy.paros.core.scanner.Scanner;
 import org.parosproxy.paros.core.scanner.ScannerHook;
 import org.parosproxy.paros.core.scanner.Variant;
@@ -161,7 +159,8 @@ public class ExtensionLoader {
     private View view = null;
     private static final Logger logger = LogManager.getLogger(ExtensionLoader.class);
 
-    private List<ProxyServer> proxyServers;
+    @SuppressWarnings("deprecation")
+    private List<org.parosproxy.paros.core.proxy.ProxyServer> proxyServers;
 
     public ExtensionLoader(Model model, View view) {
         this.model = model;
@@ -272,12 +271,15 @@ public class ExtensionLoader {
      * @since 2.8.0
      * @see #removeProxyServer(ProxyServer)
      */
-    public void addProxyServer(ProxyServer proxyServer) {
+    @SuppressWarnings("deprecation")
+    public void addProxyServer(org.parosproxy.paros.core.proxy.ProxyServer proxyServer) {
         proxyServers.add(proxyServer);
         extensionHooks.values().forEach(extHook -> hookProxyServer(extHook, proxyServer));
     }
 
-    private static void hookProxyServer(ExtensionHook extHook, ProxyServer proxyServer) {
+    @SuppressWarnings("deprecation")
+    private static void hookProxyServer(
+            ExtensionHook extHook, org.parosproxy.paros.core.proxy.ProxyServer proxyServer) {
         process(extHook.getProxyListenerList(), proxyServer::addProxyListener);
         process(
                 extHook.getOverrideMessageProxyListenerList(),
@@ -298,8 +300,9 @@ public class ExtensionLoader {
         }
     }
 
+    @SuppressWarnings("deprecation")
     private void hookProxies(ExtensionHook extHook) {
-        for (ProxyServer proxyServer : proxyServers) {
+        for (org.parosproxy.paros.core.proxy.ProxyServer proxyServer : proxyServers) {
             hookProxyServer(extHook, proxyServer);
         }
     }
@@ -311,12 +314,15 @@ public class ExtensionLoader {
      * @since 2.8.0
      * @see #addProxyServer(ProxyServer)
      */
-    public void removeProxyServer(ProxyServer proxyServer) {
+    @SuppressWarnings("deprecation")
+    public void removeProxyServer(org.parosproxy.paros.core.proxy.ProxyServer proxyServer) {
         proxyServers.remove(proxyServer);
         extensionHooks.values().forEach(extHook -> unhookProxyServer(extHook, proxyServer));
     }
 
-    private void unhookProxyServer(ExtensionHook extHook, ProxyServer proxyServer) {
+    @SuppressWarnings("deprecation")
+    private void unhookProxyServer(
+            ExtensionHook extHook, org.parosproxy.paros.core.proxy.ProxyServer proxyServer) {
         process(extHook.getProxyListenerList(), proxyServer::removeProxyListener);
         process(
                 extHook.getOverrideMessageProxyListenerList(),
@@ -329,19 +335,23 @@ public class ExtensionLoader {
                 proxyServer::removeConnectRequestProxyListener);
     }
 
+    @SuppressWarnings("deprecation")
     private void unhookProxies(ExtensionHook extHook) {
-        for (ProxyServer proxyServer : proxyServers) {
+        for (org.parosproxy.paros.core.proxy.ProxyServer proxyServer : proxyServers) {
             unhookProxyServer(extHook, proxyServer);
         }
     }
 
-    public void hookProxyListener(Proxy proxy) {
+    @SuppressWarnings("deprecation")
+    public void hookProxyListener(org.parosproxy.paros.control.Proxy proxy) {
         for (ExtensionHook hook : extensionHooks.values()) {
             hookProxyListeners(proxy, hook.getProxyListenerList());
         }
     }
 
-    private static void hookProxyListeners(Proxy proxy, List<ProxyListener> listeners) {
+    @SuppressWarnings("deprecation")
+    private static void hookProxyListeners(
+            org.parosproxy.paros.control.Proxy proxy, List<ProxyListener> listeners) {
         for (ProxyListener listener : listeners) {
             try {
                 if (listener != null) {
@@ -353,50 +363,22 @@ public class ExtensionLoader {
         }
     }
 
-    private void removeProxyListener(ExtensionHook hook) {
-        Proxy proxy = Control.getSingleton().getProxy();
-        List<ProxyListener> listenerList = hook.getProxyListenerList();
-        for (ProxyListener listener : listenerList) {
-            try {
-                if (listener != null) {
-                    proxy.removeProxyListener(listener);
-                }
-
-            } catch (Exception e) {
-                logger.error(e.getMessage(), e);
-            }
-        }
-    }
-
-    public void hookOverrideMessageProxyListener(Proxy proxy) {
+    @SuppressWarnings("deprecation")
+    public void hookOverrideMessageProxyListener(org.parosproxy.paros.control.Proxy proxy) {
         for (ExtensionHook hook : extensionHooks.values()) {
             hookOverrideMessageProxyListeners(proxy, hook.getOverrideMessageProxyListenerList());
         }
     }
 
+    @SuppressWarnings("deprecation")
     private static void hookOverrideMessageProxyListeners(
-            Proxy proxy, List<OverrideMessageProxyListener> listeners) {
+            org.parosproxy.paros.control.Proxy proxy,
+            List<OverrideMessageProxyListener> listeners) {
         for (OverrideMessageProxyListener listener : listeners) {
             try {
                 if (listener != null) {
                     proxy.addOverrideMessageProxyListener(listener);
                 }
-            } catch (Exception e) {
-                logger.error(e.getMessage(), e);
-            }
-        }
-    }
-
-    private void removeOverrideMessageProxyListener(ExtensionHook hook) {
-        Proxy proxy = Control.getSingleton().getProxy();
-        List<OverrideMessageProxyListener> listenerList =
-                hook.getOverrideMessageProxyListenerList();
-        for (OverrideMessageProxyListener listener : listenerList) {
-            try {
-                if (listener != null) {
-                    proxy.removeOverrideMessageProxyListener(listener);
-                }
-
             } catch (Exception e) {
                 logger.error(e.getMessage(), e);
             }
@@ -413,54 +395,37 @@ public class ExtensionLoader {
      * @param proxy the local proxy
      * @since 2.5.0
      */
-    public void hookConnectRequestProxyListeners(Proxy proxy) {
+    @SuppressWarnings("deprecation")
+    public void hookConnectRequestProxyListeners(org.parosproxy.paros.control.Proxy proxy) {
         for (ExtensionHook hook : extensionHooks.values()) {
             hookConnectRequestProxyListeners(proxy, hook.getConnectRequestProxyListeners());
         }
     }
 
+    @SuppressWarnings("deprecation")
     private static void hookConnectRequestProxyListeners(
-            Proxy proxy, List<ConnectRequestProxyListener> listeners) {
+            org.parosproxy.paros.control.Proxy proxy, List<ConnectRequestProxyListener> listeners) {
         for (ConnectRequestProxyListener listener : listeners) {
             proxy.addConnectRequestProxyListener(listener);
         }
     }
 
-    private void removeConnectRequestProxyListener(ExtensionHook hook) {
-        Proxy proxy = Control.getSingleton().getProxy();
-        for (ConnectRequestProxyListener listener : hook.getConnectRequestProxyListeners()) {
-            proxy.removeConnectRequestProxyListener(listener);
-        }
-    }
-
-    public void hookPersistentConnectionListener(Proxy proxy) {
+    @SuppressWarnings("deprecation")
+    public void hookPersistentConnectionListener(org.parosproxy.paros.control.Proxy proxy) {
         for (ExtensionHook hook : extensionHooks.values()) {
             hookPersistentConnectionListeners(proxy, hook.getPersistentConnectionListener());
         }
     }
 
+    @SuppressWarnings("deprecation")
     private static void hookPersistentConnectionListeners(
-            Proxy proxy, List<PersistentConnectionListener> listeners) {
+            org.parosproxy.paros.control.Proxy proxy,
+            List<PersistentConnectionListener> listeners) {
         for (PersistentConnectionListener listener : listeners) {
             try {
                 if (listener != null) {
                     proxy.addPersistentConnectionListener(listener);
                 }
-            } catch (Exception e) {
-                logger.error(e.getMessage(), e);
-            }
-        }
-    }
-
-    private void removePersistentConnectionListener(ExtensionHook hook) {
-        Proxy proxy = Control.getSingleton().getProxy();
-        List<PersistentConnectionListener> listenerList = hook.getPersistentConnectionListener();
-        for (PersistentConnectionListener listener : listenerList) {
-            try {
-                if (listener != null) {
-                    proxy.removePersistentConnectionListener(listener);
-                }
-
             } catch (Exception e) {
                 logger.error(e.getMessage(), e);
             }
@@ -849,12 +814,6 @@ public class ExtensionLoader {
         }
 
         ext.start();
-
-        Proxy proxy = Control.getSingleton().getProxy();
-        hookProxyListeners(proxy, extHook.getProxyListenerList());
-        hookOverrideMessageProxyListeners(proxy, extHook.getOverrideMessageProxyListenerList());
-        hookPersistentConnectionListeners(proxy, extHook.getPersistentConnectionListener());
-        hookConnectRequestProxyListeners(proxy, extHook.getConnectRequestProxyListeners());
 
         if (hasView()) {
             hookSiteMapListeners(view.getSiteTreePanel(), extHook.getSiteMapListenerList());
@@ -1509,14 +1468,6 @@ public class ExtensionLoader {
         unloadOptions(hook);
 
         unhookProxies(hook);
-
-        removePersistentConnectionListener(hook);
-
-        removeProxyListener(hook);
-
-        removeOverrideMessageProxyListener(hook);
-
-        removeConnectRequestProxyListener(hook);
 
         removeSiteMapListener(hook);
 

--- a/zap/src/main/java/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -93,6 +93,7 @@
 // ZAP: 2019/09/30 Use hasView().
 // ZAP: 2020/01/02 Do not display messages being deleted.
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
+// ZAP: 2022/02/09 Deprecate methods related to core proxy.
 package org.parosproxy.paros.extension.history;
 
 import java.awt.EventQueue;
@@ -108,7 +109,6 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.control.Control.Mode;
-import org.parosproxy.paros.core.proxy.ProxyServer;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
@@ -309,11 +309,15 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
         return proxyListener;
     }
 
-    public void registerProxy(ProxyServer ps) {
+    /** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
+    @Deprecated
+    public void registerProxy(org.parosproxy.paros.core.proxy.ProxyServer ps) {
         ps.addProxyListener(this.getProxyListenerLog());
     }
 
-    public void unregisterProxy(ProxyServer ps) {
+    /** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
+    @Deprecated
+    public void unregisterProxy(org.parosproxy.paros.core.proxy.ProxyServer ps) {
         ps.removeProxyListener(this.getProxyListenerLog());
     }
 

--- a/zap/src/main/java/org/parosproxy/paros/model/OptionsParam.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/OptionsParam.java
@@ -43,6 +43,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2021/05/25 Change the default value of userDirectory from null to the user's home directory.
+// ZAP: 2022/02/09 Deprecate methods related to core proxy options.
 package org.parosproxy.paros.model;
 
 import ch.csnc.extension.util.OptionsParamExperimentalSliSupport;
@@ -55,7 +56,6 @@ import org.apache.commons.lang3.SystemUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.common.AbstractParam;
-import org.parosproxy.paros.core.proxy.ProxyParam;
 import org.parosproxy.paros.extension.option.DatabaseParam;
 import org.parosproxy.paros.extension.option.OptionsParamCertificate;
 import org.parosproxy.paros.extension.option.OptionsParamView;
@@ -74,7 +74,10 @@ public class OptionsParam extends AbstractParam {
     // ZAP: User directory now stored in the config file
     private static final String USER_DIR = "userDir";
 
-    private ProxyParam proxyParam = new ProxyParam();
+    @SuppressWarnings("deprecation")
+    private org.parosproxy.paros.core.proxy.ProxyParam proxyParam =
+            new org.parosproxy.paros.core.proxy.ProxyParam();
+
     private ConnectionParam connectionParam = new ConnectionParam();
     private OptionsParamView viewParam = new OptionsParamView();
     private OptionsParamCertificate certificateParam = new OptionsParamCertificate();
@@ -103,13 +106,21 @@ public class OptionsParam extends AbstractParam {
         return connectionParam;
     }
 
-    /** @return Returns the proxyParam. */
-    public ProxyParam getProxyParam() {
+    /**
+     * @deprecated (2.12.0) Use the network add-on instead.
+     * @return Returns the proxyParam.
+     */
+    @Deprecated
+    public org.parosproxy.paros.core.proxy.ProxyParam getProxyParam() {
         return proxyParam;
     }
 
-    /** @param proxyParam The proxyParam to set. */
-    public void setProxyParam(ProxyParam proxyParam) {
+    /**
+     * @deprecated (2.12.0) Use the network add-on instead.
+     * @param proxyParam The proxyParam to set.
+     */
+    @Deprecated
+    public void setProxyParam(org.parosproxy.paros.core.proxy.ProxyParam proxyParam) {
         this.proxyParam = proxyParam;
     }
 

--- a/zap/src/main/java/org/parosproxy/paros/model/Session.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/Session.java
@@ -87,6 +87,7 @@
 // ZAP: 2020/10/14 Require just the name when importing context.
 // ZAP: 2020/11/02 Validate parameters in getLeafName(...)
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
+// ZAP: 2022/02/09 Remove code no longer needed and deprecate a method.
 package org.parosproxy.paros.model;
 
 import java.awt.EventQueue;
@@ -999,23 +1000,9 @@ public class Session {
 
         this.excludeFromProxyRegexs = stripEmptyLines(ignoredRegexs);
 
-        setExcludeFromProxyUrls();
-
         model.getDb()
                 .getTableSessionUrl()
                 .setUrls(RecordSessionUrl.TYPE_EXCLUDE_FROM_PROXY, this.excludeFromProxyRegexs);
-    }
-
-    /**
-     * Sets, into the Local Proxy, the URLs that should be excluded from it (URLs set in the session
-     * and global exclude URLs).
-     */
-    private void setExcludeFromProxyUrls() {
-        List<String> fullList = new ArrayList<>();
-        fullList.addAll(this.excludeFromProxyRegexs);
-        fullList.addAll(getGlobalExcludeURLRegexs());
-
-        Control.getSingleton().setExcludeFromProxyUrls(fullList);
     }
 
     public void addExcludeFromProxyRegex(String ignoredRegex) throws DatabaseException {
@@ -1023,7 +1010,6 @@ public class Session {
         Pattern.compile(ignoredRegex, Pattern.CASE_INSENSITIVE);
 
         this.excludeFromProxyRegexs.add(ignoredRegex);
-        Control.getSingleton().setExcludeFromProxyUrls(this.excludeFromProxyRegexs);
         model.getDb()
                 .getTableSessionUrl()
                 .setUrls(RecordSessionUrl.TYPE_EXCLUDE_FROM_PROXY, this.excludeFromProxyRegexs);
@@ -1108,10 +1094,10 @@ public class Session {
      * <p>This should be considered an internal method, to be called only by core code.
      *
      * @since 2.3.0
+     * @deprecated (2.12.0) No longer used/needed. It will be removed in a future release.
      */
-    public void forceGlobalExcludeURLRefresh() {
-        setExcludeFromProxyUrls();
-    }
+    @Deprecated
+    public void forceGlobalExcludeURLRefresh() {}
 
     /**
      * Gets the global exclude URLs.

--- a/zap/src/main/java/org/parosproxy/paros/view/MainFooterPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/MainFooterPanel.java
@@ -31,10 +31,6 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.net.URL;
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -43,11 +39,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JToolBar;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.core.proxy.ProxyParam;
-import org.parosproxy.paros.model.Model;
-import org.parosproxy.paros.model.OptionsParam;
-import org.zaproxy.zap.extension.proxies.ProxiesParam;
-import org.zaproxy.zap.extension.proxies.ProxiesParamProxy;
 import org.zaproxy.zap.utils.DisplayUtils;
 
 public class MainFooterPanel extends JPanel {
@@ -59,7 +50,6 @@ public class MainFooterPanel extends JPanel {
     private JLabel alertMedium = null;
     private JLabel alertLow = null;
     private JLabel alertInfo = null;
-    private JLabel primaryProxy = null;
 
     public MainFooterPanel() {
         super();
@@ -116,9 +106,6 @@ public class MainFooterPanel extends JPanel {
         footerToolbarLeft.add(getAlertLow());
 
         footerToolbarLeft.add(getAlertInfo());
-
-        footerToolbarLeft.addSeparator();
-        footerToolbarLeft.add(getPrimaryProxyLabel());
 
         // Current Scans (Right)
         footerToolbarRight.add(new JLabel(Constant.messages.getString("footer.scans.label")));
@@ -236,69 +223,6 @@ public class MainFooterPanel extends JPanel {
         return label;
     }
 
-    private JLabel getPrimaryProxyLabel() {
-        if (primaryProxy == null) {
-            ProxyParam proxyParam = Model.getSingleton().getOptionsParam().getProxyParam();
-            primaryProxy =
-                    new JLabel(
-                            Constant.messages.getString(
-                                    "footer.primary.proxy",
-                                    getProxyRepresentation(
-                                            proxyParam.getProxyIp(), proxyParam.getProxyPort())));
-        }
-        return primaryProxy;
-    }
-
-    /**
-     * Set the footer label for the primary proxy, the format should be host:port.
-     *
-     * @param proxyStr the string representation of the proxy setting that should be displayed.
-     * @since 2.9.0
-     */
-    private void setPrimaryProxyLabel(String proxyStr) {
-        getPrimaryProxyLabel()
-                .setText(Constant.messages.getString("footer.primary.proxy", proxyStr));
-    }
-
-    private static String getProxyTooltip() {
-        OptionsParam optParam = Model.getSingleton().getOptionsParam();
-        // Primary
-        ProxyParam proxyParam = optParam.getProxyParam();
-        // Alts
-        ProxiesParam proxiesParam = optParam.getParamSet(ProxiesParam.class);
-        List<ProxiesParamProxy> altList =
-                proxiesParam != null ? proxiesParam.getProxies() : Collections.emptyList();
-
-        return Constant.messages.getString(
-                        "footer.proxy.tooltip",
-                        getProxyRepresentation(proxyParam.getProxyIp(), proxyParam.getProxyPort()))
-                + "<br>"
-                + createAlternateProxiesToolTip(
-                        altList, "footer.proxy.tooltip.enabled.alts", ProxiesParamProxy::isEnabled)
-                + createAlternateProxiesToolTip(
-                        altList,
-                        "footer.proxy.tooltip.disabled.alts",
-                        ((Predicate<ProxiesParamProxy>) ProxiesParamProxy::isEnabled).negate());
-    }
-
-    private static String createAlternateProxiesToolTip(
-            List<ProxiesParamProxy> proxies,
-            String labelKey,
-            Predicate<ProxiesParamProxy> predicate) {
-        if (proxies.isEmpty()) {
-            return "";
-        }
-        String altProxies =
-                proxies.stream()
-                        .filter(predicate)
-                        .map(
-                                proxy ->
-                                        getProxyRepresentation(proxy.getAddress(), proxy.getPort())
-                                                + "<br>")
-                        .collect(Collectors.joining(""));
-        return altProxies.isEmpty() ? "" : Constant.messages.getString(labelKey, altProxies);
-    }
-
     // Support for dynamic scanning results in the footer
     public void addFooterToolbarRightLabel(JLabel label) {
         DisplayUtils.scaleIcon(label);
@@ -349,17 +273,5 @@ public class MainFooterPanel extends JPanel {
     // FIXME Still needed?
     public void addFooterSeparator() {
         this.footerToolbarRight.addSeparator();
-    }
-
-    private static String getProxyRepresentation(String address, int port) {
-        return Constant.messages.getString(
-                "footer.proxy.representation", address, String.valueOf(port));
-    }
-
-    void optionsChanged() {
-        ProxyParam proxyParam = Model.getSingleton().getOptionsParam().getProxyParam();
-        setPrimaryProxyLabel(
-                getProxyRepresentation(proxyParam.getProxyIp(), proxyParam.getProxyPort()));
-        getPrimaryProxyLabel().setToolTipText(getProxyTooltip());
     }
 }

--- a/zap/src/main/java/org/parosproxy/paros/view/MainFrame.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/MainFrame.java
@@ -35,6 +35,7 @@
 // ZAP: 2019/12/13 Display the primary proxy details (host:port) in the footer (Issue 2016).
 // ZAP: 2020/09/29 Add support for dynamic Look and Feel switching (Issue 6201)
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
+// ZAP: 2022/02/09 Remove method call no longer needed.
 package org.parosproxy.paros.view;
 
 import java.awt.CardLayout;
@@ -643,7 +644,6 @@ public class MainFrame extends AbstractFrame {
         setResponsePanelPosition(position);
 
         setShowTabNames(options.getViewParam().getShowTabNames());
-        getMainFooterPanel().optionsChanged();
     }
 
     /**

--- a/zap/src/main/java/org/parosproxy/paros/view/View.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/View.java
@@ -89,6 +89,7 @@
 // ZAP: 2019/07/10 Update to use Context.getId following deprecation of Context.getIndex
 // ZAP: 2019/12/13 Update new footer proxy label in postInit (Issue 2016)
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
+// ZAP: 2022/02/09 Remove method call no longer needed.
 package org.parosproxy.paros.view;
 
 import java.awt.Component;
@@ -351,7 +352,6 @@ public class View implements ViewDelegate {
                 });
         mainFrame.getMainMenuBar().getMenuView().add(unpinAllMenu);
 
-        mainFrame.getMainFooterPanel().optionsChanged();
         postInitialisation = true;
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/DaemonBootstrap.java
+++ b/zap/src/main/java/org/zaproxy/zap/DaemonBootstrap.java
@@ -25,8 +25,6 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
-import org.parosproxy.paros.core.proxy.ProxyParam;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.view.View;
 
 /**
@@ -92,24 +90,6 @@ class DaemonBootstrap extends HeadlessBootstrap {
                                     control.runCommandLine();
                                 } catch (Exception e) {
                                     logger.error(e.getMessage(), e);
-                                }
-
-                                if (!control.getProxy().startServer()) {
-                                    // Failed to listen on the specified proxy, no point in
-                                    // continuing (an error will already have been shown)
-                                    return;
-                                }
-
-                                ProxyParam proxyParams =
-                                        Model.getSingleton().getOptionsParam().getProxyParam();
-                                String message =
-                                        "ZAP is now listening on "
-                                                + proxyParams.getRawProxyIP()
-                                                + ":"
-                                                + proxyParams.getProxyPort();
-                                logger.info(message);
-                                if (getArgs().isNoStdOutLog()) {
-                                    System.out.println(message);
                                 }
 
                                 HeadlessBootstrap.checkForUpdates();

--- a/zap/src/main/java/org/zaproxy/zap/HeadlessBootstrap.java
+++ b/zap/src/main/java/org/zaproxy/zap/HeadlessBootstrap.java
@@ -56,7 +56,7 @@ abstract class HeadlessBootstrap extends ZapBootstrap {
      * @see Control#initSingletonWithoutViewAndProxy(org.zaproxy.zap.control.ControlOverrides)
      */
     protected Control initControl() {
-        Control.initSingletonWithoutViewAndProxy(getControlOverrides());
+        Control.initSingletonWithoutView(getControlOverrides());
         return Control.getSingleton();
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/ZapBootstrap.java
+++ b/zap/src/main/java/org/zaproxy/zap/ZapBootstrap.java
@@ -49,8 +49,6 @@ abstract class ZapBootstrap {
         this.args = args;
 
         controlOverrides = new ControlOverrides();
-        controlOverrides.setProxyPort(getArgs().getPort());
-        controlOverrides.setProxyHost(getArgs().getHost());
         controlOverrides.setOrderedConfigs(getArgs().getOrderedConfigs());
         controlOverrides.setExperimentalDb(getArgs().isExperimentalDb());
     }

--- a/zap/src/main/java/org/zaproxy/zap/control/CoreFunctionality.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/CoreFunctionality.java
@@ -132,7 +132,6 @@ public final class CoreFunctionality {
             extensions.add(new org.zaproxy.zap.extension.keyboard.ExtensionKeyboard());
             extensions.add(new org.zaproxy.zap.extension.log4j.ExtensionLog4j());
             extensions.add(new org.zaproxy.zap.extension.params.ExtensionParams());
-            extensions.add(new org.zaproxy.zap.extension.proxies.ExtensionProxies());
             extensions.add(new org.zaproxy.zap.extension.pscan.ExtensionPassiveScan());
             extensions.add(new org.zaproxy.zap.extension.ruleconfig.ExtensionRuleConfig());
             extensions.add(new org.zaproxy.zap.extension.script.ExtensionScript());

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/API.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/API.java
@@ -45,7 +45,6 @@ import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang.time.DateUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.parosproxy.paros.core.proxy.ProxyParam;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpInputStream;
@@ -130,7 +129,8 @@ public class API {
      *
      * @see #getProxyParam()
      */
-    private ProxyParam proxyParam;
+    @SuppressWarnings("deprecation")
+    private org.parosproxy.paros.core.proxy.ProxyParam proxyParam;
 
     private Random random = new SecureRandom();
     private static final Logger logger = LogManager.getLogger(API.class);
@@ -229,14 +229,16 @@ public class API {
         this.optionsParamApi = optionsParamApi;
     }
 
-    private ProxyParam getProxyParam() {
+    @SuppressWarnings("deprecation")
+    private org.parosproxy.paros.core.proxy.ProxyParam getProxyParam() {
         if (proxyParam == null) {
             proxyParam = Model.getSingleton().getOptionsParam().getProxyParam();
         }
         return proxyParam;
     }
 
-    void setProxyParam(ProxyParam proxyParam) {
+    @SuppressWarnings("deprecation")
+    void setProxyParam(org.parosproxy.paros.core.proxy.ProxyParam proxyParam) {
         this.proxyParam = proxyParam;
     }
 
@@ -756,6 +758,7 @@ public class API {
      * @return the base URL to access the ZAP API.
      * @since 2.7.0
      */
+    @SuppressWarnings("deprecation")
     public String getBaseURL(boolean proxy) {
         if (proxy) {
             return getOptionsParamApi().isSecureOnly() ? API_URL_S : API_URL;

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ApiGeneratorUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ApiGeneratorUtils.java
@@ -35,7 +35,6 @@ import org.zaproxy.zap.extension.brk.BreakAPI;
 import org.zaproxy.zap.extension.forceduser.ForcedUserAPI;
 import org.zaproxy.zap.extension.httpsessions.HttpSessionsAPI;
 import org.zaproxy.zap.extension.params.ParamsAPI;
-import org.zaproxy.zap.extension.proxies.ProxiesAPI;
 import org.zaproxy.zap.extension.pscan.PassiveScanAPI;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigAPI;
 import org.zaproxy.zap.extension.script.ScriptAPI;
@@ -100,8 +99,6 @@ public class ApiGeneratorUtils {
         imps.add(new AuthenticationAPI(null));
 
         imps.add(new AuthorizationAPI());
-
-        imps.add(new ProxiesAPI(null));
 
         imps.add(new RuleConfigAPI(null));
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -56,7 +56,6 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.control.Control.Mode;
-import org.parosproxy.paros.core.proxy.ProxyParam;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.db.RecordHistory;
 import org.parosproxy.paros.db.TableHistory;
@@ -1300,7 +1299,9 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
             throws ApiException {
 
         if (OTHER_PROXY_PAC.equals(name)) {
-            final ProxyParam proxyParam = Model.getSingleton().getOptionsParam().getProxyParam();
+            @SuppressWarnings("deprecation")
+            final org.parosproxy.paros.core.proxy.ProxyParam proxyParam =
+                    Model.getSingleton().getOptionsParam().getProxyParam();
             final int port = proxyParam.getProxyPort();
             try {
                 String domain = null;

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakPanel.java
@@ -124,7 +124,7 @@ public class BreakPanel extends AbstractPanel implements Tab, BreakpointManageme
 
         this.setLayout(new BorderLayout());
 
-        breakToolbarFactory = new BreakPanelToolbarFactory(breakpointsParams, this);
+        breakToolbarFactory = new BreakPanelToolbarFactory(extension, breakpointsParams, this);
 
         panelContent = new JPanel(new CardLayout());
         this.add(panelContent, BorderLayout.CENTER);

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakPanelToolbarFactory.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakPanelToolbarFactory.java
@@ -100,8 +100,19 @@ public class BreakPanelToolbarFactory {
     /** The object to synchronise changes to {@link #countCaughtMessages}. */
     private final Object countLock = new Object();
 
+    private final ExtensionBreak extensionBreak;
+
     public BreakPanelToolbarFactory(BreakpointsParam breakpointsParams, BreakPanel breakPanel) {
+        this(null, breakpointsParams, breakPanel);
+    }
+
+    public BreakPanelToolbarFactory(
+            ExtensionBreak extensionBreak,
+            BreakpointsParam breakpointsParams,
+            BreakPanel breakPanel) {
         super();
+
+        this.extensionBreak = extensionBreak;
 
         continueButtonAction = new ContinueButtonAction();
         stepButtonAction = new StepButtonAction();
@@ -358,10 +369,9 @@ public class BreakPanelToolbarFactory {
         }
         // If forces or either break buttons are pressed force the proxy to submit requests and
         // responses serially
-        if (forceSerialize || isBreakRequest() || isBreakResponse() || isBreakAll) {
-            Control.getSingleton().getProxy().setSerialize(true);
-        } else {
-            Control.getSingleton().getProxy().setSerialize(false);
+        boolean serialise = forceSerialize || isBreakRequest() || isBreakResponse() || isBreakAll;
+        if (extensionBreak != null) {
+            extensionBreak.getSerialisationRequiredListeners().forEach(e -> e.accept(serialise));
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/ExtensionBreak.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/ExtensionBreak.java
@@ -24,9 +24,12 @@ import java.awt.EventQueue;
 import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
 import javax.swing.JList;
 import javax.swing.JTree;
 import javax.swing.tree.TreePath;
@@ -108,6 +111,7 @@ public class ExtensionBreak extends ExtensionAdaptor
     private ZapMenuItem menuHttpBreakpoint = null;
 
     private BreakAPI api = new BreakAPI(this);
+    private List<Consumer<Boolean>> serialisationRequiredListeners;
 
     public ExtensionBreak() {
         super(NAME);
@@ -119,8 +123,27 @@ public class ExtensionBreak extends ExtensionAdaptor
         return Constant.messages.getString("brk.name");
     }
 
+    @Override
+    public void init() {
+        serialisationRequiredListeners = Collections.synchronizedList(new ArrayList<>(1));
+    }
+
     public BreakpointManagementInterface getBreakpointManagementInterface() {
         return this.breakpointManagementInterface;
+    }
+
+    public void addSerialisationRequiredListener(Consumer<Boolean> listener) {
+        Objects.requireNonNull(listener);
+        serialisationRequiredListeners.add(listener);
+    }
+
+    public void removeSerialisationRequiredListener(Consumer<Boolean> listener) {
+        Objects.requireNonNull(listener);
+        serialisationRequiredListeners.remove(listener);
+    }
+
+    List<Consumer<Boolean>> getSerialisationRequiredListeners() {
+        return serialisationRequiredListeners;
     }
 
     /** @deprecated (2.6.0) Classes outside of this package should not access the UI directly */

--- a/zap/src/main/java/org/zaproxy/zap/extension/callback/ExtensionCallback.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/callback/ExtensionCallback.java
@@ -31,7 +31,6 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.proxy.OverrideMessageProxyListener;
-import org.parosproxy.paros.core.proxy.ProxyServer;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
@@ -54,7 +53,7 @@ public class ExtensionCallback extends ExtensionAdaptor
     private static final String TEST_PREFIX = "ZapTest";
     private static final String NAME = "ExtensionCallback";
 
-    private ProxyServer proxyServer;
+    private org.parosproxy.paros.core.proxy.ProxyServer proxyServer;
     private CallbackParam callbackParam;
     private OptionsCallbackPanel optionsCallbackPanel;
 
@@ -67,7 +66,7 @@ public class ExtensionCallback extends ExtensionAdaptor
     private org.zaproxy.zap.extension.callback.ui.CallbackPanel callbackPanel;
 
     public ExtensionCallback() {
-        proxyServer = new ProxyServer("ZAP-CallbackServer");
+        proxyServer = new org.parosproxy.paros.core.proxy.ProxyServer("ZAP-CallbackServer");
         proxyServer.addOverrideMessageProxyListener(new CallbackProxyListener());
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/globalexcludeurl/GlobalExcludeURLParam.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/globalexcludeurl/GlobalExcludeURLParam.java
@@ -27,7 +27,6 @@ import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.common.AbstractParam;
-import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.extension.api.ZapApiIgnore;
 
 public class GlobalExcludeURLParam extends AbstractParam {
@@ -259,9 +258,6 @@ public class GlobalExcludeURLParam extends AbstractParam {
 
         enabledTokens.trimToSize();
         this.enabledTokensNames = enabledTokens;
-
-        // after saving, force the proxy to refresh the URL lists.
-        Model.getSingleton().getSession().forceGlobalExcludeURLRefresh();
     }
 
     public void addToken(String regex) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/proxies/DialogAddProxy.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/proxies/DialogAddProxy.java
@@ -25,6 +25,8 @@ import javax.swing.JPanel;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+/** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
+@Deprecated
 class DialogAddProxy extends AbstractFormDialog {
 
     private static final long serialVersionUID = 4460797449668634319L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/proxies/DialogModifyProxy.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/proxies/DialogModifyProxy.java
@@ -22,6 +22,8 @@ package org.zaproxy.zap.extension.proxies;
 import java.awt.Dialog;
 import org.parosproxy.paros.Constant;
 
+/** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
+@Deprecated
 class DialogModifyProxy extends DialogAddProxy {
 
     private static final long serialVersionUID = 6675509994290748494L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/proxies/OptionsLocalProxyPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/proxies/OptionsLocalProxyPanel.java
@@ -33,6 +33,8 @@ import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.utils.NetworkUtils;
 import org.zaproxy.zap.utils.ZapPortNumberSpinner;
 
+/** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
+@Deprecated
 public class OptionsLocalProxyPanel extends JPanel {
 
     private static final long serialVersionUID = -1350537974139536669L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/proxies/OptionsProxiesPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/proxies/OptionsProxiesPanel.java
@@ -37,6 +37,8 @@ import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTablePanel;
 import org.zaproxy.zap.view.LayoutHelper;
 
+/** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
+@Deprecated
 public class OptionsProxiesPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/proxies/OptionsProxiesTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/proxies/OptionsProxiesTableModel.java
@@ -24,6 +24,8 @@ import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+/** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
+@Deprecated
 public class OptionsProxiesTableModel extends AbstractMultipleOptionsTableModel<ProxiesParamProxy> {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/proxies/ProxiesAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/proxies/ProxiesAPI.java
@@ -31,6 +31,8 @@ import org.zaproxy.zap.extension.api.ApiResponseList;
 import org.zaproxy.zap.extension.api.ApiResponseSet;
 import org.zaproxy.zap.extension.api.ApiView;
 
+/** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
+@Deprecated
 public class ProxiesAPI extends ApiImplementor {
 
     private static final String PREFIX = "localProxies";

--- a/zap/src/main/java/org/zaproxy/zap/extension/proxies/ProxiesParam.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/proxies/ProxiesParam.java
@@ -27,9 +27,10 @@ import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.common.AbstractParam;
-import org.parosproxy.paros.core.proxy.ProxyParam;
 import org.parosproxy.paros.model.Model;
 
+/** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
+@Deprecated
 public class ProxiesParam extends AbstractParam {
 
     private static final Logger logger = LogManager.getLogger(ProxiesParam.class);
@@ -79,7 +80,8 @@ public class ProxiesParam extends AbstractParam {
     }
 
     public ProxiesParamProxy getMainProxy() {
-        ProxyParam mainProxyParam = Model.getSingleton().getOptionsParam().getProxyParam();
+        org.parosproxy.paros.core.proxy.ProxyParam mainProxyParam =
+                Model.getSingleton().getOptionsParam().getProxyParam();
         ProxiesParamProxy mainProxy =
                 new ProxiesParamProxy(
                         mainProxyParam.getRawProxyIP(), mainProxyParam.getProxyPort(), true);
@@ -110,7 +112,8 @@ public class ProxiesParam extends AbstractParam {
     }
 
     public void setMainProxy(ProxiesParamProxy proxy) {
-        ProxyParam proxyParam = Model.getSingleton().getOptionsParam().getProxyParam();
+        org.parosproxy.paros.core.proxy.ProxyParam proxyParam =
+                Model.getSingleton().getOptionsParam().getProxyParam();
         proxyParam.setProxyIp(proxy.getAddress());
         proxyParam.setProxyPort(proxy.getPort());
         proxyParam.setAlwaysDecodeGzip(proxy.isAlwaysDecodeGzip());

--- a/zap/src/main/java/org/zaproxy/zap/extension/proxies/ProxiesParamProxy.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/proxies/ProxiesParamProxy.java
@@ -21,6 +21,8 @@ package org.zaproxy.zap.extension.proxies;
 
 import org.zaproxy.zap.utils.Enableable;
 
+/** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
+@Deprecated
 public class ProxiesParamProxy extends Enableable {
 
     private String address = "localhost";

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -1218,8 +1218,6 @@ Core options:\n\
 \t-help                    The same as -h\n\
 \t-newsession <path>       Creates a new session at the given location\n\
 \t-session <path>          Opens the given session after starting ZAP\n\
-\t-host <host>             Overrides the host used for proxying specified in the configuration file\n\
-\t-port <port>             Overrides the port used for proxying specified in the configuration file\n\
 \t-lowmem                  Use the database instead of memory as much as possible - this is still experimental\n\
 \t-experimentaldb          Use the experimental generic database code, which is not surprisingly also still experimental\n\
 \t-nostdout                Disables the default logging through standard output\n\
@@ -1721,11 +1719,6 @@ footer.alerts.info.tooltip   = Informational Priority Alerts
 footer.alerts.label          = <html>&nbsp;Alerts&nbsp;</html>
 footer.alerts.low.tooltip    = Low Priority Alerts
 footer.alerts.medium.tooltip = Medium Priority Alerts
-footer.primary.proxy = Primary Proxy: {0}
-footer.proxy.representation = {0}:{1} 
-footer.proxy.tooltip = <html>Primary Proxy:<br>{0}<html>
-footer.proxy.tooltip.enabled.alts = Alternate (Enabled):<br>{0}
-footer.proxy.tooltip.disabled.alts = Alternate (Disabled):<br>{0}
 footer.scans.label           = Current Scans
 
 form.dialog.button.cancel = Cancel

--- a/zap/src/test/java/org/parosproxy/paros/CommandLineUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/CommandLineUnitTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -181,48 +182,25 @@ class CommandLineUnitTest {
     }
 
     @Test
-    void shouldFailIfPortArgumentDoesNotHaveValue() throws Exception {
-        // Given
-        String[] args = {CommandLine.PORT};
-        // When / Then
-        assertThrows(ArrayIndexOutOfBoundsException.class, () -> new CommandLine(args));
-    }
-
-    @Test
-    void shouldFailToParseInvalidPortArgument() throws Exception {
-        // Given
-        String[] args = {CommandLine.PORT, "InvalidPort"};
-        // When / Then
-        assertThrows(IllegalArgumentException.class, () -> new CommandLine(args));
-    }
-
-    @Test
-    void shouldParseValidPortArgument() throws Exception {
+    @SuppressWarnings("deprecation")
+    void shouldNotParsePortArgument() throws Exception {
         // Given
         int port = 8080;
         // When
         cmdLine = new CommandLine(new String[] {CommandLine.PORT, Integer.toString(port)});
         // Then
-        assertThat(cmdLine.getPort(), is(equalTo(port)));
-        assertThat(cmdLine.getArgument(CommandLine.PORT), is(equalTo("8080")));
+        assertThat(cmdLine.getPort(), is(equalTo(-1)));
     }
 
     @Test
-    void shouldFailIfHostArgumentDoesNotHaveValue() throws Exception {
-        // Given
-        String[] args = {CommandLine.HOST};
-        // When / Then
-        assertThrows(ArrayIndexOutOfBoundsException.class, () -> new CommandLine(args));
-    }
-
-    @Test
-    void shouldParseHostArgument() throws Exception {
+    @SuppressWarnings("deprecation")
+    void shouldNotParseHostArgument() throws Exception {
         // Given
         String hostname = "127.0.0.1";
         // When
         cmdLine = new CommandLine(new String[] {CommandLine.HOST, hostname});
         // Then
-        assertThat(cmdLine.getHost(), is(equalTo(hostname)));
+        assertThat(cmdLine.getHost(), is(nullValue()));
     }
 
     @Test

--- a/zap/src/test/java/org/parosproxy/paros/core/proxy/ProxyThreadUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/proxy/ProxyThreadUnitTest.java
@@ -36,6 +36,7 @@ import org.zaproxy.zap.network.HttpEncoding;
 import org.zaproxy.zap.network.HttpResponseBody;
 
 /** Unit test for {@link ProxyThread}. */
+@Deprecated
 class ProxyThreadUnitTest {
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/extension/api/APIUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/api/APIUnitTest.java
@@ -42,7 +42,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.parosproxy.paros.core.proxy.ProxyParam;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpInputStream;
 import org.parosproxy.paros.network.HttpMessage;
@@ -710,8 +709,11 @@ class APIUnitTest {
         return optionsParamApi;
     }
 
-    private static ProxyParam createProxyParam(String proxyAddress, int proxyPort) {
-        ProxyParam proxyParam = new ProxyParam();
+    @SuppressWarnings("deprecation")
+    private static org.parosproxy.paros.core.proxy.ProxyParam createProxyParam(
+            String proxyAddress, int proxyPort) {
+        org.parosproxy.paros.core.proxy.ProxyParam proxyParam =
+                new org.parosproxy.paros.core.proxy.ProxyParam();
         proxyParam.load(new ZapXmlConfiguration());
         proxyParam.setProxyIp(proxyAddress);
         proxyParam.setProxyPort(proxyPort);


### PR DESCRIPTION
No longer manage the main nor additional proxies.
Remove proxy info in the main footer.
Do not parse `-host` and `-port`.
Add listener of break serialise requirement for the proxies in
the add-on.
Suppress deprecation warnings where needed.