### PR TITLE
Fix NullPointerException when running Kotlin scripts without view

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -63,8 +63,6 @@ import org.parosproxy.paros.extension.CommandLineListener;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.SessionChangedListener;
-import org.parosproxy.paros.extension.ViewDelegate;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
@@ -1494,20 +1492,14 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
     private Invocable invokeScriptImpl(ScriptWrapper script) {
         ScriptEngine se = script.getEngine().getEngine();
         Writer writer = getWriters(script);
-        Model model = getModel();
-        ViewDelegate view = getView();
-
         se.getContext().setWriter(writer);
+
         // Set the script name as a context attribute - this is used for script level variables
         se.getContext().setAttribute(SCRIPT_NAME_ATT, script.getName(), ScriptContext.ENGINE_SCOPE);
 
         se.put("control", Control.getSingleton());
-        if (model != null) {
-            se.put("model", model);
-        }
-        if (view != null) {
-            se.put("view", view);
-        }
+        se.put("model", getModel());
+        se.put("view", getView());
 
         reloadIfChangedOnDisk(script);
         recordScriptCalledStats(script);

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -63,6 +63,8 @@ import org.parosproxy.paros.extension.CommandLineListener;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.SessionChangedListener;
+import org.parosproxy.paros.extension.ViewDelegate;
+import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
@@ -1492,14 +1494,20 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
     private Invocable invokeScriptImpl(ScriptWrapper script) {
         ScriptEngine se = script.getEngine().getEngine();
         Writer writer = getWriters(script);
-        se.getContext().setWriter(writer);
+        Model model = getModel();
+        ViewDelegate view = getView();
 
+        se.getContext().setWriter(writer);
         // Set the script name as a context attribute - this is used for script level variables
         se.getContext().setAttribute(SCRIPT_NAME_ATT, script.getName(), ScriptContext.ENGINE_SCOPE);
 
         se.put("control", Control.getSingleton());
-        se.put("model", getModel());
-        se.put("view", getView());
+        if (model != null) {
+            se.put("model", model);
+        }
+        if (view != null) {
+            se.put("view", view);
+        }
 
         reloadIfChangedOnDisk(script);
         recordScriptCalledStats(script);

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -1499,7 +1499,10 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 
         se.put("control", Control.getSingleton());
         se.put("model", getModel());
-        se.put("view", getView());
+
+        if (hasView()) {
+            se.put("view", getView());
+        }
 
         reloadIfChangedOnDisk(script);
         recordScriptCalledStats(script);


### PR DESCRIPTION
Adding null checks for view for Kotlin script engine to allow running in headless mode again.