### PR TITLE
Clarify History Tags vs Alert Tags

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -1472,6 +1472,30 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
             return this;
         }
 
+        @Override
+        public AlertBuilder addTag(String tag) {
+            super.addTag(tag);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder addTag(String tag, String value) {
+            super.addTag(tag, value);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder removeTag(String tag) {
+            super.removeTag(tag);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder removeTag(String tag, String value) {
+            super.removeTag(tag, value);
+            return this;
+        }
+
         /**
          * Raises the alert with specified data.
          *

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Alert.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Alert.java
@@ -63,10 +63,12 @@
 // ZAP: 2022/02/03 Removed SUSPICIOUS, WARNING, MSG_RELIABILITY, setRiskReliability(int, int) and
 // getReliability()
 // ZAP: 2022/02/25 Remove code deprecated in 2.5.0
+// ZAP: 2022/05/26 Add addTag and removeTag methods
 package org.parosproxy.paros.core.scanner;
 
 import java.net.URL;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import javax.swing.ImageIcon;
 import org.apache.commons.httpclient.URI;
@@ -1084,6 +1086,59 @@ public class Alert implements Comparable<Alert> {
         /** @since 2.11.0 */
         public Builder setTags(Map<String, String> tags) {
             this.tags = tags;
+            return this;
+        }
+
+        /**
+         * Adds an Alert tag with the given key (tag/name) to the existing collection for this
+         * Alert/Builder.
+         *
+         * @since 2.12.0
+         */
+        public Builder addTag(String tag) {
+            addTag(tag, "");
+            return this;
+        }
+
+        /**
+         * Adds an Alert tag with the given key (tag/name) and value to the existing collection for
+         * this Alert/Builder.
+         *
+         * @since 2.12.0
+         */
+        public Builder addTag(String tag, String value) {
+            if (this.tags == null) {
+                this.tags = new HashMap<>();
+            }
+            this.tags.put(tag, value);
+            return this;
+        }
+
+        /**
+         * Removes an Alert tag with the given key (tag/name) from the existing collection for this
+         * Alert/Builder.
+         *
+         * @since 2.12.0
+         */
+        public Builder removeTag(String tag) {
+            if (this.tags == null) {
+                return this;
+            }
+            this.tags.remove(tag);
+            return this;
+        }
+
+        /**
+         * Removes an Alert tag with the given key (tag/name) and value from the existing collection
+         * for this Alert/Builder.
+         *
+         * @since 2.12.0
+         */
+        public Builder removeTag(String tag, String value) {
+            if (this.tags == null) {
+                return this;
+            }
+            this.tags.remove(tag, value);
             return this;
         }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/AntiCsrfDetectScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/AntiCsrfDetectScanner.java
@@ -66,7 +66,7 @@ public class AntiCsrfDetectScanner implements PassiveScanner {
         for (AntiCsrfToken token : list) {
             if (this.registerToken(msg.getHistoryRef().getHistoryType())) {
                 if (helper != null) {
-                    helper.addTag(msg.getHistoryRef(), ExtensionAntiCSRF.TAG);
+                    helper.addHistoryTag(msg.getHistoryRef(), ExtensionAntiCSRF.TAG);
                 }
                 extAntiCSRF.registerAntiCsrfToken(token);
             }

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanTaskHelper.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanTaskHelper.java
@@ -169,7 +169,7 @@ public class PassiveScanTaskHelper {
      *
      * @param tag the name of the tag.
      */
-    public void addTag(HistoryReference href, String tag) {
+    public void addHistoryTag(HistoryReference href, String tag) {
         if (shutDown) {
             return;
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
@@ -84,7 +84,7 @@ public class PassiveScanThread extends Thread {
      * @since 2.11.0
      */
     public void addTag(String tag) {
-        helper.addTag(href, tag);
+        helper.addHistoryTag(href, tag);
     }
     /**
      * Add the History Type ({@code int}) to the set of applicable history types.

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
@@ -101,7 +101,7 @@ public abstract class PluginPassiveScanner extends Enableable
     /**
      * <strong>Note:</strong> This method should no longer need to be overridden, the functionality
      * provided by the {@code parent} can be obtained directly with {@link #newAlert()} and {@link
-     * #addTag(String)}.
+     * #addHistoryTag(String)}.
      */
     @Override
     @SuppressWarnings("deprecation")
@@ -410,9 +410,21 @@ public abstract class PluginPassiveScanner extends Enableable
      *
      * @param tag the name of the tag.
      * @since 2.11.0
+     * @deprecated (2.12.0) Replaced by {@link #addHistoryTag(String)}.
      */
+    @Deprecated
     protected void addTag(String tag) {
-        this.taskHelper.addTag(this.message.getHistoryRef(), tag);
+        addHistoryTag(tag);
+    }
+
+    /**
+     * Adds the given tag to the message being passive scanned.
+     *
+     * @param tag the name of the tag.
+     * @since 2.12.0
+     */
+    protected void addHistoryTag(String tag) {
+        this.taskHelper.addHistoryTag(this.message.getHistoryRef(), tag);
     }
 
     /**
@@ -620,6 +632,30 @@ public abstract class PluginPassiveScanner extends Enableable
         @Override
         public AlertBuilder setTags(Map<String, String> tags) {
             super.setTags(tags);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder addTag(String tag) {
+            super.addTag(tag, "");
+            return this;
+        }
+
+        @Override
+        public AlertBuilder addTag(String tag, String value) {
+            super.addTag(tag, value);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder removeTag(String tag) {
+            super.removeTag(tag);
+            return this;
+        }
+
+        @Override
+        public AlertBuilder removeTag(String tag, String value) {
+            super.removeTag(tag, value);
             return this;
         }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/RegexAutoTagScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/RegexAutoTagScanner.java
@@ -330,7 +330,7 @@ public class RegexAutoTagScanner extends PluginPassiveScanner {
             if (matcher.groupCount() > 0) {
                 tag = matcher.pattern().matcher(matcher.group()).replaceFirst(tag);
             }
-            addTag(tag);
+            addHistoryTag(tag);
         }
 
         try {

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
@@ -193,9 +193,16 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
                 .raise();
     }
 
+    /** @deprecated 2.12.0 Replaced by {@link #addHistoryTag(String)} */
     @Override
+    @Deprecated
     public void addTag(String tag) {
-        super.addTag(tag);
+        super.addHistoryTag(tag);
+    }
+
+    @Override
+    public void addHistoryTag(String tag) {
+        super.addHistoryTag(tag);
     }
 
     @Override

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/AlertUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/AlertUnitTest.java
@@ -24,7 +24,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.Alert.Builder;
 
 class AlertUnitTest {
 
@@ -97,5 +100,61 @@ class AlertUnitTest {
         int cmp = alertA.compareTo(alertB);
         // Then
         assertThat(cmp, is(equalTo(-1)));
+    }
+
+    @Test
+    void shouldBuildAlertWithOneTag() {
+        // Given
+        Builder builder = new Alert.Builder();
+        // When
+        builder.addTag("Test");
+        Alert alert = builder.build();
+        int tagCount = alert.getTags().size();
+        // Then
+        assertThat(tagCount, is(equalTo(1)));
+    }
+
+    @Test
+    void shouldBuildAlertWithTwoTagsWhenOneSetAndOneAdded() {
+        // Given
+        Builder builder = new Alert.Builder();
+        // When
+        Map<String, String> tags = new HashMap<>();
+        tags.put("Test1", "Test");
+        builder.setTags(tags);
+        builder.addTag("Test2");
+        Alert alert = builder.build();
+        int tagCount = alert.getTags().size();
+        // Then
+        assertThat(tagCount, is(equalTo(2)));
+    }
+
+    @Test
+    void shouldBuildAlertWithOneTagWhenOneSetAndOneAddedOneRemoved() {
+        // Given
+        Builder builder = new Alert.Builder();
+        // When
+        Map<String, String> tags = new HashMap<>();
+        tags.put("Test1", "Test");
+        builder.setTags(tags);
+        builder.addTag("Test2");
+        builder.removeTag("Test1");
+        Alert alert = builder.build();
+        int tagCount = alert.getTags().size();
+        // Then
+        assertThat(tagCount, is(equalTo(1)));
+        assertThat(alert.getTags().get("Test2"), is(equalTo("")));
+    }
+
+    @Test
+    void shouldBuildAlertWithNoTagsWhenOneRemoved() {
+        // Given
+        Builder builder = new Alert.Builder();
+        // When
+        builder.removeTag("Test");
+        Alert alert = builder.build();
+        int tagCount = alert.getTags().size();
+        // Then
+        assertThat(tagCount, is(equalTo(0)));
     }
 }

--- a/zap/src/test/java/org/zaproxy/zap/extension/pscan/PluginPassiveScannerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/pscan/PluginPassiveScannerUnitTest.java
@@ -505,9 +505,9 @@ class PluginPassiveScannerUnitTest {
         scanner.init(null, msg, mock(PassiveScanData.class));
         scanner.setTaskHelper(taskHelper);
         // When
-        scanner.addTag(tag);
+        scanner.addHistoryTag(tag);
         // Then
-        verify(taskHelper).addTag(href, tag);
+        verify(taskHelper).addHistoryTag(href, tag);
     }
 
     private static class TestPluginPassiveScanner extends PluginPassiveScanner {

--- a/zap/src/test/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScannerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScannerUnitTest.java
@@ -130,9 +130,9 @@ class ScriptsPassiveScannerUnitTest extends WithConfigsTest {
                 scriptsPassiveScanner, null, message, mock(PassiveScanData.class));
         scriptsPassiveScanner.setTaskHelper(taskHelper);
         // When
-        scriptsPassiveScanner.addTag(tag);
+        scriptsPassiveScanner.addHistoryTag(tag);
         // Then
-        verify(taskHelper).addTag(href, tag);
+        verify(taskHelper).addHistoryTag(href, tag);
     }
 
     @Test
@@ -141,7 +141,7 @@ class ScriptsPassiveScannerUnitTest extends WithConfigsTest {
         String tag = "Tag";
         ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
         // When / Then
-        assertThrows(NullPointerException.class, () -> scriptsPassiveScanner.addTag(tag));
+        assertThrows(NullPointerException.class, () -> scriptsPassiveScanner.addHistoryTag(tag));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
As discussed on the weekly team call and IRC.

- AbstractPlugin
    - Add overridden methods from super class.
- Alert
    - Add ZAP note.
    - Add addTag(String)
    - Add addTag(String, String)
    - Add removeTag(String)
    - Add removeTag(String, String)
- AlertUnitTest
    - Add tests asserting the new behavior.
- AntiCsrfDetectScanner
    - Updated to use the new method.
- PluginPassiveScanner
    - Add overridden methods from super class.
    - Deprecate addTag(String)
    - Add addHistoryTag(String)
- RegexAutoTagScanner
    - Use addHistoryTag(String)
- ScriptspassiveScanner
    - Deprecate addTag(String)
    - Add addHistoryTag(String)
- PassiveScanTaskHelper
    - Rename addTag(String) to addHistoryTag(String)
- PassiveScanThread
    - Use renamed method from helper.
- ScriptsPassiveScannerUnitTest
    - Updated to use new methods.
- PluginPassiveScannerUnitTest
    - Updated to use new methods.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>