### PR TITLE
Fix loss of new line chars when converting msg with GZIP HTTP responses into an ApiResponseSet

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ApiResponseConversionUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ApiResponseConversionUtils.java
@@ -19,16 +19,11 @@
  */
 package org.zaproxy.zap.extension.api;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.zip.GZIPInputStream;
 import net.sf.json.JSON;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
@@ -37,7 +32,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.model.HistoryReference;
-import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -89,28 +83,7 @@ public final class ApiResponseConversionUtils {
         map.put("requestHeader", msg.getRequestHeader().toString());
         map.put("requestBody", msg.getRequestBody().toString());
         map.put("responseHeader", msg.getResponseHeader().toString());
-
-        if (HttpHeader.GZIP.equals(
-                msg.getResponseHeader().getHeader(HttpHeader.CONTENT_ENCODING))) {
-            // Uncompress gziped content
-            try (ByteArrayInputStream bais =
-                            new ByteArrayInputStream(msg.getResponseBody().getBytes());
-                    GZIPInputStream gis = new GZIPInputStream(bais);
-                    InputStreamReader isr = new InputStreamReader(gis);
-                    BufferedReader br = new BufferedReader(isr); ) {
-                StringBuilder sb = new StringBuilder();
-                String line = null;
-                while ((line = br.readLine()) != null) {
-                    sb.append(line);
-                }
-                map.put("responseBody", sb.toString());
-            } catch (IOException e) {
-                LOGGER.error("Unable to uncompress gzip content: " + e.getMessage(), e);
-                map.put("responseBody", msg.getResponseBody().toString());
-            }
-        } else {
-            map.put("responseBody", msg.getResponseBody().toString());
-        }
+        map.put("responseBody", msg.getResponseBody().toString());
 
         List<String> tags = Collections.emptyList();
         try {

--- a/zap/src/test/java/org/zaproxy/zap/extension/api/ApiResponseConversionUtilsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/api/ApiResponseConversionUtilsUnitTest.java
@@ -24,14 +24,11 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 
-import java.io.ByteArrayOutputStream;
-import java.util.zip.GZIPOutputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
@@ -111,33 +108,5 @@ class ApiResponseConversionUtilsUnitTest {
         assertThat(response.getValues(), hasEntry("responseHeader", responseHeader.toString()));
         assertThat(response.getValues(), hasEntry("timestamp", "1010101010101"));
         assertThat(response.getValues(), hasEntry("rtt", "200"));
-    }
-
-    @Test
-    void compressedResponseBodyShouldBeDeflatedIntoApiResponse() throws Exception {
-        given(responseHeader.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn(HttpHeader.GZIP);
-        given(responseBody.getBytes()).willReturn(gzip(new byte[] {97, 98, 99}));
-
-        ApiResponseSet<String> response = ApiResponseConversionUtils.httpMessageToSet(0, message);
-
-        assertThat(response.getValues(), hasEntry("responseBody", "abc"));
-    }
-
-    @Test
-    void brokenCompressedResponseBodyShouldBeStoredAsStringRepresentationInApiResponse() {
-        given(responseHeader.getHeader(HttpHeader.CONTENT_ENCODING)).willReturn(HttpHeader.GZIP);
-        given(responseBody.getBytes()).willReturn(new byte[] {0, 0, 0});
-
-        ApiResponseSet<String> response = ApiResponseConversionUtils.httpMessageToSet(0, message);
-
-        assertThat(response.getValues(), hasEntry("responseBody", responseBody.toString()));
-    }
-
-    private static byte[] gzip(byte[] raw) throws Exception {
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream(raw.length);
-        try (GZIPOutputStream zip = new GZIPOutputStream(bytes)) {
-            zip.write(raw);
-        }
-        return bytes.toByteArray();
     }
 }


### PR DESCRIPTION
Closes https://github.com/zaproxy/zaproxy/issues/7171

I couldn't find any changelog file, let me know if the PR misses something.
