### PR TITLE
Fix escaping on API param desc for setContextCheckingStrategy

### DIFF
--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -1396,7 +1396,7 @@ context.api.action.setContextCheckingStrategy.param.contextName = The name of th
 context.api.action.setContextCheckingStrategy.param.checkingStrategy = One of EACH_RESP, EACH_REQ, EACH_REQ_RESP, POLL_URL
 context.api.action.setContextCheckingStrategy.param.pollUrl = The URL for ZAP to poll, must be supplied if checkingStrategy = POLL_URL, otherwise ignored
 context.api.action.setContextCheckingStrategy.param.pollData = The POST data to supply to the pollUrl, option and only takes effect if checkingStrategy = POLL_URL
-context.api.action.setContextCheckingStrategy.param.pollHeaders = Any additional headers that need to be added to the poll request, separated by '\n' characters, only takes effect if checkingStrategy = POLL_URL
+context.api.action.setContextCheckingStrategy.param.pollHeaders = Any additional headers that need to be added to the poll request, separated by '\\n' characters, only takes effect if checkingStrategy = POLL_URL
 context.api.action.setContextCheckingStrategy.param.pollFrequency = An integer greater than zero, must be supplied if checkingStrategy = POLL_URL, otherwise ignored
 context.api.action.setContextCheckingStrategy.param.pollFrequencyUnits =  One of REQUESTS, SECONDS, must be supplied if checkingStrategy = POLL_URL, otherwise ignored
 context.api.action.setContextRegexs     = Set the regexs to include and exclude for a context, both supplied as JSON string arrays


### PR DESCRIPTION
As reported via the User Group:
https://groups.google.com/g/zaproxy-users/c/tHYYmw3joYI

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>