### PR TITLE
Use HttpSender to query global HTTP state status

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
@@ -96,6 +96,7 @@
 // ZAP: 2022/04/24 Notify listeners of all redirects followed.
 // ZAP: 2022/04/24 Move network initialisations from ZAP class.
 // ZAP: 2022/04/24 Allow to download to file.
+// ZAP: 2022/04/27 Expose global HTTP state enabled status.
 package org.parosproxy.paros.network;
 
 import java.io.IOException;
@@ -373,12 +374,24 @@ public class HttpSender {
      * @param enableGlobalState {@code true} if the global state should be used, {@code false}
      *     otherwise.
      * @since 2.8.0
+     * @see #isGlobalStateEnabled()
      * @see #setUseCookies(boolean)
      */
     public void setUseGlobalState(boolean enableGlobalState) {
         this.useGlobalState = enableGlobalState;
 
         checkState();
+    }
+
+    /**
+     * Tells whether or not the global HTTP state is enabled.
+     *
+     * @return {@code true} if the global HTTP state is enabled, {@code false} otherwise.
+     * @since 2.12.0
+     * @see #setUseGlobalState(boolean)
+     */
+    public boolean isGlobalStateEnabled() {
+        return param.isHttpStateEnabled();
     }
 
     /**

--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderThread.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderThread.java
@@ -228,14 +228,7 @@ public class SpiderThread extends ScanThread implements SpiderListener {
     /** Start spider. */
     private void startSpider() {
 
-        spider =
-                new Spider(
-                        id,
-                        extension,
-                        spiderParams,
-                        extension.getModel().getOptionsParam().getConnectionParam(),
-                        extension.getModel(),
-                        this.scanContext);
+        spider = new Spider(id, extension, spiderParams, extension.getModel(), this.scanContext);
 
         // Register this thread as a Spider Listener, so it gets notified of events and is able
         // to manipulate the UI accordingly

--- a/zap/src/main/java/org/zaproxy/zap/spider/Spider.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/Spider.java
@@ -57,9 +57,6 @@ public class Spider {
     /** The spider parameters. */
     private SpiderParam spiderParam;
 
-    /** The connection parameters. */
-    private ConnectionParam connectionParam;
-
     /** The model. */
     private Model model;
 
@@ -149,7 +146,10 @@ public class Spider {
      * @param scanContext if a scan context is set, only URIs within the context are fetched and
      *     processed
      * @since 2.6.0
+     * @deprecated (2.12.0) Use {@link #Spider(String, ExtensionSpider, SpiderParam, Model,
+     *     Context)} instead.
      */
+    @Deprecated
     public Spider(
             String id,
             ExtensionSpider extension,
@@ -157,11 +157,30 @@ public class Spider {
             ConnectionParam connectionParam,
             Model model,
             Context scanContext) {
+        this(id, extension, spiderParam, model, scanContext);
+    }
+
+    /**
+     * Constructs a {@code Spider} with the given data.
+     *
+     * @param id the ID of the spider, usually a unique integer
+     * @param extension the extension
+     * @param spiderParam the spider param
+     * @param model the model
+     * @param scanContext if a scan context is set, only URIs within the context are fetched and
+     *     processed
+     * @since 2.12.0
+     */
+    public Spider(
+            String id,
+            ExtensionSpider extension,
+            SpiderParam spiderParam,
+            Model model,
+            Context scanContext) {
         super();
         log.info("Spider initializing...");
         this.id = id;
         this.spiderParam = spiderParam;
-        this.connectionParam = connectionParam;
         this.model = model;
         this.extension = extension;
         this.controller = new SpiderController(this, extension.getCustomParsers());
@@ -516,7 +535,7 @@ public class Spider {
         // Initialize the HTTP sender
         httpSender = new HttpSender(HttpSender.SPIDER_INITIATOR);
         httpSender.setUseGlobalState(
-                connectionParam.isHttpStateEnabled() || !spiderParam.isAcceptCookies());
+                httpSender.isGlobalStateEnabled() || !spiderParam.isAcceptCookies());
 
         // Do not follow redirections because the request is not updated, the redirections will be
         // handled manually.


### PR DESCRIPTION
Expose the global HTTP state enabled status through the `HttpSender` to
not rely directly on `ConnectionsParam`, which will be superseded by
the options in the network add-on.
Change the spider to use the new method.