### PR TITLE
Deprecate HttpSender implementation classes

### DIFF
--- a/zap/src/main/java/org/apache/commons/httpclient/HttpConnection.java
+++ b/zap/src/main/java/org/apache/commons/httpclient/HttpConnection.java
@@ -43,7 +43,6 @@ import java.net.SocketException;
 import org.apache.commons.httpclient.params.HttpConnectionParams;
 import org.apache.commons.httpclient.protocol.Protocol;
 import org.apache.commons.httpclient.protocol.ProtocolSocketFactory;
-import org.apache.commons.httpclient.protocol.SecureProtocolSocketFactory;
 import org.apache.commons.httpclient.util.EncodingUtil;
 import org.apache.commons.httpclient.util.ExceptionUtil;
 import org.apache.commons.logging.Log;
@@ -102,7 +101,8 @@ import org.apache.commons.logging.LogFactory;
  * @author Laura Werner
  * 
  * @version   $Revision: 832758 $ $Date: 2009-11-04 14:28:27 +0000 (Wed, 04 Nov 2009) $
- */
+* @deprecated (2.12.0) Implementation details, do not use. */
+@Deprecated
 public class HttpConnection {
 
     // ----------------------------------------------------------- Constructors
@@ -798,8 +798,8 @@ public class HttpConnection {
         }
         
         if (isSecure()) {
-            SecureProtocolSocketFactory socketFactory =
-                (SecureProtocolSocketFactory) protocolInUse.getSocketFactory();
+        	org.apache.commons.httpclient.protocol.SecureProtocolSocketFactory socketFactory =
+                (org.apache.commons.httpclient.protocol.SecureProtocolSocketFactory) protocolInUse.getSocketFactory();
 
             socket = socketFactory.createSocket(socket, hostName, portNumber, true, params);
         }

--- a/zap/src/main/java/org/apache/commons/httpclient/HttpMethodBase.java
+++ b/zap/src/main/java/org/apache/commons/httpclient/HttpMethodBase.java
@@ -118,8 +118,9 @@ import org.parosproxy.paros.network.HttpHeader;
  * @author Christian Kohlschuetter
  *
  * @version $Revision: 775455 $ $Date: 2009-05-16 13:28:40 +0100 (Sat, 16 May 2009) $
+ * @deprecated (2.12.0) Implementation details, do not use.
  */
-@SuppressWarnings("deprecation")
+@Deprecated
 public abstract class HttpMethodBase implements HttpMethod {
 
     private static final String HOST_HEADER = "Host";

--- a/zap/src/main/java/org/apache/commons/httpclient/HttpMethodDirector.java
+++ b/zap/src/main/java/org/apache/commons/httpclient/HttpMethodDirector.java
@@ -77,9 +77,9 @@ import org.apache.commons.logging.LogFactory;
 /**
  * Handles the process of executing a method including authentication, redirection and retries.
  * 
- * @since 3.0
- */
-@SuppressWarnings("deprecation")
+ *
+ * @deprecated (2.12.0) Implementation details, do not use. */
+@Deprecated
 public class HttpMethodDirector {
 
     /**

--- a/zap/src/main/java/org/apache/commons/httpclient/protocol/SecureProtocolSocketFactory.java
+++ b/zap/src/main/java/org/apache/commons/httpclient/protocol/SecureProtocolSocketFactory.java
@@ -53,8 +53,9 @@ import org.apache.commons.httpclient.params.HttpConnectionParams;
  *
  * @author Michael Becke
  * @author <a href="mailto:mbowler@GargoyleSoftware.com">Mike Bowler</a>
- * @since 2.0
+ * @deprecated (2.12.0) Implementation details, do not use.
  */
+@Deprecated
 public interface SecureProtocolSocketFactory extends ProtocolSocketFactory {
 
     /**

--- a/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyParam.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyParam.java
@@ -45,6 +45,7 @@
 // ZAP: 2022/02/08 Use isEmpty where applicable.
 // ZAP: 2022/02/09 Deprecate the class.
 // ZAP: 2022/02/28 Remove code deprecated in 2.6.0
+// ZAP: 2022/06/07 Address deprecation warnings with SSLConnector.
 package org.parosproxy.paros.core.proxy;
 
 import java.net.InetAddress;
@@ -55,7 +56,6 @@ import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.common.AbstractParam;
-import org.parosproxy.paros.network.SSLConnector;
 
 /**
  * @author simon
@@ -347,23 +347,29 @@ public class ProxyParam extends AbstractParam {
             securityProtocolsEnabled = protocols.toArray(securityProtocolsEnabled);
             setServerEnabledProtocols();
         } else {
-            setSecurityProtocolsEnabled(SSLConnector.getServerEnabledProtocols());
+            setSecurityProtocolsEnabled(
+                    org.parosproxy.paros.network.SSLConnector.getServerEnabledProtocols());
         }
     }
 
     private void setServerEnabledProtocols() {
         try {
-            SSLConnector.setServerEnabledProtocols(securityProtocolsEnabled);
+            org.parosproxy.paros.network.SSLConnector.setServerEnabledProtocols(
+                    securityProtocolsEnabled);
         } catch (IllegalArgumentException e) {
             logger.warn(
                     "Failed to set persisted protocols "
                             + Arrays.toString(securityProtocolsEnabled)
                             + " falling back to "
-                            + Arrays.toString(SSLConnector.getFailSafeProtocols())
+                            + Arrays.toString(
+                                    org.parosproxy.paros.network.SSLConnector
+                                            .getFailSafeProtocols())
                             + " caused by: "
                             + e.getMessage());
-            securityProtocolsEnabled = SSLConnector.getFailSafeProtocols();
-            SSLConnector.setServerEnabledProtocols(securityProtocolsEnabled);
+            securityProtocolsEnabled =
+                    org.parosproxy.paros.network.SSLConnector.getFailSafeProtocols();
+            org.parosproxy.paros.network.SSLConnector.setServerEnabledProtocols(
+                    securityProtocolsEnabled);
         }
     }
 

--- a/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyPortRetryPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyPortRetryPanel.java
@@ -26,6 +26,8 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import org.zaproxy.zap.utils.ZapPortNumberSpinner;
 
+/** @deprecated (2.12.0) */
+@Deprecated
 class ProxyPortRetryPanel extends JPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyServerSSL.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyServerSSL.java
@@ -27,6 +27,7 @@
 //
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2022/06/07 Address deprecation warnings with SSLConnector.
 package org.parosproxy.paros.core.proxy;
 
 import java.io.IOException;
@@ -35,12 +36,11 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import org.parosproxy.paros.network.HttpSender;
-import org.parosproxy.paros.network.SSLConnector;
 
 @Deprecated
 public class ProxyServerSSL extends ProxyServer {
 
-    private static SSLConnector ssl = HttpSender.getSSLConnector();
+    private static org.parosproxy.paros.network.SSLConnector ssl = HttpSender.getSSLConnector();
 
     public ProxyServerSSL() {
         super();

--- a/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyThread.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/proxy/ProxyThread.java
@@ -89,6 +89,7 @@
 // ZAP: 2022/02/09 Deprecate the class.
 // ZAP: 2022/05/20 Address deprecation warnings with ConnectionParam.
 // ZAP: 2022/06/05 Address deprecation warnings with HttpException.
+// ZAP: 2022/06/07 Address deprecation warnings with ZapGetMethod.
 package org.parosproxy.paros.core.proxy;
 
 import java.io.BufferedInputStream;
@@ -123,7 +124,6 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.zap.PersistentConnectionListener;
-import org.zaproxy.zap.ZapGetMethod;
 import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.network.HttpRequestBody;
 import org.zaproxy.zap.network.HttpRequestConfig;
@@ -503,7 +503,7 @@ public class ProxyThread implements Runnable {
                     if (msg.getRequestHeader().isEmpty()) {
                         return;
                     }
-                    ZapGetMethod method = new ZapGetMethod();
+                    org.zaproxy.zap.ZapGetMethod method = new org.zaproxy.zap.ZapGetMethod();
                     method.setUpgradedSocket(inSocket);
                     method.setUpgradedInputStream(httpIn);
                     keepSocketOpen = notifyPersistentConnectionListener(msg, inSocket, method);
@@ -616,7 +616,8 @@ public class ProxyThread implements Runnable {
                 }
             } // release semaphore
 
-            ZapGetMethod method = (ZapGetMethod) msg.getUserObject();
+            org.zaproxy.zap.ZapGetMethod method =
+                    (org.zaproxy.zap.ZapGetMethod) msg.getUserObject();
             keepSocketOpen = notifyPersistentConnectionListener(msg, inSocket, method);
             if (keepSocketOpen) {
                 // do not wait for close
@@ -781,7 +782,7 @@ public class ProxyThread implements Runnable {
      * @return Boolean to indicate if socket should be kept open.
      */
     private boolean notifyPersistentConnectionListener(
-            HttpMessage httpMessage, Socket inSocket, ZapGetMethod method) {
+            HttpMessage httpMessage, Socket inSocket, org.zaproxy.zap.ZapGetMethod method) {
         boolean keepSocketOpen = false;
         PersistentConnectionListener listener = null;
         List<PersistentConnectionListener> listenerList =

--- a/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
@@ -46,7 +46,6 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.PersistentConnectionListener;
-import org.zaproxy.zap.ZapGetMethod;
 import org.zaproxy.zap.extension.anticsrf.ExtensionAntiCSRF;
 import org.zaproxy.zap.extension.httppanel.HttpPanel;
 import org.zaproxy.zap.extension.httppanel.HttpPanelRequest;
@@ -147,7 +146,9 @@ public class HttpPanelSender implements MessageSender {
                         }
                     });
 
-            ZapGetMethod method = (ZapGetMethod) httpMessage.getUserObject();
+            @SuppressWarnings("deprecation")
+            org.zaproxy.zap.ZapGetMethod method =
+                    (org.zaproxy.zap.ZapGetMethod) httpMessage.getUserObject();
             notifyPersistentConnectionListener(httpMessage, null, method);
 
         } catch (final HttpMalformedHeaderException mhe) {
@@ -198,7 +199,9 @@ public class HttpPanelSender implements MessageSender {
      * @return Boolean to indicate if socket should be kept open.
      */
     private boolean notifyPersistentConnectionListener(
-            HttpMessage httpMessage, Socket inSocket, ZapGetMethod method) {
+            HttpMessage httpMessage,
+            Socket inSocket,
+            @SuppressWarnings("deprecation") org.zaproxy.zap.ZapGetMethod method) {
         boolean keepSocketOpen = false;
         PersistentConnectionListener listener = null;
         synchronized (persistentConnectionListener) {

--- a/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsParamCertificate.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsParamCertificate.java
@@ -31,6 +31,7 @@
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/05/21 Disable unsafe SSL/TLS renegotiation option.
 // ZAP: 2022/05/29 Deprecate the class.
+// ZAP: 2022/06/07 Address deprecation warnings with SSLConnector.
 package org.parosproxy.paros.extension.option;
 
 import java.io.File;
@@ -44,7 +45,6 @@ import org.apache.commons.httpclient.protocol.ProtocolSocketFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.common.AbstractParam;
-import org.parosproxy.paros.network.SSLConnector;
 
 /** @deprecated (2.12.0) No longer in use. */
 @Deprecated
@@ -181,8 +181,9 @@ public class OptionsParamCertificate extends AbstractParam {
     public void setEnableCertificate(boolean enabled) {
         ProtocolSocketFactory sslFactory = Protocol.getProtocol("https").getSocketFactory();
 
-        if (sslFactory instanceof SSLConnector) {
-            SSLConnector ssl = (SSLConnector) sslFactory;
+        if (sslFactory instanceof org.parosproxy.paros.network.SSLConnector) {
+            org.parosproxy.paros.network.SSLConnector ssl =
+                    (org.parosproxy.paros.network.SSLConnector) sslFactory;
             ssl.setEnableClientCert(enabled);
 
             setUseClientCert(enabled);
@@ -193,8 +194,9 @@ public class OptionsParamCertificate extends AbstractParam {
 
         ProtocolSocketFactory sslFactory = Protocol.getProtocol("https").getSocketFactory();
 
-        if (sslFactory instanceof SSLConnector) {
-            SSLConnector ssl = (SSLConnector) sslFactory;
+        if (sslFactory instanceof org.parosproxy.paros.network.SSLConnector) {
+            org.parosproxy.paros.network.SSLConnector ssl =
+                    (org.parosproxy.paros.network.SSLConnector) sslFactory;
             ssl.setActiveCertificate();
         }
     }
@@ -202,8 +204,9 @@ public class OptionsParamCertificate extends AbstractParam {
     public ch.csnc.extension.httpclient.SSLContextManager getSSLContextManager() {
 
         ProtocolSocketFactory sslFactory = Protocol.getProtocol("https").getSocketFactory();
-        if (sslFactory instanceof SSLConnector) {
-            SSLConnector ssl = (SSLConnector) sslFactory;
+        if (sslFactory instanceof org.parosproxy.paros.network.SSLConnector) {
+            org.parosproxy.paros.network.SSLConnector ssl =
+                    (org.parosproxy.paros.network.SSLConnector) sslFactory;
 
             return ssl.getSSLContextManager();
         }

--- a/zap/src/main/java/org/parosproxy/paros/extension/option/SecurityProtocolsPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/option/SecurityProtocolsPanel.java
@@ -28,7 +28,6 @@ import java.util.Map.Entry;
 import javax.swing.JCheckBox;
 import javax.swing.JPanel;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.network.SSLConnector;
 import org.zaproxy.zap.utils.FontUtils;
 
 /**
@@ -69,7 +68,8 @@ public class SecurityProtocolsPanel extends JPanel {
                         Constant.messages.getString(
                                 "generic.options.panel.security.protocols.ssl2hello.label"));
         checkBox.setEnabled(false);
-        checkBoxesSslTlsProtocols.put(SSLConnector.SECURITY_PROTOCOL_SSL_V2_HELLO, checkBox);
+        checkBoxesSslTlsProtocols.put(
+                org.parosproxy.paros.network.SSLConnector.SECURITY_PROTOCOL_SSL_V2_HELLO, checkBox);
         add(checkBox, gbc);
 
         checkBox =
@@ -77,7 +77,8 @@ public class SecurityProtocolsPanel extends JPanel {
                         Constant.messages.getString(
                                 "generic.options.panel.security.protocols.ssl3.label"));
         checkBox.setEnabled(false);
-        checkBoxesSslTlsProtocols.put(SSLConnector.SECURITY_PROTOCOL_SSL_V3, checkBox);
+        checkBoxesSslTlsProtocols.put(
+                org.parosproxy.paros.network.SSLConnector.SECURITY_PROTOCOL_SSL_V3, checkBox);
         add(checkBox, gbc);
 
         checkBox =
@@ -85,7 +86,8 @@ public class SecurityProtocolsPanel extends JPanel {
                         Constant.messages.getString(
                                 "generic.options.panel.security.protocols.tlsv1.label"));
         checkBox.setEnabled(false);
-        checkBoxesSslTlsProtocols.put(SSLConnector.SECURITY_PROTOCOL_TLS_V1, checkBox);
+        checkBoxesSslTlsProtocols.put(
+                org.parosproxy.paros.network.SSLConnector.SECURITY_PROTOCOL_TLS_V1, checkBox);
         add(checkBox, gbc);
 
         checkBox =
@@ -93,7 +95,8 @@ public class SecurityProtocolsPanel extends JPanel {
                         Constant.messages.getString(
                                 "generic.options.panel.security.protocols.tlsv1.1.label"));
         checkBox.setEnabled(false);
-        checkBoxesSslTlsProtocols.put(SSLConnector.SECURITY_PROTOCOL_TLS_V1_1, checkBox);
+        checkBoxesSslTlsProtocols.put(
+                org.parosproxy.paros.network.SSLConnector.SECURITY_PROTOCOL_TLS_V1_1, checkBox);
         add(checkBox, gbc);
 
         checkBox =
@@ -101,7 +104,8 @@ public class SecurityProtocolsPanel extends JPanel {
                         Constant.messages.getString(
                                 "generic.options.panel.security.protocols.tlsv1.2.label"));
         checkBox.setEnabled(false);
-        checkBoxesSslTlsProtocols.put(SSLConnector.SECURITY_PROTOCOL_TLS_V1_2, checkBox);
+        checkBoxesSslTlsProtocols.put(
+                org.parosproxy.paros.network.SSLConnector.SECURITY_PROTOCOL_TLS_V1_2, checkBox);
         add(checkBox, gbc);
 
         checkBox =
@@ -109,13 +113,14 @@ public class SecurityProtocolsPanel extends JPanel {
                         Constant.messages.getString(
                                 "generic.options.panel.security.protocols.tlsv1.3.label"));
         checkBox.setEnabled(false);
-        checkBoxesSslTlsProtocols.put(SSLConnector.SECURITY_PROTOCOL_TLS_V1_3, checkBox);
+        checkBoxesSslTlsProtocols.put(
+                org.parosproxy.paros.network.SSLConnector.SECURITY_PROTOCOL_TLS_V1_3, checkBox);
         add(checkBox, gbc);
     }
 
     public void setSecurityProtocolsEnabled(String[] selectedProtocols) {
         if (!supportedSecurityProtocolsInitialised) {
-            String[] protocols = SSLConnector.getSupportedProtocols();
+            String[] protocols = org.parosproxy.paros.network.SSLConnector.getSupportedProtocols();
             for (String protocol : protocols) {
                 JCheckBox checkBox = checkBoxesSslTlsProtocols.get(protocol);
                 if (checkBox != null) {
@@ -178,7 +183,9 @@ public class SecurityProtocolsPanel extends JPanel {
 
             if (protocolsSelected == 1
                     && checkBoxesSslTlsProtocols
-                            .get(SSLConnector.SECURITY_PROTOCOL_SSL_V2_HELLO)
+                            .get(
+                                    org.parosproxy.paros.network.SSLConnector
+                                            .SECURITY_PROTOCOL_SSL_V2_HELLO)
                             .isSelected()) {
                 checkBoxEnabledProtocol.requestFocusInWindow();
                 throw new IllegalArgumentException(

--- a/zap/src/main/java/org/parosproxy/paros/network/DecoratedSocketsSslSocketFactory.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/DecoratedSocketsSslSocketFactory.java
@@ -32,7 +32,9 @@ import javax.net.ssl.SSLSocketFactory;
  *
  * @see SSLSocketFactory
  * @see SslSocketDecorator
+ * @deprecated (2.12.0) Implementation details, do not use.
  */
+@Deprecated
 public class DecoratedSocketsSslSocketFactory extends SSLSocketFactory {
 
     private final SSLSocketFactory delegate;

--- a/zap/src/main/java/org/parosproxy/paros/network/GenericMethod.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/GenericMethod.java
@@ -29,7 +29,6 @@ import java.util.Iterator;
 import java.util.Vector;
 
 import org.apache.commons.httpclient.Header;
-import org.apache.commons.httpclient.HttpConnection;
 import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.NameValuePair;
 import org.apache.commons.httpclient.methods.ByteArrayRequestEntity;
@@ -38,11 +37,13 @@ import org.apache.commons.httpclient.methods.RequestEntity;
 import org.apache.commons.httpclient.util.EncodingUtil;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.zaproxy.zap.network.ZapHttpParser;
 
 /**
  * This class is basing on the HttpClient under Apache licence 2.0
+ *
+ * @deprecated (2.12.0) Implementation details, do not use.
  */
+@Deprecated
 public class GenericMethod extends EntityEnclosingMethod {
     
     /** Log object for this class. */
@@ -380,10 +381,10 @@ public class GenericMethod extends EntityEnclosingMethod {
      * header parser (ZapHttpParser#parseHeaders(InputStream, String)).
      */
     @Override
-    protected void readResponseHeaders(HttpState state, HttpConnection conn) throws IOException {
+    protected void readResponseHeaders(HttpState state, org.apache.commons.httpclient.HttpConnection conn) throws IOException {
         getResponseHeaderGroup().clear();
 
-        Header[] headers = ZapHttpParser.parseHeaders(conn.getResponseInputStream(), getParams().getHttpElementCharset());
+        Header[] headers = org.zaproxy.zap.network.ZapHttpParser.parseHeaders(conn.getResponseInputStream(), getParams().getHttpElementCharset());
         // Wire logging moved to HttpParser
         getResponseHeaderGroup().setHeaders(headers);
     }

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpMethodHelper.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpMethodHelper.java
@@ -33,6 +33,7 @@
 // ZAP: 2017/06/19 Allow to create a method with custom parameters.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2022/06/07 Deprecate the class.
 package org.parosproxy.paros.network;
 
 import java.util.regex.Pattern;
@@ -46,14 +47,9 @@ import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
 import org.apache.commons.httpclient.params.HttpMethodParams;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.zaproxy.zap.ZapGetMethod;
-import org.zaproxy.zap.network.ZapDeleteMethod;
-import org.zaproxy.zap.network.ZapHeadMethod;
-import org.zaproxy.zap.network.ZapOptionsMethod;
-import org.zaproxy.zap.network.ZapPostMethod;
-import org.zaproxy.zap.network.ZapPutMethod;
-import org.zaproxy.zap.network.ZapTraceMethod;
 
+/** @deprecated (2.12.0) Implementation details, do not use. */
+@Deprecated
 public class HttpMethodHelper {
 
     private static final Logger logger = LogManager.getLogger(HttpMethodHelper.class);
@@ -155,19 +151,19 @@ public class HttpMethodHelper {
 
         if (method.equalsIgnoreCase(GET)) {
             // ZAP: avoid discarding HTTP status code 101 that is used for WebSocket upgrade
-            httpMethod = new ZapGetMethod();
+            httpMethod = new org.zaproxy.zap.ZapGetMethod();
         } else if (method.equalsIgnoreCase(POST)) {
-            httpMethod = new ZapPostMethod();
+            httpMethod = new org.zaproxy.zap.network.ZapPostMethod();
         } else if (method.equalsIgnoreCase(DELETE)) {
-            httpMethod = new ZapDeleteMethod();
+            httpMethod = new org.zaproxy.zap.network.ZapDeleteMethod();
         } else if (method.equalsIgnoreCase(PUT)) {
-            httpMethod = new ZapPutMethod();
+            httpMethod = new org.zaproxy.zap.network.ZapPutMethod();
         } else if (method.equalsIgnoreCase(HEAD)) {
-            httpMethod = new ZapHeadMethod();
+            httpMethod = new org.zaproxy.zap.network.ZapHeadMethod();
         } else if (method.equalsIgnoreCase(OPTIONS)) {
-            httpMethod = new ZapOptionsMethod();
+            httpMethod = new org.zaproxy.zap.network.ZapOptionsMethod();
         } else if (method.equalsIgnoreCase(TRACE)) {
-            httpMethod = new ZapTraceMethod(uri.toString());
+            httpMethod = new org.zaproxy.zap.network.ZapTraceMethod(uri.toString());
         } else {
             httpMethod = new GenericMethod(method);
         }

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
@@ -107,6 +107,7 @@
 // ZAP: 2022/06/03 Remove commented code and make listeners comparator final.
 // ZAP: 2022/06/03 Move implementation to HttpSenderParos.
 // ZAP: 2022/06/05 Remove usage of HttpException.
+// ZAP: 2022/06/07 Address deprecation warnings with HttpSenderParos.
 package org.parosproxy.paros.network;
 
 import java.io.IOException;
@@ -143,6 +144,7 @@ public class HttpSender {
     private static final HttpRequestConfig FOLLOW_REDIRECTS =
             HttpRequestConfig.builder().setFollowRedirects(true).build();
 
+    @SuppressWarnings("deprecation")
     private static final HttpSenderParos PAROS_IMPL = new HttpSenderParos();
 
     @SuppressWarnings("rawtypes")

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpSenderContextParos.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpSenderContextParos.java
@@ -21,7 +21,6 @@ package org.parosproxy.paros.network;
 
 import org.apache.commons.httpclient.DefaultHttpMethodRetryHandler;
 import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpMethodDirector;
 import org.apache.commons.httpclient.HttpMethodRetryHandler;
 import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.cookie.CookiePolicy;
@@ -30,12 +29,13 @@ import org.apache.commons.httpclient.params.HttpMethodParams;
 import org.zaproxy.zap.network.HttpSenderContext;
 import org.zaproxy.zap.users.User;
 
+/** @deprecated (2.12.0) Implementation details, do not use. */
+@Deprecated
 public class HttpSenderContextParos implements HttpSenderContext {
 
     private final HttpSender parent;
     private final int initiator;
 
-    @SuppressWarnings("deprecation")
     private final ConnectionParam param;
 
     private final HttpClient client;
@@ -45,7 +45,6 @@ public class HttpSenderContextParos implements HttpSenderContext {
     private boolean useCookies;
     private boolean useGlobalState;
 
-    @SuppressWarnings("deprecation")
     HttpSenderContextParos(
             HttpSender parent, int initiator, ConnectionParam param, HttpClient client) {
         this.parent = parent;
@@ -111,7 +110,9 @@ public class HttpSenderContextParos implements HttpSenderContext {
     public void setRemoveUserDefinedAuthHeaders(boolean remove) {
         client.getParams()
                 .setBooleanParameter(
-                        HttpMethodDirector.PARAM_REMOVE_USER_DEFINED_AUTH_HEADERS, remove);
+                        org.apache.commons.httpclient.HttpMethodDirector
+                                .PARAM_REMOVE_USER_DEFINED_AUTH_HEADERS,
+                        remove);
     }
 
     @Override
@@ -127,7 +128,6 @@ public class HttpSenderContextParos implements HttpSenderContext {
         return msg.getRequestingUser();
     }
 
-    @SuppressWarnings("deprecation")
     private void checkState() {
         if (!useCookies) {
             resetState();

--- a/zap/src/main/java/org/parosproxy/paros/network/SSLConnector.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/SSLConnector.java
@@ -44,6 +44,7 @@
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2021/11/23 Allow to set certificates service.
 // ZAP: 2022/05/29 Address deprecations related to client certificates.
+// ZAP: 2022/06/07 Deprecate the class.
 package org.parosproxy.paros.network;
 
 import java.io.IOException;
@@ -89,14 +90,15 @@ import javax.net.ssl.X509KeyManager;
 import org.apache.commons.collections.MapIterator;
 import org.apache.commons.collections.map.LRUMap;
 import org.apache.commons.httpclient.ConnectTimeoutException;
-import org.apache.commons.httpclient.HttpMethodDirector;
 import org.apache.commons.httpclient.params.HttpConnectionParams;
-import org.apache.commons.httpclient.protocol.SecureProtocolSocketFactory;
 import org.apache.commons.validator.routines.InetAddressValidator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class SSLConnector implements SecureProtocolSocketFactory {
+/** @deprecated (2.12.0) Implementation details, do not use. */
+@Deprecated
+public class SSLConnector
+        implements org.apache.commons.httpclient.protocol.SecureProtocolSocketFactory {
 
     private static final String SSL = "SSL";
 
@@ -448,7 +450,9 @@ public class SSLConnector implements SecureProtocolSocketFactory {
             } catch (SSLException e) {
                 if (!e.getMessage().contains(CONTENTS_UNRECOGNIZED_NAME_EXCEPTION)
                         || !params.getBooleanParameter(
-                                HttpMethodDirector.PARAM_RESOLVE_HOSTNAME, true)) {
+                                org.apache.commons.httpclient.HttpMethodDirector
+                                        .PARAM_RESOLVE_HOSTNAME,
+                                true)) {
                     throw e;
                 }
 
@@ -471,7 +475,9 @@ public class SSLConnector implements SecureProtocolSocketFactory {
     private static InetSocketAddress createRemoteAddr(
             HttpConnectionParams params, String host, int port) {
         if (params == null
-                || params.getBooleanParameter(HttpMethodDirector.PARAM_RESOLVE_HOSTNAME, true)) {
+                || params.getBooleanParameter(
+                        org.apache.commons.httpclient.HttpMethodDirector.PARAM_RESOLVE_HOSTNAME,
+                        true)) {
             return new InetSocketAddress(host, port);
         }
         return InetSocketAddress.createUnresolved(host, port);
@@ -633,7 +639,8 @@ public class SSLConnector implements SecureProtocolSocketFactory {
         } catch (SSLException e) {
             if (e.getMessage().contains(CONTENTS_UNRECOGNIZED_NAME_EXCEPTION)
                     && params.getBooleanParameter(
-                            HttpMethodDirector.PARAM_RESOLVE_HOSTNAME, true)) {
+                            org.apache.commons.httpclient.HttpMethodDirector.PARAM_RESOLVE_HOSTNAME,
+                            true)) {
                 cacheMisconfiguredHost(host, port, InetAddress.getByName(host));
             }
             // Throw the exception anyway because the socket might no longer be usable (e.g.

--- a/zap/src/main/java/org/zaproxy/zap/PersistentConnectionListener.java
+++ b/zap/src/main/java/org/zaproxy/zap/PersistentConnectionListener.java
@@ -37,5 +37,8 @@ public interface PersistentConnectionListener extends ArrangeableProxyListener {
      * @param method May contain TCP connection to server.
      * @return True if connection is took over, false if not interested.
      */
-    boolean onHandshakeResponse(HttpMessage httpMessage, Socket inSocket, ZapGetMethod method);
+    boolean onHandshakeResponse(
+            HttpMessage httpMessage,
+            Socket inSocket,
+            @SuppressWarnings("deprecation") ZapGetMethod method);
 }

--- a/zap/src/main/java/org/zaproxy/zap/ZapGetMethod.java
+++ b/zap/src/main/java/org/zaproxy/zap/ZapGetMethod.java
@@ -24,13 +24,11 @@ import java.io.InputStream;
 import java.net.Socket;
 import java.util.Locale;
 import org.apache.commons.httpclient.Header;
-import org.apache.commons.httpclient.HttpConnection;
 import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.zaproxy.zap.network.ZapHttpParser;
 
 /**
  * Do not ignore HTTP status code of 101 and keep {@link Socket} &amp; {@link InputStream} open, as
@@ -39,7 +37,10 @@ import org.zaproxy.zap.network.ZapHttpParser;
  * <p>Is essential for the WebSockets extension.
  *
  * <p>Malformed HTTP response header lines are ignored.
+ *
+ * @deprecated (2.12.0) Implementation details, do not use.
  */
+@Deprecated
 public class ZapGetMethod extends EntityEnclosingMethod {
     private static final Log LOG = LogFactory.getLog(ZapGetMethod.class);
 
@@ -86,8 +87,8 @@ public class ZapGetMethod extends EntityEnclosingMethod {
     }
 
     @Override
-    protected void addContentLengthRequestHeader(HttpState state, HttpConnection conn)
-            throws IOException {
+    protected void addContentLengthRequestHeader(
+            HttpState state, org.apache.commons.httpclient.HttpConnection conn) throws IOException {
         if (getRequestContentLength() == 0) {
             // Don't add the header with 0 length, not everything accepts it.
             return;
@@ -101,7 +102,8 @@ public class ZapGetMethod extends EntityEnclosingMethod {
      * @see GetMethod#readResponse(HttpState, HttpConnection)
      */
     @Override
-    protected void readResponse(HttpState state, HttpConnection conn) throws IOException {
+    protected void readResponse(HttpState state, org.apache.commons.httpclient.HttpConnection conn)
+            throws IOException {
         LOG.trace("enter HttpMethodBase.readResponse(HttpState, HttpConnection)");
 
         boolean isUpgrade = false;
@@ -216,11 +218,12 @@ public class ZapGetMethod extends EntityEnclosingMethod {
      * header parser (ZapHttpParser#parseHeaders(InputStream, String)).
      */
     @Override
-    protected void readResponseHeaders(HttpState state, HttpConnection conn) throws IOException {
+    protected void readResponseHeaders(
+            HttpState state, org.apache.commons.httpclient.HttpConnection conn) throws IOException {
         getResponseHeaderGroup().clear();
 
         Header[] headers =
-                ZapHttpParser.parseHeaders(
+                org.zaproxy.zap.network.ZapHttpParser.parseHeaders(
                         conn.getResponseInputStream(), getParams().getHttpElementCharset());
         // Wire logging moved to HttpParser
         getResponseHeaderGroup().setHeaders(headers);

--- a/zap/src/main/java/org/zaproxy/zap/ZapHttpConnection.java
+++ b/zap/src/main/java/org/zaproxy/zap/ZapHttpConnection.java
@@ -21,10 +21,14 @@ package org.zaproxy.zap;
 
 import java.net.Socket;
 import org.apache.commons.httpclient.HostConfiguration;
-import org.apache.commons.httpclient.HttpConnection;
 
-/** Custom {@link HttpConnection} that exposes its socket and avoids closing. */
-public class ZapHttpConnection extends HttpConnection {
+/**
+ * Custom {@link HttpConnection} that exposes its socket and avoids closing.
+ *
+ * @deprecated (2.12.0) Implementation details, do not use.
+ */
+@Deprecated
+public class ZapHttpConnection extends org.apache.commons.httpclient.HttpConnection {
 
     /**
      * Creates a new HTTP connection for the given host configuration.

--- a/zap/src/main/java/org/zaproxy/zap/ZapHttpConnectionManager.java
+++ b/zap/src/main/java/org/zaproxy/zap/ZapHttpConnectionManager.java
@@ -20,18 +20,20 @@
 package org.zaproxy.zap;
 
 import org.apache.commons.httpclient.HostConfiguration;
-import org.apache.commons.httpclient.HttpConnection;
 import org.apache.commons.httpclient.SimpleHttpConnectionManager;
 
 /**
  * Custom {@link SimpleHttpConnectionManager} that uses {@link ZapHttpConnection} for connection
  * creation. Needed to expose the underlying socket.
+ *
+ * @deprecated (2.12.0) Implementation details, do not use.
  */
+@Deprecated
 public class ZapHttpConnectionManager extends SimpleHttpConnectionManager {
 
     /** Use custom {@link ZapHttpConnection} to allow for socket exposure. */
     @Override
-    public HttpConnection getConnectionWithTimeout(
+    public org.apache.commons.httpclient.HttpConnection getConnectionWithTimeout(
             HostConfiguration hostConfiguration, long timeout) {
 
         if (httpConnection == null) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/dynssl/ExtensionDynSSL.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/dynssl/ExtensionDynSSL.java
@@ -50,12 +50,12 @@ import org.parosproxy.paros.extension.CommandLineArgument;
 import org.parosproxy.paros.extension.CommandLineListener;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
-import org.parosproxy.paros.network.SSLConnector;
 
 /**
  * Extension enables configuration for Root CA certificate
  *
  * @author MaWoKi
+ * @deprecated (2.12.0)
  */
 @Deprecated
 public class ExtensionDynSSL extends ExtensionAdaptor implements CommandLineListener {
@@ -98,7 +98,7 @@ public class ExtensionDynSSL extends ExtensionAdaptor implements CommandLineList
         try {
             startImpl();
         } finally {
-            SSLConnector.setSslCertificateService(
+            org.parosproxy.paros.network.SSLConnector.setSslCertificateService(
                     org.parosproxy.paros.security.CachedSslCertifificateServiceImpl.getService());
         }
     }

--- a/zap/src/main/java/org/zaproxy/zap/network/ZapCookieSpec.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/ZapCookieSpec.java
@@ -27,7 +27,9 @@ import org.apache.commons.httpclient.cookie.MalformedCookieException;
  * A {@link CookieSpecBase} that does not do any path validation.
  *
  * @since 2.7.0
+ * @deprecated (2.12.0) Implementation details, do not use.
  */
+@Deprecated
 public class ZapCookieSpec extends CookieSpecBase {
 
     // ZAP: Same implementation as base class but without the path validation.

--- a/zap/src/main/java/org/zaproxy/zap/network/ZapDeleteMethod.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/ZapDeleteMethod.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.network;
 
 import java.io.IOException;
 import org.apache.commons.httpclient.Header;
-import org.apache.commons.httpclient.HttpConnection;
 import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.methods.DeleteMethod;
 import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
@@ -30,7 +29,9 @@ import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
  * An HTTP DELETE method implementation that ignores malformed HTTP response header lines.
  *
  * @see DeleteMethod
+ * @deprecated (2.12.0) Implementation details, do not use.
  */
+@Deprecated
 public class ZapDeleteMethod extends EntityEnclosingMethod {
 
     public ZapDeleteMethod() {
@@ -63,7 +64,8 @@ public class ZapDeleteMethod extends EntityEnclosingMethod {
      * header parser (ZapHttpParser#parseHeaders(InputStream, String)).
      */
     @Override
-    protected void readResponseHeaders(HttpState state, HttpConnection conn) throws IOException {
+    protected void readResponseHeaders(
+            HttpState state, org.apache.commons.httpclient.HttpConnection conn) throws IOException {
         getResponseHeaderGroup().clear();
 
         Header[] headers =

--- a/zap/src/main/java/org/zaproxy/zap/network/ZapHeadMethod.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/ZapHeadMethod.java
@@ -21,8 +21,6 @@ package org.zaproxy.zap.network;
 
 import java.io.IOException;
 import org.apache.commons.httpclient.Header;
-import org.apache.commons.httpclient.HttpConnection;
-import org.apache.commons.httpclient.HttpMethodBase;
 import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.ProtocolException;
 import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
@@ -35,7 +33,9 @@ import org.apache.commons.logging.LogFactory;
  * An HTTP HEAD method implementation that ignores malformed HTTP response header lines.
  *
  * @see HeadMethod
+ * @deprecated (2.12.0) Implementation details, do not use.
  */
+@Deprecated
 public class ZapHeadMethod extends EntityEnclosingMethod {
 
     /** Log object for this class. */
@@ -68,7 +68,8 @@ public class ZapHeadMethod extends EntityEnclosingMethod {
      */
     // Implementation copied from HeadMethod.
     @Override
-    protected void readResponseBody(HttpState state, HttpConnection conn) throws IOException {
+    protected void readResponseBody(
+            HttpState state, org.apache.commons.httpclient.HttpConnection conn) throws IOException {
         LOG.trace("enter HeadMethod.readResponseBody(HttpState, HttpConnection)");
 
         int bodyCheckTimeout =
@@ -116,7 +117,8 @@ public class ZapHeadMethod extends EntityEnclosingMethod {
      * header parser (ZapHttpParser#parseHeaders(InputStream, String)).
      */
     @Override
-    protected void readResponseHeaders(HttpState state, HttpConnection conn) throws IOException {
+    protected void readResponseHeaders(
+            HttpState state, org.apache.commons.httpclient.HttpConnection conn) throws IOException {
         getResponseHeaderGroup().clear();
 
         Header[] headers =

--- a/zap/src/main/java/org/zaproxy/zap/network/ZapHttpParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/ZapHttpParser.java
@@ -33,7 +33,10 @@ import org.apache.logging.log4j.Logger;
  * <p>Used to override the {@code HttpClient} behaviour to accept HTTP responses which contain
  * malformed HTTP header lines. <strong>Note:</strong> Malformed HTTP header lines are ignored
  * (instead of throwing an exception).
+ *
+ * @deprecated (2.12.0) Implementation details, do not use.
  */
+@Deprecated
 public class ZapHttpParser {
 
     private static final Logger logger = LogManager.getLogger(ZapHttpParser.class);

--- a/zap/src/main/java/org/zaproxy/zap/network/ZapNTLMEngineImpl.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/ZapNTLMEngineImpl.java
@@ -63,8 +63,9 @@ import org.apache.commons.httpclient.auth.AuthenticationException;
  * Provides an implementation for NTLMv1, NTLMv2, and NTLM2 Session forms of the NTLM
  * authentication protocol.
  *
- * @since 4.1
+ * @deprecated (2.12.0) Implementation details, do not use.
  */
+@Deprecated
 final class ZapNTLMEngineImpl {
 
     /** Unicode encoding */

--- a/zap/src/main/java/org/zaproxy/zap/network/ZapNTLMScheme.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/ZapNTLMScheme.java
@@ -65,8 +65,9 @@ import org.apache.commons.httpclient.auth.MalformedChallengeException;
  * NTLM is a proprietary authentication scheme developed by Microsoft
  * and optimized for Windows platforms.
  *
- * @since 4.0
+ * @deprecated (2.12.0) Implementation details, do not use.
  */
+@Deprecated
 public class ZapNTLMScheme implements AuthScheme {
 
     enum State {

--- a/zap/src/main/java/org/zaproxy/zap/network/ZapOptionsMethod.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/ZapOptionsMethod.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.network;
 
 import java.io.IOException;
 import org.apache.commons.httpclient.Header;
-import org.apache.commons.httpclient.HttpConnection;
 import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
 import org.apache.commons.httpclient.methods.OptionsMethod;
@@ -30,7 +29,9 @@ import org.apache.commons.httpclient.methods.OptionsMethod;
  * An HTTP OPTIONS method implementation that ignores malformed HTTP response header lines.
  *
  * @see OptionsMethod
+ * @deprecated (2.12.0) Implementation details, do not use.
  */
+@Deprecated
 public class ZapOptionsMethod extends EntityEnclosingMethod {
 
     public ZapOptionsMethod() {
@@ -57,7 +58,8 @@ public class ZapOptionsMethod extends EntityEnclosingMethod {
      * header parser (ZapHttpParser#parseHeaders(InputStream, String)).
      */
     @Override
-    protected void readResponseHeaders(HttpState state, HttpConnection conn) throws IOException {
+    protected void readResponseHeaders(
+            HttpState state, org.apache.commons.httpclient.HttpConnection conn) throws IOException {
         getResponseHeaderGroup().clear();
 
         Header[] headers =

--- a/zap/src/main/java/org/zaproxy/zap/network/ZapPostMethod.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/ZapPostMethod.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.network;
 
 import java.io.IOException;
 import org.apache.commons.httpclient.Header;
-import org.apache.commons.httpclient.HttpConnection;
 import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.methods.PostMethod;
 
@@ -29,7 +28,9 @@ import org.apache.commons.httpclient.methods.PostMethod;
  * An HTTP POST method implementation that ignores malformed HTTP response header lines.
  *
  * @see PostMethod
+ * @deprecated (2.12.0) Implementation details, do not use.
  */
+@Deprecated
 public class ZapPostMethod extends PostMethod {
 
     public ZapPostMethod() {
@@ -51,7 +52,8 @@ public class ZapPostMethod extends PostMethod {
      * header parser (ZapHttpParser#parseHeaders(InputStream, String)).
      */
     @Override
-    protected void readResponseHeaders(HttpState state, HttpConnection conn) throws IOException {
+    protected void readResponseHeaders(
+            HttpState state, org.apache.commons.httpclient.HttpConnection conn) throws IOException {
         getResponseHeaderGroup().clear();
 
         Header[] headers =

--- a/zap/src/main/java/org/zaproxy/zap/network/ZapPutMethod.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/ZapPutMethod.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.network;
 
 import java.io.IOException;
 import org.apache.commons.httpclient.Header;
-import org.apache.commons.httpclient.HttpConnection;
 import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.methods.PutMethod;
 
@@ -29,7 +28,9 @@ import org.apache.commons.httpclient.methods.PutMethod;
  * An HTTP PUT method implementation that ignores malformed HTTP response header lines.
  *
  * @see PutMethod
+ * @deprecated (2.12.0) Implementation details, do not use.
  */
+@Deprecated
 public class ZapPutMethod extends PutMethod {
 
     public ZapPutMethod() {
@@ -51,7 +52,8 @@ public class ZapPutMethod extends PutMethod {
      * header parser (ZapHttpParser#parseHeaders(InputStream, String)).
      */
     @Override
-    protected void readResponseHeaders(HttpState state, HttpConnection conn) throws IOException {
+    protected void readResponseHeaders(
+            HttpState state, org.apache.commons.httpclient.HttpConnection conn) throws IOException {
         getResponseHeaderGroup().clear();
 
         Header[] headers =

--- a/zap/src/main/java/org/zaproxy/zap/network/ZapTraceMethod.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/ZapTraceMethod.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.network;
 
 import java.io.IOException;
 import org.apache.commons.httpclient.Header;
-import org.apache.commons.httpclient.HttpConnection;
 import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
 import org.apache.commons.httpclient.methods.TraceMethod;
@@ -30,7 +29,9 @@ import org.apache.commons.httpclient.methods.TraceMethod;
  * An HTTP TRACE method implementation that ignores malformed HTTP response header lines.
  *
  * @see TraceMethod
+ * @deprecated (2.12.0) Implementation details, do not use.
  */
+@Deprecated
 public class ZapTraceMethod extends EntityEnclosingMethod {
 
     public ZapTraceMethod(String uri) {
@@ -53,7 +54,8 @@ public class ZapTraceMethod extends EntityEnclosingMethod {
      * header parser (ZapHttpParser#parseHeaders(InputStream, String)).
      */
     @Override
-    protected void readResponseHeaders(HttpState state, HttpConnection conn) throws IOException {
+    protected void readResponseHeaders(
+            HttpState state, org.apache.commons.httpclient.HttpConnection conn) throws IOException {
         getResponseHeaderGroup().clear();
 
         Header[] headers =

--- a/zap/src/test/java/org/apache/commons/httpclient/HttpMethodBaseUnitTest.java
+++ b/zap/src/test/java/org/apache/commons/httpclient/HttpMethodBaseUnitTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+@SuppressWarnings("deprecation")
 class HttpMethodBaseUnitTest {
 
     private static final Header EXPECTED_HOST_HEADER = header("Host", "example.com");

--- a/zap/src/test/java/org/zaproxy/zap/network/ZapCookieSpecUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/network/ZapCookieSpecUnitTest.java
@@ -124,6 +124,7 @@ class ZapCookieSpecUnitTest {
         assertDoesNotThrow(() -> cookieSpec.validate(HOST, PORT, PATH, SECURE, cookie));
     }
 
+    @SuppressWarnings("deprecation")
     private static CookieSpec createCookieSpec() {
         return new ZapCookieSpec();
     }


### PR DESCRIPTION
Deprecate all classes that are related to the `HttpSender`
implementation which should no longer be used, they will be superseded
by the Network add-on.