### PR TITLE
Remove ConnectionParam usage in request editor

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
@@ -82,6 +82,7 @@ public class HttpPanelSender implements MessageSender {
         extAntiCSRF =
                 Control.getSingleton().getExtensionLoader().getExtension(ExtensionAntiCSRF.class);
 
+        delegate = new HttpSender(HttpSender.MANUAL_REQUEST_INITIATOR);
         requestPanel.addOptions(
                 getButtonUseTrackingSessionState(), HttpPanel.OptionsLocation.AFTER_COMPONENTS);
         requestPanel.addOptions(getButtonUseCookies(), HttpPanel.OptionsLocation.AFTER_COMPONENTS);
@@ -93,9 +94,7 @@ public class HttpPanelSender implements MessageSender {
             requestPanel.addOptions(getButtonUseCsrf(), HttpPanel.OptionsLocation.AFTER_COMPONENTS);
         }
 
-        final boolean isSessionTrackingEnabled =
-                Model.getSingleton().getOptionsParam().getConnectionParam().isHttpStateEnabled();
-        getButtonUseTrackingSessionState().setEnabled(isSessionTrackingEnabled);
+        updateButtonTrackingSessionState();
     }
 
     @Override
@@ -112,18 +111,17 @@ public class HttpPanelSender implements MessageSender {
             boolean followRedirects = getButtonFollowRedirects().isSelected();
 
             if (extAntiCSRF != null && getButtonUseCsrf().isSelected()) {
-                extAntiCSRF.regenerateAntiCsrfToken(httpMessage, getDelegate()::sendAndReceive);
+                extAntiCSRF.regenerateAntiCsrfToken(httpMessage, delegate::sendAndReceive);
             }
 
             if (followRedirects) {
-                getDelegate()
-                        .sendAndReceive(
-                                httpMessage,
-                                HttpRequestConfig.builder()
-                                        .setRedirectionValidator(redirectionValidator)
-                                        .build());
+                delegate.sendAndReceive(
+                        httpMessage,
+                        HttpRequestConfig.builder()
+                                .setRedirectionValidator(redirectionValidator)
+                                .build());
             } else {
-                getDelegate().sendAndReceive(httpMessage, false);
+                delegate.sendAndReceive(httpMessage, false);
             }
 
             EventQueue.invokeAndWait(
@@ -232,21 +230,7 @@ public class HttpPanelSender implements MessageSender {
     }
 
     @Override
-    public void cleanup() {
-        if (delegate != null) {
-            delegate.shutdown();
-            delegate = null;
-        }
-    }
-
-    private HttpSender getDelegate() {
-        if (delegate == null) {
-            delegate = new HttpSender(HttpSender.MANUAL_REQUEST_INITIATOR);
-            delegate.setUseGlobalState(getButtonUseTrackingSessionState().isSelected());
-            delegate.setUseCookies(getButtonUseCookies().isSelected());
-        }
-        return delegate;
-    }
+    public void cleanup() {}
 
     private JToggleButton getButtonFollowRedirects() {
         if (followRedirect == null) {
@@ -275,7 +259,7 @@ public class HttpPanelSender implements MessageSender {
             useTrackingSessionState.setToolTipText(
                     Constant.messages.getString("manReq.checkBox.useSession"));
             useTrackingSessionState.addItemListener(
-                    e -> setUseTrackingSessionState(e.getStateChange() == ItemEvent.SELECTED));
+                    e -> delegate.setUseGlobalState(e.getStateChange() == ItemEvent.SELECTED));
         }
         return useTrackingSessionState;
     }
@@ -290,7 +274,7 @@ public class HttpPanelSender implements MessageSender {
                             true);
             useCookies.setToolTipText(Constant.messages.getString("manReq.checkBox.useCookies"));
             useCookies.addItemListener(
-                    e -> setUseCookies(e.getStateChange() == ItemEvent.SELECTED));
+                    e -> delegate.setUseCookies(e.getStateChange() == ItemEvent.SELECTED));
         }
         return useCookies;
     }
@@ -392,20 +376,13 @@ public class HttpPanelSender implements MessageSender {
         }
     }
 
-    private void setUseTrackingSessionState(boolean shouldUseTrackingSessionState) {
-        if (delegate != null) {
-            delegate.setUseGlobalState(shouldUseTrackingSessionState);
-        }
-    }
-
-    private void setUseCookies(boolean shouldUseCookies) {
-        if (delegate != null) {
-            delegate.setUseCookies(shouldUseCookies);
-        }
+    void updateButtonTrackingSessionState() {
+        setButtonTrackingSessionStateEnabled(delegate.isGlobalStateEnabled());
     }
 
     public void setButtonTrackingSessionStateEnabled(boolean enabled) {
         getButtonUseTrackingSessionState().setEnabled(enabled);
         getButtonUseTrackingSessionState().setSelected(enabled);
+        delegate.setUseGlobalState(enabled);
     }
 }

--- a/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/ManualHttpRequestEditorDialog.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/ManualHttpRequestEditorDialog.java
@@ -33,6 +33,7 @@
 // ZAP: 2020/11/20 Support Send button in response panel in tab mode
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2021/02/12 Add shortcut key to Send button (Issue 6448).
+// ZAP: 2022/04/28 Call the new message sender method.
 package org.parosproxy.paros.extension.manualrequest.http.impl;
 
 import java.awt.BorderLayout;
@@ -693,8 +694,6 @@ public class ManualHttpRequestEditorDialog extends ManualRequestEditorDialog
 
     @Override
     public void optionsChanged(OptionsParam optionsParam) {
-        getMessageSender()
-                .setButtonTrackingSessionStateEnabled(
-                        optionsParam.getConnectionParam().isHttpStateEnabled());
+        getMessageSender().updateButtonTrackingSessionState();
     }
 }


### PR DESCRIPTION
Use only the `HttpSender` to query the global HTTP state status, also,
use the same instance always as it no longer needs to be reset to use
the latest proxy settings.