### PR TITLE
Skip empty javascript URIs when canonicalizing

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/spider/URLCanonicalizer.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/URLCanonicalizer.java
@@ -103,6 +103,9 @@ public final class URLCanonicalizer {
      * @return the canonical url
      */
     public static String getCanonicalURL(String url, String baseURL) {
+        if ("javascript:".equals(url)) {
+            return null;
+        }
 
         try {
             /* Build the absolute URL, from the url and the baseURL */

--- a/zap/src/test/java/org/zaproxy/zap/spider/URLCanonicalizerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/URLCanonicalizerUnitTest.java
@@ -26,6 +26,8 @@ import static org.hamcrest.Matchers.is;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.zaproxy.zap.spider.SpiderParam.HandleParametersOption;
 
 /**
@@ -142,16 +144,19 @@ class URLCanonicalizerUnitTest {
         }
     }
 
-    @Test
-    void shouldIgnoreURIsWithNoAuthority() {
-        // Given
-        String[] uris = {"javascript:ignore()", "mailto:ignore@example.com"};
-        for (String uri : uris) {
-            // When
-            String canonicalizedUri = URLCanonicalizer.getCanonicalURL(uri);
-            // Then
-            assertThat(canonicalizedUri, canonicalizedUri, is(equalTo(null)));
-        }
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "javascript:",
+                "javascript:ignore()",
+                "mailto:ignore@example.com",
+                "tel:+1-900-555-0191"
+            })
+    void shouldIgnoreURIsWithNoAuthority(String uri) {
+        // Given / When
+        String canonicalizedUri = URLCanonicalizer.getCanonicalURL(uri);
+        // Then
+        assertThat(canonicalizedUri, canonicalizedUri, is(equalTo(null)));
     }
 
     @Test


### PR DESCRIPTION
Do not try to canonicalize empty javascript URIs, it just leads to
unnecessary log warnings when pages are crawled.
Parameterize related test, add the empty javascript URI and a tel URI
for another example scheme that's ignored.
