### PR TITLE
Add Java 17 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11]
+        java: [8, 11, 17]
 
     steps:
       - uses: actions/checkout@v2

--- a/zap/src/main/java/org/zaproxy/zap/spider/Spider.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/Spider.java
@@ -873,8 +873,7 @@ public class Spider {
         public SpiderThreadFactory(String namePrefix) {
             threadNumber = new AtomicInteger(1);
             this.namePrefix = namePrefix;
-            SecurityManager s = System.getSecurityManager();
-            group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+            group = Thread.currentThread().getThreadGroup();
         }
 
         @Override

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -100,7 +100,7 @@ dependencies {
         setTransitive(false)
     }
 
-    testImplementation("com.github.tomakehurst:wiremock-jre8:2.31.0") {
+    testImplementation("com.github.tomakehurst:wiremock-jre8:2.32.0") {
         // Not needed.
         exclude(group = "org.junit")
     }


### PR DESCRIPTION
Build with Java 17 which is a LTS version.
Address deprecation warning (remove Security Manager usage which will
be removed in a future release, JEP 411).
Update Wiremock which supports newer Java version.