### PR TITLE
Spider: find table/td background, video src/poster, and img srcset

### DIFF
--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlParserUnitTest.java
@@ -635,6 +635,69 @@ class SpiderHtmlParserUnitTest extends SpiderParserTestUtils {
     }
 
     @Test
+    void shouldFindUrlsInTableElements() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("TableElementsSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed =
+                htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(11)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "http://table.background.example.com/base/scheme",
+                        "http://table.background.example.com:8000/b",
+                        "https://table.background.example.com/c?a=b",
+                        "http://example.com/sample/background/relative",
+                        "http://example.com/sample/",
+                        "http://example.com/background/absolute",
+                        "ftp://background.example.com/",
+                        "http://example.com/background/td_absolute1",
+                        "http://example.com/background/td_absolute2",
+                        "http://example.com/sample/background/td_relative1",
+                        "http://td.background.example.com/"));
+    }
+
+    @Test
+    void shouldFindUrlsInVideoElements() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("VideoElementsSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed =
+                htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(14)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "http://video.example.com/base/scheme",
+                        "http://video.example.com:8000/b",
+                        "https://video.example.com/c?a=b",
+                        "http://example.com/sample/video/relative",
+                        "http://example.com/sample/",
+                        "http://example.com/video/absolute",
+                        "ftp://video.example.com/",
+                        "http://poster.example.com/",
+                        "http://example.com/sample/poster/relative",
+                        "http://example.com/media/cc0-videos/flower.webm",
+                        "http://example.com/media/cc0-videos/flower.mp4",
+                        "ftp://src.precedence.example.com/",
+                        "http://example.com/media/cc0-videos/stillFound.webm",
+                        "http://example.com/media/cc0-videos/stillFound.mp4"));
+    }
+
+    @Test
     void shouldFindUrlsInImgElements() {
         // Given
         SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
@@ -647,7 +710,7 @@ class SpiderHtmlParserUnitTest extends SpiderParserTestUtils {
                 htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
         // Then
         assertThat(completelyParsed, is(equalTo(false)));
-        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(11)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(24)));
         assertThat(
                 listener.getUrlsFound(),
                 contains(
@@ -661,7 +724,20 @@ class SpiderHtmlParserUnitTest extends SpiderParserTestUtils {
                         "http://example.com/sample/relative/longdesc",
                         "https://img.example.com/full/longdesc",
                         "http://example.com/img/lowsrc",
-                        "https://video.example.com/dynsrc/video"));
+                        "https://video.example.com/dynsrc/video",
+                        "http://example.com/test/html/body/img/srcset1x.found",
+                        "http://example.com/test/html/body/img/srcset2x.found",
+                        "http://example.com/test/html/body/img/normal_srcset.found",
+                        "http://example.com/test/html/body/img/normal_srcset1.found",
+                        "http://example.com/test/html/body/img/normal_srcset2.found",
+                        "http://example.com/test/html/body/img/normal_srcset3.found",
+                        "http://example.com/test/html/body/img/compact_srcset1.found",
+                        "http://example.com/test/html/body/img/compact_srcset2.found",
+                        "http://example.com/test/html/body/img/compact_srcset3.found",
+                        "http://example.com/test/html/body/img/mixed_compact_srcset1.found",
+                        "http://example.com/test/html/body/img/mixed_compact_srcset2.found",
+                        "http://example.com/sample/pixel_width1.png",
+                        "http://example.com/sample/pixel_width2.png"));
     }
 
     @Test

--- a/zap/src/test/resources/org/zaproxy/zap/spider/parser/html/ImgElementsSpiderHtmlParser.html
+++ b/zap/src/test/resources/org/zaproxy/zap/spider/parser/html/ImgElementsSpiderHtmlParser.html
@@ -18,12 +18,20 @@
 <img longdesc="https://img.example.com/full/longdesc">
 <img lowsrc="/img/lowsrc">
 <img dynsrc="https://video.example.com/dynsrc/video">
