### PR TITLE
Spider: Parse Links from embed src

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderHtmlParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderHtmlParser.java
@@ -153,6 +153,12 @@ public class SpiderHtmlParser extends SpiderParser {
             resourcesfound |= processAttributeElement(message, depth, baseURL, el, "ping");
         }
 
+        // Process Embed Elements
+        elements = source.getAllElements(HTMLElementName.EMBED);
+        for (Element el : elements) {
+            resourcesfound |= processAttributeElement(message, depth, baseURL, el, "src");
+        }
+
         // Process Frame Elements
         elements = source.getAllElements(HTMLElementName.FRAME);
         for (Element el : elements) {

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlParserUnitTest.java
@@ -409,6 +409,32 @@ class SpiderHtmlParserUnitTest extends SpiderParserTestUtils {
     }
 
     @Test
+    void shouldFindUrlsInEmbedElements() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("EmbedElementsSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed =
+                htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(7)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "http://embed.example.com/base/scheme",
+                        "http://embed.example.com:8000/b",
+                        "https://embed.example.com/c?a=b",
+                        "http://example.com/sample/embed/relative",
+                        "http://example.com/sample/",
+                        "http://example.com/embed/absolute",
+                        "ftp://embed.example.com/"));
+    }
+
+    @Test
     void shouldFindUrlsInFrameElements() {
         // Given
         SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());

--- a/zap/src/test/resources/org/zaproxy/zap/spider/parser/html/EmbedElementsSpiderHtmlParser.html
+++ b/zap/src/test/resources/org/zaproxy/zap/spider/parser/html/EmbedElementsSpiderHtmlParser.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://example.com/sample/">
+<meta charset="UTF-8">
+<title>Enbed Elements - Spider HTML Parser</title>
+</head>
+<body>
+
+<embed src="//embed.example.com/base/scheme">
+<embed src="http://embed.example.com:8000/b">
+<embed src="https://embed.example.com/c?a=b#fragment">
+<embed src="embed/relative">
+<embed src="">
+<embed src="/embed/absolute">
+<embed src="ftp://embed.example.com/">
+
+<!--  Ignored: -->
+<embed>
+<embed src="mailto:embed@example.com">
+<embed src="javascript:hello();">
+<embed src="scheme://embed.example.com/invalid">
+
+</body>
+</html>


### PR DESCRIPTION
- EmbedElementsSpiderHtmlParser.html > Test resource file.
- SpiderHtmlParser > Updated to include embed elements' src attributes.
- SpiderHtmlParserUnitTest > Updated to assert the new behavior.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>