### PR TITLE
Use HttpSender to download add-ons

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/DownloadManager.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/DownloadManager.java
@@ -20,8 +20,6 @@
 package org.zaproxy.zap.extension.autoupdate;
 
 import java.io.File;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -31,37 +29,33 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.ConnectionParam;
+import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.view.View;
 
 public class DownloadManager extends Thread {
     private static final Logger logger = LogManager.getLogger(DownloadManager.class);
+    private final int initiator;
     private Collection<Downloader> currentDownloads = new ConcurrentLinkedQueue<>();
     private Collection<Downloader> completedDownloads = new ConcurrentLinkedQueue<>();
     private boolean shutdown = false;
     private boolean cancelDownloads = false;
-    private ConnectionParam connectionParam;
 
+    /** @deprecated (2.12.0) */
+    @Deprecated
     public DownloadManager(ConnectionParam connectionParam) {
+        this(HttpSender.CHECK_FOR_UPDATES_INITIATOR);
+    }
+
+    DownloadManager(int initiator) {
         super("ZAP-DownloadManager");
-        this.connectionParam = connectionParam;
         setDaemon(true);
+        this.initiator = initiator;
     }
 
     public Downloader downloadFile(URL url, File targetFile, long size, String hash) {
         logger.debug("Download file " + url + " to " + targetFile.getAbsolutePath());
 
-        Proxy proxy;
-        if (connectionParam.isUseProxy(url.getHost())) {
-            InetSocketAddress socketAddress =
-                    new InetSocketAddress(
-                            connectionParam.getProxyChainName(),
-                            connectionParam.getProxyChainPort());
-            proxy = new Proxy(Proxy.Type.HTTP, socketAddress);
-        } else {
-            proxy = Proxy.NO_PROXY;
-        }
-
-        Downloader dl = new Downloader(url, proxy, targetFile, size, hash);
+        Downloader dl = new Downloader(url, targetFile, size, hash, initiator);
         dl.start();
         this.currentDownloads.add(dl);
         return dl;

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -64,6 +64,7 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.model.FileCopier;
 import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.control.AddOn;
@@ -142,8 +143,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
     private void initialize() {
         this.setName(NAME);
         this.setOrder(1); // High order so that cmdline updates are installed asap
-        this.downloadManager =
-                new DownloadManager(Model.getSingleton().getOptionsParam().getConnectionParam());
+        this.downloadManager = new DownloadManager(HttpSender.CHECK_FOR_UPDATES_INITIATOR);
         this.downloadManager.start();
         // Do this before it can get overwritten by the latest one
         this.getPreviousVersionInfo();

--- a/zap/src/test/java/org/zaproxy/zap/extension/autoupdate/DownloadManagerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/autoupdate/DownloadManagerUnitTest.java
@@ -26,7 +26,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.Mockito.mock;
 
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
@@ -35,36 +34,31 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.io.TempDir;
-import org.parosproxy.paros.network.ConnectionParam;
+import org.zaproxy.zap.WithConfigsTest;
 import org.zaproxy.zap.testutils.NanoServerHandler;
-import org.zaproxy.zap.testutils.TestUtils;
 
 /** Unit test for {@link DownloadManager}. */
-class DownloadManagerUnitTest extends TestUtils {
+class DownloadManagerUnitTest extends WithConfigsTest {
 
     private static final String HASH =
             "SHA-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
-
-    @TempDir static Path tempDir;
 
     private DownloadManager downloadManager;
 
     @BeforeEach
     void setUp() throws Exception {
-        downloadManager = new DownloadManager(mock(ConnectionParam.class));
+        downloadManager = new DownloadManager(-1);
 
         startServer();
     }
 
     @AfterEach
-    void cleanUp() {
+    void tearDown() {
         downloadManager.shutdown(true);
 
         stopServer();
@@ -105,6 +99,7 @@ class DownloadManagerUnitTest extends TestUtils {
         assertThat(progress, hasSize(numberOfDownloads));
         progress.forEach(
                 download -> {
+                    assertThat(download.getException(), is(nullValue()));
                     assertThat(download.getFinished(), is(not(nullValue())));
                 });
     }

--- a/zap/src/test/java/org/zaproxy/zap/extension/autoupdate/DownloaderUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/autoupdate/DownloaderUnitTest.java
@@ -19,57 +19,101 @@
  */
 package org.zaproxy.zap.extension.autoupdate;
 
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
+import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
+import fi.iki.elonen.NanoHTTPD.Response.Status;
 import java.io.IOException;
-import java.net.Proxy;
+import java.io.InputStream;
 import java.net.URL;
+import java.nio.channels.ClosedByInterruptException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.Timeout;
+import org.zaproxy.zap.WithConfigsTest;
+import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link Downloader}. */
-class DownloaderUnitTest {
+class DownloaderUnitTest extends WithConfigsTest {
 
     private static final String FILE_CONTENTS = "0123456789ABCDEF";
+    private static final int FILE_LENGTH = FILE_CONTENTS.length();
 
-    @TempDir static Path tempDir;
+    private static final String FILE_PATH = "/file.txt";
+    private NanoServerHandler defaultHandler;
 
-    private static URL downloadUrl;
+    private URL downloadUrl;
+    private Downloader downloader;
 
-    @BeforeAll
-    static void setUp() throws IOException {
-        Path file = Files.createTempFile(tempDir, "file", "");
-        Files.write(file, FILE_CONTENTS.getBytes(StandardCharsets.UTF_8));
-        downloadUrl = file.toUri().toURL();
+    @BeforeEach
+    void setUp() throws IOException {
+        startServer();
+
+        defaultHandler =
+                new NanoServerHandler(FILE_PATH) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        return newFixedLengthResponse(FILE_CONTENTS);
+                    }
+                };
+        nano.addHandler(defaultHandler);
+
+        downloadUrl = new URL("http://127.0.0.1:" + nano.getListeningPort() + FILE_PATH);
+    }
+
+    @AfterEach
+    void tearDown() {
+        stopServer();
+    }
+
+    void createDowloader(String hash) throws IOException {
+        createDowloader(hash, FILE_LENGTH);
+    }
+
+    void createDowloader(String hash, long size) throws IOException {
+        downloader =
+                new Downloader(
+                        downloadUrl,
+                        Files.createTempFile(tempDir, "download", "").toFile(),
+                        size,
+                        hash,
+                        -1);
     }
 
     @Test
     void shouldValidateDownloadWithEqualSha1Hash() throws Exception {
         // Given
         String hash = "SHA1:ce27cb141098feb00714e758646be3e99c185b71";
-        Downloader downloader = noProxyDownloader(downloadUrl, hash);
+        createDowloader(hash);
         // When
         downloader.start();
         // Then
-        waitDownloadFinish(downloader);
+        waitDownloadFinish();
         assertThat(downloader.isValidated(), is(equalTo(true)));
+        assertFileContents();
     }
 
     @Test
     void shouldNotValidateDownloadWithDifferentSha1Hash() throws Exception {
         // Given
         String hash = "SHA1:ce27cb";
-        Downloader downloader = noProxyDownloader(downloadUrl, hash);
+        createDowloader(hash);
         // When
         downloader.start();
         // Then
-        waitDownloadFinish(downloader);
+        waitDownloadFinish();
         assertThat(downloader.isValidated(), is(equalTo(false)));
     }
 
@@ -77,23 +121,24 @@ class DownloaderUnitTest {
     void shouldValidateDownloadWithEqualSha256Hash() throws Exception {
         // Given
         String hash = "SHA-256:2125b2c332b1113aae9bfc5e9f7e3b4c91d828cb942c2df1eeb02502eccae9e9";
-        Downloader downloader = noProxyDownloader(downloadUrl, hash);
+        createDowloader(hash);
         // When
         downloader.start();
         // Then
-        waitDownloadFinish(downloader);
+        waitDownloadFinish();
         assertThat(downloader.isValidated(), is(equalTo(true)));
+        assertFileContents();
     }
 
     @Test
     void shouldNotValidateDownloadWithDifferentSha256Hash() throws Exception {
         // Given
         String hash = "SHA-256:2125bc";
-        Downloader downloader = noProxyDownloader(downloadUrl, hash);
+        createDowloader(hash);
         // When
         downloader.start();
         // Then
-        waitDownloadFinish(downloader);
+        waitDownloadFinish();
         assertThat(downloader.isValidated(), is(equalTo(false)));
     }
 
@@ -101,20 +146,89 @@ class DownloaderUnitTest {
     void shouldNotValidateDownloadWithUnsupportedAlgorithm() throws Exception {
         // Given
         String hash = "~NotHashAlg~:ce27cb141098feb00714e758646be3e99c185b71";
-        Downloader downloader = noProxyDownloader(downloadUrl, hash);
+        createDowloader(hash);
         // When
         downloader.start();
         // Then
-        waitDownloadFinish(downloader);
+        waitDownloadFinish();
         assertThat(downloader.isValidated(), is(equalTo(false)));
     }
 
-    private static Downloader noProxyDownloader(URL url, String hash) throws IOException {
-        return new Downloader(
-                url, Proxy.NO_PROXY, Files.createTempFile(tempDir, "download", "").toFile(), hash);
+    @Test
+    void shouldDownloadBigFile() throws Exception {
+        // Given
+        long size = 10485760L;
+        nano.removeHandler(defaultHandler);
+        nano.addHandler(
+                new NanoServerHandler(FILE_PATH) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        return newFixedLengthResponse(
+                                Status.OK,
+                                NanoHTTPD.MIME_PLAINTEXT,
+                                new InputStream() {
+                                    @Override
+                                    public int read() throws IOException {
+                                        return 'A';
+                                    }
+                                },
+                                size);
+                    }
+                });
+        createDowloader(
+                "SHA-256:eb6183addde05c2196ce25e6fa34a4baf20f9bf30d33892f452a9a1e88c9a472", size);
+        // When
+        downloader.start();
+        // Then
+        waitDownloadFinish();
+        assertThat(downloader.getException(), is(nullValue()));
+        assertThat(downloader.getFinished(), is(not(nullValue())));
+        assertThat(downloader.isValidated(), is(equalTo(true)));
+        assertThat(downloader.getTargetFile().length(), is(equalTo(size)));
     }
 
-    private static void waitDownloadFinish(Downloader downloader) throws InterruptedException {
+    @Test
+    @Timeout(25)
+    void shouldCancelDownload() throws Exception {
+        // Given
+        nano.removeHandler(defaultHandler);
+        nano.addHandler(
+                new NanoServerHandler(FILE_PATH) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        return newFixedLengthResponse(
+                                Status.OK,
+                                NanoHTTPD.MIME_PLAINTEXT,
+                                new InputStream() {
+                                    @Override
+                                    public int read() throws IOException {
+                                        return 'A';
+                                    }
+                                },
+                                Integer.MAX_VALUE);
+                    }
+                });
+        createDowloader(
+                "SHA-256:eb6183addde05c2196ce25e6fa34a4baf20f9bf30d33892f452a9a1e88c9a472",
+                Integer.MAX_VALUE);
+        // When
+        downloader.start();
+        downloader.cancelDownload();
+        // Then
+        waitDownloadFinish();
+        assertThat(downloader.getException(), is(instanceOf(ClosedByInterruptException.class)));
+        assertThat(downloader.getFinished(), is(not(nullValue())));
+        assertThat(downloader.isValidated(), is(equalTo(false)));
+        assertThat(Files.notExists(downloader.getTargetFile().toPath()), is(equalTo(true)));
+    }
+
+    void assertFileContents() throws IOException {
+        Path file = downloader.getTargetFile().toPath();
+        String downloadedContents = new String(Files.readAllBytes(file), StandardCharsets.US_ASCII);
+        assertThat(downloadedContents, is(equalTo(FILE_CONTENTS)));
+    }
+
+    private void waitDownloadFinish() throws InterruptedException {
         int i = 1;
         while (downloader.getFinished() == null) {
             Thread.sleep(50);


### PR DESCRIPTION
Remove custom HTTP handling when downloading add-ons, relying on
`HttpSender` to download allows an easier replacement later.