### PR TITLE
Deprecate HttpUtil

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyServer.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyServer.java
@@ -63,7 +63,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.ConnectionParam;
-import org.parosproxy.paros.network.HttpUtil;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.PersistentConnectionListener;
 
@@ -294,7 +293,7 @@ public class ProxyServer implements Runnable {
         }
 
         isProxyRunning = false;
-        HttpUtil.closeServerSocket(proxySocket);
+        org.parosproxy.paros.network.HttpUtil.closeServerSocket(proxySocket);
 
         try {
             thread.join(); // (PORT_TIME_OUT);

--- a/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyThread.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyThread.java
@@ -122,7 +122,6 @@ import org.parosproxy.paros.network.HttpOutputStream;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.network.HttpSender;
-import org.parosproxy.paros.network.HttpUtil;
 import org.zaproxy.zap.PersistentConnectionListener;
 import org.zaproxy.zap.ZapGetMethod;
 import org.zaproxy.zap.extension.api.API;
@@ -687,7 +686,7 @@ public class ProxyThread implements Runnable {
             }
         }
 
-        HttpUtil.closeSocket(inSocket);
+        org.parosproxy.paros.network.HttpUtil.closeSocket(inSocket);
 
         if (httpSender != null) {
             httpSender.shutdown();

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpUtil.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpUtil.java
@@ -22,6 +22,7 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2021/09/18 Remove commented code.
+// ZAP: 2022/04/10 Deprecated.
 package org.parosproxy.paros.network;
 
 import java.io.InputStream;
@@ -30,6 +31,11 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URISyntaxException;
 
+/**
+ * @deprecated (2.12.0) No longer in effective use by core. It will be removed in a following
+ *     release.
+ */
+@Deprecated
 public class HttpUtil {
 
     public static String encodeURI(String uri) throws URISyntaxException {


### PR DESCRIPTION
No longer in effective use (only used by deprecated core classes).