### PR TITLE
Do not process location URL when processing links

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderHttpHeaderParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderHttpHeaderParser.java
@@ -66,7 +66,6 @@ public class SpiderHttpHeaderParser extends SpiderParser {
                 processURL(message, depth, link.substring(i + 1, j), baseURL);
                 offset = j;
             }
-            processURL(message, depth, location, baseURL);
         }
         // We do not consider the message fully parsed
         return false;


### PR DESCRIPTION
Remove the process URL call with the location since that's already
being done early and would lead to warnings if the location was not
present.