### PR TITLE
Integration Tests: Fix session-script test

### DIFF
--- a/docker/integration_tests/configs/plans/contexts/session-script.context
+++ b/docker/integration_tests/configs/plans/contexts/session-script.context
@@ -66,7 +66,7 @@
             <type>2</type>
             <script>
                 <name>session-mgmt-script.js</name>
-                <params>YWFh:QUFB&amp;Y2Nj:Q0ND&amp;YmJi:QkJC&amp;ZGRk:RERE</params>
+                <params>YWFh:QUFB&amp;Y2Nj:Q0ND&amp;YmJi:QkJC&amp;ZGRk:RERE&amp;c2NyaXB0RW5naW5l:T3JhY2xlIE5hc2hvcm4=&amp;c2NyaXB0:L3phcC93cmsvY29uZmlncy9zY3JpcHRzL3Nlc3Npb24vc2Vzc2lvbi1tZ210LXNjcmlwdC5qcw==</params>
             </script>
         </session>
         <authorization>


### PR DESCRIPTION
The Script engine and file name are now added to the script parameters, hence the difference when we compare the session files.

https://github.com/zaproxy/zaproxy/runs/5297437578?check_suite_focus=true

Signed-off-by: Simon Bennetts <psiinon@gmail.com>