### PR TITLE
Allow to replace HttpSender implementation

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
@@ -105,61 +105,20 @@
 // ZAP: 2022/05/29 Remove redundant checks and create SSLConnector always.
 // ZAP: 2022/05/30 Use shared connection pool.
 // ZAP: 2022/06/03 Remove commented code and make listeners comparator final.
+// ZAP: 2022/06/03 Move implementation to HttpSenderParos.
 // ZAP: 2022/06/05 Remove usage of HttpException.
 package org.parosproxy.paros.network;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.Socket;
-import java.net.SocketAddress;
-import java.nio.channels.Channels;
-import java.nio.channels.FileChannel;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
-import java.util.concurrent.TimeUnit;
-import javax.net.SocketFactory;
-import org.apache.commons.httpclient.DefaultHttpMethodRetryHandler;
-import org.apache.commons.httpclient.Header;
-import org.apache.commons.httpclient.HostConfiguration;
 import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpHost;
 import org.apache.commons.httpclient.HttpMethod;
-import org.apache.commons.httpclient.HttpMethodDirector;
-import org.apache.commons.httpclient.HttpMethodRetryHandler;
 import org.apache.commons.httpclient.HttpState;
-import org.apache.commons.httpclient.InvalidRedirectLocationException;
-import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
-import org.apache.commons.httpclient.NTCredentials;
-import org.apache.commons.httpclient.URI;
-import org.apache.commons.httpclient.URIException;
-import org.apache.commons.httpclient.auth.AuthPolicy;
-import org.apache.commons.httpclient.auth.AuthScope;
-import org.apache.commons.httpclient.cookie.CookiePolicy;
-import org.apache.commons.httpclient.params.HttpClientParams;
-import org.apache.commons.httpclient.params.HttpConnectionParams;
-import org.apache.commons.httpclient.params.HttpMethodParams;
-import org.apache.commons.httpclient.protocol.Protocol;
-import org.apache.commons.httpclient.protocol.ProtocolSocketFactory;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.parosproxy.paros.model.Model;
-import org.zaproxy.zap.ZapGetMethod;
-import org.zaproxy.zap.ZapHttpConnectionManager;
 import org.zaproxy.zap.network.HttpRedirectionValidator;
 import org.zaproxy.zap.network.HttpRequestConfig;
+import org.zaproxy.zap.network.HttpSenderContext;
+import org.zaproxy.zap.network.HttpSenderImpl;
 import org.zaproxy.zap.network.HttpSenderListener;
