### PR TITLE
Disable and deprecate resend context menu

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -97,6 +97,7 @@
 // ZAP: 2022/02/28 Remove code deprecated in 2.6.0
 // ZAP: 2022/05/12 Remove URL, messages, and response export menus and functionality, migrated to
 // the exim add-on.
+// ZAP: 2022/06/12 Deprecate getResendDialog().
 package org.parosproxy.paros.extension.history;
 
 import java.awt.EventQueue;
@@ -117,7 +118,6 @@ import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.ExtensionHookView;
-import org.parosproxy.paros.extension.OptionsChangedListener;
 import org.parosproxy.paros.extension.SessionChangedListener;
 import org.parosproxy.paros.extension.manualrequest.ManualRequestEditorDialog;
 import org.parosproxy.paros.extension.manualrequest.http.impl.ManualHttpRequestEditorDialog;
@@ -158,7 +158,6 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
     private HistoryFilterPlusDialog filterPlusDialog = null;
 
     private PopupMenuPurgeHistory popupMenuPurgeHistory = null;
-    private ManualRequestEditorDialog resendDialog = null;
 
     private PopupMenuTag popupMenuTag = null;
 
@@ -255,7 +254,6 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
         if (hasView()) {
             ExtensionHookView pv = extensionHook.getHookView();
             pv.addStatusPanel(getLogPanel());
-            extensionHook.addOptionsChangedListener((OptionsChangedListener) getResendDialog());
 
             extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuTag());
             // ZAP: Added history notes
@@ -572,12 +570,13 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
      * This method initializes resendDialog
      *
      * @return org.parosproxy.paros.extension.history.ResendDialog
+     * @deprecated (2.12.0) Replaced by Requester add-on.
      */
+    @Deprecated
     public ManualRequestEditorDialog getResendDialog() {
-        if (resendDialog == null) {
-            resendDialog = new ManualHttpRequestEditorDialog(true, "resend", "ui.dialogs.manreq");
-            resendDialog.setTitle(Constant.messages.getString("manReq.dialog.title")); // ZAP: i18n
-        }
+        ManualRequestEditorDialog resendDialog =
+                new ManualHttpRequestEditorDialog(true, "resend", "ui.dialogs.manreq");
+        resendDialog.setTitle(Constant.messages.getString("manReq.dialog.title")); // ZAP: i18n
         return resendDialog;
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuResendMessage.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuResendMessage.java
@@ -24,6 +24,8 @@ import org.parosproxy.paros.extension.manualrequest.ManualRequestEditorDialog;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
+/** @deprecated (2.12.0) Replaced by Requester add-on. */
+@Deprecated
 public class PopupMenuResendMessage extends PopupMenuItemHttpMessageContainer {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
@@ -38,7 +38,6 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
-import org.parosproxy.paros.extension.manualrequest.ExtensionManualRequestEditor;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.model.Context;
@@ -59,7 +58,6 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
     private PopupExcludeFromProxyMenu popupExcludeFromProxyMenu = null;
     private PopupExcludeFromScanMenu popupExcludeFromScanMenu = null;
     private PopupExcludeFromSpiderMenu popupExcludeFromSpiderMenu = null;
-    private PopupMenuResendMessage popupMenuResendMessage = null;
     private PopupMenuShowInHistory popupMenuShowInHistory = null;
     private PopupMenuShowInSites popupMenuShowInSites = null;
     private PopupMenuOpenUrlInBrowser popupMenuOpenUrlInBrowser = null;
@@ -138,12 +136,7 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
                         .addPopupMenuItem(getPopupMenuActiveScanCustom(++indexMenuItem));
             }
 
-            if (isExtensionHistoryEnabled) {
-                extensionHook
-                        .getHookMenu()
-                        .addPopupMenuItem(getPopupMenuResendMessage(++indexMenuItem));
-            }
-            indexMenuItem += 2;
+            indexMenuItem += 1;
             if (isExtensionHistoryEnabled) {
                 extensionHook
                         .getHookMenu()
@@ -391,20 +384,6 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
             popupExcludeFromSpiderMenu.setMenuIndex(menuIndex);
         }
         return popupExcludeFromSpiderMenu;
-    }
-
-    private PopupMenuResendMessage getPopupMenuResendMessage(int menuIndex) {
-        if (popupMenuResendMessage == null) {
-            popupMenuResendMessage =
-                    new PopupMenuResendMessage(
-                            Constant.messages.getString("history.resend.popup"),
-                            Control.getSingleton()
-                                    .getExtensionLoader()
-                                    .getExtension(ExtensionHistory.class));
-            popupMenuResendMessage.setMenuIndex(menuIndex);
-            popupMenuResendMessage.setIcon(ExtensionManualRequestEditor.getIcon());
-        }
-        return popupMenuResendMessage;
     }
 
     private PopupMenuShowInSites getPopupMenuShowInSites(int menuIndex) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuResendMessage.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuResendMessage.java
@@ -24,6 +24,8 @@ import org.parosproxy.paros.extension.manualrequest.ManualRequestEditorDialog;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
+/** @deprecated (2.12.0) Replaced by Requester add-on. */
+@Deprecated
 public class PopupMenuResendMessage extends PopupMenuItemHttpMessageContainer {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -1806,7 +1806,6 @@ history.panel.mnemonic		           = h
 history.panel.title                    = History
 history.purge.popup                    = Delete
 history.purge.warning                  = Are you sure you want to delete the record(s)?
-history.resend.popup                   = Open/Resend with Request Editor...
 history.scan.warning                   = Error getting History.
 history.scope.button.selected          = Show all URLs
 history.scope.button.unselected        = Show only URLs in Scope


### PR DESCRIPTION
Deprecate the context menus `PopupMenuResendMessage` (one of them was
not in actual use), it will be provided by the requester add-on.
Deprecate `ExtensionHistory#getResendDialog()` which was being called
by the now deprecated menus.