### PR TITLE
Fix NullPointerException when obtaining host name

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/model/SessionStructure.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/SessionStructure.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
@@ -673,7 +674,7 @@ public class SessionStructure {
     public static String getHostName(URI uri) throws URIException {
         StringBuilder host = new StringBuilder();
 
-        String scheme = uri.getScheme().toLowerCase();
+        String scheme = getScheme(uri);
         host.append(scheme).append("://").append(uri.getHost());
 
         int port = uri.getPort();
@@ -685,6 +686,14 @@ public class SessionStructure {
         }
 
         return host.toString();
+    }
+
+    private static String getScheme(URI uri) {
+        String scheme = uri.getScheme();
+        if (scheme == null) {
+            return uri.getPort() == 443 ? "https" : "http";
+        }
+        return scheme.toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/zap/src/test/java/org/zaproxy/zap/model/SessionStructureUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/model/SessionStructureUnitTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -68,6 +69,23 @@ class SessionStructureUnitTest {
     @AfterEach
     void cleanUp() {
         Constant.messages = null;
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "example.com,http://example.com",
+        "example.com:80,http://example.com",
+        "example.com:443,https://example.com",
+        "example.com:8080,http://example.com:8080"
+    })
+    void shouldReturnHostNameFromAuthority(String authority, String expectedHostName)
+            throws Exception {
+        // Given
+        URI uri = URI.fromAuthority(authority);
+        // When
+        String hostName = SessionStructure.getHostName(uri);
+        // Then
+        assertThat(hostName, is(equalTo(expectedHostName)));
     }
 
     static Stream<String> methodProvider() {


### PR DESCRIPTION
Do not attempt to lower case the scheme if the URI does not have one
(i.e. an authority).