### PR TITLE
Spider: Import tags, csp and msapplication-config attributes of meta, strings in html

### DIFF
--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlParserUnitTest.java
@@ -237,6 +237,30 @@ class SpiderHtmlParserUnitTest extends SpiderParserTestUtils {
     }
 
     @Test
+    void shouldFindUrlsInImportElements() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("ImportElementsSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed =
+                htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(5)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "http://example.com/import/namespace/implementation",
+                        "https://import.example.com:9000/namespace/implementation",
+                        "http://import.example.com/namespace/implementation",
+                        "http://example.com/sample/import/namespace/implementation",
+                        "ftp://import.example.com/namespace/implementation"));
+    }
+
+    @Test
     void shouldFindUrlsInAreaPingElements() {
         // Given
         SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
@@ -753,7 +777,7 @@ class SpiderHtmlParserUnitTest extends SpiderParserTestUtils {
                 htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
         // Then
         assertThat(completelyParsed, is(equalTo(false)));
-        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(12)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(22)));
         assertThat(
                 listener.getUrlsFound(),
                 contains(
@@ -768,7 +792,39 @@ class SpiderHtmlParserUnitTest extends SpiderParserTestUtils {
                         "https://meta.example.com/location",
                         "http://example.com/sample/meta/location/relative",
                         "http://example.com/meta/location/absolute",
-                        "ftp://meta.example.com/location"));
+                        "ftp://meta.example.com/location",
+                        "http://example.com/meta/csp",
+                        "http://meta.example.com:4444/meta/base/csp/scheme",
+                        "https://meta.example.com/meta/csp",
+                        "http://example.com/sample/meta/csp/refresh/relative",
+                        "ftp://meta.example.com/meta/csp/",
+                        "http://example.com/meta/msapplication",
+                        "http://meta.example.com:1337/meta/msapplication",
+                        "https://meta.example.com/meta/msapplication",
+                        "http://example.com/sample/meta/msapplication/refresh/relative",
+                        "ftp://meta.example.com/meta/msapplication/refresh"));
+    }
+
+    @Test
+    void shouldFindUrlsInString() {
+        // Given
+        SpiderHtmlParser htmlParser = new SpiderHtmlParser(new SpiderParam());
+        TestSpiderParserListener listener = createTestSpiderParserListener();
+        htmlParser.addSpiderParserListener(listener);
+        HttpMessage messageHtmlResponse = createMessageWith("StringSpiderHtmlParser.html");
+        Source source = createSource(messageHtmlResponse);
+        // When
+        boolean completelyParsed =
+                htmlParser.parseResource(messageHtmlResponse, source, BASE_DEPTH);
+        // Then
+        assertThat(completelyParsed, is(equalTo(false)));
+        assertThat(listener.getNumberOfUrlsFound(), is(equalTo(3)));
+        assertThat(
+                listener.getUrlsFound(),
+                contains(
+                        "http://example2.com/test/p/string/fullUrl",
+                        "http://example.com/sample/with/base/tag",
+                        "http://meta.example.com:8443/inline/string/scheme"));
     }
 
     @Test

--- a/zap/src/test/resources/org/zaproxy/zap/spider/parser/html/ImportElementsSpiderHtmlParser.html
+++ b/zap/src/test/resources/org/zaproxy/zap/spider/parser/html/ImportElementsSpiderHtmlParser.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://example.com/sample/">
+<meta charset="UTF-8">
+<title>Import Elements - Spider HTML Parser</title>
+</head>
+<body>
+    
+<IMPORT namespace="myNS" implementation="/import/namespace/implementation" /></IMPORT>
+<IMPORT namespace="myNS" implementation="https://import.example.com:9000/namespace/implementation" /></IMPORT>
+<IMPORT namespace="myNS" implementation="//import.example.com/namespace/implementation" /></IMPORT>
+<IMPORT namespace="myNS" implementation="import/namespace/implementation" /></IMPORT>
+<IMPORT namespace="myNS" implementation="ftp://import.example.com/namespace/implementation" /></IMPORT>
+
+</body>
+</html>

--- a/zap/src/test/resources/org/zaproxy/zap/spider/parser/html/MetaElementsSpiderHtmlParser.html
+++ b/zap/src/test/resources/org/zaproxy/zap/spider/parser/html/MetaElementsSpiderHtmlParser.html
@@ -19,6 +19,18 @@
 <meta http-equiv="location" content="url=/meta/location/absolute">
 <meta http-equiv="location" content="url=ftp://meta.example.com/location">
 
+<meta http-equiv="Content-Security-Policy" content="script-src 'self'; report-uri /meta/csp">
+<meta http-equiv="Content-Security-Policy" content="script-src 'self'; report-uri //meta.example.com:4444/meta/base/csp/scheme">
+<meta http-equiv="Content-Security-Policy" content="script-src 'self'; report-uri https://meta.example.com/meta/csp">
+<meta http-equiv="Content-Security-Policy" content="script-src 'self'; report-uri meta/csp/refresh/relative">
+<meta http-equiv="Content-Security-Policy" content="script-src 'self'; report-uri ftp://meta.example.com/meta/csp/">
+
+<meta name="msapplication-config" content="/meta/msapplication">
+<meta name="msapplication-config" content="//meta.example.com:1337/meta/msapplication">
+<meta name="msapplication-config" content="https://meta.example.com/meta/msapplication">
+<meta name="msapplication-config" content="meta/msapplication/refresh/relative">
+<meta name="msapplication-config" content="ftp://meta.example.com/meta/msapplication/refresh">
+
 <!-- Ignored: -->
 <meta http-equiv="refresh" content="0;URL=scheme://meta.example.com/refresh/ignored">
 <meta http-equiv="refresh" content="0;URL=">
@@ -32,6 +44,13 @@
 
 <meta http-equiv="ignored" content="0;URL=http://meta.example.com/ignored/1">
 <meta http-equiv="ignored" content="url=http://meta.example.com/ignored/2">
+
+
+<meta name="" content="ftp://meta.example.com/meta/msapplication/name/empty">
+<meta name="not-msapplication" content="http://meta.example.com/meta/notmsapplication">
+<meta name="msapplication-config" content="">
+<meta name="msapplication-config">
+<meta name="msapplication-config" content=none>
 
 </head>
 <body>

--- a/zap/src/test/resources/org/zaproxy/zap/spider/parser/html/StringSpiderHtmlParser.html
+++ b/zap/src/test/resources/org/zaproxy/zap/spider/parser/html/StringSpiderHtmlParser.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="http://example.com/sample">
+<meta charset="UTF-8">
+<title>String - Spider HTML Parser</title>
+</head>
+<body>
+
+<p>The test contains an inline string - http://example2.com/test/p/string/fullUrl</p>
+<p>The test contains an inline string - /with/base/tag</p>
+<p>The test contains an inline string - //meta.example.com:8443/inline/string/scheme</p>
+
+</body>
+</html>


### PR DESCRIPTION
This PR fixes the following false negatives of the crawlmaze tests:

```
/test/html/head/import/implementation.found
/test/html/head/meta/content-csp.found
/test/html/head/meta/content-pinned-websites.found
/test/html/misc/string/url-string.found
/test/html/misc/string/string-known-extension.pdf
```

Fixes #7209