### PR TITLE
Correct Enable/Disable All buttons enabled state

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/view/AbstractMultipleOptionsTablePanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/AbstractMultipleOptionsTablePanel.java
@@ -82,7 +82,7 @@ public abstract class AbstractMultipleOptionsTablePanel<E extends EnableableInte
                                 if (TableModelEvent.ALL_COLUMNS == e.getColumn()
                                         || TableModelEvent.INSERT == e.getType()
                                         || TableModelEvent.DELETE == e.getType()) {
-                                    boolean enabled = getModel().getRowCount() > 0;
+                                    boolean enabled = isEnabled() && getModel().getRowCount() > 0;
 
                                     enableAllButton.setEnabled(enabled);
                                     disableAllButton.setEnabled(enabled);


### PR DESCRIPTION
Do not enable the Enable/Disable All buttons if the component is not
enabled, to keep the expected state when the table data changes.