### PR TITLE
chore: Remove triple hyphen lines from Support Info output

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/utils/ZapSupportUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/ZapSupportUtils.java
@@ -136,9 +136,9 @@ public final class ZapSupportUtils {
     public static String getAll(boolean formatted) {
         StringBuilder installedAddons = new StringBuilder(200);
         if (formatted) {
-            installedAddons.append("---").append(NEWLINE);
+            installedAddons.append(NEWLINE);
             installedAddons.append(WordUtils.wrap(getInstalledAddons(), 60)).append(NEWLINE);
-            installedAddons.append("---").append(NEWLINE);
+            installedAddons.append(NEWLINE);
         } else {
             installedAddons.append(getInstalledAddons()).append(NEWLINE);
         }


### PR DESCRIPTION
- Drop the `---` to prevent them from being interpreted as a MD heading tag when included in tickets.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>