### PR TITLE
Reinstate constructor call

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/HostProcess.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/HostProcess.java
@@ -263,7 +263,9 @@ public class HostProcess implements Runnable {
             ScannerParam scannerParam,
             ConnectionParam connectionParam,
             ScanPolicy scanPolicy,
-            RuleConfigParam ruleConfigParam) {}
+            RuleConfigParam ruleConfigParam) {
+        this(hostAndPort, parentScanner, scannerParam, scanPolicy, ruleConfigParam);
+    }
 
     /**
      * Constructs a {@code HostProcess}.


### PR DESCRIPTION
Call newer constructor to keep same behaviour for the deprecated
constructor. Mistake done in #7233.