### PR TITLE
chore: Upgrade Dependencies

### DIFF
--- a/LEGALNOTICE.md
+++ b/LEGALNOTICE.md
@@ -49,7 +49,7 @@ and subject to their respective licenses.
 | commons-text-1.9.jar                | Apache 2.0                |
 | commons-validator-1.7.jar           | Apache 2.0                |
 | ezmorph-1.0.6.jar                   | Apache 2.0                |
-| flatlaf-2.0.1.jar                   | Apache 2.0                |
+| flatlaf-2.0.2.jar                   | Apache 2.0                |
 | harlib-1.1.3.jar                    | Apache 2.0                |
 | hsqldb-2.5.2.jar                    | BSD                       |
 | ice4j-3.0-24-g34c2ce5.jar           | Apache 2.0                |
@@ -60,10 +60,10 @@ and subject to their respective licenses.
 | jfreechart-1.5.3.jar                | LGPL                      |
 | jgrapht-core-0.9.0.jar              | LGPL 2.1                  |
 | json-lib-2.4-jdk15.jar              | MIT + "Good, Not Evil"    |
-| log4j-1.2-api-2.17.1.jar            | Apache 2.0                |
-| log4j-api-2.17.1.jar                | Apache 2.0                |
-| log4j-core-2.17.1.jar               | Apache 2.0                |
-| rsyntaxtextarea-3.1.4.jar           | BSD-3 clause              |
+| log4j-1.2-api-2.17.2.jar            | Apache 2.0                |
+| log4j-api-2.17.2.jar                | Apache 2.0                |
+| log4j-core-2.17.2.jar               | Apache 2.0                |
+| rsyntaxtextarea-3.2.0.jar           | BSD-3 clause              |
 | sqlite-jdbc-3.36.0.3.jar            | BSD-2 clause              |
 | - NestedVM                          | Apache 2.0                |
 | swingx-all-1.6.5-1.jar              | LGPL 2.1                  |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import net.ltgt.gradle.errorprone.errorprone
 plugins {
     id("com.diffplug.spotless")
     id("org.sonarqube") version "3.3"
-    id("com.github.ben-manes.versions") version "0.39.0"
+    id("com.github.ben-manes.versions") version "0.42.0"
     id("net.ltgt.errorprone") version "2.0.2"
 }
 

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -56,7 +56,7 @@ tasks.named<JacocoReport>("jacocoTestReport") {
 }
 
 dependencies {
-    api("com.fifesoft:rsyntaxtextarea:3.1.4")
+    api("com.fifesoft:rsyntaxtextarea:3.2.0")
     api("com.github.zafarkhaja:java-semver:0.9.0")
     api("commons-beanutils:commons-beanutils:1.9.4")
     api("commons-codec:commons-codec:1.15")
@@ -69,7 +69,7 @@ dependencies {
     api("org.apache.commons:commons-text:1.9")
     api("edu.umass.cs.benchlab:harlib:1.1.3")
     api("javax.help:javahelp:2.0.05")
-    val log4jVersion = "2.17.1"
+    val log4jVersion = "2.17.2"
     api("org.apache.logging.log4j:log4j-api:$log4jVersion")
     api("org.apache.logging.log4j:log4j-1.2-api:$log4jVersion")
     implementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
@@ -92,7 +92,7 @@ dependencies {
     implementation("org.jitsi:ice4j:3.0-24-g34c2ce5") {
         setTransitive(false)
     }
-    implementation("com.formdev:flatlaf:2.0.1")
+    implementation("com.formdev:flatlaf:2.0.2")
 
     runtimeOnly("commons-jxpath:commons-jxpath:1.3")
     runtimeOnly("commons-logging:commons-logging:1.2")
@@ -105,11 +105,11 @@ dependencies {
         exclude(group = "org.junit")
     }
     testImplementation("org.hamcrest:hamcrest-core:2.2")
-    val jupiterVersion = "5.8.1"
+    val jupiterVersion = "5.8.2"
     testImplementation("org.junit.jupiter:junit-jupiter-api:$jupiterVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-params:$jupiterVersion")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$jupiterVersion")
-    testImplementation("org.mockito:mockito-junit-jupiter:4.0.0")
+    testImplementation("org.mockito:mockito-junit-jupiter:4.4.0")
     testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion")
     testImplementation("org.nanohttpd:nanohttpd-webserver:2.3.1")
 


### PR DESCRIPTION
https://logging.apache.org/log4j/2.x/changes-report.html#a2.17.2

Log4j to 2.17.2
flatlaf to 2.0.2
rsyntxtextarea to 3.2.0

As well as junit/mockito bits, errorprone, and versions.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>