### PR TITLE
Deprecate proxy.pac core endpoint

### DIFF
--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -216,7 +216,7 @@ api.home.cacert	= <h2>HTTPS Warnings Prevention</h2>\
 api.home.proxypac			= <h2>Proxy Configuration</h2>\
 <p>To use ZAP effectively it is recommended that you configure your browser to proxy via ZAP.</p><p></p>\
 <p>The easiest way to do this is to launch your browser from ZAP via the "Quick Start / Manual Explore" panel - it will be configured to proxy via ZAP and ignore any certificate warnings.<br>\
-Alternatively you can configure your browser manually or use the generated <a href="/OTHER/core/other/proxy.pac{0}">PAC file</a>.</p>
+Alternatively you can configure your browser manually or use the generated <a href="/OTHER/network/other/proxy.pac{0}">PAC file</a>.</p>
 api.home.topmsg				= <h1>Welcome to the OWASP Zed Attack Proxy (ZAP)</h1>\
 <p>ZAP is an easy to use integrated penetration testing tool for finding vulnerabilities in web applications.</p><p></p>\
 <p>Please be aware that you should only attack applications that you have been specifically been given permission to test.</p>


### PR DESCRIPTION
Deprecate the core endpoint `proxy.pac` and remove respective shortcut,
use the network API to serve them instead.

---
WIP pending changes in the add-on.