### PR TITLE
Deprecate and remove use of URL Export menu items being moved to exim

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -95,6 +95,8 @@
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/02/09 Deprecate methods related to core proxy.
 // ZAP: 2022/02/28 Remove code deprecated in 2.6.0
+// ZAP: 2022/05/12 Remove URL, messages, and response export menus and functionality, migrated to
+// the exim add-on.
 package org.parosproxy.paros.extension.history;
 
 import java.awt.EventQueue;
@@ -137,9 +139,6 @@ import org.zaproxy.zap.extension.help.ExtensionHelp;
 import org.zaproxy.zap.extension.history.HistoryFilterPlusDialog;
 import org.zaproxy.zap.extension.history.ManageTagsDialog;
 import org.zaproxy.zap.extension.history.NotesAddDialog;
-import org.zaproxy.zap.extension.history.PopupMenuExportContextURLs;
-import org.zaproxy.zap.extension.history.PopupMenuExportSelectedURLs;
-import org.zaproxy.zap.extension.history.PopupMenuExportURLs;
 import org.zaproxy.zap.extension.history.PopupMenuNote;
 import org.zaproxy.zap.extension.history.PopupMenuPurgeHistory;
 import org.zaproxy.zap.extension.history.PopupMenuTag;
@@ -161,13 +160,8 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
     private PopupMenuPurgeHistory popupMenuPurgeHistory = null;
     private ManualRequestEditorDialog resendDialog = null;
 
-    private PopupMenuExportMessage popupMenuExportMessage2 = null;
-    private PopupMenuExportResponse popupMenuExportResponse2 = null;
     private PopupMenuTag popupMenuTag = null;
-    // ZAP: Added Export URLs
-    private PopupMenuExportURLs popupMenuExportURLs = null;
-    private PopupMenuExportSelectedURLs popupMenuExportSelectedURLs = null;
-    private PopupMenuExportContextURLs popupMenuExportContextURLs = null;
+
     // ZAP: Added history notes
     private PopupMenuNote popupMenuNote = null;
     private NotesAddDialog dialogNotesAdd = null;
@@ -267,27 +261,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
             // ZAP: Added history notes
             extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuNote());
 
-            //	        extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuExportMessage());
-            //          extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuExportResponse());
-
             extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuPurgeHistory());
-
-            // same as PopupMenuExport but for File menu
-            // ZAP: Move 'export' menu items to Report menu
-            extensionHook.getHookMenu().addReportMenuItem(getPopupMenuExportMessage2());
-            extensionHook.getHookMenu().addReportMenuItem(getPopupMenuExportResponse2());
-            extensionHook
-                    .getHookMenu()
-                    .addReportMenuItem(extensionHook.getHookMenu().getMenuSeparator());
-            extensionHook.getHookMenu().addReportMenuItem(getPopupMenuExportURLs());
-            extensionHook.getHookMenu().addReportMenuItem(getPopupMenuExportSelectedURLs());
-            extensionHook.getHookMenu().addReportMenuItem(getPopupMenuExportContextURLs());
-            extensionHook
-                    .getHookMenu()
-                    .addReportMenuItem(extensionHook.getHookMenu().getMenuSeparator());
-
-            extensionHook.getHookMenu().addPopupMenuItem(createPopupMenuExportURLs());
-            extensionHook.getHookMenu().addPopupMenuItem(createPopupMenuExportSelectedURLs());
 
             ExtensionHelp.enableHelpKey(this.getLogPanel(), "ui.tabs.history");
         }
@@ -607,32 +581,6 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
         return resendDialog;
     }
 
