### PR TITLE
Add text/plain as a expected entry for content_type

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2022-08-05
+ - Alert_on_Unexpected_Content_Types.js > Added Content-Type text/plain to the list of expected types.
+ 
 ### 2022-07-30
  - Updated to use Webswing 22.1.3.
 

--- a/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
+++ b/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
@@ -24,7 +24,7 @@ var expectedTypes = [
 		"application/x-yaml",
 		"text/x-json",
 		"text/json",
-		"text/yaml"
+		"text/yaml",
 		"text/plain"
 	]
 

--- a/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
+++ b/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
@@ -25,6 +25,7 @@ var expectedTypes = [
 		"text/x-json",
 		"text/json",
 		"text/yaml"
+		"text/plain"
 	]
 
 function sendingRequest(msg, initiator, helper) {


### PR DESCRIPTION
Fixes zaproxy/zaproxy#7405

Signed-off-by: kiranj2506 <110659428+kiranj2506@users.noreply.github.com>