### PR TITLE
Follow unencoded redirects

### DIFF
--- a/zap/src/main/java/org/apache/commons/httpclient/HttpMethodDirector.java
+++ b/zap/src/main/java/org/apache/commons/httpclient/HttpMethodDirector.java
@@ -686,7 +686,11 @@ public class HttpMethodDirector {
 			);
 			
             String charset = method.getParams().getUriCharset();
-            redirectUri = new URI(location, true, charset);
+            try {
+                redirectUri =  new URI(location, true, charset);
+            } catch (URIException ex) {
+                redirectUri =  new URI(location, false, charset);
+            }
 			
             if (redirectUri.isRelativeURI()) {
 				if (this.params.isParameterTrue(HttpClientParams.REJECT_RELATIVE_REDIRECT)) {


### PR DESCRIPTION
If a redirect location is not encoded zap will throw an exception and not follow the redirect
![image](https://user-images.githubusercontent.com/6045401/160683876-a37f7ba4-21ad-4c23-af4b-74e02bca6f63.png)
```
HTTP/1.1 302 Found
Date: Tue, 29 Mar 2022 18:47:19 GMT
Server: Apache/2.4.38 (Debian)
Location: ./error.php?msg=Error, need to provide a query to sear
Content-Length: 0
Content-Type: text/html; charset=UTF-8
```

there is an example on the `WackoPicko` `/error?msg=...` endpoint.
The browsers follow this redirects, so I think zap should also support them.

Could add a test but need to change the method permission to access it directly