### PR TITLE
API - Do not require Authentication Realm and use default value

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/authentication/HttpAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/HttpAuthenticationMethodType.java
@@ -382,8 +382,8 @@ public class HttpAuthenticationMethodType extends AuthenticationMethodType {
     public ApiDynamicActionImplementor getSetMethodForContextApiAction() {
         return new ApiDynamicActionImplementor(
                 API_METHOD_NAME,
-                new String[] {PARAM_HOSTNAME, PARAM_REALM},
-                new String[] {PARAM_PORT}) {
+                new String[] {PARAM_HOSTNAME},
+                new String[] {PARAM_REALM, PARAM_PORT}) {
 
             @Override
             public void handleAction(JSONObject params) throws ApiException {
@@ -398,7 +398,7 @@ public class HttpAuthenticationMethodType extends AuthenticationMethodType {
                     throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_HOSTNAME);
                 }
 
-                if (params.containsKey(PARAM_REALM)) method.realm = params.getString(PARAM_REALM);
+                method.realm = params.optString(PARAM_REALM);
 
                 if (params.containsKey(PARAM_PORT))
                     try {


### PR DESCRIPTION
Despite realm being required field in documentation it's not enforced.

That's good, because user may not care about specific realm - unfortunately setting null realm cause hard to debug issue:

- NTCredentials constructor will throw on null realm: https://github.com/zaproxy/zaproxy/blob/8ac4b10d3d9d816957985694c2b7cf127d1364d3/zap/src/main/java/org/zaproxy/zap/authentication/HttpAuthenticationMethodType.java#L168-L173
- This exception will not be printed when using importurls endpoint in daemon mode: https://github.com/zaproxy/zap-extensions/blob/main/addOns/importurls/src/main/java/org/zaproxy/zap/extension/importurls/ExtensionImportUrls.java#L100