### PR TITLE
Correct parent of user related dialogues

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/users/ContextUsersPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/users/ContextUsersPanel.java
@@ -122,8 +122,7 @@ public class ContextUsersPanel extends AbstractContextPropertiesPanel {
 
             if (addDialog == null) {
                 addDialog =
-                        new DialogAddUser(
-                                View.getSingleton().getOptionsDialog(null), this.extension);
+                        new DialogAddUser(View.getSingleton().getSessionDialog(), this.extension);
                 addDialog.pack();
             }
             addDialog.setWorkingContext(this.uiSharedContext);
@@ -140,7 +139,7 @@ public class ContextUsersPanel extends AbstractContextPropertiesPanel {
             if (modifyDialog == null) {
                 modifyDialog =
                         new DialogModifyUser(
-                                View.getSingleton().getOptionsDialog(null), this.extension);
+                                View.getSingleton().getSessionDialog(), this.extension);
                 modifyDialog.pack();
             }
             modifyDialog.setWorkingContext(this.uiSharedContext);
@@ -160,7 +159,7 @@ public class ContextUsersPanel extends AbstractContextPropertiesPanel {
             Object[] messages = {REMOVE_DIALOG_TEXT, " ", removeWithoutConfirmationCheckBox};
             int option =
                     JOptionPane.showOptionDialog(
-                            View.getSingleton().getMainFrame(),
+                            View.getSingleton().getSessionDialog(),
                             messages,
                             REMOVE_DIALOG_TITLE,
                             JOptionPane.OK_CANCEL_OPTION,


### PR DESCRIPTION
Change the parent of add, modify, and remove user dialogues to be the
sessions properties dialogue so they are shown/centred in the expected
dialogue.