### PR TITLE
Fix copy of passive script scan rule

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
@@ -86,7 +86,9 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
 
     @Override
     public ScriptsPassiveScanner copy() {
-        return new ScriptsPassiveScanner();
+        ScriptsPassiveScanner copy = new ScriptsPassiveScanner();
+        copy.currentHistoryType = currentHistoryType;
+        return copy;
     }
 
     private boolean appliesToCurrentHistoryType(ScriptWrapper wrapper, PassiveScript ps) {

--- a/zap/src/test/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScannerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScannerUnitTest.java
@@ -198,6 +198,24 @@ class ScriptsPassiveScannerUnitTest extends WithConfigsTest {
     }
 
     @Test
+    void shouldScanWithCopy() throws Exception {
+        // Given
+        PassiveScript script = mock(TARGET_INTERFACE);
+        given(script.appliesToHistoryType(anyInt())).willReturn(true);
+        ScriptsCache<PassiveScript> scriptsCache = createScriptsCache(createCachedScript(script));
+        given(extensionScript.<PassiveScript>createScriptsCache(any())).willReturn(scriptsCache);
+        int historyType = 5;
+        ScriptsPassiveScanner scriptsPassiveScanner = new ScriptsPassiveScanner();
+        scriptsPassiveScanner.appliesToHistoryType(historyType);
+        // When
+        ScriptsPassiveScanner copy = scriptsPassiveScanner.copy();
+        copy.scanHttpResponseReceive(message, id, source);
+        // Then
+        verify(script, times(1)).appliesToHistoryType(historyType);
+        verify(script, times(1)).scan(any(), any(), any());
+    }
+
+    @Test
     void shouldNotCallScanIfScriptDoesNotApplyToHistoryType() throws Exception {
         // Given
         PassiveScript script = mock(TARGET_INTERFACE);


### PR DESCRIPTION
Copy the current history type to the new instance, otherwise no
messages would be scanned by default.