### PR TITLE
Allow to hook history type info

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/ExtensionHook.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/ExtensionHook.java
@@ -35,6 +35,7 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/08/27 Added support for plugable variants
+// ZAP: 2022/06/13 Allow to add HrefTypeInfo.
 package org.parosproxy.paros.extension;
 
 import java.util.ArrayList;
@@ -54,6 +55,7 @@ import org.zaproxy.zap.extension.AddonFilesChangedListener;
 import org.zaproxy.zap.extension.api.ApiImplementor;
 import org.zaproxy.zap.model.ContextDataFactory;
 import org.zaproxy.zap.network.HttpSenderListener;
+import org.zaproxy.zap.view.HrefTypeInfo;
 import org.zaproxy.zap.view.SiteMapListener;
 
 public class ExtensionHook {
@@ -161,6 +163,16 @@ public class ExtensionHook {
      * @see #getVariants()
      */
     private List<Class<? extends Variant>> variants;
+
+    /**
+     * The {@link HrefTypeInfo} added to this extension hook.
+     *
+     * <p>Lazily initialised.
+     *
+     * @see #addHrefType(HrefTypeInfo)
+     * @see #getHrefsTypeInfo()
+     */
+    private List<HrefTypeInfo> hrefsTypeInfo;
 
     private ViewDelegate view = null;
     private CommandLineArgument[] arg = new CommandLineArgument[0];
@@ -553,5 +565,31 @@ public class ExtensionHook {
             return Collections.emptyList();
         }
         return Collections.unmodifiableList(variants);
+    }
+
+    /**
+     * Adds the given {@link HrefTypeInfo} to the hook.
+     *
+     * @param hrefTypeInfo the {@code HrefTypeInfo}.
+     * @since 2.12.0
+     */
+    public void addHrefType(HrefTypeInfo hrefTypeInfo) {
+        if (hrefsTypeInfo == null) {
+            hrefsTypeInfo = new ArrayList<>(1);
+        }
+        hrefsTypeInfo.add(hrefTypeInfo);
+    }
+
+    /**
+     * Gets the {@link HrefTypeInfo} added to this hook.
+     *
+     * @return an unmodifiable {@code List} containing the added {@code HrefTypeInfo}, never {@code
+     *     null}.
+     */
+    List<HrefTypeInfo> getHrefsTypeInfo() {
+        if (hrefsTypeInfo == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableList(hrefsTypeInfo);
     }
 }

--- a/zap/src/main/java/org/parosproxy/paros/extension/ExtensionLoader.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/ExtensionLoader.java
@@ -95,6 +95,7 @@
 // ZAP: 2022/02/09 Deprecate code related to core proxy, remove code no longer needed.
 // ZAP: 2022/04/17 Log extension name prior to description when loading.
 // ZAP: 2022/04/17 Address various SAST (SonarLint) issues.
+// ZAP: 2022/06/13 Hook HrefTypeInfo.
 package org.parosproxy.paros.extension;
 
 import java.awt.Component;
@@ -148,6 +149,7 @@ import org.zaproxy.zap.extension.httppanel.DisplayedMessageChangedListener;
 import org.zaproxy.zap.model.ContextDataFactory;
 import org.zaproxy.zap.network.HttpSenderListener;
 import org.zaproxy.zap.view.ContextPanelFactory;
+import org.zaproxy.zap.view.HrefTypeInfo;
 import org.zaproxy.zap.view.MainToolbarPanel;
 import org.zaproxy.zap.view.SiteMapListener;
 
@@ -800,6 +802,7 @@ public class ExtensionLoader {
             hookApiImplementors(ext, extHook);
             hookHttpSenderListeners(ext, extHook);
             hookVariant(ext, extHook);
+            hookHrefTypeInfo(ext, extHook);
 
             if (hasView()) {
                 // no need to hook view if no GUI
@@ -873,6 +876,7 @@ public class ExtensionLoader {
                 hookApiImplementors(ext, extHook);
                 hookHttpSenderListeners(ext, extHook);
                 hookVariant(ext, extHook);
+                hookHrefTypeInfo(ext, extHook);
 
                 if (hasView()) {
                     EventQueue.invokeAndWait(
@@ -978,6 +982,19 @@ public class ExtensionLoader {
             } catch (Exception e) {
                 logger.error(
                         "Error while adding a Variant from {}",
+                        extension.getClass().getCanonicalName(),
+                        e);
+            }
+        }
+    }
+
+    private void hookHrefTypeInfo(Extension extension, ExtensionHook extHook) {
+        for (HrefTypeInfo hrefTypeInfo : extHook.getHrefsTypeInfo()) {
+            try {
+                HrefTypeInfo.addType(hrefTypeInfo);
+            } catch (Exception e) {
+                logger.error(
+                        "Error while adding a HrefTypeInfo from {}",
                         extension.getClass().getCanonicalName(),
                         e);
             }
@@ -1505,6 +1522,17 @@ public class ExtensionLoader {
             } catch (Exception e) {
                 logger.error(
                         "Error while removing a Variant from {}",
+                        extension.getClass().getCanonicalName(),
+                        e);
+            }
+        }
+
+        for (HrefTypeInfo hrefTypeInfo : hook.getHrefsTypeInfo()) {
+            try {
+                HrefTypeInfo.removeType(hrefTypeInfo);
+            } catch (Exception e) {
+                logger.error(
+                        "Error while removing a HrefTypeInfo from {}",
                         extension.getClass().getCanonicalName(),
                         e);
             }

--- a/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/ExtensionManualRequestEditor.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/ExtensionManualRequestEditor.java
@@ -47,6 +47,7 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/10/04 Add dialog/menu icon.
+// ZAP: 2022/06/13 Add HrefTypeInfo on hook.
 package org.parosproxy.paros.extension.manualrequest;
 
 import java.awt.EventQueue;
@@ -63,8 +64,10 @@ import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.extension.SessionChangedListener;
 import org.parosproxy.paros.extension.ViewDelegate;
 import org.parosproxy.paros.extension.manualrequest.http.impl.ManualHttpRequestEditorDialog;
+import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Session;
 import org.zaproxy.zap.extension.httppanel.Message;
+import org.zaproxy.zap.view.HrefTypeInfo;
 
 public class ExtensionManualRequestEditor extends ExtensionAdaptor
         implements SessionChangedListener {
@@ -136,6 +139,13 @@ public class ExtensionManualRequestEditor extends ExtensionAdaptor
     @Override
     public void hook(ExtensionHook extensionHook) {
         super.hook(extensionHook);
+
+        extensionHook.addHrefType(
+                new HrefTypeInfo(
+                        HistoryReference.TYPE_ZAP_USER,
+                        Constant.messages.getString("view.href.type.name.manual"),
+                        hasView() ? ExtensionManualRequestEditor.getIcon() : null));
+
         if (getView() != null) {
             for (Entry<Class<? extends Message>, ManualRequestEditorDialog> dialogue :
                     dialogues.entrySet()) {

--- a/zap/src/main/java/org/zaproxy/zap/view/table/AbstractHistoryReferencesTableEntry.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/table/AbstractHistoryReferencesTableEntry.java
@@ -223,7 +223,7 @@ public abstract class AbstractHistoryReferencesTableEntry implements HistoryRefe
             case HREF_TYPE:
                 return Integer.toString(0);
             case HREF_TYPE_INFO:
-                return HrefTypeInfo.getFromType(HistoryReference.TYPE_ZAP_USER);
+                return "Manual";
             case METHOD:
                 return "GET";
             case URL:

--- a/zap/src/test/java/org/zaproxy/zap/view/HrefTypeInfoUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/view/HrefTypeInfoUnitTest.java
@@ -1,0 +1,118 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.view;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.utils.I18N;
+
+/** Unit test for {@link HrefTypeInfo}. */
+class HrefTypeInfoUnitTest {
+
+    private static final int TEST_TYPE = 1234;
+
+    @BeforeEach
+    void setUp() {
+        Constant.messages = mock(I18N.class);
+
+        HrefTypeInfo.values.remove(TEST_TYPE);
+    }
+
+    @Test
+    void shouldAddTypeInfo() {
+        // Given
+        int type = TEST_TYPE;
+        HrefTypeInfo typeInfo = new HrefTypeInfo(type, "Name");
+        // When
+        HrefTypeInfo.addType(typeInfo);
+        // Then
+        assertThat(HrefTypeInfo.getFromType(type), is(sameInstance(typeInfo)));
+    }
+
+    @Test
+    void shouldNotAddSameType() {
+        // Given
+        int type = TEST_TYPE;
+        HrefTypeInfo typeInfo = new HrefTypeInfo(type, "Name");
+        HrefTypeInfo otherTypeInfo = new HrefTypeInfo(type, "Other Name");
+        // When
+        HrefTypeInfo.addType(typeInfo);
+        HrefTypeInfo.addType(otherTypeInfo);
+        // Then
+        assertThat(HrefTypeInfo.getFromType(type), is(sameInstance(typeInfo)));
+    }
+
+    @Test
+    void shouldThrowWhenAddingNullType() {
+        // Given
+        HrefTypeInfo typeInfo = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> HrefTypeInfo.addType(typeInfo));
+    }
+
+    @Test
+    void shouldRemoveTypeInfo() {
+        // Given
+        int type = TEST_TYPE;
+        HrefTypeInfo typeInfo = new HrefTypeInfo(type, "Name");
+        HrefTypeInfo.addType(typeInfo);
+        // When
+        HrefTypeInfo.removeType(typeInfo);
+        // Then
+        assertThat(HrefTypeInfo.getFromType(type), is(HrefTypeInfo.UNDEFINED_TYPE));
+    }
+
+    @Test
+    void shouldThrowWhenRemovingNullType() {
+        // Given
+        HrefTypeInfo typeInfo = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> HrefTypeInfo.removeType(typeInfo));
+    }
+
+    @Test
+    void shouldNotOverrideNoType() {
+        // Given
+        int type = HrefTypeInfo.NO_TYPE.getType();
+        HrefTypeInfo typeInfo = new HrefTypeInfo(type, "Name");
+        // When
+        HrefTypeInfo.addType(typeInfo);
+        // Then
+        assertThat(HrefTypeInfo.getFromType(type), is(sameInstance(HrefTypeInfo.NO_TYPE)));
+    }
+
+    @Test
+    void shouldNotOverrideUndefinedType() {
+        // Given
+        int type = HrefTypeInfo.UNDEFINED_TYPE.getType();
+        HrefTypeInfo typeInfo = new HrefTypeInfo(type, "Name");
+        // When
+        HrefTypeInfo.addType(typeInfo);
+        // Then
+        assertThat(HrefTypeInfo.getFromType(type), is(sameInstance(HrefTypeInfo.UNDEFINED_TYPE)));
+    }
+}


### PR DESCRIPTION
Change `ExtensionHook` to keep a list of types.
Change `ExtensionLoader` to add/remove the types when the extension is
added/removed.
Change `HrefTypeInfo` to allow to dynamically add/remove the types.
Move the manual type to `ExtensionManualRequestEditor` to not have
other parts of the codebase depend on its classes, which will be
superseded.
Remove usage of the type in `AbstractHistoryReferencesTableEntry` use
hardcoded value instead.