-import org.zaproxy.zap.network.ZapCookieSpec;
-import org.zaproxy.zap.network.ZapNTLMScheme;
 import org.zaproxy.zap.users.User;
 
 public class HttpSender {
@@ -180,57 +139,22 @@ public class HttpSender {
     public static final int AUTHENTICATION_POLL_INITIATOR = 15;
     public static final int OAST_INITIATOR = 16;
 
-    private static Logger log = LogManager.getLogger(HttpSender.class);
-
-    private static SSLConnector sslConnector;
-
-    private static List<HttpSenderListener> listeners = new ArrayList<>();
-    private static final Comparator<HttpSenderListener> LISTENERS_COMPARATOR =
-            (o1, o2) -> Integer.compare(o1.getListenerOrder(), o2.getListenerOrder());
-
-    private User user = null;
-
-    static {
-        sslConnector = new SSLConnector(true);
-
-        Protocol.registerProtocol(
-                "https", new Protocol("https", (ProtocolSocketFactory) sslConnector, 443));
-
-        Protocol.registerProtocol(
-                "http", new Protocol("http", new ProtocolSocketFactoryImpl(), 80));
-
-        AuthPolicy.registerAuthScheme(AuthPolicy.NTLM, ZapNTLMScheme.class);
-        CookiePolicy.registerCookieSpec(CookiePolicy.DEFAULT, ZapCookieSpec.class);
-        CookiePolicy.registerCookieSpec(CookiePolicy.BROWSER_COMPATIBILITY, ZapCookieSpec.class);
-    }
-
-    private static HttpMethodHelper helper = new HttpMethodHelper();
-    private static final ThreadLocal<Boolean> IN_LISTENER = new ThreadLocal<>();
     private static final HttpRequestConfig NO_REDIRECTS = HttpRequestConfig.builder().build();
     private static final HttpRequestConfig FOLLOW_REDIRECTS =
             HttpRequestConfig.builder().setFollowRedirects(true).build();
 
-    private static final ResponseBodyConsumer DEFAULT_BODY_CONSUMER =
-            (msg, method) -> {
-                if (msg.isEventStream()) {
-                    msg.getResponseBody().setCharset(msg.getResponseHeader().getCharset());
-                    msg.getResponseBody().setLength(0);
-                    return;
-                }
+    private static final HttpSenderParos PAROS_IMPL = new HttpSenderParos();
 
-                msg.setResponseBody(method.getResponseBody());
-            };
+    @SuppressWarnings("rawtypes")
+    private static HttpSenderImpl impl = PAROS_IMPL;
 
-    private HttpClient client = null;
+    private final HttpSenderContext ctx;
+    private final int initiator;
 
-    @SuppressWarnings("deprecation")
-    private ConnectionParam param = null;
-
-    private static MultiThreadedHttpConnectionManager httpConnManager;
-    private HttpRequestConfig followRedirect = NO_REDIRECTS;
-    private boolean useCookies;
-    private boolean useGlobalState;
-    private int initiator = -1;
+    /** <strong>Note:</strong> Not part of the public API. */
+    public static <T extends HttpSenderContext> void setImpl(HttpSenderImpl<T> impl) {
+        HttpSender.impl = impl == null ? PAROS_IMPL : impl;
+    }
 
     /**
      * Constructs an {@code HttpSender}.
@@ -250,7 +174,7 @@ public class HttpSender {
      */
     @Deprecated
     public HttpSender(ConnectionParam connectionParam, boolean useGlobalState, int initiator) {
-        init(useGlobalState, initiator);
+        this(useGlobalState, initiator);
     }
 
     /**
@@ -266,44 +190,15 @@ public class HttpSender {
      * @see HttpSenderListener
      */
     public HttpSender(int initiator) {
-        init(true, initiator);
+        this(true, initiator);
     }
 
-    @SuppressWarnings("deprecation")
-    private void init(boolean useGlobalState, int initiator) {
-        this.param = Model.getSingleton().getOptionsParam().getConnectionParam();
+    private HttpSender(boolean useGlobalState, int initiator) {
         this.initiator = initiator;
-
-        client = new HttpClient(getConnectionManager());
-        client.getParams().setBooleanParameter(HttpClientParams.ALLOW_CIRCULAR_REDIRECTS, true);
-
-        // Set how cookie headers are sent no matter of the "allowState", in case a state is forced
-        // by other extensions (e.g. Authentication)
-        client.getParams().setBooleanParameter(HttpMethodParams.SINGLE_COOKIE_HEADER, true);
+        ctx = impl.createContext(this, initiator);
 
         setUseGlobalState(useGlobalState);
         setUseCookies(true);
-    }
-
-    private static MultiThreadedHttpConnectionManager getConnectionManager() {
-        if (httpConnManager == null) {
-            createConnectionManager();
-        }
-        return httpConnManager;
-    }
-
-    private static synchronized void createConnectionManager() {
-        if (httpConnManager == null) {
-            httpConnManager = new MultiThreadedHttpConnectionManager();
-            httpConnManager.getParams().setStaleCheckingEnabled(true);
-            // Set to arbitrary large values to prevent locking
-            httpConnManager.getParams().setDefaultMaxConnectionsPerHost(10000);
-            httpConnManager.getParams().setMaxTotalConnections(200000);
-        }
-    }
-
-    private void setClientsCookiePolicy(String policy) {
-        client.getParams().setCookiePolicy(policy);
     }
 
     /**
@@ -314,31 +209,7 @@ public class HttpSender {
      */
     @Deprecated
     public static SSLConnector getSSLConnector() {
-        return sslConnector;
-    }
-
-    @SuppressWarnings("deprecation")
-    private void checkState() {
-        if (!useCookies) {
-            resetState();
-            setClientsCookiePolicy(CookiePolicy.IGNORE_COOKIES);
-        } else if (useGlobalState) {
-            if (param.isHttpStateEnabled()) {
-                client.setState(param.getHttpState());
-                setClientsCookiePolicy(CookiePolicy.BROWSER_COMPATIBILITY);
-            } else {
-                setClientsCookiePolicy(CookiePolicy.IGNORE_COOKIES);
-            }
-        } else {
-            resetState();
-
-            setClientsCookiePolicy(CookiePolicy.BROWSER_COMPATIBILITY);
-        }
-    }
-
-    private void resetState() {
-        HttpState state = new HttpState();
-        client.setState(state);
+        return PAROS_IMPL.getSslConnector();
     }
 
     /**
@@ -359,9 +230,7 @@ public class HttpSender {
      * @see #setUseCookies(boolean)
      */
     public void setUseGlobalState(boolean enableGlobalState) {
-        this.useGlobalState = enableGlobalState;
-
-        checkState();
+        ctx.setUseGlobalState(enableGlobalState);
     }
 
     /**
@@ -371,9 +240,8 @@ public class HttpSender {
      * @since 2.12.0
      * @see #setUseGlobalState(boolean)
      */
-    @SuppressWarnings("deprecation")
     public boolean isGlobalStateEnabled() {
-        return param.isHttpStateEnabled();
+        return impl.isGlobalStateEnabled();
     }
 
     /**
@@ -384,28 +252,7 @@ public class HttpSender {
      * @see #setUseGlobalState(boolean)
      */
     public void setUseCookies(boolean shouldUseCookies) {
-        this.useCookies = shouldUseCookies;
-
-        checkState();
-    }
-
-    @SuppressWarnings("deprecation")
-    private void setProxyAuth(HttpState state) {
-        if (param.isUseProxyChain() && param.isUseProxyChainAuth()) {
-            String realm = param.getProxyChainRealm();
-            state.setProxyCredentials(
-                    new AuthScope(
-                            param.getProxyChainName(),
-                            param.getProxyChainPort(),
-                            realm.isEmpty() ? AuthScope.ANY_REALM : realm),
-                    new NTCredentials(
-                            param.getProxyChainUserName(),
-                            param.getProxyChainPassword(),
-                            "",
-                            realm));
-        } else {
-            state.clearProxyCredentials();
-        }
+        ctx.setUseCookies(shouldUseCookies);
     }
 
     /**
@@ -420,99 +267,11 @@ public class HttpSender {
      */
     @Deprecated
     public int executeMethod(HttpMethod method, HttpState state) throws IOException {
-        return executeMethodImpl(method, state);
-    }
-
-    @SuppressWarnings("deprecation")
-    private int executeMethodImpl(HttpMethod method, HttpState state) throws IOException {
-        int responseCode = -1;
-
-        String hostName;
-        hostName = method.getURI().getHost();
-        method.setDoAuthentication(true);
-        HostConfiguration hc = null;
-
-        HttpClient requestClient;
-        if (isConnectionUpgrade(method)) {
-            requestClient = new HttpClient(new ZapHttpConnectionManager());
-        } else {
-            requestClient = client;
+        HttpSenderContext ctxTemp = ctx;
+        if (!(ctxTemp instanceof HttpSenderContextParos)) {
+            ctxTemp = PAROS_IMPL.createContext(this, initiator);
         }
-
-        if (this.initiator == CHECK_FOR_UPDATES_INITIATOR) {
-            // Use the 'strict' SSLConnector, i.e. one that performs all the usual cert checks
-            // The 'standard' one 'trusts' everything
-            // This is to ensure that all 'check-for update' calls are made to the expected https
-            // urls
-            // without this is would be possible to intercept and change the response which could
-            // result
-            // in the user downloading and installing a malicious add-on
-            hc =
-                    new HostConfiguration() {
-                        @Override
-                        public synchronized void setHost(URI uri) {
-                            try {
-                                setHost(new HttpHost(uri.getHost(), uri.getPort(), getProtocol()));
-                            } catch (URIException e) {
-                                throw new IllegalArgumentException(e.toString());
-                            }
-                        }
-                    };
-
-            hc.setHost(
-                    hostName,
-                    method.getURI().getPort(),
-                    new Protocol("https", (ProtocolSocketFactory) new SSLConnector(false), 443));
-        }
-
-        method.getParams()
-                .setBooleanParameter(
-                        HttpMethodDirector.PARAM_RESOLVE_HOSTNAME,
-                        param.shouldResolveRemoteHostname(hostName));
-        method.getParams()
-                .setParameter(
-                        HttpMethodDirector.PARAM_DEFAULT_USER_AGENT_CONNECT_REQUESTS,
-                        param.getDefaultUserAgent());
-
-        int timeout = (int) TimeUnit.SECONDS.toMillis(this.param.getTimeoutInSecs());
-        method.getParams().setSoTimeout(timeout);
-        httpConnManager.getParams().setConnectionTimeout(timeout);
-
-        // ZAP: Check if a custom state is being used
-        if (state != null) {
-            // Make sure cookies are enabled
-            method.getParams().setCookiePolicy(CookiePolicy.BROWSER_COMPATIBILITY);
-            setProxyAuth(state);
-        } else {
-            setProxyAuth(requestClient.getState());
-        }
-
-        if (param.isUseProxy(hostName)) {
-            if (hc == null) {
-                hc = new HostConfiguration();
-                hc.setHost(hostName, method.getURI().getPort(), method.getURI().getScheme());
-            }
-            hc.setProxy(param.getProxyChainName(), param.getProxyChainPort());
-        }
-
-        responseCode = requestClient.executeMethod(hc, method, state);
-
-        return responseCode;
-    }
-
-    /**
-     * Tells whether or not the given {@code method} has a {@code Connection} request header with
-     * {@code Upgrade} value.
-     *
-     * @param method the method that will be checked
-     * @return {@code true} if the {@code method} has a connection upgrade, {@code false} otherwise
-     */
-    private static boolean isConnectionUpgrade(HttpMethod method) {
-        Header connectionHeader = method.getRequestHeader("connection");
-        if (connectionHeader == null) {
-            return false;
-        }
-        return connectionHeader.getValue().toLowerCase(Locale.ROOT).contains("upgrade");
+        return PAROS_IMPL.executeMethodImpl((HttpSenderContextParos) ctxTemp, method, state);
     }
 
     /** @deprecated (2.12.0) No longer needed. */
@@ -530,38 +289,14 @@ public class HttpSender {
      * @since 2.12.0
      * @see #setFollowRedirect(boolean)
      */
+    @SuppressWarnings("unchecked")
     public void sendAndReceive(HttpMessage message, Path file) throws IOException {
-        sendAndReceive(
-                message,
-                followRedirect,
-                (msg, method) -> {
-                    if (followRedirect.isFollowRedirects()
-                            && isRedirectionNeeded(msg.getResponseHeader().getStatusCode())) {
-                        DEFAULT_BODY_CONSUMER.accept(message, method);
-                        return;
-                    }
-
-                    HttpResponseHeader header = msg.getResponseHeader();
-                    try (FileChannel channel =
-                                    (FileChannel)
-                                            Files.newByteChannel(
-                                                    file,
-                                                    EnumSet.of(
-                                                            StandardOpenOption.WRITE,
-                                                            StandardOpenOption.CREATE,
-                                                            StandardOpenOption.TRUNCATE_EXISTING));
-                            InputStream is = method.getResponseBodyAsStream()) {
-                        long totalRead = 0;
-                        while ((totalRead +=
-                                        channel.transferFrom(
-                                                Channels.newChannel(is), totalRead, 1 << 24))
-                                < header.getContentLength()) ;
-                    }
-                });
+        impl.sendAndReceive(ctx, null, message, file);
     }
 
+    @SuppressWarnings("unchecked")
     public void sendAndReceive(HttpMessage msg) throws IOException {
-        sendAndReceive(msg, followRedirect);
+        impl.sendAndReceive(ctx, null, msg, null);
     }
 
     /**
@@ -572,46 +307,9 @@ public class HttpSender {
      * @throws IOException
      * @see #sendAndReceive(HttpMessage, HttpRequestConfig)
      */
+    @SuppressWarnings("unchecked")
     public void sendAndReceive(HttpMessage msg, boolean isFollowRedirect) throws IOException {
-        sendAndReceive(msg, isFollowRedirect ? FOLLOW_REDIRECTS : NO_REDIRECTS);
-    }
-
-    private void notifyRequestListeners(HttpMessage msg) {
-        if (IN_LISTENER.get() != null) {
-            // This is a request from one of the listeners - prevent infinite recursion
-            return;
-        }
-        try {
-            IN_LISTENER.set(true);
-            for (HttpSenderListener listener : listeners) {
-                try {
-                    listener.onHttpRequestSend(msg, initiator, this);
-                } catch (Exception e) {
-                    log.error(e.getMessage(), e);
-                }
-            }
-        } finally {
-            IN_LISTENER.remove();
-        }
-    }
-
-    private void notifyResponseListeners(HttpMessage msg) {
-        if (IN_LISTENER.get() != null) {
-            // This is a request from one of the listeners - prevent infinite recursion
-            return;
-        }
-        try {
-            IN_LISTENER.set(true);
-            for (HttpSenderListener listener : listeners) {
-                try {
-                    listener.onHttpResponseReceive(msg, initiator, this);
-                } catch (Exception e) {
-                    log.error(e.getMessage(), e);
-                }
-            }
-        } finally {
-            IN_LISTENER.remove();
-        }
+        impl.sendAndReceive(ctx, isFollowRedirect ? FOLLOW_REDIRECTS : NO_REDIRECTS, msg, null);
     }
 
     /**
@@ -627,93 +325,11 @@ public class HttpSender {
      * @see HttpMessage#getRequestingUser()
      */
     public User getUser(HttpMessage msg) {
-        if (this.user != null) {
-            return user;
-        }
-        return msg.getRequestingUser();
-    }
-
-    private void sendAuthenticated(
-            HttpMessage msg, HttpMethodParams params, ResponseBodyConsumer responseBodyConsumer)
-            throws IOException {
-        // Modify the request message if a 'Requesting User' has been set
-        User forceUser = this.getUser(msg);
-        if (forceUser != null) {
-            if (initiator == AUTHENTICATION_POLL_INITIATOR) {
-                forceUser.processMessageToMatchAuthenticatedSession(msg);
-            } else if (initiator != AUTHENTICATION_INITIATOR) {
-                forceUser.processMessageToMatchUser(msg);
-            }
-        }
-
-        log.debug("Sending message to: " + msg.getRequestHeader().getURI().toString());
-        // Send the message
-        send(msg, params, responseBodyConsumer);
-
-        // If there's a 'Requesting User', make sure the response corresponds to an authenticated
-        // session and, if not, attempt a reauthentication and try again
-        if (initiator != AUTHENTICATION_INITIATOR
-                && initiator != AUTHENTICATION_POLL_INITIATOR
-                && forceUser != null
-                && !msg.getRequestHeader().isImage()
-                && !forceUser.isAuthenticated(msg)) {
-            log.debug(
-                    "First try to send authenticated message failed for "
-                            + msg.getRequestHeader().getURI()
-                            + ". Authenticating and trying again...");
-            forceUser.queueAuthentication(msg);
-            forceUser.processMessageToMatchUser(msg);
-            send(msg, params, responseBodyConsumer);
-        } else log.debug("SUCCESSFUL");
-    }
-
-    private void send(
-            HttpMessage msg, HttpMethodParams params, ResponseBodyConsumer responseBodyConsumer)
-            throws IOException {
-        HttpMethod method = null;
-        HttpResponseHeader resHeader = null;
-
-        try {
-            method = runMethod(msg, params);
-            // successfully executed;
-            resHeader = HttpMethodHelper.getHttpResponseHeader(method);
-            resHeader.setHeader(HttpHeader.TRANSFER_ENCODING, null);
-            msg.setResponseHeader(resHeader);
-
-            responseBodyConsumer.accept(msg, method);
-            msg.setResponseFromTargetHost(true);
-
-            // ZAP: set method to retrieve upgraded channel later
-            if (method instanceof ZapGetMethod) {
-                msg.setUserObject(method);
-            }
-        } finally {
-            if (method != null) {
-                method.releaseConnection();
-            }
-        }
-    }
-
-    private HttpMethod runMethod(HttpMessage msg, HttpMethodParams params) throws IOException {
-        HttpMethod method = null;
-        // no more retry
-        method = helper.createRequestMethod(msg.getRequestHeader(), msg.getRequestBody(), params);
-        method.setFollowRedirects(false);
-
-        HttpState state = null;
-        User forceUser = this.getUser(msg);
-        if (forceUser != null) {
-            state = forceUser.getCorrespondingHttpState();
-        }
-        executeMethodImpl(method, state);
-
-        HttpMethodHelper.updateHttpRequestHeaderSent(msg.getRequestHeader(), method);
-
-        return method;
+        return ctx.getUser(msg);
     }
 
     public void setFollowRedirect(boolean followRedirect) {
-        this.followRedirect = followRedirect ? FOLLOW_REDIRECTS : NO_REDIRECTS;
+        ctx.setFollowRedirects(followRedirect);
     }
 
     /**
@@ -745,9 +361,7 @@ public class HttpSender {
      * @throws NullPointerException if the given listener is {@code null}.
      */
     public static void addListener(HttpSenderListener listener) {
-        Objects.requireNonNull(listener);
-        listeners.add(listener);
-        Collections.sort(listeners, LISTENERS_COMPARATOR);
+        impl.addListener(listener);
     }
 
     /**
@@ -758,8 +372,7 @@ public class HttpSender {
      * @throws NullPointerException if the given listener is {@code null}.
      */
     public static void removeListener(HttpSenderListener listener) {
-        Objects.requireNonNull(listener);
-        listeners.remove(listener);
+        impl.removeListener(listener);
     }
 
     /**
@@ -768,7 +381,7 @@ public class HttpSender {
      * @param user
      */
     public void setUser(User user) {
-        this.user = user;
+        ctx.setUser(user);
     }
 
     /**
@@ -778,7 +391,7 @@ public class HttpSender {
      */
     @Deprecated
     public HttpClient getClient() {
-        return this.client;
+        return PAROS_IMPL.getClient();
     }
 
     /**
@@ -799,9 +412,7 @@ public class HttpSender {
      *     removed when challenged, {@code false} otherwise
      */
     public void setRemoveUserDefinedAuthHeaders(boolean removeHeaders) {
-        client.getParams()
-                .setBooleanParameter(
-                        HttpMethodDirector.PARAM_REMOVE_USER_DEFINED_AUTH_HEADERS, removeHeaders);
+        ctx.setRemoveUserDefinedAuthHeaders(removeHeaders);
     }
 
     /**
@@ -814,13 +425,7 @@ public class HttpSender {
      * @since 2.4.0
      */
     public void setMaxRetriesOnIOError(int retries) {
-        if (retries < 0) {
-            throw new IllegalArgumentException(
-                    "Parameter retries must be greater or equal to zero.");
-        }
-
-        HttpMethodRetryHandler retryHandler = new DefaultHttpMethodRetryHandler(retries, false);
-        client.getParams().setParameter(HttpMethodParams.RETRY_HANDLER, retryHandler);
+        ctx.setMaxRetriesOnIoError(retries);
     }
 
     /**
@@ -833,11 +438,7 @@ public class HttpSender {
      * @since 2.4.0
      */
     public void setMaxRedirects(int maxRedirects) {
-        if (maxRedirects < 0) {
-            throw new IllegalArgumentException(
-                    "Parameter maxRedirects must be greater or equal to zero.");
-        }
-        client.getParams().setIntParameter(HttpClientParams.MAX_REDIRECTS, maxRedirects);
+        ctx.setMaxRedirects(maxRedirects);
     }
 
     /**
@@ -867,271 +468,9 @@ public class HttpSender {
      * @since 2.6.0
      * @see #sendAndReceive(HttpMessage, boolean)
      */
+    @SuppressWarnings("unchecked")
     public void sendAndReceive(HttpMessage message, HttpRequestConfig requestConfig)
             throws IOException {
-        sendAndReceive(message, requestConfig, DEFAULT_BODY_CONSUMER);
-    }
-
-    private void sendAndReceive(
-            HttpMessage message,
-            HttpRequestConfig requestConfig,
-            ResponseBodyConsumer responseBodyConsumer)
-            throws IOException {
-        if (message == null) {
-            throw new IllegalArgumentException("Parameter message must not be null.");
-        }
-        if (requestConfig == null) {
-            throw new IllegalArgumentException("Parameter requestConfig must not be null.");
-        }
-
-        sendAndReceiveImpl(message, requestConfig, responseBodyConsumer);
-
-        if (requestConfig.isFollowRedirects()) {
-            followRedirections(message, requestConfig, responseBodyConsumer);
-        }
-    }
-
-    /**
-     * Helper method that sends the request of the given HTTP {@code message} with the given
-     * configurations.
-     *
-     * <p>No redirections are followed (see {@link #followRedirections(HttpMessage,
-     * HttpRequestConfig)}).
-     *
-     * @param message the message that will be sent.
-     * @param requestConfig the request configurations.
-     * @throws IOException if an error occurred while sending the message or following the
-     *     redirections.
-     */
-    private void sendAndReceiveImpl(
-            HttpMessage message,
-            HttpRequestConfig requestConfig,
-            ResponseBodyConsumer responseBodyConsumer)
-            throws IOException {
-        if (log.isDebugEnabled()) {
-            log.debug(
-                    "Sending "
-                            + message.getRequestHeader().getMethod()
-                            + " "
-                            + message.getRequestHeader().getURI());
-        }
-        message.setTimeSentMillis(System.currentTimeMillis());
-
-        try {
-            if (requestConfig.isNotifyListeners()) {
-                notifyRequestListeners(message);
-            }
-
-            HttpMethodParams params = null;
-            if (requestConfig.getSoTimeout() != HttpRequestConfig.NO_VALUE_SET) {
-                params = new HttpMethodParams();
-                params.setSoTimeout(requestConfig.getSoTimeout());
-            }
-            sendAuthenticated(message, params, responseBodyConsumer);
-
-        } finally {
-            message.setTimeElapsedMillis(
-                    (int) (System.currentTimeMillis() - message.getTimeSentMillis()));
-
-            if (log.isDebugEnabled()) {
-                log.debug(
-                        "Received response after "
-                                + message.getTimeElapsedMillis()
-                                + "ms for "
-                                + message.getRequestHeader().getMethod()
-                                + " "
-                                + message.getRequestHeader().getURI());
-            }
-
-            if (requestConfig.isNotifyListeners()) {
-                notifyResponseListeners(message);
-            }
-        }
-    }
-
-    /**
-     * Follows redirections using the response of the given {@code message}. The {@code validator}
-     * in the given request configuration will be called for each redirection received. After the
-     * call to this method the given {@code message} will have the contents of the last response
-     * received (possibly the response of a redirection).
-     *
-     * <p>The validator is notified of each message sent and received (first message and
-     * redirections followed, if any).
-     *
-     * @param message the message that will be sent, must not be {@code null}
-     * @param requestConfig the request configuration that contains the validator responsible for
-     *     validation of redirections, must not be {@code null}.
-     * @throws IOException if an error occurred while sending the message or following the
-     *     redirections
-     * @see #isRedirectionNeeded(int)
-     */
-    private void followRedirections(
-            HttpMessage message,
-            HttpRequestConfig requestConfig,
-            ResponseBodyConsumer responseBodyConsumer)
-            throws IOException {
-        HttpRedirectionValidator validator = requestConfig.getRedirectionValidator();
-        validator.notifyMessageReceived(message);
-
-        User requestingUser = getUser(message);
-        HttpMessage redirectMessage = message;
-        int maxRedirections =
-                client.getParams().getIntParameter(HttpClientParams.MAX_REDIRECTS, 100);
-        for (int i = 0;
-                i < maxRedirections
-                        && isRedirectionNeeded(redirectMessage.getResponseHeader().getStatusCode());
-                i++) {
-            URI newLocation = extractRedirectLocation(redirectMessage);
-            if (newLocation == null || !validator.isValid(newLocation)) {
-                return;
-            }
-
-            redirectMessage = redirectMessage.cloneAll();
-            redirectMessage.setRequestingUser(requestingUser);
-            redirectMessage.getRequestHeader().setURI(newLocation);
-
-            if (isRequestRewriteNeeded(redirectMessage)) {
-                redirectMessage.getRequestHeader().setMethod(HttpRequestHeader.GET);
-                redirectMessage.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, null);
-                redirectMessage.getRequestHeader().setHeader(HttpHeader.CONTENT_LENGTH, null);
-                redirectMessage.setRequestBody("");
-            }
-
-            sendAndReceiveImpl(redirectMessage, requestConfig, responseBodyConsumer);
-            validator.notifyMessageReceived(redirectMessage);
-
-            // Update the response of the (original) message
-            message.setResponseHeader(redirectMessage.getResponseHeader());
-            message.setResponseBody(redirectMessage.getResponseBody());
-        }
-    }
-
-    /**
-     * Tells whether or not a redirection is needed based on the given status code.
-     *
-     * <p>A redirection is needed if the status code is 301, 302, 303, 307 or 308.
-     *
-     * @param statusCode the status code that will be checked
-     * @return {@code true} if a redirection is needed, {@code false} otherwise
-     * @see #isRequestRewriteNeeded(HttpMessage)
-     */
-    private static boolean isRedirectionNeeded(int statusCode) {
-        switch (statusCode) {
-            case 301:
-            case 302:
-            case 303:
-            case 307:
-            case 308:
-                return true;
-            default:
-                return false;
-        }
-    }
-
-    /**
-     * Tells whether or not the (original) request of the redirection, should be rewritten.
-     *
-     * <p>For status codes 301 and 302 the request should be changed from POST to GET when following
-     * redirections, for status code 303 it should be changed to GET for all methods except GET/HEAD
-     * (mimicking the behaviour of browsers, which per <a
-     * href="https://tools.ietf.org/html/rfc7231#section-6.4">RFC 7231, Section 6.4</a> is now OK).
-     *
-     * @param message the message with the redirection.
-     * @return {@code true} if the request should be rewritten, {@code false} otherwise
-     * @see #isRedirectionNeeded(int)
-     */
-    private static boolean isRequestRewriteNeeded(HttpMessage message) {
-        int statusCode = message.getResponseHeader().getStatusCode();
-        String method = message.getRequestHeader().getMethod();
-        if (statusCode == 301 || statusCode == 302) {
-            return HttpRequestHeader.POST.equalsIgnoreCase(method);
-        }
-        return statusCode == 303
-                && !(HttpRequestHeader.GET.equalsIgnoreCase(method)
-                        || HttpRequestHeader.HEAD.equalsIgnoreCase(method));
-    }
-
-    /**
-     * Extracts a {@code URI} from the {@code Location} header of the given HTTP {@code message}.
-     *
-     * <p>If there's no {@code Location} header this method returns {@code null}.
-     *
-     * @param message the HTTP message that will processed
-     * @return the {@code URI} created from the value of the {@code Location} header, might be
-     *     {@code null}
-     * @throws InvalidRedirectLocationException if the value of {@code Location} header is not a
-     *     valid {@code URI}
-     */
-    private static URI extractRedirectLocation(HttpMessage message)
-            throws InvalidRedirectLocationException {
-        String location = message.getResponseHeader().getHeader(HttpHeader.LOCATION);
-        if (location == null) {
-            if (log.isDebugEnabled()) {
-                log.debug("No Location header found: " + message.getResponseHeader());
-            }
-            return null;
-        }
-
-        try {
-            return new URI(message.getRequestHeader().getURI(), location, true);
-        } catch (URIException ex) {
-            try {
-                // Handle redirect URLs that are unencoded
-                return new URI(message.getRequestHeader().getURI(), location, false);
-            } catch (URIException e) {
-                throw new InvalidRedirectLocationException(
-                        "Invalid redirect location: " + location, location, ex);
-            }
-        }
-    }
-
-    private interface ResponseBodyConsumer {
-
-        void accept(HttpMessage message, HttpMethod method) throws IOException;
-    }
-
-    /**
-     * A {@link ProtocolSocketFactory} for plain sockets.
-     *
-     * <p>Remote hostnames are not resolved if {@link HttpMethodDirector#PARAM_RESOLVE_HOSTNAME} is
-     * {@code false}.
-     */
-    private static class ProtocolSocketFactoryImpl implements ProtocolSocketFactory {
-
-        @Override
-        public Socket createSocket(
-                String host,
-                int port,
-                InetAddress localAddress,
-                int localPort,
-                HttpConnectionParams params)
-                throws IOException {
-            if (params == null) {
-                throw new IllegalArgumentException("Parameters may not be null");
-            }
-            Socket socket = SocketFactory.getDefault().createSocket();
-            socket.bind(new InetSocketAddress(localAddress, localPort));
-            SocketAddress remoteAddress;
-            if (params.getBooleanParameter(HttpMethodDirector.PARAM_RESOLVE_HOSTNAME, true)) {
-                remoteAddress = new InetSocketAddress(host, port);
-            } else {
-                remoteAddress = InetSocketAddress.createUnresolved(host, port);
-            }
-            socket.connect(remoteAddress, params.getConnectionTimeout());
-            return socket;
-        }
-
-        @Override
-        public Socket createSocket(String host, int port, InetAddress localAddress, int localPort)
-                throws IOException {
-            throw new UnsupportedOperationException(
-                    "Method not supported, not required/called by Commons HttpClient library (version >= 3.0).");
-        }
-
-        @Override
-        public Socket createSocket(String host, int port) throws IOException {
-            throw new UnsupportedOperationException(
-                    "Method not supported, not required/called by Commons HttpClient library (version >= 3.0).");
-        }
+        impl.sendAndReceive(ctx, requestConfig, message, null);
     }
 }

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpSenderContextParos.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpSenderContextParos.java
@@ -1,0 +1,157 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.network;
+
+import org.apache.commons.httpclient.DefaultHttpMethodRetryHandler;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpMethodDirector;
+import org.apache.commons.httpclient.HttpMethodRetryHandler;
+import org.apache.commons.httpclient.HttpState;
+import org.apache.commons.httpclient.cookie.CookiePolicy;
+import org.apache.commons.httpclient.params.HttpClientParams;
+import org.apache.commons.httpclient.params.HttpMethodParams;
+import org.zaproxy.zap.network.HttpSenderContext;
+import org.zaproxy.zap.users.User;
+
+public class HttpSenderContextParos implements HttpSenderContext {
+
+    private final HttpSender parent;
+    private final int initiator;
+
+    @SuppressWarnings("deprecation")
+    private final ConnectionParam param;
+
+    private final HttpClient client;
+
+    private boolean followRedirects;
+    private User user;
+    private boolean useCookies;
+    private boolean useGlobalState;
+
+    @SuppressWarnings("deprecation")
+    HttpSenderContextParos(
+            HttpSender parent, int initiator, ConnectionParam param, HttpClient client) {
+        this.parent = parent;
+        this.initiator = initiator;
+        this.param = param;
+        this.client = client;
+    }
+
+    HttpSender getParent() {
+        return parent;
+    }
+
+    int getInitiator() {
+        return initiator;
+    }
+
+    HttpClient getHttpClient() {
+        return client;
+    }
+
+    @Override
+    public void setUseGlobalState(boolean use) {
+        this.useGlobalState = use;
+        checkState();
+    }
+
+    @Override
+    public void setUseCookies(boolean use) {
+        this.useCookies = use;
+        checkState();
+    }
+
+    @Override
+    public void setFollowRedirects(boolean followRedirects) {
+        this.followRedirects = followRedirects;
+    }
+
+    boolean isFollowRedirects() {
+        return followRedirects;
+    }
+
+    @Override
+    public void setMaxRedirects(int max) {
+        if (max < 0) {
+            throw new IllegalArgumentException(
+                    "Parameter maxRedirects must be greater or equal to zero.");
+        }
+        client.getParams().setIntParameter(HttpClientParams.MAX_REDIRECTS, max);
+    }
+
+    @Override
+    public void setMaxRetriesOnIoError(int max) {
+        if (max < 0) {
+            throw new IllegalArgumentException(
+                    "Parameter retries must be greater or equal to zero.");
+        }
+
+        HttpMethodRetryHandler retryHandler = new DefaultHttpMethodRetryHandler(max, false);
+        client.getParams().setParameter(HttpMethodParams.RETRY_HANDLER, retryHandler);
+    }
+
+    @Override
+    public void setRemoveUserDefinedAuthHeaders(boolean remove) {
+        client.getParams()
+                .setBooleanParameter(
+                        HttpMethodDirector.PARAM_REMOVE_USER_DEFINED_AUTH_HEADERS, remove);
+    }
+
+    @Override
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public User getUser(HttpMessage msg) {
+        if (user != null) {
+            return user;
+        }
+        return msg.getRequestingUser();
+    }
+
+    @SuppressWarnings("deprecation")
+    private void checkState() {
+        if (!useCookies) {
+            resetState();
+            setClientsCookiePolicy(CookiePolicy.IGNORE_COOKIES);
+        } else if (useGlobalState) {
+            if (param.isHttpStateEnabled()) {
+                client.setState(param.getHttpState());
+                setClientsCookiePolicy(CookiePolicy.BROWSER_COMPATIBILITY);
+            } else {
+                setClientsCookiePolicy(CookiePolicy.IGNORE_COOKIES);
+            }
+        } else {
+            resetState();
+
+            setClientsCookiePolicy(CookiePolicy.BROWSER_COMPATIBILITY);
+        }
+    }
+
+    private void setClientsCookiePolicy(String policy) {
+        client.getParams().setCookiePolicy(policy);
+    }
+
+    private void resetState() {
+        HttpState state = new HttpState();
+        client.setState(state);
+    }
+}

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpSenderParos.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpSenderParos.java
@@ -1,0 +1,740 @@
+/*
+ *
+ * Paros and its related class files.
+ *
+ * Paros is an HTTP/HTTPS proxy for assessing web application security.
+ * Copyright (C) 2003-2004 Chinotec Technologies Company
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Clarified Artistic License
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Clarified Artistic License for more details.
+ *
+ * You should have received a copy of the Clarified Artistic License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+// ZAP: 2022/06/03 Move implementation from HttpSender.
+package org.parosproxy.paros.network;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import javax.net.SocketFactory;
+import org.apache.commons.httpclient.Header;
+import org.apache.commons.httpclient.HostConfiguration;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpHost;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.HttpMethodDirector;
+import org.apache.commons.httpclient.HttpState;
+import org.apache.commons.httpclient.InvalidRedirectLocationException;
+import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
+import org.apache.commons.httpclient.NTCredentials;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.apache.commons.httpclient.auth.AuthPolicy;
+import org.apache.commons.httpclient.auth.AuthScope;
+import org.apache.commons.httpclient.cookie.CookiePolicy;
+import org.apache.commons.httpclient.params.HttpClientParams;
+import org.apache.commons.httpclient.params.HttpConnectionParams;
+import org.apache.commons.httpclient.params.HttpMethodParams;
+import org.apache.commons.httpclient.protocol.Protocol;
+import org.apache.commons.httpclient.protocol.ProtocolSocketFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.ZapGetMethod;
+import org.zaproxy.zap.ZapHttpConnectionManager;
+import org.zaproxy.zap.network.HttpRedirectionValidator;
+import org.zaproxy.zap.network.HttpRequestConfig;
+import org.zaproxy.zap.network.HttpSenderImpl;
+import org.zaproxy.zap.network.HttpSenderListener;
+import org.zaproxy.zap.network.ZapCookieSpec;
+import org.zaproxy.zap.network.ZapNTLMScheme;
+import org.zaproxy.zap.users.User;
+
+class HttpSenderParos implements HttpSenderImpl<HttpSenderContextParos> {
+
+    private static final Logger log = LogManager.getLogger(HttpSenderParos.class);
+
+    private static SSLConnector sslConnector;
+
+    private static List<HttpSenderListener> listeners = new ArrayList<>();
+    private static final Comparator<HttpSenderListener> LISTENERS_COMPARATOR =
+            (o1, o2) -> Integer.compare(o1.getListenerOrder(), o2.getListenerOrder());
+
+    static {
+        sslConnector = new SSLConnector(true);
+
+        Protocol.registerProtocol(
+                "https", new Protocol("https", (ProtocolSocketFactory) sslConnector, 443));
+
+        Protocol.registerProtocol(
+                "http", new Protocol("http", new ProtocolSocketFactoryImpl(), 80));
+
+        AuthPolicy.registerAuthScheme(AuthPolicy.NTLM, ZapNTLMScheme.class);
+        CookiePolicy.registerCookieSpec(CookiePolicy.DEFAULT, ZapCookieSpec.class);
+        CookiePolicy.registerCookieSpec(CookiePolicy.BROWSER_COMPATIBILITY, ZapCookieSpec.class);
+    }
+
+    private static HttpMethodHelper helper = new HttpMethodHelper();
+    private static final ThreadLocal<Boolean> IN_LISTENER = new ThreadLocal<>();
+    private static final HttpRequestConfig NO_REDIRECTS = HttpRequestConfig.builder().build();
+    private static final HttpRequestConfig FOLLOW_REDIRECTS =
+            HttpRequestConfig.builder().setFollowRedirects(true).build();
+
+    private static final ResponseBodyConsumer DEFAULT_BODY_CONSUMER =
+            (msg, method) -> {
+                if (msg.isEventStream()) {
+                    msg.getResponseBody().setCharset(msg.getResponseHeader().getCharset());
+                    msg.getResponseBody().setLength(0);
+                    return;
+                }
+
+                msg.setResponseBody(method.getResponseBody());
+            };
+
+    @SuppressWarnings("deprecation")
+    private ConnectionParam param = null;
+
+    private static MultiThreadedHttpConnectionManager httpConnManager;
+
+    @SuppressWarnings("deprecation")
+    private ConnectionParam getParam() {
+        if (param == null) {
+            param = Model.getSingleton().getOptionsParam().getConnectionParam();
+        }
+        return param;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isGlobalStateEnabled() {
+        return getParam().isHttpStateEnabled();
+    }
+
+    private static MultiThreadedHttpConnectionManager getConnectionManager() {
+        if (httpConnManager == null) {
+            createConnectionManager();
+        }
+        return httpConnManager;
+    }
+
+    private static synchronized void createConnectionManager() {
+        if (httpConnManager == null) {
+            httpConnManager = new MultiThreadedHttpConnectionManager();
+            httpConnManager.getParams().setStaleCheckingEnabled(true);
+            // Set to arbitrary large values to prevent locking
+            httpConnManager.getParams().setDefaultMaxConnectionsPerHost(10000);
+            httpConnManager.getParams().setMaxTotalConnections(200000);
+        }
+    }
+
+    SSLConnector getSslConnector() {
+        return sslConnector;
+    }
+
+    HttpClient getClient() {
+        return new HttpClient(getConnectionManager());
+    }
+
+    @SuppressWarnings("deprecation")
+    private void setProxyAuth(HttpState state) {
+        if (getParam().isUseProxyChain() && getParam().isUseProxyChainAuth()) {
+            String realm = getParam().getProxyChainRealm();
+            state.setProxyCredentials(
+                    new AuthScope(
+                            getParam().getProxyChainName(),
+                            getParam().getProxyChainPort(),
+                            realm.isEmpty() ? AuthScope.ANY_REALM : realm),
+                    new NTCredentials(
+                            getParam().getProxyChainUserName(),
+                            getParam().getProxyChainPassword(),
+                            "",
+                            realm));
+        } else {
+            state.clearProxyCredentials();
+        }
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public HttpSenderContextParos createContext(HttpSender parent, int initiator) {
+        HttpClient client = new HttpClient(getConnectionManager());
+        client.getParams().setBooleanParameter(HttpClientParams.ALLOW_CIRCULAR_REDIRECTS, true);
+
+        // Set how cookie headers are sent no matter of the "allowState", in case a state is forced
+        // by other extensions (e.g. Authentication)
+        client.getParams().setBooleanParameter(HttpMethodParams.SINGLE_COOKIE_HEADER, true);
+        return new HttpSenderContextParos(parent, initiator, getParam(), client);
+    }
+
+    @SuppressWarnings("deprecation")
+    int executeMethodImpl(HttpSenderContextParos ctx, HttpMethod method, HttpState state)
+            throws IOException {
+        int responseCode = -1;
+
+        String hostName;
+        hostName = method.getURI().getHost();
+        method.setDoAuthentication(true);
+        HostConfiguration hc = null;
+
+        HttpClient requestClient;
+        if (isConnectionUpgrade(method)) {
+            requestClient = new HttpClient(new ZapHttpConnectionManager());
+        } else {
+            requestClient = ctx.getHttpClient();
+        }
+
+        if (ctx.getInitiator() == HttpSender.CHECK_FOR_UPDATES_INITIATOR) {
+            // Use the 'strict' SSLConnector, i.e. one that performs all the usual cert checks
+            // The 'standard' one 'trusts' everything
+            // This is to ensure that all 'check-for update' calls are made to the expected https
+            // urls
+            // without this is would be possible to intercept and change the response which could
+            // result
+            // in the user downloading and installing a malicious add-on
+            hc =
+                    new HostConfiguration() {
+                        @Override
+                        public synchronized void setHost(URI uri) {
+                            try {
+                                setHost(new HttpHost(uri.getHost(), uri.getPort(), getProtocol()));
+                            } catch (URIException e) {
+                                throw new IllegalArgumentException(e.toString());
+                            }
+                        }
+                    };
+
+            hc.setHost(
+                    hostName,
+                    method.getURI().getPort(),
+                    new Protocol("https", (ProtocolSocketFactory) new SSLConnector(false), 443));
+        }
+
+        method.getParams()
+                .setBooleanParameter(
+                        HttpMethodDirector.PARAM_RESOLVE_HOSTNAME,
+                        getParam().shouldResolveRemoteHostname(hostName));
+        method.getParams()
+                .setParameter(
+                        HttpMethodDirector.PARAM_DEFAULT_USER_AGENT_CONNECT_REQUESTS,
+                        getParam().getDefaultUserAgent());
+
+        int timeout = (int) TimeUnit.SECONDS.toMillis(getParam().getTimeoutInSecs());
+        method.getParams().setSoTimeout(timeout);
+        httpConnManager.getParams().setConnectionTimeout(timeout);
+
+        // ZAP: Check if a custom state is being used
+        if (state != null) {
+            // Make sure cookies are enabled
+            method.getParams().setCookiePolicy(CookiePolicy.BROWSER_COMPATIBILITY);
+            setProxyAuth(state);
+        } else {
+            setProxyAuth(requestClient.getState());
+        }
+
+        if (getParam().isUseProxy(hostName)) {
+            if (hc == null) {
+                hc = new HostConfiguration();
+                hc.setHost(hostName, method.getURI().getPort(), method.getURI().getScheme());
+            }
+            hc.setProxy(getParam().getProxyChainName(), getParam().getProxyChainPort());
+        }
+
+        responseCode = requestClient.executeMethod(hc, method, state);
+
+        return responseCode;
+    }
+
+    /**
+     * Tells whether or not the given {@code method} has a {@code Connection} request header with
+     * {@code Upgrade} value.
+     *
+     * @param method the method that will be checked
+     * @return {@code true} if the {@code method} has a connection upgrade, {@code false} otherwise
+     */
+    private static boolean isConnectionUpgrade(HttpMethod method) {
+        Header connectionHeader = method.getRequestHeader("connection");
+        if (connectionHeader == null) {
+            return false;
+        }
+        return connectionHeader.getValue().toLowerCase(Locale.ROOT).contains("upgrade");
+    }
+
+    @Override
+    public void sendAndReceive(
+            HttpSenderContextParos ctx, HttpRequestConfig config, HttpMessage message, Path file)
+            throws IOException {
+        HttpRequestConfig effectiveConfig = getEffectiveConfig(ctx, config);
+
+        if (file != null) {
+            sendAndReceive(
+                    ctx,
+                    message,
+                    effectiveConfig,
+                    (msg, method) -> {
+                        if (effectiveConfig.isFollowRedirects()
+                                && isRedirectionNeeded(msg.getResponseHeader().getStatusCode())) {
+                            DEFAULT_BODY_CONSUMER.accept(msg, method);
+                            return;
+                        }
+
+                        HttpResponseHeader header = msg.getResponseHeader();
+                        try (FileChannel channel =
+                                        (FileChannel)
+                                                Files.newByteChannel(
+                                                        file,
+                                                        EnumSet.of(
+                                                                StandardOpenOption.WRITE,
+                                                                StandardOpenOption.CREATE,
+                                                                StandardOpenOption
+                                                                        .TRUNCATE_EXISTING));
+                                InputStream is = method.getResponseBodyAsStream()) {
+                            long totalRead = 0;
+                            while ((totalRead +=
+                                            channel.transferFrom(
+                                                    Channels.newChannel(is), totalRead, 1 << 24))
+                                    < header.getContentLength()) ;
+                        }
+                    });
+        }
+
+        sendAndReceive(ctx, message, effectiveConfig, DEFAULT_BODY_CONSUMER);
+    }
+
+    private HttpRequestConfig getEffectiveConfig(
+            HttpSenderContextParos ctx, HttpRequestConfig config) {
+        if (config != null) {
+            return config;
+        }
+        return ctx.isFollowRedirects() ? FOLLOW_REDIRECTS : NO_REDIRECTS;
+    }
+
+    private static void notifyRequestListeners(HttpSenderContextParos ctx, HttpMessage msg) {
+        if (IN_LISTENER.get() != null) {
+            // This is a request from one of the listeners - prevent infinite recursion
+            return;
+        }
+        try {
+            IN_LISTENER.set(true);
+            for (HttpSenderListener listener : listeners) {
+                try {
+                    listener.onHttpRequestSend(msg, ctx.getInitiator(), ctx.getParent());
+                } catch (Exception e) {
+                    log.error(e.getMessage(), e);
+                }
+            }
+        } finally {
+            IN_LISTENER.remove();
+        }
+    }
+
+    private static void notifyResponseListeners(HttpSenderContextParos ctx, HttpMessage msg) {
+        if (IN_LISTENER.get() != null) {
+            // This is a request from one of the listeners - prevent infinite recursion
+            return;
+        }
+        try {
+            IN_LISTENER.set(true);
+            for (HttpSenderListener listener : listeners) {
+                try {
+                    listener.onHttpResponseReceive(msg, ctx.getInitiator(), ctx.getParent());
+                } catch (Exception e) {
+                    log.error(e.getMessage(), e);
+                }
+            }
+        } finally {
+            IN_LISTENER.remove();
+        }
+    }
+
+    private void sendAuthenticated(
+            HttpSenderContextParos ctx,
+            HttpMessage msg,
+            HttpMethodParams params,
+            ResponseBodyConsumer responseBodyConsumer)
+            throws IOException {
+        // Modify the request message if a 'Requesting User' has been set
+        User forceUser = ctx.getUser(msg);
+        if (forceUser != null) {
+            if (ctx.getInitiator() == HttpSender.AUTHENTICATION_POLL_INITIATOR) {
+                forceUser.processMessageToMatchAuthenticatedSession(msg);
+            } else if (ctx.getInitiator() != HttpSender.AUTHENTICATION_INITIATOR) {
+                forceUser.processMessageToMatchUser(msg);
+            }
+        }
+
+        log.debug("Sending message to: " + msg.getRequestHeader().getURI().toString());
+        // Send the message
+        send(ctx, msg, params, responseBodyConsumer);
+
+        // If there's a 'Requesting User', make sure the response corresponds to an authenticated
+        // session and, if not, attempt a reauthentication and try again
+        if (ctx.getInitiator() != HttpSender.AUTHENTICATION_INITIATOR
+                && ctx.getInitiator() != HttpSender.AUTHENTICATION_POLL_INITIATOR
+                && forceUser != null
+                && !msg.getRequestHeader().isImage()
+                && !forceUser.isAuthenticated(msg)) {
+            log.debug(
+                    "First try to send authenticated message failed for "
+                            + msg.getRequestHeader().getURI()
+                            + ". Authenticating and trying again...");
+            forceUser.queueAuthentication(msg);
+            forceUser.processMessageToMatchUser(msg);
+            send(ctx, msg, params, responseBodyConsumer);
+        } else log.debug("SUCCESSFUL");
+    }
+
+    private void send(
+            HttpSenderContextParos ctx,
+            HttpMessage msg,
+            HttpMethodParams params,
+            ResponseBodyConsumer responseBodyConsumer)
+            throws IOException {
+        HttpMethod method = null;
+        HttpResponseHeader resHeader = null;
+
+        try {
+            method = runMethod(ctx, msg, params);
+            // successfully executed;
+            resHeader = HttpMethodHelper.getHttpResponseHeader(method);
+            resHeader.setHeader(HttpHeader.TRANSFER_ENCODING, null);
+            msg.setResponseHeader(resHeader);
+
+            responseBodyConsumer.accept(msg, method);
+            msg.setResponseFromTargetHost(true);
+
+            // ZAP: set method to retrieve upgraded channel later
+            if (method instanceof ZapGetMethod) {
+                msg.setUserObject(method);
+            }
+        } finally {
+            if (method != null) {
+                method.releaseConnection();
+            }
+        }
+    }
+
+    private HttpMethod runMethod(
+            HttpSenderContextParos ctx, HttpMessage msg, HttpMethodParams params)
+            throws IOException {
+        HttpMethod method = null;
+        // no more retry
+        method = helper.createRequestMethod(msg.getRequestHeader(), msg.getRequestBody(), params);
+        method.setFollowRedirects(false);
+
+        HttpState state = null;
+        User forceUser = ctx.getUser(msg);
+        if (forceUser != null) {
+            state = forceUser.getCorrespondingHttpState();
+        }
+        executeMethodImpl(ctx, method, state);
+
+        HttpMethodHelper.updateHttpRequestHeaderSent(msg.getRequestHeader(), method);
+
+        return method;
+    }
+
+    @Override
+    public void addListener(HttpSenderListener listener) {
+        Objects.requireNonNull(listener);
+        listeners.add(listener);
+        Collections.sort(listeners, LISTENERS_COMPARATOR);
+    }
+
+    @Override
+    public void removeListener(HttpSenderListener listener) {
+        Objects.requireNonNull(listener);
+        listeners.remove(listener);
+    }
+
+    private void sendAndReceive(
+            HttpSenderContextParos ctx,
+            HttpMessage message,
+            HttpRequestConfig requestConfig,
+            ResponseBodyConsumer responseBodyConsumer)
+            throws IOException {
+        if (message == null) {
+            throw new IllegalArgumentException("Parameter message must not be null.");
+        }
+        if (requestConfig == null) {
+            throw new IllegalArgumentException("Parameter requestConfig must not be null.");
+        }
+
+        sendAndReceiveImpl(ctx, message, requestConfig, responseBodyConsumer);
+
+        if (requestConfig.isFollowRedirects()) {
+            followRedirections(ctx, message, requestConfig, responseBodyConsumer);
+        }
+    }
+
+    /**
+     * Helper method that sends the request of the given HTTP {@code message} with the given
+     * configurations.
+     *
+     * <p>No redirections are followed (see {@link #followRedirections(HttpMessage,
+     * HttpRequestConfig)}).
+     *
+     * @param message the message that will be sent.
+     * @param requestConfig the request configurations.
+     * @throws IOException if an error occurred while sending the message or following the
+     *     redirections.
+     */
+    private void sendAndReceiveImpl(
+            HttpSenderContextParos ctx,
+            HttpMessage message,
+            HttpRequestConfig requestConfig,
+            ResponseBodyConsumer responseBodyConsumer)
+            throws IOException {
+        if (log.isDebugEnabled()) {
+            log.debug(
+                    "Sending "
+                            + message.getRequestHeader().getMethod()
+                            + " "
+                            + message.getRequestHeader().getURI());
+        }
+        message.setTimeSentMillis(System.currentTimeMillis());
+
+        try {
+            if (requestConfig.isNotifyListeners()) {
+                notifyRequestListeners(ctx, message);
+            }
+
+            HttpMethodParams params = null;
+            if (requestConfig.getSoTimeout() != HttpRequestConfig.NO_VALUE_SET) {
+                params = new HttpMethodParams();
+                params.setSoTimeout(requestConfig.getSoTimeout());
+            }
+            sendAuthenticated(ctx, message, params, responseBodyConsumer);
+
+        } finally {
+            message.setTimeElapsedMillis(
+                    (int) (System.currentTimeMillis() - message.getTimeSentMillis()));
+
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "Received response after "
+                                + message.getTimeElapsedMillis()
+                                + "ms for "
+                                + message.getRequestHeader().getMethod()
+                                + " "
+                                + message.getRequestHeader().getURI());
+            }
+
+            if (requestConfig.isNotifyListeners()) {
+                notifyResponseListeners(ctx, message);
+            }
+        }
+    }
+
+    /**
+     * Follows redirections using the response of the given {@code message}. The {@code validator}
+     * in the given request configuration will be called for each redirection received. After the
+     * call to this method the given {@code message} will have the contents of the last response
+     * received (possibly the response of a redirection).
+     *
+     * <p>The validator is notified of each message sent and received (first message and
+     * redirections followed, if any).
+     *
+     * @param message the message that will be sent, must not be {@code null}
+     * @param requestConfig the request configuration that contains the validator responsible for
+     *     validation of redirections, must not be {@code null}.
+     * @throws IOException if an error occurred while sending the message or following the
+     *     redirections
+     * @see #isRedirectionNeeded(int)
+     */
+    private void followRedirections(
+            HttpSenderContextParos ctx,
+            HttpMessage message,
+            HttpRequestConfig requestConfig,
+            ResponseBodyConsumer responseBodyConsumer)
+            throws IOException {
+        HttpRedirectionValidator validator = requestConfig.getRedirectionValidator();
+        validator.notifyMessageReceived(message);
+
+        User requestingUser = ctx.getUser(message);
+        HttpMessage redirectMessage = message;
+        int maxRedirections =
+                ctx.getHttpClient()
+                        .getParams()
+                        .getIntParameter(HttpClientParams.MAX_REDIRECTS, 100);
+        for (int i = 0;
+                i < maxRedirections
+                        && isRedirectionNeeded(redirectMessage.getResponseHeader().getStatusCode());
+                i++) {
+            URI newLocation = extractRedirectLocation(redirectMessage);
+            if (newLocation == null || !validator.isValid(newLocation)) {
+                return;
+            }
+
+            redirectMessage = redirectMessage.cloneAll();
+            redirectMessage.setRequestingUser(requestingUser);
+            redirectMessage.getRequestHeader().setURI(newLocation);
+
+            if (isRequestRewriteNeeded(redirectMessage)) {
+                redirectMessage.getRequestHeader().setMethod(HttpRequestHeader.GET);
+                redirectMessage.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, null);
+                redirectMessage.getRequestHeader().setHeader(HttpHeader.CONTENT_LENGTH, null);
+                redirectMessage.setRequestBody("");
+            }
+
+            sendAndReceiveImpl(ctx, redirectMessage, requestConfig, responseBodyConsumer);
+            validator.notifyMessageReceived(redirectMessage);
+
+            // Update the response of the (original) message
+            message.setResponseHeader(redirectMessage.getResponseHeader());
+            message.setResponseBody(redirectMessage.getResponseBody());
+        }
+    }
+
+    /**
+     * Tells whether or not a redirection is needed based on the given status code.
+     *
+     * <p>A redirection is needed if the status code is 301, 302, 303, 307 or 308.
+     *
+     * @param statusCode the status code that will be checked
+     * @return {@code true} if a redirection is needed, {@code false} otherwise
+     * @see #isRequestRewriteNeeded(HttpMessage)
+     */
+    private static boolean isRedirectionNeeded(int statusCode) {
+        switch (statusCode) {
+            case 301:
+            case 302:
+            case 303:
+            case 307:
+            case 308:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Tells whether or not the (original) request of the redirection, should be rewritten.
+     *
+     * <p>For status codes 301 and 302 the request should be changed from POST to GET when following
+     * redirections, for status code 303 it should be changed to GET for all methods except GET/HEAD
+     * (mimicking the behaviour of browsers, which per <a
+     * href="https://tools.ietf.org/html/rfc7231#section-6.4">RFC 7231, Section 6.4</a> is now OK).
+     *
+     * @param message the message with the redirection.
+     * @return {@code true} if the request should be rewritten, {@code false} otherwise
+     * @see #isRedirectionNeeded(int)
+     */
+    private static boolean isRequestRewriteNeeded(HttpMessage message) {
+        int statusCode = message.getResponseHeader().getStatusCode();
+        String method = message.getRequestHeader().getMethod();
+        if (statusCode == 301 || statusCode == 302) {
+            return HttpRequestHeader.POST.equalsIgnoreCase(method);
+        }
+        return statusCode == 303
+                && !(HttpRequestHeader.GET.equalsIgnoreCase(method)
+                        || HttpRequestHeader.HEAD.equalsIgnoreCase(method));
+    }
+
+    /**
+     * Extracts a {@code URI} from the {@code Location} header of the given HTTP {@code message}.
+     *
+     * <p>If there's no {@code Location} header this method returns {@code null}.
+     *
+     * @param message the HTTP message that will processed
+     * @return the {@code URI} created from the value of the {@code Location} header, might be
+     *     {@code null}
+     * @throws InvalidRedirectLocationException if the value of {@code Location} header is not a
+     *     valid {@code URI}
+     */
+    private static URI extractRedirectLocation(HttpMessage message)
+            throws InvalidRedirectLocationException {
+        String location = message.getResponseHeader().getHeader(HttpHeader.LOCATION);
+        if (location == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("No Location header found: " + message.getResponseHeader());
+            }
+            return null;
+        }
+
+        try {
+            return new URI(message.getRequestHeader().getURI(), location, true);
+        } catch (URIException ex) {
+            try {
+                // Handle redirect URLs that are unencoded
+                return new URI(message.getRequestHeader().getURI(), location, false);
+            } catch (URIException e) {
+                throw new InvalidRedirectLocationException(
+                        "Invalid redirect location: " + location, location, ex);
+            }
+        }
+    }
+
+    private interface ResponseBodyConsumer {
+
+        void accept(HttpMessage message, HttpMethod method) throws IOException;
+    }
+
+    /**
+     * A {@link ProtocolSocketFactory} for plain sockets.
+     *
+     * <p>Remote hostnames are not resolved if {@link HttpMethodDirector#PARAM_RESOLVE_HOSTNAME} is
+     * {@code false}.
+     */
+    private static class ProtocolSocketFactoryImpl implements ProtocolSocketFactory {
+
+        @Override
+        public Socket createSocket(
+                String host,
+                int port,
+                InetAddress localAddress,
+                int localPort,
+                HttpConnectionParams params)
+                throws IOException {
+            if (params == null) {
+                throw new IllegalArgumentException("Parameters may not be null");
+            }
+            Socket socket = SocketFactory.getDefault().createSocket();
+            socket.bind(new InetSocketAddress(localAddress, localPort));
+            SocketAddress remoteAddress;
+            if (params.getBooleanParameter(HttpMethodDirector.PARAM_RESOLVE_HOSTNAME, true)) {
+                remoteAddress = new InetSocketAddress(host, port);
+            } else {
+                remoteAddress = InetSocketAddress.createUnresolved(host, port);
+            }
+            socket.connect(remoteAddress, params.getConnectionTimeout());
+            return socket;
+        }
+
+        @Override
+        public Socket createSocket(String host, int port, InetAddress localAddress, int localPort)
+                throws IOException {
+            throw new UnsupportedOperationException(
+                    "Method not supported, not required/called by Commons HttpClient library (version >= 3.0).");
+        }
+
+        @Override
+        public Socket createSocket(String host, int port) throws IOException {
+            throw new UnsupportedOperationException(
+                    "Method not supported, not required/called by Commons HttpClient library (version >= 3.0).");
+        }
+    }
+}

