### PR TITLE
 Scan Policy Manager Policy multiplies while modifying the name

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyAllCategoryPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyAllCategoryPanel.java
@@ -535,7 +535,8 @@ public class PolicyAllCategoryPanel extends AbstractParamPanel {
 
         } else if (!newName.equals(currentName)) {
             // Name changed
-            if (extension.getPolicyManager().getAllPolicyNames().contains(newName)) {
+            if (extension.getPolicyManager().getAllPolicyNames().stream()
+                    .anyMatch(newName::equalsIgnoreCase)) {
                 getPolicyName().requestFocusInWindow();
                 throw new Exception(Constant.messages.getString("ascan.policy.warn.exists"));
             }

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyManager.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyManager.java
@@ -104,6 +104,13 @@ public class PolicyManager {
 
         policy.getPluginFactory().saveTo(conf);
 
+        if (previousName != null && !previousName.equals(policy.getName())) {
+            File oldFile = new File(Constant.getPoliciesDir(), previousName + POLICY_EXTENSION);
+            if (oldFile.exists()) {
+                oldFile.delete();
+            }
+        }
+
         conf.save(file);
 
         if (previousName != null && previousName.length() > 0) {

--- a/zap/src/test/java/org/zaproxy/zap/extension/ascan/PolicyManagerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/ascan/PolicyManagerUnitTest.java
@@ -1,0 +1,112 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascan;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.WithConfigsTest;
+
+/** Unit test for {@link PolicyManager}. */
+class PolicyManagerUnitTest extends WithConfigsTest {
+
+    private static final String POLICY_EXTENSION = ".policy";
+
+    @Test
+    void shouldCreatePolicyFileIfSavingPolicy() throws Exception {
+        // Given
+        ExtensionActiveScan activeScan = new ExtensionActiveScan();
+        PolicyManager policyManager = new PolicyManager(activeScan);
+        policyManager.init();
+
+        ScanPolicy policy = new ScanPolicy();
+        policy.setName("test");
+
+        File file = new File(Constant.getPoliciesDir(), policy.getName() + POLICY_EXTENSION);
+
+        // When
+        policyManager.savePolicy(policy);
+        // Then
+        assertTrue(file.exists());
+    }
+
+    @Test
+    void shouldChangePolicyFileNameIfModifyingPolicyName() throws Exception {
+        // Given
+        ExtensionActiveScan activeScan = new ExtensionActiveScan();
+        PolicyManager policyManager = new PolicyManager(activeScan);
+        policyManager.init();
+
+        ScanPolicy policy = new ScanPolicy();
+        policy.setName("test");
+
+        File file = new File(Constant.getPoliciesDir(), policy.getName() + POLICY_EXTENSION);
+
+        ScanPolicy newPolicy = new ScanPolicy();
+        newPolicy.setName("newTest");
+        File newFile = new File(Constant.getPoliciesDir(), newPolicy.getName() + POLICY_EXTENSION);
+        policyManager.savePolicy(policy);
+
+        // When
+        policyManager.savePolicy(newPolicy, "test");
+        // Then
+        assertFalse(file.exists());
+        assertTrue(newFile.exists());
+    }
+
+    @Test
+    void shouldChangePolicyNameIfModifyingUpperOrLowerCase() throws Exception {
+        // Given
+        ExtensionActiveScan activeScan = new ExtensionActiveScan();
+        PolicyManager policyManager = new PolicyManager(activeScan);
+        policyManager.init();
+
+        ScanPolicy policy = new ScanPolicy();
+        policy.setName("test");
+
+        File file = new File(Constant.getPoliciesDir(), policy.getName() + POLICY_EXTENSION);
+
+        ScanPolicy newPolicy = new ScanPolicy();
+        newPolicy.setName("TeSt");
+        File newFile = new File(Constant.getPoliciesDir(), newPolicy.getName() + POLICY_EXTENSION);
+        policyManager.savePolicy(policy);
+
+        // When
+        policyManager.savePolicy(newPolicy, "test");
+        // Then
+        assertFalse(existsFileCaseSensitive(file.getName()));
+        assertTrue(newFile.exists());
+    }
+
+    // Helper Function for checking existing file(case-sensitive). For files.exists() test and Test
+    // are the same on some systems
+    private static boolean existsFileCaseSensitive(String filename) {
+        String[] files = Constant.getPoliciesDir().list();
+        for (String file : files) {
+            if (file.equals(filename)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Added condition to delete old policy file in case of a namechange, plus some tests to check it. Testfile got another file.exists() method otherwise the usuall exists()-method wouldn't differ between "Test" and "test". I've tested it on a Windows-System.

Fix  #7134.