### PR TITLE
Remove -nouseragent and deprecate related methods

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/CommandLine.java
+++ b/zap/src/main/java/org/parosproxy/paros/CommandLine.java
@@ -50,6 +50,7 @@
 // ZAP: 2021/05/14 Remove redundant type arguments.
 // ZAP: 2022/02/09 No longer parse host/port and deprecate related code.
 // ZAP: 2022/02/28 Remove code deprecated in 2.6.0
+// ZAP: 2022/04/11 Remove -nouseragent option.
 package org.parosproxy.paros;
 
 import java.io.File;
@@ -66,7 +67,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.extension.CommandLineArgument;
 import org.parosproxy.paros.extension.CommandLineListener;
-import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.zap.ZAP;
 
 public class CommandLine {
@@ -117,8 +117,6 @@ public class CommandLine {
      * @since 2.8.0
      */
     public static final String DEV_MODE = "-dev";
-
-    static final String NO_USER_AGENT = "-nouseragent";
 
     private boolean GUI = true;
     private boolean daemon = false;
@@ -325,12 +323,7 @@ public class CommandLine {
 
         boolean result = false;
 
-        if (checkSwitch(args, NO_USER_AGENT, i)) {
-            HttpSender.setUserAgent("");
-            Constant.setEyeCatcher("");
-            result = true;
-
-        } else if (checkSwitch(args, CMD, i)) {
+        if (checkSwitch(args, CMD, i)) {
             setDaemon(false);
             setGUI(false);
 

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
@@ -90,6 +90,7 @@
 // ZAP: 2022/01/04 Add initiator constant OAST_INITIATOR for OAST requests.
 // ZAP: 2022/04/08 Deprecate getSSLConnector() and executeMethod.
 // ZAP: 2022/04/10 Add support for unencoded redirects
+// ZAP: 2022/04/11 Deprecate set/getUserAgent() and remove userAgent/modifyUserAgent().
 package org.parosproxy.paros.network;
 
 import java.io.IOException;
@@ -181,7 +182,6 @@ public class HttpSender {
     }
 
     private static HttpMethodHelper helper = new HttpMethodHelper();
-    private static String userAgent = "";
     private static final ThreadLocal<Boolean> IN_LISTENER = new ThreadLocal<>();
 
     private HttpClient client = null;
@@ -682,7 +682,6 @@ public class HttpSender {
             throws IOException {
         HttpMethod method = null;
         // no more retry
-        modifyUserAgent(msg);
         method = helper.createRequestMethod(msg.getRequestHeader(), msg.getRequestBody(), params);
         if (!(method instanceof EntityEnclosingMethod) || method instanceof ZapGetMethod) {
             // cant do this for EntityEnclosingMethod methods - it will fail
@@ -705,45 +704,23 @@ public class HttpSender {
         this.followRedirect = followRedirect;
     }
 
-    private void modifyUserAgent(HttpMessage msg) {
-
-        try {
-            // no modification to user agent if empty
-            if (userAgent.equals("") || msg.getRequestHeader().isEmpty()) {
-                return;
-            }
-
-            // append new user agent to existing user agent
-            String currentUserAgent = msg.getRequestHeader().getHeader(HttpHeader.USER_AGENT);
-            if (currentUserAgent == null) {
-                currentUserAgent = "";
-            }
-
-            if (currentUserAgent.indexOf(userAgent) >= 0) {
-                // user agent already in place, exit
-                return;
-            }
-
-            String delimiter = "";
-            if (!currentUserAgent.equals("") && !currentUserAgent.endsWith(" ")) {
-                delimiter = " ";
-            }
-
-            currentUserAgent = currentUserAgent + delimiter + userAgent;
-            msg.getRequestHeader().setHeader(HttpHeader.USER_AGENT, currentUserAgent);
-        } catch (Exception e) {
-        }
-    }
-
-    /** @return Returns the userAgent. */
+    /**
+     * @return Returns the userAgent.
+     * @deprecated (2.12.0) No longer supported, it returns an empty string.
+     * @see #setUserAgent(String)
+     */
+    @Deprecated
     public static String getUserAgent() {
-        return userAgent;
+        return "";
     }
 
-    /** @param userAgent The userAgent to set. */
-    public static void setUserAgent(String userAgent) {
-        HttpSender.userAgent = userAgent;
-    }
+    /**
+     * @param userAgent The userAgent to set.
+     * @deprecated (2.12.0) No longer supported, use a {@link HttpSenderListener} to actually set
+     *     the user agent.
+     */
+    @Deprecated
+    public static void setUserAgent(String userAgent) {}
 
     private void setCommonManagerParams(MultiThreadedHttpConnectionManager mgr) {
         int timeout = (int) TimeUnit.SECONDS.toMillis(this.param.getTimeoutInSecs());


### PR DESCRIPTION
Remove the undocumented/Paros command line option `-nouseragent`,
didn't do anything anymore (the user agent was already an empty string
which would have no effect later when attempting to change it).
Deprecate `HttpSender#setUserAgent` and `getUserAgent()`, the user
agent was not being set but appended, also, better alternatives exist
to actually set/change it programmatically (e.g. `HttpSenderListener`).
Remove related instance variable and private method no longer needed.