### PR TITLE
Prepare deprecation of connection API endpoints

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ApiGeneratorUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ApiGeneratorUtils.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.extension.api;
 import java.util.ArrayList;
 import java.util.List;
 import org.parosproxy.paros.core.scanner.ScannerParam;
-import org.parosproxy.paros.network.ConnectionParam;
 import org.zaproxy.zap.extension.alert.AlertAPI;
 import org.zaproxy.zap.extension.anticsrf.AntiCsrfAPI;
 import org.zaproxy.zap.extension.anticsrf.AntiCsrfParam;
@@ -81,7 +80,7 @@ public class ApiGeneratorUtils {
         api.addApiOptions(new SpiderParam());
         imps.add(api);
 
-        api = new CoreAPI(new ConnectionParam());
+        api = new CoreAPI();
         imps.add(api);
 
         imps.add(new ParamsAPI(null));

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ExtensionAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ExtensionAPI.java
@@ -61,7 +61,7 @@ public class ExtensionAPI extends ExtensionAdaptor {
             extensionHook.getHookMenu().addToolsMenuItem(getMenuAPI());
         }
 
-        coreApi = new CoreAPI(extensionHook.getModel().getOptionsParam().getConnectionParam());
+        coreApi = new CoreAPI();
 
         extensionHook.addApiImplementor(coreApi);
         extensionHook.addApiImplementor(new ContextAPI());

--- a/zap/src/test/java/org/zaproxy/zap/extension/api/CoreAPIUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/api/CoreAPIUnitTest.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.api;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.BDDMockito.given;
@@ -35,7 +36,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.Model;
-import org.parosproxy.paros.network.ConnectionParam;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.utils.I18N;
 
@@ -53,13 +53,20 @@ class CoreAPIUnitTest {
         networkApi = mock(ApiImplementor.class, withSettings().lenient());
         given(networkApi.getPrefix()).willReturn("network");
         API.getInstance().registerApiImplementor(networkApi);
-        coreApi = new CoreAPI(mock(ConnectionParam.class));
+        coreApi = new CoreAPI();
     }
 
     @AfterEach
     void cleanUp() {
         API.getInstance().removeApiImplementor(networkApi);
         Constant.messages = null;
+    }
+
+    @Test
+    void shouldAddApiElements() {
+        assertThat(coreApi.getApiActions(), hasSize(40));
+        assertThat(coreApi.getApiViews(), hasSize(40));
+        assertThat(coreApi.getApiOthers(), hasSize(11));
     }
 
     @Test


### PR DESCRIPTION
Register the connection options manually and stop using the
`ConnectionParam`, to be replaced/handled by network add-on.