### PR TITLE
Use main connection options directly

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/HostProcess.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/HostProcess.java
@@ -100,6 +100,7 @@
 // ZAP: 2021/09/14 No longer force single threading if Anti CSRF handling turned on.
 // ZAP: 2021/09/30 Pass plugin to PluginStats instead of just the name.
 // ZAP: 2022/02/25 Remove code deprecated in 2.5.0
+// ZAP: 2022/04/23 Use new HttpSender constructor.
 package org.parosproxy.paros.core.scanner;
 
 import java.io.IOException;
@@ -252,12 +253,32 @@ public class HostProcess implements Runnable {
      * @param scanPolicy the scan policy
      * @param ruleConfigParam the rules' configurations, might be {@code null}.
      * @since 2.6.0
+     * @deprecated (2.12.0) Use {@link #HostProcess(String, Scanner, ScannerParam, ScanPolicy,
+     *     RuleConfigParam)} instead.
      */
+    @Deprecated
     public HostProcess(
             String hostAndPort,
             Scanner parentScanner,
             ScannerParam scannerParam,
             ConnectionParam connectionParam,
+            ScanPolicy scanPolicy,
+            RuleConfigParam ruleConfigParam) {}
+
+    /**
+     * Constructs a {@code HostProcess}.
+     *
+     * @param hostAndPort the host:port value of the site that need to be processed
+     * @param parentScanner the scanner instance which instantiated this process
+     * @param scannerParam the session scanner parameters
+     * @param scanPolicy the scan policy
+     * @param ruleConfigParam the rules' configurations, might be {@code null}.
+     * @since 2.12.0
+     */
+    public HostProcess(
+            String hostAndPort,
+            Scanner parentScanner,
+            ScannerParam scannerParam,
             ScanPolicy scanPolicy,
             RuleConfigParam ruleConfigParam) {
 
@@ -271,7 +292,7 @@ public class HostProcess implements Runnable {
         this.messagesIdsToAppScan = new ArrayList<>();
         this.startNodes = new ArrayList<>();
 
-        httpSender = new HttpSender(connectionParam, true, HttpSender.ACTIVE_SCANNER_INITIATOR);
+        httpSender = new HttpSender(HttpSender.ACTIVE_SCANNER_INITIATOR);
         httpSender.setUser(this.user);
         httpSender.setRemoveUserDefinedAuthHeaders(true);
 

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Scanner.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Scanner.java
@@ -52,6 +52,7 @@
 // ZAP: 2020/11/17 Use new TechSet#getAllTech().
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2021/05/14 Remove redundant type arguments.
+// ZAP: 2022/04/23 Use new HttpSender constructor.
 package org.parosproxy.paros.core.scanner;
 
 import java.security.InvalidParameterException;
@@ -111,7 +112,6 @@ public class Scanner implements Runnable {
     // ZAP: Added a list of scannerhooks
     private Vector<ScannerHook> hookList = new Vector<>();
     private ScannerParam scannerParam = null;
-    private ConnectionParam connectionParam = null;
     private ScanPolicy scanPolicy;
     private RuleConfigParam ruleConfigParam;
     private boolean isStop = false;
@@ -154,13 +154,27 @@ public class Scanner implements Runnable {
      * @param scanPolicy the scan policy
      * @param ruleConfigParam the rules' configurations, might be {@code null}.
      * @since 2.6.0
+     * @deprecated (2.12.0) Use {@link #Scanner(ScannerParam, ScanPolicy, RuleConfigParam)} instead.
      */
+    @Deprecated
     public Scanner(
             ScannerParam scannerParam,
             ConnectionParam param,
             ScanPolicy scanPolicy,
             RuleConfigParam ruleConfigParam) {
-        this.connectionParam = param;
+        this(scannerParam, scanPolicy, ruleConfigParam);
+    }
+
+    /**
+     * Constructs a {@code Scanner}.
+     *
+     * @param scannerParam the scanner parameters
+     * @param scanPolicy the scan policy
+     * @param ruleConfigParam the rules' configurations, might be {@code null}.
+     * @since 2.12.0
+     */
+    public Scanner(
+            ScannerParam scannerParam, ScanPolicy scanPolicy, RuleConfigParam ruleConfigParam) {
         this.scannerParam = scannerParam;
         this.scanPolicy = scanPolicy;
         this.ruleConfigParam = ruleConfigParam;
@@ -317,13 +331,7 @@ public class Scanner implements Runnable {
 
     private HostProcess createHostProcess(String hostAndPort, StructuralNode node) {
         HostProcess hostProcess =
-                new HostProcess(
-                        hostAndPort,
-                        this,
-                        scannerParam,
-                        connectionParam,
-                        scanPolicy,
-                        ruleConfigParam);
+                new HostProcess(hostAndPort, this, scannerParam, scanPolicy, ruleConfigParam);
         hostProcess.setStartNode(node);
         hostProcess.setUser(this.user);
         hostProcess.setTechSet(this.techSet);

--- a/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
@@ -241,11 +241,8 @@ public class HttpPanelSender implements MessageSender {
 
     private HttpSender getDelegate() {
         if (delegate == null) {
-            delegate =
-                    new HttpSender(
-                            Model.getSingleton().getOptionsParam().getConnectionParam(),
-                            getButtonUseTrackingSessionState().isSelected(),
-                            HttpSender.MANUAL_REQUEST_INITIATOR);
+            delegate = new HttpSender(HttpSender.MANUAL_REQUEST_INITIATOR);
+            delegate.setUseGlobalState(getButtonUseTrackingSessionState().isSelected());
             delegate.setUseCookies(getButtonUseCookies().isSelected());
         }
         return delegate;

--- a/zap/src/main/java/org/zaproxy/zap/authentication/AuthenticationMethod.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/AuthenticationMethod.java
@@ -32,7 +32,6 @@ import org.apache.commons.httpclient.URIException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpSender;
@@ -220,11 +219,7 @@ public abstract class AuthenticationMethod {
 
     private HttpSender getHttpSender() {
         if (this.httpSender == null) {
-            this.httpSender =
-                    new HttpSender(
-                            Model.getSingleton().getOptionsParam().getConnectionParam(),
-                            true,
-                            HttpSender.AUTHENTICATION_POLL_INITIATOR);
+            this.httpSender = new HttpSender(HttpSender.AUTHENTICATION_POLL_INITIATOR);
         }
         return httpSender;
     }

--- a/zap/src/main/java/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodType.java
@@ -231,11 +231,7 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
 
         protected HttpSender getHttpSender() {
             if (this.httpSender == null) {
-                this.httpSender =
-                        new HttpSender(
-                                Model.getSingleton().getOptionsParam().getConnectionParam(),
-                                true,
-                                HttpSender.AUTHENTICATION_INITIATOR);
+                this.httpSender = new HttpSender(HttpSender.AUTHENTICATION_INITIATOR);
             }
             return httpSender;
         }

--- a/zap/src/main/java/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
@@ -55,7 +55,6 @@ import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.db.RecordContext;
 import org.parosproxy.paros.extension.ExtensionHook;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
@@ -119,11 +118,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
 
         protected HttpSender getHttpSender() {
             if (this.httpSender == null) {
-                this.httpSender =
-                        new HttpSender(
-                                Model.getSingleton().getOptionsParam().getConnectionParam(),
-                                true,
-                                HttpSender.AUTHENTICATION_INITIATOR);
+                this.httpSender = new HttpSender(HttpSender.AUTHENTICATION_INITIATOR);
             }
             return httpSender;
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -1015,10 +1015,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
     }
 
     private static HttpSender createHttpSender() {
-        return new HttpSender(
-                Model.getSingleton().getOptionsParam().getConnectionParam(),
-                true,
-                HttpSender.MANUAL_REQUEST_INITIATOR);
+        return new HttpSender(HttpSender.MANUAL_REQUEST_INITIATOR);
     }
 
     private static void persistMessage(final HttpMessage message) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScan.java
@@ -91,13 +91,26 @@ public class ActiveScan extends org.parosproxy.paros.core.scanner.Scanner
         this(displayName, scannerParam, param, scanPolicy, null);
     }
 
+    /**
+     * @deprecated (2.12.0) Use {@link #ActiveScan(String, ScannerParam, ScanPolicy,
+     *     RuleConfigParam)} instead.
+     */
+    @Deprecated
     public ActiveScan(
             String displayName,
             ScannerParam scannerParam,
             ConnectionParam param,
             ScanPolicy scanPolicy,
             RuleConfigParam ruleConfigParam) {
-        super(scannerParam, param, scanPolicy, ruleConfigParam);
+        this(displayName, scannerParam, scanPolicy, ruleConfigParam);
+    }
+
+    public ActiveScan(
+            String displayName,
+            ScannerParam scannerParam,
+            ScanPolicy scanPolicy,
+            RuleConfigParam ruleConfigParam) {
+        super(scannerParam, scanPolicy, ruleConfigParam);
         this.displayName = displayName;
         this.maxResultsToList = scannerParam.getMaxResultsToList();
         // Easiest way to get the messages and alerts ;)

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanController.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanController.java
@@ -115,12 +115,7 @@ public class ActiveScanController implements ScanController<ActiveScan> {
             }
 
             ActiveScan ascan =
-                    new ActiveScan(
-                            name,
-                            extension.getScannerParam(),
-                            extension.getModel().getOptionsParam().getConnectionParam(),
-                            null,
-                            ruleConfigParam) {
+                    new ActiveScan(name, extension.getScannerParam(), null, ruleConfigParam) {
                         @Override
                         public void alertFound(Alert alert) {
                             alert.setSource(Alert.Source.ACTIVE);

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/AttackModeScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/AttackModeScanner.java
@@ -279,7 +279,6 @@ public class AttackModeScanner implements EventConsumer {
                     new AttackScan(
                             Constant.messages.getString("ascan.attack.scan"),
                             extension.getScannerParam(),
-                            extension.getModel().getOptionsParam().getConnectionParam(),
                             extension.getPolicyManager().getAttackScanPolicy(),
                             ruleConfigParam,
                             this);
@@ -308,7 +307,6 @@ public class AttackModeScanner implements EventConsumer {
                     Scanner scanner =
                             new Scanner(
                                     extension.getScannerParam(),
-                                    extension.getModel().getOptionsParam().getConnectionParam(),
                                     extension.getPolicyManager().getAttackScanPolicy(),
                                     ruleConfigParam);
                     scanner.setStartNode(node);

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/AttackScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/AttackScan.java
@@ -40,17 +40,16 @@ public class AttackScan extends ActiveScan {
             ConnectionParam param,
             ScanPolicy scanPolicy,
             RuleConfigParam ruleConfigParam) {
-        this(displayName, scannerParam, param, scanPolicy, ruleConfigParam, null);
+        this(displayName, scannerParam, scanPolicy, ruleConfigParam, null);
     }
 
     AttackScan(
             String displayName,
             ScannerParam scannerParam,
-            ConnectionParam param,
             ScanPolicy scanPolicy,
             RuleConfigParam ruleConfigParam,
             AttackModeScannerThread attackModeScannerThread) {
-        super(displayName, scannerParam, param, scanPolicy, ruleConfigParam);
+        super(displayName, scannerParam, scanPolicy, ruleConfigParam);
         this.attackModeScannerThread = attackModeScannerThread;
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/spider/Spider.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/Spider.java
@@ -514,13 +514,10 @@ public class Spider {
                         new SpiderThreadFactory("ZAP-SpiderThreadPool-" + id + "-thread-"));
 
         // Initialize the HTTP sender
-        httpSender =
-                new HttpSender(
-                        connectionParam,
-                        connectionParam.isHttpStateEnabled()
-                                ? true
-                                : !spiderParam.isAcceptCookies(),
-                        HttpSender.SPIDER_INITIATOR);
+        httpSender = new HttpSender(HttpSender.SPIDER_INITIATOR);
+        httpSender.setUseGlobalState(
+                connectionParam.isHttpStateEnabled() || !spiderParam.isAcceptCookies());
+
         // Do not follow redirections because the request is not updated, the redirections will be
         // handled manually.
         httpSender.setFollowRedirect(false);

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/HostProcessUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/HostProcessUnitTest.java
@@ -40,6 +40,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.network.ConnectionParam;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.ascan.ScanPolicy;
@@ -59,7 +61,6 @@ class HostProcessUnitTest {
     private String hostAndPort;
     private Scanner scanner;
     private ScannerParam scannerParam;
-    private ConnectionParam connectionParam;
     private PluginFactory pluginFactory;
     private RuleConfigParam ruleConfigParam;
 
@@ -78,7 +79,11 @@ class HostProcessUnitTest {
         given(scanner.isInScope(any())).willReturn(true);
 
         scannerParam = mock(ScannerParam.class);
-        connectionParam = mock(ConnectionParam.class);
+        Model model = mock(Model.class);
+        Model.setSingletonForTesting(model);
+        OptionsParam optionsParam = mock(OptionsParam.class);
+        given(model.getOptionsParam()).willReturn(optionsParam);
+        given(optionsParam.getConnectionParam()).willReturn(mock(ConnectionParam.class));
 
         pluginFactory = mock(PluginFactory.class);
         given(pluginFactory.clone()).willReturn(pluginFactory);
@@ -86,13 +91,7 @@ class HostProcessUnitTest {
         given(scanPolicy.getPluginFactory()).willReturn(pluginFactory);
 
         hostProcess =
-                new HostProcess(
-                        hostAndPort,
-                        scanner,
-                        scannerParam,
-                        connectionParam,
-                        scanPolicy,
-                        ruleConfigParam);
+                new HostProcess(hostAndPort, scanner, scannerParam, scanPolicy, ruleConfigParam);
     }
 
     @Test


### PR DESCRIPTION
Change `HttpSender` to obtain the connection options directly to allow
the `HttpSender` implementation (e.g. network add-on) to be responsible
to provide/use them, instead of having callers passing them around.
Deprecate old constructor and change core to stop using it.