### PR TITLE
Include default charset in support info

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/utils/ZapSupportUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/ZapSupportUtils.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.utils;
 
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -133,6 +134,18 @@ public final class ZapSupportUtils {
         return Constant.messages.getString("support.installed.addons.label") + " " + sortedAddOns;
     }
 
+    /**
+     * Gets the default charset (preceded with the corresponding label).
+     *
+     * @return the default charset.
+     * @since 2.12.0
+     */
+    public static String getDefaultCharset() {
+        return Constant.messages.getString("support.charset.default.label")
+                + " "
+                + Charset.defaultCharset();
+    }
+
     public static String getAll(boolean formatted) {
         StringBuilder installedAddons = new StringBuilder(200);
         if (formatted) {
@@ -153,6 +166,7 @@ public final class ZapSupportUtils {
         supportDetailsBuilder.append(getLocaleSystem()).append(NEWLINE);
         supportDetailsBuilder.append(getLocaleDisplay()).append(NEWLINE);
         supportDetailsBuilder.append(getLocaleFormat()).append(NEWLINE);
+        supportDetailsBuilder.append(getDefaultCharset()).append(NEWLINE);
         supportDetailsBuilder.append(getZapHomeDirectory()).append(NEWLINE);
         supportDetailsBuilder.append(getZapInstallDirectory()).append(NEWLINE);
         supportDetailsBuilder.append(getLookAndFeel()).append(NEWLINE);

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -3128,6 +3128,7 @@ std.menu.ext.name = Standard Menus Extension
 stdexts.copyurls.popup = Copy URLs to Clipboard
 stdexts.desc = A set of common popup menus for miscellaneous tasks
 
+support.charset.default.label = Default Charset:
 support.home.directory.label = ZAP Home Directory:
 support.install.directory.label = ZAP Installation Directory:
 support.installed.addons.label = Installed Add-ons:


### PR DESCRIPTION
Include the default charset which useful to debug/reproduce issues.