### PR TITLE
Fix to run Docker images on Mac M1

### DIFF
--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -1,5 +1,6 @@
 # This dockerfile builds the zap stable release
-FROM openjdk:8-jdk-alpine AS builder
+# FROM openjdk:8-jdk-alpine AS builder
+FROM bellsoft/liberica-openjdk-alpine:11 AS builder
 
 WORKDIR /zap
 
@@ -71,7 +72,7 @@ RUN if [ -z "$WEBSWING_URL" ] ; \
 # Copy stable release
 COPY --from=builder /zap .
 
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64/
+# ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64/
 ENV PATH $JAVA_HOME/bin:/zap/:$PATH
 ENV ZAP_PATH /zap/zap.sh
 


### PR DESCRIPTION
How to run zaproxy on Mac M1.

**darunesh@darunesh-mac docker % uname -a**
Darwin darunesh-mac 21.4.0 Darwin Kernel Version 21.4.0: Fri Mar 18 00:46:32 PDT 2022; root:xnu-8020.101.4~15/RELEASE_ARM64_T6000 arm64
**darunesh@darunesh-mac docker %** 
**darunesh@darunesh-mac docker % docker build -t zapm1 -f Dockerfile-stable .**
[+] Building 1.3s (31/31) FINISHED                                                                                                                                                                                    
 => [internal] load build definition from Dockerfile-stable                                                                                                                                                      
 => => naming to docker.io/library/zapm1                                                                                                                                                                         0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them

darunesh@darunesh-mac docker % docker images  
REPOSITORY           TAG               IMAGE ID       CREATED              SIZE
zapm1                latest            15511dbd1fb5   About a minute ago   1.82GB

**darunesh@darunesh-mac docker % docker run -it zapm1:latest**
**zap@180f8295b903:/zap$ ls**
CHANGELOG.md  container  lang  license  scripts   xml             zap-api-scan.py  zap-full-scan.py  zap-x.sh  zap.ico  zap_common.py
README        db         lib   plugin   webswing  zap-2.11.1.jar  zap-baseline.py  zap-webswing.sh   zap.bat   zap.sh
**zap@180f8295b903:/zap$ ./zap.sh -cmd -quickurl https://example.com -quickprogress -quickout ~/result.xml**
Found Java version 11.0.15
Available memory: 7851 MB
Using JVM args: -Xmx1962m
517 [main] INFO  org.parosproxy.paros.Constant - Copying default configuration to /home/zap/.ZAP/config.xml
624 [main] INFO  org.parosproxy.paros.Constant - Creating directory /home/zap/.ZAP/session
624 [main] INFO  org.parosproxy.paros.Constant - Creating directory /home/zap/.ZAP/dirbuster
624 [main] INFO  org.parosproxy.paros.Constant - Creating directory /home/zap/.ZAP/fuzzers
625 [main] INFO  org.parosproxy.paros.Constant - Creating directory /home/zap/.ZAP/plugin
May 09, 2022 3:49:46 PM java.util.prefs.FileSystemPreferences$1 run
INFO: Created user preferences directory.
Accessing URL
Using traditional spider
Active scanning
[====================] 100% 
Attack complete
Writing results to /home/zap/result.xml
zap@180f8295b903:/zap$ 
