### PR TITLE
Allow Default threshold OFF

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -829,12 +829,21 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
     @Override
     public void setAlertThreshold(AlertThreshold level) {
         setProperty("level", level.name());
-        setEnabled(level != AlertThreshold.OFF);
+        setEnabledFromLevel();
     }
 
     @Override
     public void setDefaultAlertThreshold(AlertThreshold level) {
         this.defaultAttackThreshold = level;
+        setEnabledFromLevel();
+    }
+
+    private void setEnabledFromLevel() {
+        AlertThreshold level = getAlertThreshold(true);
+        setEnabled(
+                level != AlertThreshold.OFF
+                        && !(level == AlertThreshold.DEFAULT
+                                && this.defaultAttackThreshold == AlertThreshold.OFF));
     }
 
     /** Override this if you plugin supports other levels. */

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyAllCategoryPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyAllCategoryPanel.java
@@ -587,6 +587,7 @@ public class PolicyAllCategoryPanel extends AbstractParamPanel {
     private JComboBox<String> getComboThreshold() {
         if (comboThreshold == null) {
             comboThreshold = new JComboBox<>();
+            comboThreshold.addItem(Constant.messages.getString("ascan.options.level.off"));
             comboThreshold.addItem(Constant.messages.getString("ascan.options.level.low"));
             comboThreshold.addItem(Constant.messages.getString("ascan.options.level.medium"));
             comboThreshold.addItem(Constant.messages.getString("ascan.options.level.high"));
@@ -596,6 +597,17 @@ public class PolicyAllCategoryPanel extends AbstractParamPanel {
                         public void actionPerformed(ActionEvent e) {
                             // Set the explanation and save
                             if (comboThreshold
+                                    .getSelectedItem()
+                                    .equals(
+                                            Constant.messages.getString(
+                                                    "ascan.options.level.off"))) {
+                                getThresholdNotes()
+                                        .setText(
+                                                Constant.messages.getString(
+                                                        "ascan.options.level.off.label"));
+                                policy.setDefaultThreshold(AlertThreshold.OFF);
+
+                            } else if (comboThreshold
                                     .getSelectedItem()
                                     .equals(
                                             Constant.messages.getString(

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanPolicy.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanPolicy.java
@@ -96,9 +96,9 @@ public class ScanPolicy {
     }
 
     public void setDefaultThreshold(AlertThreshold defaultThreshold) {
-        if (defaultThreshold == AlertThreshold.OFF || defaultThreshold == AlertThreshold.DEFAULT) {
+        if (defaultThreshold == AlertThreshold.DEFAULT) {
             throw new IllegalArgumentException(
-                    "Default threshold must be one of LOW, MEDIUM, or HIGH.");
+                    "Default threshold must be one of OFF, LOW, MEDIUM, or HIGH.");
         }
         this.defaultThreshold = defaultThreshold;
         for (Plugin plugin : pluginFactory.getAllPlugin()) {
@@ -125,7 +125,6 @@ public class ScanPolicy {
         String alertThreshold = conf.getString("scanner.level", "");
         if (alertThreshold.isEmpty()
                 || !EnumUtils.isValidEnum(AlertThreshold.class, alertThreshold)
-                || AlertThreshold.OFF.name().equals(alertThreshold)
                 || AlertThreshold.DEFAULT.name().equals(alertThreshold)) {
             logger.warn(
                     "Found illegal value {} for alert threshold, using MEDIUM instead.",

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -484,6 +484,7 @@ ascan.options.go.button			= Go
 ascan.options.level.label	   = Default Alert Threshold:
 ascan.options.level.default	   = Default
 ascan.options.level.off		   = Off
+ascan.options.level.off.label  = (All rules turned off)
 ascan.options.level.low		   = Low
 ascan.options.level.low.label  = (More potential issues flagged)
 ascan.options.level.medium	   = Medium

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/AbstractPluginUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/AbstractPluginUnitTest.java
@@ -40,6 +40,7 @@ import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.parosproxy.paros.Constant;
@@ -189,6 +190,51 @@ class AbstractPluginUnitTest extends PluginTestUtils {
     void shouldBeEnabledByDefault() {
         // Given / When
         AbstractPlugin plugin = createAbstractPlugin();
+        // Then
+        assertThat(plugin.isEnabled(), is(equalTo(Boolean.TRUE)));
+    }
+
+    @Test
+    void shouldBeDisabledWhenOffThresholdSet() {
+        // Given
+        AbstractPlugin plugin = createAbstractPluginWithConfig();
+        // When
+        plugin.setAlertThreshold(AlertThreshold.OFF);
+        // Then
+        assertThat(plugin.isEnabled(), is(equalTo(Boolean.FALSE)));
+    }
+
+    @Test
+    void shouldBeDisabledWhenDefaultOffThresholdSet() {
+        // Given
+        AbstractPlugin plugin = createAbstractPluginWithConfig();
+        // When
+        plugin.setDefaultAlertThreshold(AlertThreshold.OFF);
+        // Then
+        assertThat(plugin.isEnabled(), is(equalTo(Boolean.FALSE)));
+    }
+
+    @Test
+    void shouldBeDisabledWhenOffAndDefaultOffThresholdSet() {
+        // Given
+        AbstractPlugin plugin = createAbstractPluginWithConfig();
+        // When
+        plugin.setAlertThreshold(AlertThreshold.OFF);
+        plugin.setDefaultAlertThreshold(AlertThreshold.OFF);
+        // Then
+        assertThat(plugin.isEnabled(), is(equalTo(Boolean.FALSE)));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = AlertThreshold.class,
+            names = {"LOW", "MEDIUM", "HIGH"})
+    void shouldBeEnabledWhenThresholdSetButDefaultOff(AlertThreshold threshold) {
+        // Given
+        AbstractPlugin plugin = createAbstractPluginWithConfig();
+        // When
+        plugin.setDefaultAlertThreshold(AlertThreshold.OFF);
+        plugin.setAlertThreshold(threshold);
         // Then
         assertThat(plugin.isEnabled(), is(equalTo(Boolean.TRUE)));
     }
@@ -406,7 +452,6 @@ class AbstractPluginUnitTest extends PluginTestUtils {
         pluginA.setDefaultAttackStrength(Plugin.AttackStrength.LOW);
         pluginA.setTechSet(TechSet.getAllTech());
         pluginA.setStatus(AddOn.Status.beta);
-        pluginA.setEnabled(false);
         AbstractPlugin pluginB = createAbstractPluginWithConfig();
         // When
         pluginA.cloneInto(pluginB);

--- a/zap/src/test/java/org/zaproxy/zap/extension/ascan/ScanPolicyUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/ascan/ScanPolicyUnitTest.java
@@ -25,8 +25,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.parosproxy.paros.core.scanner.Plugin;
 import org.zaproxy.zap.WithConfigsTest;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
@@ -81,18 +79,14 @@ class ScanPolicyUnitTest extends WithConfigsTest {
         assertThat(scanPolicy.getDefaultStrength(), is(equalTo(Plugin.AttackStrength.MEDIUM)));
     }
 
-    @ParameterizedTest
-    @EnumSource(
-            value = Plugin.AlertThreshold.class,
-            names = {"OFF", "DEFAULT"})
-    void shouldThrowIfDefaultScannerLevelIsSetToOffOrDefault(Plugin.AlertThreshold alertThreshold)
-            throws Exception {
+    @Test
+    void shouldThrowIfDefaultScannerLevelIsSetToDefault() throws Exception {
         // Given
         ScanPolicy scanPolicy = new ScanPolicy();
         // When / Then
         assertThrows(
                 IllegalArgumentException.class,
-                () -> scanPolicy.setDefaultThreshold(alertThreshold));
+                () -> scanPolicy.setDefaultThreshold(Plugin.AlertThreshold.DEFAULT));
     }
 
     @Test
@@ -105,15 +99,11 @@ class ScanPolicyUnitTest extends WithConfigsTest {
                 () -> scanPolicy.setDefaultStrength(Plugin.AttackStrength.DEFAULT));
     }
 
-    @ParameterizedTest
-    @EnumSource(
-            value = Plugin.AlertThreshold.class,
-            names = {"OFF", "DEFAULT"})
-    void shouldUseMediumIfDefaultScannerLevelFromConfigIsOffOrDefault(
-            Plugin.AlertThreshold alertThreshold) throws Exception {
+    @Test
+    void shouldUseMediumIfDefaultScannerLevelFromConfigIsDefault() throws Exception {
         // Given
         ZapXmlConfiguration conf = new ZapXmlConfiguration();
-        conf.setProperty(DEFAULT_SCANNER_LEVEL_KEY, alertThreshold.name());
+        conf.setProperty(DEFAULT_SCANNER_LEVEL_KEY, Plugin.AlertThreshold.DEFAULT.name());
         // When
         ScanPolicy scanPolicy = new ScanPolicy(conf);
         // Then


### PR DESCRIPTION
Undoing part of the change done in https://github.com/zaproxy/zaproxy/pull/7110 ;)
But also allowing the option to be set in the GUI.
Its a perfectly valid and very useful option as it allows people to explicitly enable specific rules.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>