### PR TITLE
Expose OptionsDialog through ViewDelegate

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/ViewDelegate.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/ViewDelegate.java
@@ -29,12 +29,14 @@
 // ZAP: 2018/07/17 Allow to obtain a KeyStroke with menu shortcut key mask.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2022/05/29 Allow to obtain the OptionsDialog.
 package org.parosproxy.paros.extension;
 
 import java.awt.Toolkit;
 import javax.swing.KeyStroke;
 import org.parosproxy.paros.view.MainFrame;
 import org.parosproxy.paros.view.MainPopupMenu;
+import org.parosproxy.paros.view.OptionsDialog;
 import org.parosproxy.paros.view.OutputPanel;
 import org.parosproxy.paros.view.SessionDialog;
 import org.parosproxy.paros.view.SiteMapPanel;
@@ -51,6 +53,14 @@ public interface ViewDelegate {
     SiteMapPanel getSiteTreePanel();
 
     OutputPanel getOutputPanel();
+
+    /**
+     * Gets the Options dialogue.
+     *
+     * @return the Options dialogue.
+     * @since 2.12.0
+     */
+    OptionsDialog getOptionsDialog();
 
     // ZAP: expose dialog
     SessionDialog getSessionDialog();

--- a/zap/src/main/java/org/parosproxy/paros/view/View.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/View.java
@@ -91,6 +91,7 @@
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/02/09 Remove method call no longer needed.
 // ZAP: 2022/02/26 Remove code deprecated in 2.5.0
+// ZAP: 2022/05/29 Implement getOptionsDialog().
 package org.parosproxy.paros.view;
 
 import java.awt.Component;
@@ -870,6 +871,11 @@ public class View implements ViewDelegate {
         }
         contextPanels.clear();
         this.getSiteTreePanel().reloadContextTree();
+    }
+
+    @Override
+    public OptionsDialog getOptionsDialog() {
+        return getOptionsDialog(null);
     }
 
     public OptionsDialog getOptionsDialog(String title) {


### PR DESCRIPTION
Allow extensions to access the options dialogue without requiring the
use of the view singleton.