-    /**
-     * This method initializes popupMenuExport1
-     *
-     * @return org.parosproxy.paros.extension.history.PopupMenuExport
-     */
-    private PopupMenuExportMessage getPopupMenuExportMessage2() {
-        if (popupMenuExportMessage2 == null) {
-            popupMenuExportMessage2 = new PopupMenuExportMessage();
-            popupMenuExportMessage2.setExtension(this);
-        }
-        return popupMenuExportMessage2;
-    }
-
-    /**
-     * This method initializes popupMenuExportResponse2
-     *
-     * @return org.parosproxy.paros.extension.history.PopupMenuExportResponse
-     */
-    private PopupMenuExportResponse getPopupMenuExportResponse2() {
-        if (popupMenuExportResponse2 == null) {
-            popupMenuExportResponse2 = new PopupMenuExportResponse();
-            popupMenuExportResponse2.setExtension(this);
-        }
-        return popupMenuExportResponse2;
-    }
-
     private PopupMenuTag getPopupMenuTag() {
         if (popupMenuTag == null) {
             popupMenuTag = new PopupMenuTag(this);
@@ -739,38 +687,6 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
         } else if (!manageTags.isVisible()) {
             populateManageTagsDialogAndSetVisible(ref, tags);
         }
-    }
-
-    private PopupMenuExportURLs getPopupMenuExportURLs() {
-        if (popupMenuExportURLs == null) {
-            popupMenuExportURLs = createPopupMenuExportURLs();
-        }
-        return popupMenuExportURLs;
-    }
-
-    private PopupMenuExportURLs createPopupMenuExportURLs() {
-        return new PopupMenuExportURLs(Constant.messages.getString("exportUrls.popup"), this);
-    }
-
-    private PopupMenuExportSelectedURLs getPopupMenuExportSelectedURLs() {
-        if (popupMenuExportSelectedURLs == null) {
-            popupMenuExportSelectedURLs = createPopupMenuExportSelectedURLs();
-        }
-        return popupMenuExportSelectedURLs;
-    }
-
-    private PopupMenuExportSelectedURLs createPopupMenuExportSelectedURLs() {
-        return new PopupMenuExportSelectedURLs(
-                Constant.messages.getString("exportUrls.popup.selected"), this);
-    }
-
-    private PopupMenuExportContextURLs getPopupMenuExportContextURLs() {
-        if (popupMenuExportContextURLs == null) {
-            popupMenuExportContextURLs =
-                    new PopupMenuExportContextURLs(
-                            Constant.messages.getString("context.export.urls.menu"), this);
-        }
-        return popupMenuExportContextURLs;
     }
 
     public void showInHistory(HistoryReference href) {

--- a/zap/src/main/java/org/parosproxy/paros/extension/history/PopupMenuExportMessage.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/PopupMenuExportMessage.java
@@ -36,6 +36,7 @@
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2021/04/08 Name logger (LOG) fullcaps as constant, use LF as EOL for text file content
 // ZAP: 2022/02/08 Use isEmpty where applicable.
+// ZAP: 2022/05/13 Deprecated for relocation to exim.
 package org.parosproxy.paros.extension.history;
 
 import java.io.BufferedWriter;
@@ -55,6 +56,8 @@ import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
+/** @deprecated (2.12.0) see the exim add-on */
+@Deprecated
 public class PopupMenuExportMessage extends JMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/parosproxy/paros/extension/history/PopupMenuExportResponse.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/PopupMenuExportResponse.java
@@ -32,6 +32,7 @@
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2021/04/08 Set/name logger (LOG) fullcaps as constant, use LF as EOL for text file content
 // ZAP: 2022/02/08 Use isEmpty where applicable.
+// ZAP: 2022/05/13 Deprecated for relocation to exim.
 package org.parosproxy.paros.extension.history;
 
 import java.io.BufferedOutputStream;
@@ -48,6 +49,8 @@ import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
+/** @deprecated (2.12.0) see the exim add-on */
+@Deprecated
 public class PopupMenuExportResponse extends JMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuExportContextURLs.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuExportContextURLs.java
@@ -33,6 +33,8 @@ import org.parosproxy.paros.view.SiteMapPanel;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.model.Context;
 
+/** @deprecated (2.12.0) see the exim add-on */
+@Deprecated
 public class PopupMenuExportContextURLs extends PopupMenuExportURLs {
 
     private static final long serialVersionUID = -4426560452505908380L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuExportSelectedURLs.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuExportSelectedURLs.java
@@ -33,6 +33,8 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.model.SiteNode;
 
+/** @deprecated (2.12.0) see the exim add-on */
+@Deprecated
 public class PopupMenuExportSelectedURLs extends PopupMenuExportURLs {
 
     private static final long serialVersionUID = -4426560452505908380L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuExportURLs.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuExportURLs.java
@@ -38,6 +38,8 @@ import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.parosproxy.paros.model.SiteNode;
 import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
+/** @deprecated (2.12.0) see the exim add-on */
+@Deprecated
 public class PopupMenuExportURLs extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
@@ -41,7 +41,6 @@ import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.extension.manualrequest.ExtensionManualRequestEditor;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
-import org.zaproxy.zap.extension.history.PopupMenuExportContextURLs;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.ContextExportDialog;
@@ -68,12 +67,10 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
     private PopupMenuItemContextSiteInclude popupContextIncludeSiteMenu = null;
     private PopupMenuItemContextExclude popupContextExcludeMenu = null;
     private PopupMenuItemContextDataDriven popupContextDataDrivenMenu = null;
-    private PopupMenuCopyUrls popupMenuCopyUrls = null;
     private PopupContextTreeMenu popupContextTreeMenuInScope = null;
     private PopupContextTreeMenu popupContextTreeMenuOutScope = null;
     private PopupContextTreeMenu popupContextTreeMenuDelete = null;
     private PopupContextTreeMenu popupContextTreeMenuExport;
-    private PopupMenuExportContextURLs popupContextTreeMenuExportUrls;
 
     // Still being developed
     // private PopupMenuShowResponseInBrowser popupMenuShowResponseInBrowser = null;
@@ -161,13 +158,11 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
                     .getHookMenu()
                     .addPopupMenuItem(getPopupMenuOpenUrlInBrowser(++indexMenuItem));
             // extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuShowResponseInBrowser(indexMenuItem));
-            extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuCopyUrls(++indexMenuItem));
 
             extensionHook.getHookMenu().addPopupMenuItem(getPopupContextTreeMenuInScope());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupContextTreeMenuOutScope());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupContextTreeMenuDelete());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupContextTreeMenuExport());
