### PR TITLE
Use shared connection pool

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/HostProcess.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/HostProcess.java
@@ -102,6 +102,7 @@
 // ZAP: 2022/02/25 Remove code deprecated in 2.5.0
 // ZAP: 2022/04/23 Use new HttpSender constructor.
 // ZAP: 2022/05/20 Address deprecation warnings with ConnectionParam.
+// ZAP: 2022/05/30 Remove deprecation usage.
 package org.parosproxy.paros.core.scanner;
 
 import java.io.IOException;
@@ -404,7 +405,6 @@ public class HostProcess implements Runnable {
         } finally {
             notifyHostProgress(null);
             notifyHostComplete();
-            getHttpSender().shutdown();
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/Downloader.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/Downloader.java
@@ -93,18 +93,13 @@ public class Downloader extends Thread {
     }
 
     private void downloadFile() {
-        HttpSender sender = null;
         try {
-            sender = new HttpSender(initiator);
+            HttpSender sender = new HttpSender(initiator);
             sender.setFollowRedirect(true);
             HttpMessage message = new HttpMessage(new URI(url.toString(), true));
             sender.sendAndReceive(message, targetFile.toPath());
         } catch (Exception e) {
             this.exception = e;
-        } finally {
-            if (sender != null) {
-                sender.shutdown();
-            }
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/spider/Spider.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/Spider.java
@@ -606,10 +606,7 @@ public class Spider {
         } catch (InterruptedException ignore) {
             log.warn("Interrupted while awaiting for all spider threads to stop...");
         }
-        if (httpSender != null) {
-            this.getHttpSender().shutdown();
-            httpSender = null;
-        }
+        httpSender = null;
 
         // Notify the controller to clean up memory
         controller.reset();
@@ -627,10 +624,7 @@ public class Spider {
 
         log.info("Spidering process is complete. Shutting down...");
         this.stopped = true;
-        if (httpSender != null) {
-            this.getHttpSender().shutdown();
-            httpSender = null;
-        }
+        httpSender = null;
 
         // Notify the controller to clean up memory
         controller.reset();


### PR DESCRIPTION
Use the same connection pool with all `HttpSender` instances, to share
available connections between all components.
Deprecate the shutdown method which was closing the pool, it will now
have the same lifecycle as ZAP itself.
Address deprecations.