### PR TITLE
fix: Change `[` to `[[` on lines 51 and 54

### DIFF
--- a/zap/src/main/dist/zap.sh
+++ b/zap/src/main/dist/zap.sh
@@ -48,10 +48,10 @@ JAVA_MAJOR_VERSION=${JAVA_VERSION%%[.|-]*}
 JAVA_MINOR_VERSION=$(echo $JAVA_VERSION | awk -F\. '{ print $2 }')
 
 # JEP 223, newer Java versions (>= 9) no longer use 1 as major version
-if [ $JAVA_MAJOR_VERSION -ge 9 ]; then
+if [[ $JAVA_MAJOR_VERSION -ge 9 ]]; then
   DEFAULTJAVAGC=""
   echo "Found Java version $JAVA_VERSION"
-elif [ $JAVA_MAJOR_VERSION -ge 1 ] && [ $JAVA_MINOR_VERSION -ge 8 ]; then
+elif [[ $JAVA_MAJOR_VERSION -ge 1 ]] && [[ $JAVA_MINOR_VERSION -ge 8 ]]; then
   echo "Found Java version $JAVA_VERSION"
 else
   echo "Exiting: ZAP requires a minimum of Java 8 to run, found $JAVA_VERSION"


### PR DESCRIPTION
/usr/share/zaproxy/zap/src/main/dist/zap.sh: line 51: [: -ge: unary operator expected
/usr/share/zaproxy/zap/src/main/dist/zap.sh: line 54: [: -ge: unary operator expected

Signed-off-by: Cosmonaut <olubemiga@gmail.com>