### PR TITLE
Fix PatternSyntaxException in Analyser

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Analyser.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Analyser.java
@@ -44,6 +44,7 @@
 // ZAP: 2019/07/26 Remove null check in sendAndReceive(HttpMessage). (LGTM Issue)
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/06/05 Remove usage of HttpException.
+// ZAP: 2022/06/09 Quote the query component used in the regular expression.
 package org.parosproxy.paros.core.scanner;
 
 import java.io.IOException;
@@ -283,7 +284,7 @@ public class Analyser {
         return resultSuffix;
     }
 
-    private String getPathRegex(URI uri) throws URIException {
+    static String getPathRegex(URI uri) throws URIException {
         URI newUri;
         // ZAP: catch CloneNotSupportedException as introduced with version 3.1 of HttpClient
         try {
@@ -302,7 +303,7 @@ public class Analyser {
 
         sb.append(newUri.toString().replaceAll("\\.", "\\."));
         if (query != null) {
-            String queryPattern = "(\\?" + query + ")?";
+            String queryPattern = "(\\?" + Pattern.quote(query) + ")?";
             sb.append(queryPattern);
         }
 

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/AnalyserUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/AnalyserUnitTest.java
@@ -1,0 +1,40 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.core.scanner;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.util.regex.Pattern;
+import org.apache.commons.httpclient.URI;
+import org.junit.jupiter.api.Test;
+
+/** Unit test for {@link Analyser}. */
+class AnalyserUnitTest {
+
+    @Test
+    void shouldNotFailToCreatePathRegexWithReservedCharsInQuery() throws Exception {
+        // Given
+        URI uri = new URI("http://example.com/path?query=**", true);
+        // When
+        String regex = Analyser.getPathRegex(uri);
+        // Then
+        assertDoesNotThrow(() -> Pattern.compile(regex));
+    }
+}


### PR DESCRIPTION
Quote the query component that's going to be used in the regular
expression, it might have reserved characters (e.g. `*`).