--- a/zap/src/main/java/org/zaproxy/zap/network/HttpSenderContext.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/HttpSenderContext.java
@@ -1,0 +1,43 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.network;
+
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.users.User;
+
+/** <strong>Note:</strong> Not part of the public API. */
+public interface HttpSenderContext {
+
+    void setUseGlobalState(boolean use);
+
+    void setUseCookies(boolean use);
+
+    void setFollowRedirects(boolean followRedirects);
+
+    void setMaxRedirects(int max);
+
+    void setMaxRetriesOnIoError(int max);
+
+    void setRemoveUserDefinedAuthHeaders(boolean remove);
+
+    void setUser(User user);
+
+    User getUser(HttpMessage msg);
+}

--- a/zap/src/main/java/org/zaproxy/zap/network/HttpSenderImpl.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/HttpSenderImpl.java
@@ -1,0 +1,40 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.network;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+
+/** <strong>Note:</strong> Not part of the public API. */
+public interface HttpSenderImpl<T extends HttpSenderContext> {
+
+    boolean isGlobalStateEnabled();
+
+    void addListener(HttpSenderListener listener);
+
+    void removeListener(HttpSenderListener listener);
+
+    T createContext(HttpSender parent, int initiator);
+
+    void sendAndReceive(T ctx, HttpRequestConfig config, HttpMessage msg, Path file)
+            throws IOException;
+}

--- a/zap/src/test/java/org/parosproxy/paros/network/HttpSenderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/network/HttpSenderUnitTest.java
@@ -86,6 +86,8 @@ class HttpSenderUnitTest {
         OptionsParam optionsParam = mock(OptionsParam.class);
         given(optionsParam.getConnectionParam()).willReturn(options);
         given(model.getOptionsParam()).willReturn(optionsParam);
+
+        HttpSender.setImpl(new HttpSenderParos());
     }
 
     @AfterEach


### PR DESCRIPTION
Add two interfaces to allow to replace the implementation:
 - `HttpSenderContext`, to keep the state of each `HttpSender`
 instance;
 - `HttpSenderImpl`, creates contexts and sends the messages. It also
 keeps the listeners as they are shared between all `HttpSender`s.

Extract the current implementation into `HttpSenderContextParos` and
`HttpSenderParos`.
An add-on should now be able to set its own implementation.