-            extensionHook.getHookMenu().addPopupMenuItem(getPopupContextTreeMenuExportUrls());
         }
     }
 
@@ -229,15 +224,6 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
                     });
         }
         return popupContextTreeMenuOutScope;
-    }
-
-    private PopupMenuExportContextURLs getPopupContextTreeMenuExportUrls() {
-        if (popupContextTreeMenuExportUrls == null) {
-            popupContextTreeMenuExportUrls =
-                    new PopupMenuExportContextURLs(
-                            Constant.messages.getString("context.export.urls.menu"), this);
-        }
-        return popupContextTreeMenuExportUrls;
     }
 
     private PopupContextTreeMenu getPopupContextTreeMenuDelete() {
@@ -374,15 +360,6 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
             popupMenuOpenUrlInBrowser.setMenuIndex(menuIndex);
         }
         return popupMenuOpenUrlInBrowser;
-    }
-
-    private PopupMenuCopyUrls getPopupMenuCopyUrls(int menuIndex) {
-        if (popupMenuCopyUrls == null) {
-            popupMenuCopyUrls =
-                    new PopupMenuCopyUrls(Constant.messages.getString("stdexts.copyurls.popup"));
-            popupMenuCopyUrls.setMenuIndex(menuIndex);
-        }
-        return popupMenuCopyUrls;
     }
 
     /*

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuCopyUrls.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuCopyUrls.java
@@ -28,6 +28,8 @@ import java.util.List;
 import org.parosproxy.paros.model.HistoryReference;
 import org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer;
 
+/** @deprecated (2.12.0) see the exim add-on */
+@Deprecated
 public class PopupMenuCopyUrls extends PopupMenuItemHistoryReferenceContainer
         implements ClipboardOwner {
 


### PR DESCRIPTION
- ExtensionHistory and ExtendionStdMenus no longer use pop-up export URLs menu items.
- PopupMenuExportContextURLs, PopupMenuExportSelectedURLs, PopupMenuExportURLs, PopupMenuCopyUrls deprecated.

Related to: zaproxy/zaproxy#6579

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>