### PR TITLE
Centre dialogue on screen if no owner

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/view/AbstractFormDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/AbstractFormDialog.java
@@ -24,6 +24,7 @@ import java.awt.Dialog;
 import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.Rectangle;
+import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -235,9 +236,17 @@ public abstract class AbstractFormDialog extends JDialog {
 
     private void centreOnOwner() {
         Dimension frameSize = this.getSize();
-        Rectangle mainrect = getOwner().getBounds();
+        Rectangle mainrect = getMainRectangle();
         int x = mainrect.x + (mainrect.width - frameSize.width) / 2;
         int y = mainrect.y + (mainrect.height - frameSize.height) / 2;
         this.setLocation(x, y);
+    }
+
+    private Rectangle getMainRectangle() {
+        Window owner = getOwner();
+        if (owner != null) {
+            return owner.getBounds();
+        }
+        return new Rectangle(Toolkit.getDefaultToolkit().getScreenSize());
     }
 }


### PR DESCRIPTION
Change `AbstractFormDialog` to centre the dialogue on the screen when
it has no owner.