### PR TITLE
Allow to request shutdown when executing args

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/CommandLineListener.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/CommandLineListener.java
@@ -24,16 +24,19 @@
 // ZAP: 2013/12/03 Issue 934: Handle files on the command line via extension
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2022/05/02 Document usage of ShutdownRequestedException.
 package org.parosproxy.paros.extension;
 
 import java.io.File;
 import java.util.List;
+import org.zaproxy.zap.ShutdownRequestedException;
 
 public interface CommandLineListener {
     /**
      * execute the command line using the argument provided.
      *
      * @param args the command line arguments
+     * @throws ShutdownRequestedException (since 2.12.0) if ZAP should shutdown immediately.
      */
     void execute(CommandLineArgument[] args);
 

--- a/zap/src/main/java/org/zaproxy/zap/CommandLineBootstrap.java
+++ b/zap/src/main/java/org/zaproxy/zap/CommandLineBootstrap.java
@@ -100,7 +100,8 @@ public class CommandLineBootstrap extends HeadlessBootstrap {
                     rc = 1;
                 }
             }
-
+        } catch (ShutdownRequestedException e) {
+            rc = 1;
         } catch (final Exception e) {
             logger.error(e.getMessage(), e);
             System.out.println(e.getMessage());

--- a/zap/src/main/java/org/zaproxy/zap/DaemonBootstrap.java
+++ b/zap/src/main/java/org/zaproxy/zap/DaemonBootstrap.java
@@ -88,6 +88,10 @@ class DaemonBootstrap extends HeadlessBootstrap {
                                     // Allow extensions to pick up command line args in daemon mode
                                     control.getExtensionLoader().hookCommandLineListener(getArgs());
                                     control.runCommandLine();
+                                } catch (ShutdownRequestedException e) {
+                                    control.shutdown(false);
+                                    logger.info("{} terminated.", Constant.PROGRAM_TITLE);
+                                    return;
                                 } catch (Exception e) {
                                     logger.error(e.getMessage(), e);
                                 }

--- a/zap/src/main/java/org/zaproxy/zap/ShutdownRequestedException.java
+++ b/zap/src/main/java/org/zaproxy/zap/ShutdownRequestedException.java
@@ -1,0 +1,44 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap;
+
+import org.parosproxy.paros.extension.CommandLineArgument;
+import org.parosproxy.paros.extension.CommandLineListener;
+
+/**
+ * Indicates that ZAP should shutdown immediately, for example, when required components were not
+ * fully initialised because of some error. The error should be properly logged/printed by the
+ * extension before throwing the exception.
+ *
+ * <p>Only honoured when running in daemon or command line modes and executing the extensions'
+ * command line arguments, with GUI the user should be informed instead.
+ *
+ * @since 2.12.0
+ * @see CommandLineListener#execute(CommandLineArgument[])
+ */
+public class ShutdownRequestedException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Constructs a {@code ShutdownRequestedException}. */
+    public ShutdownRequestedException() {
+        super();
+    }
+}


### PR DESCRIPTION
Allow extensions to request the shutdown when executing their command
line arguments in daemon and command line modes (e.g. network add-on is
not able to start the main proxy).