### PR TITLE
Do not validate the policy ID if not provided

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
@@ -1061,7 +1061,9 @@ public class ActiveScanAPI extends ApiImplementor {
                 List<Plugin> scanners = policy.getPluginFactory().getAllPlugin();
 
                 categoryId = getParam(params, PARAM_CATEGORY_ID, -1);
-                verifyCategoryId(categoryId, PARAM_CATEGORY_ID);
+                if (categoryId != -1) {
+                    verifyCategoryId(categoryId, PARAM_CATEGORY_ID);
+                }
                 resultList = new ApiResponseList(name);
                 for (Plugin scanner : scanners) {
                     if (categoryId == -1 || categoryId == scanner.getCategory()) {


### PR DESCRIPTION
Add a check to prevent the validation when the policy ID is not
provided.

Fix #7218.