### PR TITLE
feat: Support Info dialog user friendliness improvements (copy button)

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/view/ZapSupportDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ZapSupportDialog.java
@@ -25,6 +25,9 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.HeadlessException;
 import java.awt.Insets;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
 import java.io.File;
 import java.io.IOException;
 import javax.swing.JButton;
@@ -49,6 +52,7 @@ public class ZapSupportDialog extends AbstractDialog {
     private ZapSupportPanel supportPanel = null;
     private JButton btnOK = null;
     private JButton btnOpen = null;
+    private JButton btnCopy = null;
 
     /**
      * Constructs an {@code ZapSupportDialog} with no owner and not modal.
@@ -56,8 +60,7 @@ public class ZapSupportDialog extends AbstractDialog {
      * @throws HeadlessException when {@code GraphicsEnvironment.isHeadless()} returns {@code true}
      */
     public ZapSupportDialog() {
-        super();
-        initialize();
+        this(null, true);
     }
 
     /**
@@ -69,10 +72,7 @@ public class ZapSupportDialog extends AbstractDialog {
      */
     public ZapSupportDialog(Frame owner, boolean modal) {
         super(owner, modal);
-        initialize();
-    }
 
-    private void initialize() {
         this.setContentPane(getMainPanel());
         this.pack();
     }
@@ -83,6 +83,7 @@ public class ZapSupportDialog extends AbstractDialog {
 
             GridBagConstraints gbcPanel = new GridBagConstraints();
             GridBagConstraints gbcOpenButton = new GridBagConstraints();
+            GridBagConstraints gbcCopyButton = new GridBagConstraints();
             GridBagConstraints gbcOkButton = new GridBagConstraints();
 
             gbcPanel.gridx = 0;
@@ -93,20 +94,29 @@ public class ZapSupportDialog extends AbstractDialog {
             gbcPanel.weightx = 1.0D;
             gbcPanel.weighty = 1.0D;
             gbcPanel.ipady = 2;
-            gbcPanel.gridwidth = 2;
+            gbcPanel.gridwidth = 3;
 
-            gbcOpenButton.gridx = 0;
+            int gridx = 0;
+            Insets insets = new Insets(2, 2, 2, 2);
+            gbcOpenButton.gridx = gridx;
             gbcOpenButton.gridy = 1;
-            gbcOpenButton.insets = new Insets(2, 2, 2, 2);
+            gbcOpenButton.insets = insets;
             gbcOpenButton.anchor = GridBagConstraints.SOUTHEAST;
 
-            gbcOkButton.gridx = 1;
+            gbcCopyButton.gridx = ++gridx;
+            gbcCopyButton.gridy = 1;
+            gbcCopyButton.insets = insets;
+            gbcCopyButton.anchor = GridBagConstraints.SOUTHEAST;
+
+            gbcOkButton.gridx = ++gridx;
             gbcOkButton.gridy = 1;
-            gbcOkButton.insets = new Insets(2, 2, 2, 2);
+            gbcOkButton.insets = insets;
             gbcOkButton.anchor = GridBagConstraints.SOUTHEAST;
 
             mainPanel.add(getSupportPanel(), gbcPanel);
             mainPanel.add(getBtnOpen(), gbcOpenButton);
+            mainPanel.add(getBtnCopy(), gbcCopyButton);
+            this.getRootPane().setDefaultButton(getBtnCopy());
             mainPanel.add(getBtnOK(), gbcOkButton);
         }
         return mainPanel;
@@ -123,13 +133,7 @@ public class ZapSupportDialog extends AbstractDialog {
         if (btnOK == null) {
             btnOK = new JButton();
             btnOK.setText(Constant.messages.getString("all.button.ok"));
-            btnOK.addActionListener(
-                    new java.awt.event.ActionListener() {
-                        @Override
-                        public void actionPerformed(java.awt.event.ActionEvent e) {
-                            ZapSupportDialog.this.dispose();
-                        }
-                    });
+            btnOK.addActionListener(e -> ZapSupportDialog.this.dispose());
         }
         return btnOK;
     }
@@ -145,19 +149,32 @@ public class ZapSupportDialog extends AbstractDialog {
             btnOpen.setText(Constant.messages.getString("support.open.button"));
             btnOpen.setToolTipText(Constant.messages.getString("support.open.button.tooltip"));
             btnOpen.addActionListener(
-                    new java.awt.event.ActionListener() {
-                        @Override
-                        public void actionPerformed(java.awt.event.ActionEvent e) {
-                            try {
-                                Desktop.getDesktop().open(new File(Constant.getZapHome()));
-                            } catch (IOException e1) {
-                                LOGGER.error(
-                                        "An exception occurred while trying to have the OS open ZAP's Home Directory.",
-                                        e1);
-                            }
+                    e -> {
+                        try {
+                            Desktop.getDesktop().open(new File(Constant.getZapHome()));
+                        } catch (IOException e1) {
+                            LOGGER.error(
+                                    "An exception occurred while trying to have the OS open ZAP's Home Directory.",
+                                    e1);
                         }
                     });
         }
         return btnOpen;
+    }
+
+    private JButton getBtnCopy() {
+        if (btnCopy == null) {
+            btnCopy = new JButton();
+            btnCopy.setText(Constant.messages.getString("support.copy.button"));
+            btnCopy.setToolTipText(Constant.messages.getString("support.copy.button.tooltip"));
+            btnCopy.addActionListener(
+                    e -> {
+                        StringSelection stringSelection =
+                                new StringSelection(supportPanel.getSupportInfo());
+                        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+                        clipboard.setContents(stringSelection, null);
+                    });
+        }
+        return btnCopy;
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/view/ZapSupportPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ZapSupportPanel.java
@@ -30,6 +30,7 @@ import org.zaproxy.zap.utils.ZapSupportUtils;
 public class ZapSupportPanel extends JPanel {
 
     private static final long serialVersionUID = 1L;
+    private JTextArea supportDetailsTextArea = new JTextArea(20, 0);
 
     /** Constructs an {@code ZapSupportPanel}. */
     public ZapSupportPanel() {
@@ -37,7 +38,6 @@ public class ZapSupportPanel extends JPanel {
 
         GridBagConstraints gbcSupportDetails = new GridBagConstraints();
 
-        JTextArea supportDetailsTextArea = new JTextArea(20, 0);
         supportDetailsTextArea.setEditable(false);
 
         supportDetailsTextArea.setText(ZapSupportUtils.getAll(true));
@@ -54,5 +54,9 @@ public class ZapSupportPanel extends JPanel {
         gbcSupportDetails.insets = new Insets(2, 2, 2, 2);
 
         this.add(new JScrollPane(supportDetailsTextArea), gbcSupportDetails);
+    }
+
+    public String getSupportInfo() {
+        return supportDetailsTextArea.getText();
     }
 }

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -3132,7 +3132,9 @@ support.locale.display.label = Display Locale:
 support.locale.format.label = Format Locale:
 support.locale.system.label = System's Locale:
 support.operating.system.label = Operating System:
-support.open.button = Open
+support.copy.button = Copy
+support.copy.button.tooltip = Copy the displayed support information
+support.open.button = Open ZAP Home
 support.open.button.tooltip = Open ZAP's Home Directory
 support.version.label = Version:
 


### PR DESCRIPTION
- ZapSupportDialog.java > Add copy button. Set new copy button as default. Address some SAST (sonarlint) items, method hiding, anonymous inner classes on listeners.
- ZapSupportPanel > Add utility method to return the content from the support info textarea.
- Messages.properties > Add necessary key/value pairs. Update label text for the Open button to make it more specific and user friendly.

![image](https://user-images.githubusercontent.com/7570458/153870681-f6bd312b-316d-4be8-b306-29e7972a8334.png)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>