+<img srcset="/test/html/body/img/srcset1x.found 1x, /test/html/body/img/srcset2x.found 2x">
+<img srcset="/test/html/body/img/normal_srcset.found">
+<img srcset="/test/html/body/img/normal_srcset1.found, /test/html/body/img/normal_srcset2.found, /test/html/body/img/normal_srcset3.found">
+<img srcset="/test/html/body/img/compact_srcset1.found,/test/html/body/img/compact_srcset2.found,/test/html/body/img/compact_srcset3.found">
+<img srcset="/test/html/body/img/mixed_compact_srcset1.found 1x,/test/html/body/img/mixed_compact_srcset2.found">
+<img srcset="pixel_width1.png 200w, pixel_width2.png 400w">
+
 
 <!--  Ignored: -->
 <img>
 <img src="mailto:img@example.com">
 <img src="javascript:hello();">
 <img src="scheme://img.example.com/invalid">
+<img srcset="">
 
 </body>
 </html>

--- a/zap/src/test/resources/org/zaproxy/zap/spider/parser/html/TableElementsSpiderHtmlParser.html
+++ b/zap/src/test/resources/org/zaproxy/zap/spider/parser/html/TableElementsSpiderHtmlParser.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <base href="http://example.com/sample/">
+    <meta charset="UTF-8">
+    <title>Table Elements - Spider HTML Parser</title>
+</head>
+<body>
+
+<!--  Simple Table Background: -->
+<table background="http://table.background.example.com/base/scheme"></table>
+<table background="http://table.background.example.com:8000/b"></table>
+<table background="https://table.background.example.com/c?a=b#fragment"></table>
+<table background="background/relative"></table>
+<table background=""></table>
+<table background="/background/absolute"></table>
+<table background="ftp://background.example.com/"></table>
+
+<!--  Column Background: -->
+<table>
+<tr>
+<td background="/background/td_absolute1"></td>
+<td background="/background/td_absolute2"></td>
+<td background="background/td_relative1"></td>
+</tr>
+</table>
+
+<td background="http://td.background.example.com"></td>
+
+<!--  Ignored: -->
+<table></table>
+<table>
+    <tr>
+        <td></td>
+    </tr>
+</table>
+<table background="mailto:background@example.com"></table>
+
+</body>
+</html>

--- a/zap/src/test/resources/org/zaproxy/zap/spider/parser/html/VideoElementsSpiderHtmlParser.html
+++ b/zap/src/test/resources/org/zaproxy/zap/spider/parser/html/VideoElementsSpiderHtmlParser.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <base href="http://example.com/sample/">
+    <meta charset="UTF-8">
+    <title>Video Elements - Spider HTML Parser</title>
+</head>
+<body>
+
+<video src="//video.example.com/base/scheme">
+<video src="http://video.example.com:8000/b">
+<video src="https://video.example.com/c?a=b#fragment">
+<video src="video/relative">
+<video src="">
+<video src="/video/absolute">
+<video src="ftp://video.example.com/">
+<video src="http://poster.example.com/" poster="poster/relative">
+
+<video>
+    <source src="/media/cc0-videos/flower.webm"
+            type="video/webm">
+    <source src="/media/cc0-videos/flower.mp4"
+            type="video/mp4">
+</video>
+
+<video src="ftp://src.precedence.example.com/">
+    <source src="/media/cc0-videos/stillFound.webm"
+            type="video/webm">
+    <source src="/media/cc0-videos/stillFound.mp4"
+            type="video/mp4">
+</video>
+
+<!--  Ignored: -->
+<video>
+<video src="mailto:video@example.com">
+<video src="javascript:hello();">
+<video src="scheme://video.example.com/invalid">
+
+</body>
+</html>


### PR DESCRIPTION
Covers the following cases:

/test/html/body/table/background.found
/test/html/body/table/td/background.found
/test/html/body/video/src.found
/test/html/body/video/poster.found
/test/html/body/img/srcset1x.found
/test/html/body/img/srcset2x.found

Introduces a custom URL processor for URLs in attributes that require special handling (see srcset)

As always, commits will be squashed prior to final merge