### PR TITLE
Remove single cookie request header option

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsConnectionPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsConnectionPanel.java
@@ -43,6 +43,7 @@
 // ZAP: 2020/03/25 Remove hardcoded colour in titled borders (Issue 5542).
 // ZAP: 2020/04/20 Add SocksProxyPanel (Issue 29).
 // ZAP: 2021/05/14 Remove redundant type arguments.
+// ZAP: 2022/05/04 Remove single cookie request header option.
 package org.parosproxy.paros.extension.option;
 
 import java.awt.BorderLayout;
@@ -101,7 +102,6 @@ public class OptionsConnectionPanel extends AbstractParamPanel {
     private JCheckBox chkProxyChainPrompt = null;
     private ZapNumberSpinner spinnerTimeoutInSecs;
     private JPanel panelGeneral = null;
-    private JCheckBox checkBoxSingleCookieRequestHeader;
     private JCheckBox checkBoxHttpStateEnabled;
     private JComboBox<String> commonUserAgents = null;
     private ZapTextField defaultUserAgent = null;
@@ -562,8 +562,6 @@ public class OptionsConnectionPanel extends AbstractParamPanel {
 
         this.spinnerTimeoutInSecs.setValue(connectionParam.getTimeoutInSecs());
 
-        checkBoxSingleCookieRequestHeader.setSelected(
-                connectionParam.isSingleCookieRequestHeader());
         checkBoxHttpStateEnabled.setSelected(connectionParam.isHttpStateEnabled());
 
         getProxyExcludedDomainsTableModel()
@@ -693,8 +691,6 @@ public class OptionsConnectionPanel extends AbstractParamPanel {
             connectionParam.setProxyChainPassword(new String(txtProxyChainPassword.getPassword()));
         }
         connectionParam.setTimeoutInSecs(spinnerTimeoutInSecs.getValue());
-        connectionParam.setSingleCookieRequestHeader(
-                checkBoxSingleCookieRequestHeader.isSelected());
         connectionParam.setHttpStateEnabled(checkBoxHttpStateEnabled.isSelected());
 
         connectionParam.setUseProxyChain(chkUseProxyChain.isSelected());
@@ -821,13 +817,6 @@ public class OptionsConnectionPanel extends AbstractParamPanel {
             panelGeneral.add(jLabel, gridBagConstraints00);
             panelGeneral.add(getTxtTimeoutInSecs(), gridBagConstraints01);
 
-            java.awt.GridBagConstraints gbc = new java.awt.GridBagConstraints();
-            gbc.gridy = 3;
-            gbc.gridwidth = 2;
-            gbc.fill = java.awt.GridBagConstraints.HORIZONTAL;
-            gbc.insets = new java.awt.Insets(2, 2, 2, 2);
-            gbc.anchor = java.awt.GridBagConstraints.WEST;
-
             JLabel uaLabel =
                     new JLabel(Constant.messages.getString("conn.options.defaultUserAgent"));
             uaLabel.setLabelFor(this.getDefaultUserAgent());
@@ -839,12 +828,11 @@ public class OptionsConnectionPanel extends AbstractParamPanel {
                     getDefaultUserAgent(),
                     LayoutHelper.getGBC(0, 2, 2, 1.0D, new Insets(2, 2, 2, 2)));
 
-            panelGeneral.add(getCheckBoxSingleCookeRequestHeader(), gbc);
             panelGeneral.add(
                     getCheckBoxHttpStateEnabled(),
                     LayoutHelper.getGBC(
                             0,
-                            4,
+                            3,
                             3,
                             1.0D,
                             0,
@@ -868,16 +856,6 @@ public class OptionsConnectionPanel extends AbstractParamPanel {
                     new ZapNumberSpinner(0, ConnectionParam.DEFAULT_TIMEOUT, Integer.MAX_VALUE);
         }
         return spinnerTimeoutInSecs;
-    }
-
-    private JCheckBox getCheckBoxSingleCookeRequestHeader() {
-
-        if (checkBoxSingleCookieRequestHeader == null) {
-            checkBoxSingleCookieRequestHeader =
-                    new JCheckBox(
-                            Constant.messages.getString("conn.options.singleCookieRequestHeader"));
-        }
-        return checkBoxSingleCookieRequestHeader;
     }
 
     public JCheckBox getCheckBoxHttpStateEnabled() {

--- a/zap/src/main/java/org/parosproxy/paros/network/ConnectionParam.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/ConnectionParam.java
@@ -52,6 +52,7 @@
 // ZAP: 2021/10/06 Updated default user agent
 // ZAP: 2022/02/02 Removed getProxyChainSkipName() and setProxyChainSkipName(String)
 // ZAP: 2022/02/08 Use isEmpty where applicable.
+// ZAP: 2022/05/04 Deprecate single cookie request header option.
 package org.parosproxy.paros.network;
 
 import java.net.PasswordAuthentication;
@@ -560,9 +561,12 @@ public class ConnectionParam extends AbstractParam {
      *
      * @return {@code true} if the cookies should be set on a single request header, {@code false}
      *     otherwise
+     * @deprecated (2.12.0) No longer supported, when managing cookies they will be sent in a single
+     *     header field.
      */
+    @Deprecated
     public boolean isSingleCookieRequestHeader() {
-        return this.singleCookieRequestHeader;
+        return true;
     }
 
     /**
@@ -571,11 +575,11 @@ public class ConnectionParam extends AbstractParam {
      *
      * @param singleCookieRequestHeader {@code true} if the cookies should be set on a single
      *     request header, {@code false} otherwise
+     * @deprecated (2.12.0) No longer supported, when managing cookies they will be sent in a single
+     *     header field.
      */
-    public void setSingleCookieRequestHeader(boolean singleCookieRequestHeader) {
-        this.singleCookieRequestHeader = singleCookieRequestHeader;
-        getConfig().setProperty(SINGLE_COOKIE_REQUEST_HEADER, singleCookieRequestHeader);
-    }
+    @Deprecated
+    public void setSingleCookieRequestHeader(boolean singleCookieRequestHeader) {}
 
     /**
      * Returns the domains excluded from the outgoing proxy.

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
@@ -99,6 +99,7 @@
 // ZAP: 2022/04/27 Expose global HTTP state enabled status.
 // ZAP: 2022/04/27 Use latest proxy settings always.
 // ZAP: 2022/04/29 Deprecate setAllowCircularRedirects.
+// ZAP: 2022/05/04 Always use single cookie request header.
 package org.parosproxy.paros.network;
 
 import java.io.IOException;
@@ -280,12 +281,8 @@ public class HttpSender {
         client.getParams().setBooleanParameter(HttpClientParams.ALLOW_CIRCULAR_REDIRECTS, true);
 
         // Set how cookie headers are sent no matter of the "allowState", in case a state is forced
-        // by
-        // other extensions (e.g. Authentication)
-        final boolean singleCookieRequestHeader = param.isSingleCookieRequestHeader();
-        client.getParams()
-                .setBooleanParameter(
-                        HttpMethodParams.SINGLE_COOKIE_HEADER, singleCookieRequestHeader);
+        // by other extensions (e.g. Authentication)
+        client.getParams().setBooleanParameter(HttpMethodParams.SINGLE_COOKIE_HEADER, true);
         String defaultUserAgent = param.getDefaultUserAgent();
         client.getParams()
                 .setParameter(

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -1286,7 +1286,6 @@ conn.options.socks.dns = Use SOCKS' DNS
 conn.options.socks.dns.tooltip = Only supported with version 5.
 conn.options.socks.username = User Name:
 conn.options.socks.password = Password:
-conn.options.singleCookieRequestHeader = Single Cookie Request Header
 conn.options.httpStateEnabled = Enable (Global) HTTP State
 conn.options.timeout             = Timeout (in seconds):
 conn.options.title               = Connection


### PR DESCRIPTION
The option was added to allow the user to keep the old behaviour (i.e.
send the cookies in multiple headers) but since it's been enabled by
default, moreover that's the expected behaviour.