### PR TITLE
fix: Prevent Blank Scan Rule Names

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -85,6 +85,7 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.configuration.Configuration;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.control.Control;
@@ -1297,6 +1298,19 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
 
     public void setStatus(AddOn.Status status) {
         this.status = status;
+    }
+
+    /**
+     * Gets the name of the scan rule, falling back to the simple name of the class as last resort.
+     *
+     * @return a name representing the scan rule.
+     * @since 2.12.0
+     */
+    @Override
+    public final String getDisplayName() {
+        return StringUtils.isBlank(this.getName())
+                ? this.getClass().getSimpleName()
+                : this.getName();
     }
 
     /**

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Plugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Plugin.java
@@ -397,4 +397,12 @@ public interface Plugin extends Runnable, ExampleAlertProvider {
     default List<Alert> getExampleAlerts() {
         return null;
     }
+
+    /**
+     * Gets the name of the scan rule, falling back to the simple name of the class as last resort.
+     *
+     * @return a name representing the scan rule.
+     * @since 2.12.0
+     */
+    String getDisplayName();
 }

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/PluginStats.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/PluginStats.java
@@ -45,7 +45,7 @@ public class PluginStats {
      * @see #start()
      */
     PluginStats(Plugin plugin) {
-        this.pluginName = plugin.getName() == null ? "" : plugin.getName();
+        this.pluginName = plugin.getDisplayName();
         this.pluginId = plugin.getId();
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnLoader.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnLoader.java
@@ -52,6 +52,8 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.FileConfiguration;
 import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -929,7 +931,24 @@ public class AddOnLoader extends URLClassLoader {
             }
         }
         list.trimToSize();
+        validateNames(list);
         return Collections.unmodifiableList(list);
+    }
+
+    private void validateNames(List<?> scanRules) {
+        scanRules.forEach(
+                rule -> {
+                    String name =
+                            rule instanceof AbstractPlugin
+                                    ? ((AbstractPlugin) rule).getName()
+                                    : ((PluginPassiveScanner) rule).getName();
+                    if (StringUtils.isBlank(name)) {
+                        logger.log(
+                                Constant.isDevBuild() ? Level.ERROR : Level.WARN,
+                                "Scan rule {} does not have a name.",
+                                rule.getClass().getCanonicalName());
+                    }
+                });
     }
 
     /**
@@ -951,6 +970,7 @@ public class AddOnLoader extends URLClassLoader {
             }
         }
         list.trimToSize();
+        validateNames(list);
         return Collections.unmodifiableList(list);
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/CategoryTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/CategoryTableModel.java
@@ -31,6 +31,7 @@
 // not important).
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2022/08/04 Ensure scan rule names are non-blank (Issue 7228)
 package org.zaproxy.zap.extension.ascan;
 
 import java.util.ArrayList;
@@ -233,7 +234,7 @@ public class CategoryTableModel extends DefaultTableModel {
         PluginWrapper wrapper = listTestCategory.get(row);
         switch (col) {
             case 0:
-                return wrapper.getPlugin().getName();
+                return wrapper.getPlugin().getDisplayName();
             case 1:
                 if (!wrapper.getPlugin().isEnabled()) {
                     return AlertThreshold.OFF;

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.apache.commons.lang3.StringUtils;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Alert.Source;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
@@ -436,6 +437,18 @@ public abstract class PluginPassiveScanner extends Enableable
      */
     public Map<String, String> getAlertTags() {
         return null;
+    }
+
+    /**
+     * Gets the name of the scan rule, falling back to the simple name of the class as last resort.
+     *
+     * @return a name representing the scan rule.
+     * @since 2.12.0
+     */
+    public final String getDisplayName() {
+        return StringUtils.isBlank(this.getName())
+                ? this.getClass().getSimpleName()
+                : this.getName();
     }
 
     /**

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PolicyPassiveScanTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PolicyPassiveScanTableModel.java
@@ -250,7 +250,7 @@ public class PolicyPassiveScanTableModel extends DefaultTableModel {
         }
 
         public String getName() {
-            return scanner.getName();
+            return scanner.getDisplayName();
         }
 
         public AlertThreshold getThreshold() {

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/PluginTestUtils.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/PluginTestUtils.java
@@ -442,5 +442,10 @@ class PluginTestUtils {
         public Map<String, String> getAlertTags() {
             return null;
         }
+
+        @Override
+        public String getDisplayName() {
+            return null;
+        }
     }
 }

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -226,6 +226,7 @@ val japicmp by tasks.registering(JapicmpTask::class) {
         "org.parosproxy.paros.core.scanner.Alert#setRiskReliability(int,int)",
         "org.parosproxy.paros.core.scanner.HostProcess#setPluginRequestCount(int,int)",
         "org.parosproxy.paros.core.scanner.HostProcess#setTestCurrentCount(org.parosproxy.paros.core.scanner.Plugin,int)",
+        "org.parosproxy.paros.core.scanner.Plugin#getDisplayName()",
         "org.parosproxy.paros.core.scanner.PluginFactory#loadedPlugin(java.lang.String)",
         "org.parosproxy.paros.core.scanner.PluginFactory#unloadedPlugin(java.lang.String)",
         "org.parosproxy.paros.core.scanner.VariantAbstractQuery#setParams(int,java.util.Map)",


### PR DESCRIPTION
- ascan > In policy and progress dialogs display class name if rule name is blank.
- pscan > Options panel, display class name if rule name is blank.
- Missing names are logged via AddOnLoader.

Screenshots:
![image](https://user-images.githubusercontent.com/7570458/182978975-b2ffa9b2-5652-4839-ae32-22e933c93de6.png)
![image](https://user-images.githubusercontent.com/7570458/182978992-ed5f0639-696d-47ec-8dcb-bf97f1547ba8.png)
Dev example: `11728 [ZAP-BootstrapGUI] ERROR org.zaproxy.zap.control.AddOnLoader - Scan rule org.sasanlabs.fileupload.FileUploadScanRule does not have a name.` 

I didn't have a convenient way to test the pscan one.

Fixes zaproxy/zaproxy#7228

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>