### PR TITLE
Correct start time of passive scan rules

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanTask.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanTask.java
@@ -132,6 +132,7 @@ public class PassiveScanTask implements Runnable {
                                 "Running scan rule, URL {} plugin {}",
                                 msg.getRequestHeader().getURI(),
                                 scanner.getName());
+                        long scanRuleStartTime = System.currentTimeMillis();
 
                         if (maxBodySize <= 0 || msg.getRequestBody().length() < maxBodySize) {
                             scanner.scanHttpRequestSend(msg, href.getHistoryId());
@@ -162,7 +163,7 @@ public class PassiveScanTask implements Runnable {
                             }
                         }
                         if (scanned) {
-                            long timeTaken = System.currentTimeMillis() - startTime;
+                            long timeTaken = System.currentTimeMillis() - scanRuleStartTime;
                             if (scanner instanceof PluginPassiveScanner) {
                                 PluginPassiveScanner pps = (PluginPassiveScanner) scanner;
                                 Stats.incCounter(


### PR DESCRIPTION
Use a new start time for each scan rule instead of using the start time
of the scan task otherwise it would check/report the cumulative time
taken of previous scan rules too.