### PR TITLE
Confirm the deletion with the name of the context

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/view/DeleteContextAction.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/DeleteContextAction.java
@@ -64,10 +64,7 @@ public abstract class DeleteContextAction extends AbstractAction {
 
         if (View.getSingleton()
                         .showConfirmDialog(
-                                contexts.size() > 1
-                                        ? Constant.messages.getString(
-                                                "context.delete.warning.multiple", contextList)
-                                        : Constant.messages.getString("context.delete.warning"))
+                                Constant.messages.getString("context.delete.warning", contextList))
                 == JOptionPane.OK_OPTION) {
             for (Context context : contexts) {
                 Model.getSingleton().getSession().deleteContext(context);

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -1320,8 +1320,7 @@ context.ddn.table.type.struct      = Struct
 
 context.default.name			   = Default Context
 context.delete.popup			   = Delete
-context.delete.warning			   = Are you sure you want to remove this context?
-context.delete.warning.multiple	   = Are you sure you want to remove the contexts:\n{0}?
+context.delete.warning			   = Are you sure you want to remove the following context(s)?\n{0}
 context.error.name.empty = The context name must be provided.
 context.error.name.duplicated = A context with same name already exists.
 context.error.name.unknown = The context name is invalid.


### PR DESCRIPTION
Provide the name of the context being deleted instead of saying "this".
Use a single resource message for when deleting one or more contexts.

---
Suggested in the IRC channel.