### PR TITLE
Add missed connection option API endpoint

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -434,6 +434,10 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
         addApiAction(new ApiAction("setOptionProxyChainPort", PARAMS_INTEGER));
         addApiAction(new ApiAction("setOptionProxyChainPrompt", PARAMS_BOOLEAN));
         addApiAction(new ApiAction("setOptionProxyChainRealm", PARAMS_STRING));
+        addApiAction(
+                depreciatedApi(
+                        new ApiAction("setOptionProxyChainSkipName", PARAMS_STRING),
+                        Constant.messages.getString("api.deprecated.option.endpoint")));
         addApiAction(new ApiAction("setOptionProxyChainUserName", PARAMS_STRING));
         addApiAction(
                 depreciatedApi(

--- a/zap/src/test/java/org/zaproxy/zap/extension/api/CoreAPIUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/api/CoreAPIUnitTest.java
@@ -64,7 +64,7 @@ class CoreAPIUnitTest {
 
     @Test
     void shouldAddApiElements() {
-        assertThat(coreApi.getApiActions(), hasSize(40));
+        assertThat(coreApi.getApiActions(), hasSize(41));
         assertThat(coreApi.getApiViews(), hasSize(40));
         assertThat(coreApi.getApiOthers(), hasSize(11));
     }


### PR DESCRIPTION
Reinstate a connection option missed when stopping using the
`ConnectionParam` to handle the option endpoints.