### PR TITLE
Deprecate HttpException

### DIFF
--- a/zap/src/main/java/org/apache/commons/httpclient/HttpException.java
+++ b/zap/src/main/java/org/apache/commons/httpclient/HttpException.java
@@ -44,7 +44,9 @@ import java.io.IOException;
  * @author Laura Werner
  *
  * @version Revision: 608014 $ $Date: 2008-01-02 05:48:53 +0000 (Wed, 02 Jan 2008)
+ * @deprecated (2.12.0)
  */
+@Deprecated
 public class HttpException extends IOException {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/apache/commons/httpclient/HttpMethodBase.java
+++ b/zap/src/main/java/org/apache/commons/httpclient/HttpMethodBase.java
@@ -119,6 +119,7 @@ import org.parosproxy.paros.network.HttpHeader;
  *
  * @version $Revision: 775455 $ $Date: 2009-05-16 13:28:40 +0100 (Sat, 16 May 2009) $
  */
+@SuppressWarnings("deprecation")
 public abstract class HttpMethodBase implements HttpMethod {
 
     private static final String HOST_HEADER = "Host";

--- a/zap/src/main/java/org/apache/commons/httpclient/URIException.java
+++ b/zap/src/main/java/org/apache/commons/httpclient/URIException.java
@@ -43,6 +43,7 @@ package org.apache.commons.httpclient;
  * @author <a href="mailto:oleg@ural.ru">Oleg Kalnichevski</a>
  * @version Revision: 608014 Date: 2002/03/14 15:14:01
  */
+@SuppressWarnings("deprecation")
 public class URIException extends HttpException {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyThread.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyThread.java
@@ -88,6 +88,7 @@
 // ZAP: 2020/12/09 Rely on the content encodings from the body to decode.
 // ZAP: 2022/02/09 Deprecate the class.
 // ZAP: 2022/05/20 Address deprecation warnings with ConnectionParam.
+// ZAP: 2022/06/05 Address deprecation warnings with HttpException.
 package org.parosproxy.paros.core.proxy;
 
 import java.io.BufferedInputStream;
@@ -104,7 +105,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
 import javax.net.ssl.SSLException;
-import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -353,7 +353,7 @@ public class ProxyThread implements Runnable {
             }
         } catch (HttpMalformedHeaderException e) {
             log.warn("Malformed Header: ", e);
-        } catch (HttpException e) {
+        } catch (org.apache.commons.httpclient.HttpException e) {
             log.error(e.getMessage(), e);
         } catch (IOException e) {
             log.debug("IOException: ", e);
@@ -578,7 +578,7 @@ public class ProxyThread implements Runnable {
                     }
 
                     //			        notifyWrittenToForwardProxy();
-                } catch (HttpException e) {
+                } catch (org.apache.commons.httpclient.HttpException e) {
                     //			    	System.out.println("HttpException");
                     throw e;
                 } catch (SocketTimeoutException e) {

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -70,6 +70,7 @@
 // ZAP: 2020/11/17 Use new TechSet#getAllTech().
 // ZAP: 2020/11/26 Use Log4j2 getLogger() and deprecate Log4j1.x.
 // ZAP: 2021/07/20 Correct message updated with the scan rule ID header (Issue 6689).
+// ZAP: 2022/06/05 Remove usage of HttpException.
 package org.parosproxy.paros.core.scanner;
 
 import java.io.IOException;
@@ -83,7 +84,6 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.httpclient.HttpException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.control.Control;
@@ -209,7 +209,6 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
      * </ul>
      *
      * @param message the message to be sent and received
-     * @throws HttpException if a HTTP error occurred
      * @throws IOException if an I/O error occurred (for example, read time out)
      * @see #sendAndReceive(HttpMessage, boolean)
      * @see #sendAndReceive(HttpMessage, boolean, boolean)
@@ -236,7 +235,6 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
      * @param message the message to be sent and received
      * @param isFollowRedirect {@code true} if redirections should be followed, {@code false}
      *     otherwise
-     * @throws HttpException if a HTTP error occurred
      * @throws IOException if an I/O error occurred (for example, read time out)
      * @see #sendAndReceive(HttpMessage)
      * @see #sendAndReceive(HttpMessage, boolean, boolean)
@@ -266,7 +264,6 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
      *     otherwise
      * @param handleAntiCSRF {@code true} if the anti-CSRF token present in the request should be
      *     handled/regenerated, {@code false} otherwise
-     * @throws HttpException if a HTTP error occurred
      * @throws IOException if an I/O error occurred (for example, read time out)
      * @see #sendAndReceive(HttpMessage)
      * @see #sendAndReceive(HttpMessage, boolean)

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Analyser.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Analyser.java
@@ -43,6 +43,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/07/26 Remove null check in sendAndReceive(HttpMessage). (LGTM Issue)
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
+// ZAP: 2022/06/05 Remove usage of HttpException.
 package org.parosproxy.paros.core.scanner;
 
 import java.io.IOException;
@@ -51,7 +52,6 @@ import java.util.Random;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang.time.StopWatch;
@@ -507,7 +507,7 @@ public class Analyser {
         return true;
     }
 
-    private void sendAndReceive(HttpMessage msg) throws HttpException, IOException {
+    private void sendAndReceive(HttpMessage msg) throws IOException {
         if (this.getDelayInMs() > 0) {
             try {
                 Thread.sleep(this.getDelayInMs());

--- a/zap/src/main/java/org/parosproxy/paros/network/GenericMethod.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/GenericMethod.java
@@ -30,7 +30,6 @@ import java.util.Vector;
 
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpConnection;
-import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.NameValuePair;
 import org.apache.commons.httpclient.methods.ByteArrayRequestEntity;
@@ -381,7 +380,7 @@ public class GenericMethod extends EntityEnclosingMethod {
      * header parser (ZapHttpParser#parseHeaders(InputStream, String)).
      */
     @Override
-    protected void readResponseHeaders(HttpState state, HttpConnection conn) throws IOException, HttpException {
+    protected void readResponseHeaders(HttpState state, HttpConnection conn) throws IOException {
         getResponseHeaderGroup().clear();
 
         Header[] headers = ZapHttpParser.parseHeaders(conn.getResponseInputStream(), getParams().getHttpElementCharset());

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
@@ -105,6 +105,7 @@
 // ZAP: 2022/05/29 Remove redundant checks and create SSLConnector always.
 // ZAP: 2022/05/30 Use shared connection pool.
 // ZAP: 2022/06/03 Remove commented code and make listeners comparator final.
+// ZAP: 2022/06/05 Remove usage of HttpException.
 package org.parosproxy.paros.network;
 
 import java.io.IOException;
@@ -131,7 +132,6 @@ import org.apache.commons.httpclient.DefaultHttpMethodRetryHandler;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HostConfiguration;
 import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.HttpHost;
 import org.apache.commons.httpclient.HttpMethod;
 import org.apache.commons.httpclient.HttpMethodDirector;
@@ -569,7 +569,6 @@ public class HttpSender {
      *
      * @param msg
      * @param isFollowRedirect
-     * @throws HttpException
      * @throws IOException
      * @see #sendAndReceive(HttpMessage, HttpRequestConfig)
      */

--- a/zap/src/main/java/org/zaproxy/zap/ZapGetMethod.java
+++ b/zap/src/main/java/org/zaproxy/zap/ZapGetMethod.java
@@ -25,7 +25,6 @@ import java.net.Socket;
 import java.util.Locale;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpConnection;
-import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
@@ -88,7 +87,7 @@ public class ZapGetMethod extends EntityEnclosingMethod {
 
     @Override
     protected void addContentLengthRequestHeader(HttpState state, HttpConnection conn)
-            throws IOException, HttpException {
+            throws IOException {
         if (getRequestContentLength() == 0) {
             // Don't add the header with 0 length, not everything accepts it.
             return;
@@ -102,8 +101,7 @@ public class ZapGetMethod extends EntityEnclosingMethod {
      * @see GetMethod#readResponse(HttpState, HttpConnection)
      */
     @Override
-    protected void readResponse(HttpState state, HttpConnection conn)
-            throws IOException, HttpException {
+    protected void readResponse(HttpState state, HttpConnection conn) throws IOException {
         LOG.trace("enter HttpMethodBase.readResponse(HttpState, HttpConnection)");
 
         boolean isUpgrade = false;
@@ -218,8 +216,7 @@ public class ZapGetMethod extends EntityEnclosingMethod {
      * header parser (ZapHttpParser#parseHeaders(InputStream, String)).
      */
     @Override
-    protected void readResponseHeaders(HttpState state, HttpConnection conn)
-            throws IOException, HttpException {
+    protected void readResponseHeaders(HttpState state, HttpConnection conn) throws IOException {
         getResponseHeaderGroup().clear();
 
         Header[] headers =

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScriptsActiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScriptsActiveScanner.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import org.apache.commons.httpclient.HttpException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -243,19 +242,18 @@ public class ScriptsActiveScanner extends AbstractAppParamPlugin {
     }
 
     @Override
-    public void sendAndReceive(HttpMessage msg) throws HttpException, IOException {
+    public void sendAndReceive(HttpMessage msg) throws IOException {
         super.sendAndReceive(msg);
     }
 
     @Override
-    public void sendAndReceive(HttpMessage msg, boolean isFollowRedirect)
-            throws HttpException, IOException {
+    public void sendAndReceive(HttpMessage msg, boolean isFollowRedirect) throws IOException {
         super.sendAndReceive(msg, isFollowRedirect);
     }
 
     @Override
     public void sendAndReceive(HttpMessage msg, boolean isFollowRedirect, boolean handleAntiCSRF)
-            throws HttpException, IOException {
+            throws IOException {
         super.sendAndReceive(msg, isFollowRedirect, handleAntiCSRF);
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/network/ZapDeleteMethod.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/ZapDeleteMethod.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.network;
 import java.io.IOException;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpConnection;
-import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.methods.DeleteMethod;
 import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
@@ -64,8 +63,7 @@ public class ZapDeleteMethod extends EntityEnclosingMethod {
      * header parser (ZapHttpParser#parseHeaders(InputStream, String)).
      */
     @Override
-    protected void readResponseHeaders(HttpState state, HttpConnection conn)
-            throws IOException, HttpException {
+    protected void readResponseHeaders(HttpState state, HttpConnection conn) throws IOException {
         getResponseHeaderGroup().clear();
 
         Header[] headers =

--- a/zap/src/main/java/org/zaproxy/zap/network/ZapHeadMethod.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/ZapHeadMethod.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.network;
 import java.io.IOException;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpConnection;
-import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.HttpMethodBase;
 import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.ProtocolException;
@@ -63,16 +62,13 @@ public class ZapHeadMethod extends EntityEnclosingMethod {
      * @param conn the {@link HttpConnection connection} used to execute this HTTP method
      * @throws IOException if an I/O (transport) error occurs. Some transport exceptions can be
      *     recovered from.
-     * @throws HttpException if a protocol exception occurs. Usually protocol exceptions cannot be
-     *     recovered from.
      * @see #readResponse
      * @see #processResponseBody
      * @since 2.0
      */
     // Implementation copied from HeadMethod.
     @Override
-    protected void readResponseBody(HttpState state, HttpConnection conn)
-            throws HttpException, IOException {
+    protected void readResponseBody(HttpState state, HttpConnection conn) throws IOException {
         LOG.trace("enter HeadMethod.readResponseBody(HttpState, HttpConnection)");
 
         int bodyCheckTimeout =
@@ -120,8 +116,7 @@ public class ZapHeadMethod extends EntityEnclosingMethod {
      * header parser (ZapHttpParser#parseHeaders(InputStream, String)).
      */
     @Override
-    protected void readResponseHeaders(HttpState state, HttpConnection conn)
-            throws IOException, HttpException {
+    protected void readResponseHeaders(HttpState state, HttpConnection conn) throws IOException {
         getResponseHeaderGroup().clear();
 
         Header[] headers =

--- a/zap/src/main/java/org/zaproxy/zap/network/ZapHttpParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/ZapHttpParser.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import org.apache.commons.httpclient.Header;
-import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.HttpParser;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -46,8 +45,7 @@ public class ZapHttpParser {
      * malformed HTTP header lines.
      */
     @SuppressWarnings({"rawtypes", "unchecked", "null"})
-    public static Header[] parseHeaders(InputStream is, String charset)
-            throws IOException, HttpException {
+    public static Header[] parseHeaders(InputStream is, String charset) throws IOException {
         ArrayList headers = new ArrayList();
         String name = null;
         StringBuffer value = null;

--- a/zap/src/main/java/org/zaproxy/zap/network/ZapOptionsMethod.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/ZapOptionsMethod.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.network;
 import java.io.IOException;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpConnection;
-import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
 import org.apache.commons.httpclient.methods.OptionsMethod;
@@ -58,8 +57,7 @@ public class ZapOptionsMethod extends EntityEnclosingMethod {
      * header parser (ZapHttpParser#parseHeaders(InputStream, String)).
      */
     @Override
-    protected void readResponseHeaders(HttpState state, HttpConnection conn)
-            throws IOException, HttpException {
+    protected void readResponseHeaders(HttpState state, HttpConnection conn) throws IOException {
         getResponseHeaderGroup().clear();
 
         Header[] headers =

--- a/zap/src/main/java/org/zaproxy/zap/network/ZapPostMethod.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/ZapPostMethod.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.network;
 import java.io.IOException;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpConnection;
-import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.methods.PostMethod;
 
@@ -52,8 +51,7 @@ public class ZapPostMethod extends PostMethod {
      * header parser (ZapHttpParser#parseHeaders(InputStream, String)).
      */
     @Override
-    protected void readResponseHeaders(HttpState state, HttpConnection conn)
-            throws IOException, HttpException {
+    protected void readResponseHeaders(HttpState state, HttpConnection conn) throws IOException {
         getResponseHeaderGroup().clear();
 
         Header[] headers =

--- a/zap/src/main/java/org/zaproxy/zap/network/ZapPutMethod.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/ZapPutMethod.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.network;
 import java.io.IOException;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpConnection;
-import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.methods.PutMethod;
 
@@ -52,8 +51,7 @@ public class ZapPutMethod extends PutMethod {
      * header parser (ZapHttpParser#parseHeaders(InputStream, String)).
      */
     @Override
-    protected void readResponseHeaders(HttpState state, HttpConnection conn)
-            throws IOException, HttpException {
+    protected void readResponseHeaders(HttpState state, HttpConnection conn) throws IOException {
         getResponseHeaderGroup().clear();
 
         Header[] headers =

--- a/zap/src/main/java/org/zaproxy/zap/network/ZapTraceMethod.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/ZapTraceMethod.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.network;
 import java.io.IOException;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpConnection;
-import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
 import org.apache.commons.httpclient.methods.TraceMethod;
@@ -54,8 +53,7 @@ public class ZapTraceMethod extends EntityEnclosingMethod {
      * header parser (ZapHttpParser#parseHeaders(InputStream, String)).
      */
     @Override
-    protected void readResponseHeaders(HttpState state, HttpConnection conn)
-            throws IOException, HttpException {
+    protected void readResponseHeaders(HttpState state, HttpConnection conn) throws IOException {
         getResponseHeaderGroup().clear();
 
         Header[] headers =


### PR DESCRIPTION
Deprecate and reduce usage of `HttpException`, the class is still
needed/used in the hierarchy of `URIException` which is part of the
public API.