### PR TITLE
Address warns with Java 18

### DIFF
--- a/zap/src/main/java/ch/csnc/extension/ui/AliasTableModel.java
+++ b/zap/src/main/java/ch/csnc/extension/ui/AliasTableModel.java
@@ -31,6 +31,7 @@ import javax.swing.table.AbstractTableModel;
 
 /** @deprecated (2.12.0) No longer in use. */
 @Deprecated
+@SuppressWarnings("serial")
 public class AliasTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = -4387633069248206563L;

--- a/zap/src/main/java/ch/csnc/extension/ui/DriverTableModel.java
+++ b/zap/src/main/java/ch/csnc/extension/ui/DriverTableModel.java
@@ -30,6 +30,7 @@ import javax.swing.table.AbstractTableModel;
 
 /** @deprecated (2.12.0) No longer in use. */
 @Deprecated
+@SuppressWarnings("serial")
 public class DriverTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = -9114670362713975727L;

--- a/zap/src/main/java/org/parosproxy/paros/control/MenuFileControl.java
+++ b/zap/src/main/java/org/parosproxy/paros/control/MenuFileControl.java
@@ -55,6 +55,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2021/05/14 Remove redundant type arguments.
+// ZAP: 2022/08/05 Address warns with Java 18.
 package org.parosproxy.paros.control;
 
 import java.awt.EventQueue;
@@ -629,6 +630,7 @@ public class MenuFileControl implements SessionListener {
         exportDialog.setVisible(true);
     }
 
+    @SuppressWarnings("serial")
     private static class SessionFileChooser extends WritableFileChooser {
 
         public static final FileFilter SESSION_FILE_FILTER =

--- a/zap/src/main/java/org/parosproxy/paros/extension/AbstractPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/AbstractPanel.java
@@ -28,6 +28,7 @@
 // ZAP: 2018/02/22 Focus the tab of ancestor AbstractPanel.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
 package org.parosproxy.paros.extension;
 
 import java.awt.Component;
@@ -39,6 +40,7 @@ import javax.swing.SwingUtilities;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.view.TabbedPanel2;
 
+@SuppressWarnings("serial")
 public class AbstractPanel extends JPanel {
 
     private static final long serialVersionUID = 4076608955743534659L;

--- a/zap/src/main/java/org/parosproxy/paros/extension/history/LogPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/LogPanel.java
@@ -54,6 +54,7 @@
 // getScrollLog()
 // ZAP: 2022/02/26 Remove code deprecated in 2.5.0
 // ZAP: 2022/02/28 Remove code deprecated in 2.6.0
+// ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
 package org.parosproxy.paros.extension.history;
 
 import java.awt.BorderLayout;
@@ -85,6 +86,7 @@ import org.zaproxy.zap.view.table.DefaultHistoryReferencesTableEntry;
 import org.zaproxy.zap.view.table.HistoryReferencesTable;
 import org.zaproxy.zap.view.table.HistoryReferencesTableModel;
 
+@SuppressWarnings("serial")
 public class LogPanel extends AbstractPanel {
     private static final long serialVersionUID = 1L;
     private javax.swing.JScrollPane scrollLog = null;

--- a/zap/src/main/java/org/parosproxy/paros/extension/history/PopupMenuExportMessage.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/PopupMenuExportMessage.java
@@ -37,6 +37,7 @@
 // ZAP: 2021/04/08 Name logger (LOG) fullcaps as constant, use LF as EOL for text file content
 // ZAP: 2022/02/08 Use isEmpty where applicable.
 // ZAP: 2022/05/13 Deprecated for relocation to exim.
+// ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
 package org.parosproxy.paros.extension.history;
 
 import java.io.BufferedWriter;
@@ -58,6 +59,7 @@ import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
 /** @deprecated (2.12.0) see the exim add-on */
 @Deprecated
+@SuppressWarnings("serial")
 public class PopupMenuExportMessage extends JMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/parosproxy/paros/extension/history/PopupMenuExportResponse.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/PopupMenuExportResponse.java
@@ -33,6 +33,7 @@
 // ZAP: 2021/04/08 Set/name logger (LOG) fullcaps as constant, use LF as EOL for text file content
 // ZAP: 2022/02/08 Use isEmpty where applicable.
 // ZAP: 2022/05/13 Deprecated for relocation to exim.
+// ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
 package org.parosproxy.paros.extension.history;
 
 import java.io.BufferedOutputStream;
@@ -51,6 +52,7 @@ import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
 /** @deprecated (2.12.0) see the exim add-on */
 @Deprecated
+@SuppressWarnings("serial")
 public class PopupMenuExportResponse extends JMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/ManualHttpRequestEditorDialog.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/ManualHttpRequestEditorDialog.java
@@ -34,6 +34,7 @@
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2021/02/12 Add shortcut key to Send button (Issue 6448).
 // ZAP: 2022/04/28 Call the new message sender method.
+// ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
 package org.parosproxy.paros.extension.manualrequest.http.impl;
 
 import java.awt.BorderLayout;
@@ -75,6 +76,7 @@ import org.zaproxy.zap.extension.httppanel.HttpPanelResponse;
 import org.zaproxy.zap.extension.httppanel.Message;
 import org.zaproxy.zap.view.ZapMenuItem;
 
+@SuppressWarnings("serial")
 public class ManualHttpRequestEditorDialog extends ManualRequestEditorDialog
         implements OptionsChangedListener {
 

--- a/zap/src/main/java/org/parosproxy/paros/extension/option/DialogAddProxyExcludedDomain.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/option/DialogAddProxyExcludedDomain.java
@@ -35,6 +35,7 @@ import org.zaproxy.zap.view.AbstractFormDialog;
 
 /** @deprecated (2.12.0) No longer in use. */
 @Deprecated
+@SuppressWarnings("serial")
 class DialogAddProxyExcludedDomain extends AbstractFormDialog {
 
     private static final long serialVersionUID = -7356390753317082681L;

--- a/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsCertificatePanel.java
@@ -42,6 +42,7 @@
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/05/21 Remove unsafe SSL/TLS renegotiation option.
 // ZAP: 2022/05/29 Deprecate the class.
+// ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
 package org.parosproxy.paros.extension.option;
 
 // TODO: Buttons should be gray
@@ -75,6 +76,7 @@ import org.zaproxy.zap.utils.ZapTextField;
 
 /** @deprecated (2.12.0) No longer in use. */
 @Deprecated
+@SuppressWarnings("serial")
 public class OptionsCertificatePanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 4350957038174673492L;

--- a/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsViewPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsViewPanel.java
@@ -40,6 +40,7 @@
 // ZAP: 2021/05/14 Remove redundant type arguments and empty statement.
 // ZAP: 2021/09/16 Add support for enabling app integration in containers
 // ZAP: 2022/02/25 Remove options no longer in use.
+// ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
 package org.parosproxy.paros.extension.option;
 
 import java.awt.BorderLayout;
@@ -82,6 +83,7 @@ import org.zaproxy.zap.view.LayoutHelper;
 
 // ZAP: 2011: added more configuration options
 
+@SuppressWarnings("serial")
 public class OptionsViewPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/parosproxy/paros/extension/option/ProxyExcludedDomainsTableModel.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/option/ProxyExcludedDomainsTableModel.java
@@ -27,6 +27,7 @@ import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
 /** @deprecated (2.12.0) No longer in use. */
 @Deprecated
+@SuppressWarnings("serial")
 public class ProxyExcludedDomainsTableModel
         extends AbstractMultipleOptionsTableModel<DomainMatcher> {
 

--- a/zap/src/main/java/org/parosproxy/paros/extension/option/SecurityProtocolsPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/option/SecurityProtocolsPanel.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.utils.FontUtils;
  * @deprecated (2.12.0) No longer in use.
  */
 @Deprecated
+@SuppressWarnings("serial")
 public class SecurityProtocolsPanel extends JPanel {
 
     private static final long serialVersionUID = 5096843444189699353L;

--- a/zap/src/main/java/org/parosproxy/paros/model/SiteMap.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/SiteMap.java
@@ -74,6 +74,7 @@
 // ZAP: 2022/02/08 Use isEmpty where applicable.
 // ZAP: 2022/07/27 Use hrefMap to return early from addPath and findAndAddChild. Remove getHostName
 // and use SessionStructure#getHostName in its place.
+// ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
 package org.parosproxy.paros.model;
 
 import java.awt.EventQueue;
@@ -103,6 +104,7 @@ import org.zaproxy.zap.model.SessionStructure;
 import org.zaproxy.zap.model.Target;
 import org.zaproxy.zap.view.SiteTreeFilter;
 
+@SuppressWarnings("serial")
 public class SiteMap extends SortedTreeModel {
 
     private static final long serialVersionUID = 2311091007687218751L;
@@ -804,6 +806,7 @@ public class SiteMap extends SortedTreeModel {
  * href="http://www.java2s.com/Code/Java/Swing-JFC/AtreemodelusingtheSortTreeModelwithaFilehierarchyasinput.htm">Sorted
  * Tree Example</a>
  */
+@SuppressWarnings("serial")
 class SortedTreeModel extends DefaultTreeModel {
 
     private static final long serialVersionUID = 4130060741120936997L;

--- a/zap/src/main/java/org/parosproxy/paros/model/SiteNode.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/SiteNode.java
@@ -58,6 +58,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2021/05/14 Remove redundant type arguments.
+// ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
 package org.parosproxy.paros.model;
 
 import java.awt.EventQueue;
@@ -80,6 +81,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.model.SessionStructure;
 
+@SuppressWarnings("serial")
 public class SiteNode extends DefaultMutableTreeNode {
 
     private static final long serialVersionUID = 7987615016786179150L;

--- a/zap/src/main/java/org/parosproxy/paros/view/AbstractFrame.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/AbstractFrame.java
@@ -28,6 +28,7 @@
 // ZAP: 2020/11/05 Remove abstract modifier.
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/02/03 Removed deprecated loadIconImages()
+// ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
 package org.parosproxy.paros.view;
 
 import java.awt.Dimension;
@@ -62,6 +63,7 @@ import org.zaproxy.zap.utils.DisplayUtils;
  * #setPreferredSize(Dimension)} instead. Also, don't use {@link #setLocation(Point)}. This abstract
  * class will automatically take care of size and position.
  */
+@SuppressWarnings("serial")
 public class AbstractFrame extends JFrame {
 
     private static final long serialVersionUID = 6751593232255236597L;
@@ -77,7 +79,7 @@ public class AbstractFrame extends JFrame {
     private final Preferences preferences;
 
     private final String prefnzPrefix = this.getClass().getSimpleName() + ".";
-    private final Logger logger = LogManager.getLogger(AbstractFrame.class);
+    private static final Logger logger = LogManager.getLogger(AbstractFrame.class);
 
     /** This is the default constructor */
     public AbstractFrame() {

--- a/zap/src/main/java/org/parosproxy/paros/view/AbstractParamContainerPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/AbstractParamContainerPanel.java
@@ -40,6 +40,7 @@
 // ZAP: 2022/02/12 Show child panel if parent has none.
 // ZAP: 2022/05/11 Use a unique ID to identify the panels instead of their name (Issue 5637).
 // ZAP: 2022/06/08 Fix resizing issues.
+// ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
 package org.parosproxy.paros.view;
 
 import java.awt.BorderLayout;
@@ -90,6 +91,7 @@ import org.zaproxy.zap.view.panelsearch.items.AbstractComponentSearch;
 import org.zaproxy.zap.view.panelsearch.items.TreeNodeElement;
 import org.zaproxy.zap.view.panelsearch.items.TreeUtils;
 
+@SuppressWarnings("serial")
 public class AbstractParamContainerPanel extends JSplitPane {
 
     /**

--- a/zap/src/main/java/org/parosproxy/paros/view/MainFrame.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/MainFrame.java
@@ -37,6 +37,7 @@
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/02/09 Remove method call no longer needed.
 // ZAP: 2022/02/26 Remove code deprecated in 2.5.0
+// ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
 package org.parosproxy.paros.view;
 
 import java.awt.CardLayout;
@@ -70,6 +71,7 @@ import org.zaproxy.zap.view.MainToolbarPanel;
 import org.zaproxy.zap.view.ZapToggleButton;
 import org.zaproxy.zap.view.widgets.PopupButton;
 
+@SuppressWarnings("serial")
 public class MainFrame extends AbstractFrame {
 
     private static final Logger LOGGER = LogManager.getLogger(MainFrame.class);

--- a/zap/src/main/java/org/parosproxy/paros/view/MainMenuBar.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/MainMenuBar.java
@@ -43,6 +43,7 @@
 // ZAP: 2021/05/14 Remove redundant type arguments.
 // ZAP: 2021/12/30 Disable snapshot menu item if session not already persisted, add tooltip to
 // disabled menu item (Issue 6938).
+// ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
 package org.parosproxy.paros.view;
 
 import java.awt.event.ActionEvent;
@@ -69,6 +70,7 @@ import org.zaproxy.zap.view.AboutDialog;
 import org.zaproxy.zap.view.ZapMenuItem;
 import org.zaproxy.zap.view.ZapSupportDialog;
 
+@SuppressWarnings("serial")
 public class MainMenuBar extends JMenuBar {
 
     private static final long serialVersionUID = 8580116506279095244L;

--- a/zap/src/main/java/org/parosproxy/paros/view/MainPopupMenu.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/MainPopupMenu.java
@@ -48,6 +48,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/02/03 Removed deprecated prepareShow method
+// ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
 package org.parosproxy.paros.view;
 
 import java.awt.Component;
@@ -76,6 +77,7 @@ import org.zaproxy.zap.view.popup.ExtensionPopupMenuComponent;
 import org.zaproxy.zap.view.popup.PopupMenuUtils;
 import org.zaproxy.zap.view.popup.PopupMenuUtils.PopupMenuInvokerWrapper;
 
+@SuppressWarnings("serial")
 public class MainPopupMenu extends JPopupMenu {
 
     private static final long serialVersionUID = -3021348328961418293L;
@@ -85,7 +87,7 @@ public class MainPopupMenu extends JPopupMenu {
     // ZAP: Added support for submenus
     Map<String, JMenu> superMenus = new HashMap<>();
     View view = null;
-    private static Logger log = LogManager.getLogger(MainPopupMenu.class);
+    private static final Logger log = LogManager.getLogger(MainPopupMenu.class);
 
     /**
      * The change listener responsible for updating the {@code pathSelectedMenu} when the path to

--- a/zap/src/main/java/org/parosproxy/paros/view/SessionDialog.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/SessionDialog.java
@@ -26,6 +26,7 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/07/10 Update to use Context.getId following deprecation of Context.getIndex
+// ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
 package org.parosproxy.paros.view;
 
 import java.awt.Frame;
@@ -37,6 +38,7 @@ import org.parosproxy.paros.model.Session;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.view.AbstractContextPropertiesPanel;
 
+@SuppressWarnings("serial")
 public class SessionDialog extends AbstractParamDialog {
 
     private static final long serialVersionUID = 2078860056416521552L;

--- a/zap/src/main/java/org/parosproxy/paros/view/SiteMapPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/SiteMapPanel.java
@@ -54,6 +54,7 @@
 // ZAP: 2019/09/09 Issue 3491: Add support for selecting multiple contexts
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/07/04 Make delete more consistent and protective (Issue 7336).
+// ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
 package org.parosproxy.paros.view;
 
 import java.awt.Component;
@@ -118,6 +119,7 @@ import org.zaproxy.zap.view.ZapToggleButton;
 import org.zaproxy.zap.view.messagecontainer.http.DefaultSelectableHistoryReferencesContainer;
 import org.zaproxy.zap.view.messagecontainer.http.SelectableHistoryReferencesContainer;
 
+@SuppressWarnings("serial")
 public class SiteMapPanel extends AbstractPanel {
 
     public static final String CONTEXT_TREE_COMPONENT_NAME = "ContextTree";

--- a/zap/src/main/java/org/parosproxy/paros/view/TabbedPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/TabbedPanel.java
@@ -33,6 +33,7 @@ import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.view.ComponentMaximiser;
 import org.zaproxy.zap.view.ComponentMaximiserMouseListener;
 
+@SuppressWarnings("serial")
 public class TabbedPanel extends JTabbedPane {
 
     private static final long serialVersionUID = 8927990541854169615L;

--- a/zap/src/main/java/org/parosproxy/paros/view/WorkbenchPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/WorkbenchPanel.java
@@ -75,6 +75,7 @@ import org.zaproxy.zap.view.TabbedPanel2;
  *
  * @since 1.0.0
  */
+@SuppressWarnings("serial")
 public class WorkbenchPanel extends JPanel {
 
     /**

--- a/zap/src/main/java/org/zaproxy/zap/authentication/AbstractCredentialsOptionsPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/AbstractCredentialsOptionsPanel.java
@@ -29,6 +29,7 @@ import javax.swing.JPanel;
  *
  * @param <T> the authenticator type
  */
+@SuppressWarnings("serial")
 public abstract class AbstractCredentialsOptionsPanel<T extends AuthenticationCredentials>
         extends JPanel {
 

--- a/zap/src/main/java/org/zaproxy/zap/authentication/HttpAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/HttpAuthenticationMethodType.java
@@ -197,6 +197,7 @@ public class HttpAuthenticationMethodType extends AuthenticationMethodType {
     }
 
     /** The Options Panel used for configuring a {@link HttpAuthenticationMethod}. */
+    @SuppressWarnings("serial")
     private static class HttpAuthenticationMethodOptionsPanel
             extends AbstractAuthenticationMethodOptionsPanel {
 

--- a/zap/src/main/java/org/zaproxy/zap/authentication/ManualAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/ManualAuthenticationMethodType.java
@@ -63,6 +63,7 @@ import org.zaproxy.zap.view.LayoutHelper;
  * The implementation for an {@link AuthenticationMethodType} where the user manually authenticates
  * and then just selects an already authenticated {@link WebSession}.
  */
+@SuppressWarnings("serial")
 public class ManualAuthenticationMethodType extends AuthenticationMethodType {
 
     private static final int METHOD_IDENTIFIER = 0;

--- a/zap/src/main/java/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/PostBasedAuthenticationMethodType.java
@@ -696,6 +696,7 @@ public abstract class PostBasedAuthenticationMethodType extends AuthenticationMe
     }
 
     /** The Options Panel used for configuring a {@link PostBasedAuthenticationMethod}. */
+    @SuppressWarnings("serial")
     protected abstract class PostBasedAuthenticationMethodOptionsPanel
             extends AbstractAuthenticationMethodOptionsPanel {
 

--- a/zap/src/main/java/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
@@ -352,6 +352,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
         }
     }
 
+    @SuppressWarnings("serial")
     public class ScriptBasedAuthenticationMethodOptionsPanel
             extends AbstractAuthenticationMethodOptionsPanel {
 

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
@@ -2375,6 +2375,7 @@ public class AddOn {
      * @since 2.8.0
      * @see #getValidationResult()
      */
+    @SuppressWarnings("serial")
     public static class InvalidAddOnException extends IOException {
 
         private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertAddDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertAddDialog.java
@@ -36,6 +36,7 @@ import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 
+@SuppressWarnings("serial")
 public class AlertAddDialog extends AbstractDialog {
 
     private static final Logger logger = LogManager.getLogger(AlertAddDialog.class);

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertNode.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertNode.java
@@ -26,6 +26,7 @@ import javax.swing.tree.MutableTreeNode;
 import javax.swing.tree.TreeNode;
 import org.parosproxy.paros.core.scanner.Alert;
 
+@SuppressWarnings("serial")
 public class AlertNode extends DefaultMutableTreeNode {
     private static final long serialVersionUID = 1L;
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertPanel.java
@@ -72,6 +72,7 @@ import org.zaproxy.zap.view.ZapToggleButton;
 import org.zaproxy.zap.view.messagecontainer.http.DefaultSelectableHistoryReferencesContainer;
 import org.zaproxy.zap.view.messagecontainer.http.SelectableHistoryReferencesContainer;
 
+@SuppressWarnings("serial")
 public class AlertPanel extends AbstractPanel {
 
     public static final String ALERT_TREE_PANEL_NAME = "treeAlert";

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertTagsTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertTagsTableModel.java
@@ -28,6 +28,7 @@ import javax.swing.table.AbstractTableModel;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.parosproxy.paros.Constant;
 
+@SuppressWarnings("serial")
 class AlertTagsTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertViewPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertViewPanel.java
@@ -76,6 +76,7 @@ import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.ZapTable;
 
+@SuppressWarnings("serial")
 public class AlertViewPanel extends AbstractPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/DialogAddAlertTag.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/DialogAddAlertTag.java
@@ -35,6 +35,7 @@ import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 import org.zaproxy.zap.view.LayoutHelper;
 
+@SuppressWarnings("serial")
 public class DialogAddAlertTag extends AbstractFormDialog {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/PopupMenuAlert.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/PopupMenuAlert.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuAlert extends PopupMenuItemHistoryReferenceContainer {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/PopupMenuAlertEdit.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/PopupMenuAlertEdit.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.core.scanner.Alert;
  *
  * @since 1.4.0
  */
+@SuppressWarnings("serial")
 public class PopupMenuAlertEdit extends PopupMenuItemAlert {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/PopupMenuItemAlert.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/PopupMenuItemAlert.java
@@ -39,6 +39,7 @@ import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
  * @since 2.6.0
  * @see #performAction(Alert)
  */
+@SuppressWarnings("serial")
 public abstract class PopupMenuItemAlert extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/PopupMenuShowAlert.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/PopupMenuShowAlert.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 
+@SuppressWarnings("serial")
 public class PopupMenuShowAlert extends JMenuItem implements Comparable<PopupMenuShowAlert> {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/PopupMenuShowAlerts.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/PopupMenuShowAlerts.java
@@ -29,6 +29,7 @@ import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.ExtensionPopupMenuComponent;
 import org.zaproxy.zap.view.popup.PopupMenuHistoryReferenceContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuShowAlerts extends PopupMenuHistoryReferenceContainer {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/DialogAddToken.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/DialogAddToken.java
@@ -32,6 +32,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 class DialogAddToken extends AbstractFormDialog {
 
     private static final long serialVersionUID = 4460797449668634319L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/OptionsAntiCsrfTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/OptionsAntiCsrfTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+@SuppressWarnings("serial")
 public class OptionsAntiCsrfTableModel
         extends AbstractMultipleOptionsTableModel<AntiCsrfParamToken> {
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ApiException.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ApiException.java
@@ -108,7 +108,7 @@ public class ApiException extends Exception {
     private final Type type;
     private final String detail;
 
-    private final Logger logger = LogManager.getLogger(this.getClass());
+    private static final Logger logger = LogManager.getLogger(ApiException.class);
 
     public ApiException(Type type) {
         this(type, null, null);

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/DialogAddPermittedAddress.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/DialogAddPermittedAddress.java
@@ -33,6 +33,7 @@ import org.zaproxy.zap.network.DomainMatcher;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 class DialogAddPermittedAddress extends AbstractFormDialog {
 
     private static final long serialVersionUID = -7356390753317082681L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/PermittedAddressesTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/PermittedAddressesTableModel.java
@@ -25,6 +25,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.network.DomainMatcher;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+@SuppressWarnings("serial")
 public class PermittedAddressesTableModel extends AbstractMultipleOptionsTableModel<DomainMatcher> {
 
     private static final long serialVersionUID = -5411351965957264957L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanPanel.java
@@ -50,6 +50,7 @@ import org.zaproxy.zap.view.ScanPanel2;
 import org.zaproxy.zap.view.ZapTable;
 import org.zaproxy.zap.view.table.HistoryReferencesTable;
 
+@SuppressWarnings("serial")
 public class ActiveScanPanel extends ScanPanel2<ActiveScan, ScanController<ActiveScan>>
         implements ScanListenner2, ScannerListener {
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/AllCategoryTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/AllCategoryTableModel.java
@@ -43,6 +43,7 @@ import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
 import org.parosproxy.paros.core.scanner.PluginFactory;
 
+@SuppressWarnings("serial")
 public class AllCategoryTableModel extends DefaultTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/CategoryTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/CategoryTableModel.java
@@ -47,6 +47,7 @@ import org.parosproxy.paros.core.scanner.PluginFactory;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.StatusUI;
 
+@SuppressWarnings("serial")
 public class CategoryTableModel extends DefaultTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
@@ -80,6 +80,7 @@ import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 import org.zaproxy.zap.view.TechnologyTreePanel;
 
+@SuppressWarnings("serial")
 public class CustomScanDialog extends StandardFieldsDialog {
 
     protected static final String[] STD_TAB_LABELS = {

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ExcludedParameterAddDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ExcludedParameterAddDialog.java
@@ -34,6 +34,7 @@ import org.parosproxy.paros.core.scanner.ScannerParamFilter;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 class ExcludedParameterAddDialog extends AbstractFormDialog {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ExcludedParameterTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ExcludedParameterTableModel.java
@@ -26,6 +26,7 @@ import org.parosproxy.paros.core.scanner.ScannerParamFilter;
 import org.zaproxy.zap.view.AbstractMultipleOptionsBaseTableModel;
 
 /** @author yhawke (2014) */
+@SuppressWarnings("serial")
 public class ExcludedParameterTableModel
         extends AbstractMultipleOptionsBaseTableModel<ScannerParamFilter> {
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/FilterMessageTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/FilterMessageTableModel.java
@@ -28,6 +28,7 @@ import org.parosproxy.paros.Constant;
  * @author KSASAN preetkaran20@gmail.com
  * @since 2.9.0
  */
+@SuppressWarnings("serial")
 class FilterMessageTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = -6380136823410869457L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/OptionsScannerPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/OptionsScannerPanel.java
@@ -41,6 +41,7 @@ import org.zaproxy.zap.utils.ZapNumberSpinner;
 import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.PositiveValuesSlider;
 
+@SuppressWarnings("serial")
 public class OptionsScannerPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyAllCategoryPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyAllCategoryPanel.java
@@ -66,6 +66,7 @@ import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.LayoutHelper;
 
+@SuppressWarnings("serial")
 public class PolicyAllCategoryPanel extends AbstractParamPanel {
 
     // private static final String ILLEGAL_CHRS = "/`?*\\<>|\":\t\n\r";

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyDialog.java
@@ -34,6 +34,7 @@ import org.parosproxy.paros.view.AbstractParamDialog;
 import org.parosproxy.paros.view.AbstractParamPanel;
 import org.zaproxy.zap.utils.DisplayUtils;
 
+@SuppressWarnings("serial")
 public class PolicyDialog extends AbstractParamDialog {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyManagerDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyManagerDialog.java
@@ -45,6 +45,7 @@ import org.zaproxy.zap.view.SingleColumnTableModel;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
+@SuppressWarnings("serial")
 public class PolicyManagerDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanProgressActionIcon.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanProgressActionIcon.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.ZAP;
 
 /** Clickable helper class for actions */
+@SuppressWarnings("serial")
 public class ScanProgressActionIcon extends JLabel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanProgressDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanProgressDialog.java
@@ -76,6 +76,7 @@ import org.zaproxy.zap.view.LayoutHelper;
  *
  * @author yhawke (2014)
  */
+@SuppressWarnings("serial")
 public class ScanProgressDialog extends AbstractDialog {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanProgressTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanProgressTableModel.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.HostProcess;
 import org.parosproxy.paros.core.scanner.Plugin;
 
+@SuppressWarnings("serial")
 public class ScanProgressTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/authentication/ContextAuthenticationPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authentication/ContextAuthenticationPanel.java
@@ -70,6 +70,7 @@ import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.NodeSelectDialog;
 
 /** The Context Panel shown for configuring a Context's authentication methods. */
+@SuppressWarnings("serial")
 public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
 
     private static final Logger log = LogManager.getLogger(ContextAuthenticationPanel.class);

--- a/zap/src/main/java/org/zaproxy/zap/extension/authorization/ContextAuthorizationPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authorization/ContextAuthorizationPanel.java
@@ -40,6 +40,7 @@ import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.view.AbstractContextPropertiesPanel;
 import org.zaproxy.zap.view.LayoutHelper;
 
+@SuppressWarnings("serial")
 public class ContextAuthorizationPanel extends AbstractContextPropertiesPanel {
 
     private static final long serialVersionUID = 2416553589170267959L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/AddOnDependencyChecker.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/AddOnDependencyChecker.java
@@ -965,6 +965,7 @@ class AddOnDependencyChecker {
         }
     }
 
+    @SuppressWarnings("serial")
     private static class AddOnTableModel extends AbstractTableModel {
 
         private static final long serialVersionUID = 5446781970087315105L;
@@ -1113,6 +1114,7 @@ class AddOnDependencyChecker {
         }
     }
 
+    @SuppressWarnings("serial")
     private static class ExtensionsTableModel extends AbstractTableModel {
 
         private static final long serialVersionUID = 5446781970087315105L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/AddOnsTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/AddOnsTableModel.java
@@ -39,6 +39,7 @@ import org.zaproxy.zap.control.AddOnCollection;
 import org.zaproxy.zap.control.AddOnRunIssuesUtils;
 
 /** An {@code AbstractTableModel} for add-ons. */
+@SuppressWarnings("serial")
 public abstract class AddOnsTableModel extends AbstractTableModel {
 
     /** The column in the table model that allows to get the {@code AddOnWrapper} of a given row. */

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/InstalledAddOnsTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/InstalledAddOnsTableModel.java
@@ -31,6 +31,7 @@ import org.zaproxy.zap.control.AddOn.AddOnRunRequirements;
 import org.zaproxy.zap.control.AddOnCollection;
 import org.zaproxy.zap.extension.autoupdate.AddOnWrapper.Status;
 
+@SuppressWarnings("serial")
 public class InstalledAddOnsTableModel extends AddOnsTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
@@ -92,6 +92,7 @@ import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.ZapTable;
 import org.zaproxy.zap.view.panels.TableFilterPanel;
 
+@SuppressWarnings("serial")
 public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateCallback {
 
     protected enum State {

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/OptionsAutoupdateDirsTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/OptionsAutoupdateDirsTableModel.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.view.AbstractMultipleOptionsBaseTableModel;
 
+@SuppressWarnings("serial")
 public class OptionsAutoupdateDirsTableModel extends AbstractMultipleOptionsBaseTableModel<File> {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/UninstallationProgressDialogue.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/UninstallationProgressDialogue.java
@@ -47,6 +47,7 @@ import org.zaproxy.zap.control.AddOnUninstallationProgressCallback;
  *
  * @since 2.4.0
  */
+@SuppressWarnings("serial")
 class UninstallationProgressDialogue extends AbstractDialog {
 
     private static final long serialVersionUID = 6544278337930125848L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakPanel.java
@@ -51,6 +51,7 @@ import org.zaproxy.zap.extension.httppanel.view.impl.models.http.HttpPanelViewMo
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.ZapToggleButton;
 
+@SuppressWarnings("serial")
 public class BreakPanel extends AbstractPanel implements BreakpointManagementInterface {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakpointsPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakpointsPanel.java
@@ -38,6 +38,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
 import org.parosproxy.paros.view.View;
 
+@SuppressWarnings("serial")
 public class BreakpointsPanel extends AbstractPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakpointsTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakpointsTableModel.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 
+@SuppressWarnings("serial")
 public class BreakpointsTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = -8160051343126299124L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/PopupMenuEditBreak.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/PopupMenuEditBreak.java
@@ -23,6 +23,7 @@ import java.awt.Component;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 
+@SuppressWarnings("serial")
 public class PopupMenuEditBreak extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/PopupMenuRemove.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/PopupMenuRemove.java
@@ -23,6 +23,7 @@ import java.awt.Component;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 
+@SuppressWarnings("serial")
 public class PopupMenuRemove extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/impl/http/BreakAddEditDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/impl/http/BreakAddEditDialog.java
@@ -29,6 +29,7 @@ import org.zaproxy.zap.extension.brk.impl.http.HttpBreakpointMessage.Location;
 import org.zaproxy.zap.extension.brk.impl.http.HttpBreakpointMessage.Match;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class BreakAddEditDialog extends StandardFieldsDialog {
 
     private static final String FIELD_LOCATION = "brk.brkpoint.location.label";

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/impl/http/PopupMenuAddBreakHistory.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/impl/http/PopupMenuAddBreakHistory.java
@@ -29,6 +29,7 @@ import org.zaproxy.zap.extension.brk.ExtensionBreak;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuAddBreakHistory extends PopupMenuItemHistoryReferenceContainer {
 
     private static final long serialVersionUID = -1984801437717248474L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/impl/http/PopupMenuAddBreakSites.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/impl/http/PopupMenuAddBreakSites.java
@@ -26,6 +26,7 @@ import org.zaproxy.zap.model.StructuralSiteNode;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuAddBreakSites extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = -7635703590177283587L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/callback/OptionsCallbackPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/callback/OptionsCallbackPanel.java
@@ -39,6 +39,7 @@ import org.zaproxy.zap.view.LayoutHelper;
 
 /** @deprecated (2.11.0) Superseded by the OAST add-on. */
 @Deprecated
+@SuppressWarnings("serial")
 public class OptionsCallbackPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/callback/ui/CallbackPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/callback/ui/CallbackPanel.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.utils.FontUtils;
 
 /** @deprecated (2.11.0) Superseded by the OAST add-on. */
 @Deprecated
+@SuppressWarnings("serial")
 public class CallbackPanel extends AbstractPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/callback/ui/DefaultCustomColumnHistoryReferencesTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/callback/ui/DefaultCustomColumnHistoryReferencesTableModel.java
@@ -27,6 +27,7 @@ import org.zaproxy.zap.view.table.DefaultHistoryReferencesTableModel;
 
 /** @deprecated (2.11.0) Superseded by the OAST add-on. */
 @Deprecated
+@SuppressWarnings("serial")
 public class DefaultCustomColumnHistoryReferencesTableModel<
                 T extends DefaultHistoryReferencesTableEntry>
         extends DefaultHistoryReferencesTableModel {

--- a/zap/src/main/java/org/zaproxy/zap/extension/custompages/ContextCustomPagePanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/custompages/ContextCustomPagePanel.java
@@ -34,6 +34,7 @@ import org.zaproxy.zap.view.AbstractContextPropertiesPanel;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTablePanel;
 import org.zaproxy.zap.view.LayoutHelper;
 
+@SuppressWarnings("serial")
 class ContextCustomPagePanel extends AbstractContextPropertiesPanel {
 
     // The i18n prefix

--- a/zap/src/main/java/org/zaproxy/zap/extension/custompages/CustomPageTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/custompages/CustomPageTableModel.java
@@ -26,6 +26,7 @@ import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
 /** A table model for holding a set of DefaultCustomPage, for a {@link Context}. */
+@SuppressWarnings("serial")
 class CustomPageTableModel extends AbstractMultipleOptionsTableModel<CustomPage> {
 
     /** The Constant serialVersionUID. */

--- a/zap/src/main/java/org/zaproxy/zap/extension/custompages/DialogAddCustomPage.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/custompages/DialogAddCustomPage.java
@@ -44,6 +44,7 @@ import org.zaproxy.zap.view.AbstractFormDialog;
 import org.zaproxy.zap.view.LayoutHelper;
 
 /** The Dialog for adding and configuring a new {@link DefaultCustomPage}. */
+@SuppressWarnings("serial")
 class DialogAddCustomPage extends AbstractFormDialog {
 
     /** The Constant serialVersionUID. */

--- a/zap/src/main/java/org/zaproxy/zap/extension/dynssl/DynamicSSLPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/dynssl/DynamicSSLPanel.java
@@ -61,6 +61,7 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
 import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
 @Deprecated
+@SuppressWarnings("serial")
 public class DynamicSSLPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/ext/OptionsExtensionTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ext/OptionsExtensionTableModel.java
@@ -30,6 +30,7 @@ import org.parosproxy.paros.extension.Extension;
 import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.control.ExtensionFactory;
 
+@SuppressWarnings("serial")
 public class OptionsExtensionTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/forceduser/ContextForcedUserPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/forceduser/ContextForcedUserPanel.java
@@ -32,6 +32,7 @@ import org.zaproxy.zap.view.AbstractContextPropertiesPanel;
 import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.widgets.ContextPanelUsersSelectComboBox;
 
+@SuppressWarnings("serial")
 public class ContextForcedUserPanel extends AbstractContextPropertiesPanel {
 
     private static final long serialVersionUID = -6668491574669367809L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/globalexcludeurl/DialogAddToken.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/globalexcludeurl/DialogAddToken.java
@@ -33,6 +33,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 class DialogAddToken extends AbstractFormDialog {
 
     private static final long serialVersionUID = 4460797449668634319L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/globalexcludeurl/OptionsGlobalExcludeURLTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/globalexcludeurl/OptionsGlobalExcludeURLTableModel.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+@SuppressWarnings("serial")
 public class OptionsGlobalExcludeURLTableModel
         extends AbstractMultipleOptionsTableModel<GlobalExcludeURLParamToken> {
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/history/HistoryFilterPlusDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/history/HistoryFilterPlusDialog.java
@@ -52,6 +52,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.ZapLabel;
 import org.zaproxy.zap.view.LayoutHelper;
 
+@SuppressWarnings("serial")
 public class HistoryFilterPlusDialog extends AbstractDialog {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/history/ManageTagsDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/history/ManageTagsDialog.java
@@ -38,6 +38,7 @@ import org.parosproxy.paros.model.HistoryReference;
 import org.zaproxy.zap.utils.SortedComboBoxModel;
 import org.zaproxy.zap.utils.SortedListModel;
 
+@SuppressWarnings("serial")
 public class ManageTagsDialog extends AbstractDialog {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/history/NotesAddDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/history/NotesAddDialog.java
@@ -34,6 +34,7 @@ import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.utils.ZapTextArea;
 
+@SuppressWarnings("serial")
 public class NotesAddDialog extends AbstractDialog {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuExportURLs.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuExportURLs.java
@@ -40,6 +40,7 @@ import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
 /** @deprecated (2.12.0) see the exim add-on */
 @Deprecated
+@SuppressWarnings("serial")
 public class PopupMenuExportURLs extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuNote.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuNote.java
@@ -29,6 +29,7 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuNote extends PopupMenuItemHistoryReferenceContainer {
 
     private static final long serialVersionUID = -5692544221103745600L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuPurgeHistory.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuPurgeHistory.java
@@ -26,6 +26,7 @@ import org.parosproxy.paros.model.HistoryReference;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuPurgeHistory extends PopupMenuItemHistoryReferenceContainer {
 
     private static final long serialVersionUID = -155358408946131183L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuResendMessage.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuResendMessage.java
@@ -26,6 +26,7 @@ import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
 /** @deprecated (2.12.0) Replaced by Requester add-on. */
 @Deprecated
+@SuppressWarnings("serial")
 public class PopupMenuResendMessage extends PopupMenuItemHttpMessageContainer {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuTag.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuTag.java
@@ -24,6 +24,7 @@ import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.HistoryReference;
 import org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuTag extends PopupMenuItemHistoryReferenceContainer {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/ComponentChangedEvent.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/ComponentChangedEvent.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.httppanel;
 import java.util.EventObject;
 import org.zaproxy.zap.extension.httppanel.component.HttpPanelComponentInterface;
 
+@SuppressWarnings("serial")
 public class ComponentChangedEvent extends EventObject {
 
     private static final long serialVersionUID = 4097248911533000241L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/HttpPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/HttpPanel.java
@@ -59,6 +59,7 @@ import org.zaproxy.zap.extension.httppanel.view.HttpPanelView;
 import org.zaproxy.zap.extension.search.SearchMatch;
 import org.zaproxy.zap.extension.search.SearchableHttpPanelComponent;
 
+@SuppressWarnings("serial")
 public abstract class HttpPanel extends AbstractPanel {
 
     public enum OptionsLocation {

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/MessageViewSelectedEvent.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/MessageViewSelectedEvent.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.httppanel;
 import java.util.EventObject;
 import org.zaproxy.zap.extension.httppanel.view.HttpPanelView;
 
+@SuppressWarnings("serial")
 public class MessageViewSelectedEvent extends EventObject {
 
     private static final long serialVersionUID = 6491765319312775225L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/hex/HttpPanelHexModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/hex/HttpPanelHexModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import javax.swing.table.AbstractTableModel;
 import org.zaproxy.zap.utils.ByteBuilder;
 
+@SuppressWarnings("serial")
 public class HttpPanelHexModel extends AbstractTableModel {
 
     private static final String[] hexSymbols = {

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/paramtable/HttpPanelParamTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/paramtable/HttpPanelParamTableModel.java
@@ -29,6 +29,7 @@ import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.httppanel.view.paramtable.addins.ParamAddinInterface;
 
+@SuppressWarnings("serial")
 public abstract class HttpPanelParamTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 8714941615215038148L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/HttpPanelSyntaxHighlightTextArea.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/HttpPanelSyntaxHighlightTextArea.java
@@ -56,6 +56,7 @@ import org.zaproxy.zap.utils.FontUtils.FontType;
 import org.zaproxy.zap.view.HighlightSearchEntry;
 import org.zaproxy.zap.view.HighlighterManager;
 
+@SuppressWarnings("serial")
 public abstract class HttpPanelSyntaxHighlightTextArea extends RSyntaxTextArea {
 
     private static final long serialVersionUID = -9082089105656842054L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/all/request/HttpRequestAllPanelSyntaxHighlightTextView.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/all/request/HttpRequestAllPanelSyntaxHighlightTextView.java
@@ -108,6 +108,7 @@ public class HttpRequestAllPanelSyntaxHighlightTextView extends HttpPanelSyntaxH
         return (HttpRequestAllPanelSyntaxHighlightTextArea) super.getHttpPanelTextArea();
     }
 
+    @SuppressWarnings("serial")
     protected static class HttpRequestAllPanelSyntaxHighlightTextArea
             extends HttpPanelSyntaxHighlightTextArea {
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/all/response/HttpResponseAllPanelSyntaxHighlightTextView.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/all/response/HttpResponseAllPanelSyntaxHighlightTextView.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.extension.httppanel.view.syntaxhighlight.HttpPanelSyntaxH
 import org.zaproxy.zap.extension.httppanel.view.util.HttpTextViewUtils;
 import org.zaproxy.zap.extension.search.SearchMatch;
 
+@SuppressWarnings("serial")
 public class HttpResponseAllPanelSyntaxHighlightTextView extends HttpPanelSyntaxHighlightTextView {
 
     private static final String CSS =

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/split/request/HttpRequestBodyPanelSyntaxHighlightTextView.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/split/request/HttpRequestBodyPanelSyntaxHighlightTextView.java
@@ -50,6 +50,7 @@ import org.zaproxy.zap.view.messagelocation.MessageLocationProducerFocusListener
 import org.zaproxy.zap.view.messagelocation.TextMessageLocationHighlight;
 import org.zaproxy.zap.view.messagelocation.TextMessageLocationHighlightsManager;
 
+@SuppressWarnings("serial")
 public class HttpRequestBodyPanelSyntaxHighlightTextView extends HttpPanelSyntaxHighlightTextView
         implements SelectableContentHttpMessageContainer {
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/split/request/HttpRequestHeaderPanelSyntaxHighlightTextView.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/split/request/HttpRequestHeaderPanelSyntaxHighlightTextView.java
@@ -88,6 +88,7 @@ public class HttpRequestHeaderPanelSyntaxHighlightTextView extends HttpPanelSynt
         return (HttpRequestHeaderPanelSyntaxHighlightTextArea) super.getHttpPanelTextArea();
     }
 
+    @SuppressWarnings("serial")
     private static class HttpRequestHeaderPanelSyntaxHighlightTextArea
             extends HttpPanelSyntaxHighlightTextArea {
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/split/response/HttpResponseBodyPanelSyntaxHighlightTextView.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/split/response/HttpResponseBodyPanelSyntaxHighlightTextView.java
@@ -34,6 +34,7 @@ import org.zaproxy.zap.extension.httppanel.view.syntaxhighlight.HttpPanelSyntaxH
 import org.zaproxy.zap.extension.httppanel.view.syntaxhighlight.HttpPanelSyntaxHighlightTextView;
 import org.zaproxy.zap.extension.search.SearchMatch;
 
+@SuppressWarnings("serial")
 public class HttpResponseBodyPanelSyntaxHighlightTextView extends HttpPanelSyntaxHighlightTextView {
 
     private ContentSplitter contentSplitter;

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/menus/SyntaxMenu.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/menus/SyntaxMenu.java
@@ -38,6 +38,7 @@ import org.zaproxy.zap.extension.httppanel.view.syntaxhighlight.AutoDetectSyntax
 import org.zaproxy.zap.extension.httppanel.view.syntaxhighlight.HttpPanelSyntaxHighlightTextArea;
 import org.zaproxy.zap.extension.httppanel.view.syntaxhighlight.HttpPanelSyntaxHighlightTextArea.SyntaxStyle;
 
+@SuppressWarnings("serial")
 public class SyntaxMenu extends ExtensionPopupMenu {
 
     private static final long serialVersionUID = 8472491919281117716L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/text/HttpPanelTextArea.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/text/HttpPanelTextArea.java
@@ -38,6 +38,7 @@ import org.zaproxy.zap.view.HighlighterManager;
 /* ZAP Text Area
  * Which enhanced functionality. Used to display HTTP Message request / response, or parts of it.
  */
+@SuppressWarnings("serial")
 public abstract class HttpPanelTextArea extends ZapTextArea {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/DialogAddToken.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/DialogAddToken.java
@@ -33,6 +33,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 class DialogAddToken extends AbstractFormDialog {
 
     private static final long serialVersionUID = -7700616092385163201L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/HttpSessionsPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/HttpSessionsPanel.java
@@ -55,6 +55,7 @@ import org.zaproxy.zap.view.table.decorator.AbstractTableCellItemIconHighlighter
  * The HttpSessionsPanel used as a display panel for the {@link ExtensionHttpSessions}, allowing the
  * user to view and control the http sessions.
  */
+@SuppressWarnings("serial")
 public class HttpSessionsPanel extends AbstractPanel {
 
     /** The Constant serialVersionUID. */

--- a/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/HttpSessionsTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/HttpSessionsTableModel.java
@@ -26,6 +26,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.view.View;
 
 /** The Class HttpSessionsTableModel that is used as a TableModel for the Http Sessions Panel. */
+@SuppressWarnings("serial")
 public class HttpSessionsTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = -6380136823410869457L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/OptionsHttpSessionsTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/OptionsHttpSessionsTableModel.java
@@ -28,6 +28,7 @@ import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
  * The OptionsHttpSessionsTableModel is used as a table model to display the token names for {@link
  * OptionsHttpSessionsPanel}.
  */
+@SuppressWarnings("serial")
 public class OptionsHttpSessionsTableModel
         extends AbstractMultipleOptionsTableModel<HttpSessionToken> {
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/PopupMenuFactoryAddUserFromSession.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/PopupMenuFactoryAddUserFromSession.java
@@ -40,6 +40,7 @@ import org.zaproxy.zap.extension.users.ExtensionUserManagement;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.users.User;
 
+@SuppressWarnings("serial")
 public class PopupMenuFactoryAddUserFromSession extends PopupContextMenuItemFactory {
 
     private static final Logger log =
@@ -96,6 +97,7 @@ public class PopupMenuFactoryAddUserFromSession extends PopupContextMenuItemFact
         return extensionUsers;
     }
 
+    @SuppressWarnings("serial")
     protected class PopupMenuAddUserFromSession extends ExtensionPopupMenuItem {
 
         /** The Constant serialVersionUID. */

--- a/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/PopupMenuRemoveSession.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/PopupMenuRemoveSession.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
  * The PopupMenuRemoveSession is used to delete a http session from the {@link
  * ExtensionHttpSessions} .
  */
+@SuppressWarnings("serial")
 public class PopupMenuRemoveSession extends ExtensionPopupMenuItem {
 
     /** The Constant serialVersionUID. */

--- a/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/PopupMenuSessionSearch.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/PopupMenuSessionSearch.java
@@ -26,6 +26,7 @@ import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.extension.search.ExtensionSearch;
 
+@SuppressWarnings("serial")
 public class PopupMenuSessionSearch extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/PopupMenuSetActiveSession.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/PopupMenuSetActiveSession.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
  * The PopupMenuSetActiveSession is used to set the active http session for the {@link
  * ExtensionHttpSessions}.
  */
+@SuppressWarnings("serial")
 public class PopupMenuSetActiveSession extends ExtensionPopupMenuItem {
 
     /** The Constant serialVersionUID. */

--- a/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/PopupMenuUnsetActiveSession.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/PopupMenuUnsetActiveSession.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
  * The PopupMenuUnsetActiveSession is used to unset the active http session for the {@link
  * ExtensionHttpSessions}.
  */
+@SuppressWarnings("serial")
 public class PopupMenuUnsetActiveSession extends ExtensionPopupMenuItem {
 
     /** The Constant serialVersionUID. */

--- a/zap/src/main/java/org/zaproxy/zap/extension/keyboard/DialogEditShortcut.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/keyboard/DialogEditShortcut.java
@@ -32,6 +32,7 @@ import javax.swing.KeyStroke;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class DialogEditShortcut extends StandardFieldsDialog {
 
     private static final String FIELD_ACTION = "keyboard.dialog.label.action";

--- a/zap/src/main/java/org/zaproxy/zap/extension/keyboard/KeyboardShortcutTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/keyboard/KeyboardShortcutTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 
+@SuppressWarnings("serial")
 public class KeyboardShortcutTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/keyboard/OptionsKeyboardShortcutPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/keyboard/OptionsKeyboardShortcutPanel.java
@@ -39,6 +39,7 @@ import org.zaproxy.zap.utils.DesktopUtils;
 import org.zaproxy.zap.view.MultipleOptionsTablePanel;
 import org.zaproxy.zap.view.panels.TableFilterPanel;
 
+@SuppressWarnings("serial")
 public class OptionsKeyboardShortcutPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/lang/OptionsLangPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/lang/OptionsLangPanel.java
@@ -46,6 +46,7 @@ import org.zaproxy.zap.utils.LocaleUtils;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.ViewLocale;
 
+@SuppressWarnings("serial")
 public class OptionsLangPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/params/ParamsPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/params/ParamsPanel.java
@@ -42,6 +42,7 @@ import org.zaproxy.zap.utils.SortedComboBoxModel;
 import org.zaproxy.zap.utils.TableExportButton;
 import org.zaproxy.zap.view.ScanPanel;
 
+@SuppressWarnings("serial")
 public class ParamsPanel extends AbstractPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/params/ParamsTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/params/ParamsTableModel.java
@@ -26,6 +26,7 @@ import java.util.Vector;
 import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 
+@SuppressWarnings("serial")
 public class ParamsTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/params/PopupMenuAddAntiCSRF.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/params/PopupMenuAddAntiCSRF.java
@@ -24,6 +24,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.parosproxy.paros.network.HtmlParameter;
 
+@SuppressWarnings("serial")
 public class PopupMenuAddAntiCSRF extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/params/PopupMenuAddSession.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/params/PopupMenuAddSession.java
@@ -24,6 +24,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.parosproxy.paros.network.HtmlParameter;
 
+@SuppressWarnings("serial")
 public class PopupMenuAddSession extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/params/PopupMenuParamSearch.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/params/PopupMenuParamSearch.java
@@ -23,6 +23,7 @@ import java.awt.Component;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 
+@SuppressWarnings("serial")
 public class PopupMenuParamSearch extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/params/PopupMenuRemoveAntiCSRF.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/params/PopupMenuRemoveAntiCSRF.java
@@ -24,6 +24,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.parosproxy.paros.network.HtmlParameter;
 
+@SuppressWarnings("serial")
 public class PopupMenuRemoveAntiCSRF extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/params/PopupMenuRemoveSession.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/params/PopupMenuRemoveSession.java
@@ -24,6 +24,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.parosproxy.paros.network.HtmlParameter;
 
+@SuppressWarnings("serial")
 public class PopupMenuRemoveSession extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/proxies/DialogAddProxy.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/proxies/DialogAddProxy.java
@@ -27,6 +27,7 @@ import org.zaproxy.zap.view.AbstractFormDialog;
 
 /** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
 @Deprecated
+@SuppressWarnings("serial")
 class DialogAddProxy extends AbstractFormDialog {
 
     private static final long serialVersionUID = 4460797449668634319L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/proxies/OptionsProxiesPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/proxies/OptionsProxiesPanel.java
@@ -38,6 +38,7 @@ import org.zaproxy.zap.view.LayoutHelper;
 
 /** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
 @Deprecated
+@SuppressWarnings("serial")
 public class OptionsProxiesPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/proxies/OptionsProxiesTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/proxies/OptionsProxiesTableModel.java
@@ -26,6 +26,7 @@ import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
 /** @deprecated (2.12.0) No longer used/needed. It will be removed in a future release. */
 @Deprecated
+@SuppressWarnings("serial")
 public class OptionsProxiesTableModel extends AbstractMultipleOptionsTableModel<ProxiesParamProxy> {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/DialogAddAutoTagScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/DialogAddAutoTagScanner.java
@@ -34,6 +34,7 @@ import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 class DialogAddAutoTagScanner extends AbstractFormDialog {
 
     private static final long serialVersionUID = -5209887319253495735L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/OptionsPassiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/OptionsPassiveScan.java
@@ -32,6 +32,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTablePanel;
 
+@SuppressWarnings("serial")
 public class OptionsPassiveScan extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/OptionsPassiveScanTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/OptionsPassiveScanTableModel.java
@@ -25,6 +25,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+@SuppressWarnings("serial")
 public class OptionsPassiveScanTableModel
         extends AbstractMultipleOptionsTableModel<RegexAutoTagScanner> {
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PolicyPassiveScanTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PolicyPassiveScanTableModel.java
@@ -30,6 +30,7 @@ import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.StatusUI;
 
+@SuppressWarnings("serial")
 public class PolicyPassiveScanTableModel extends DefaultTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/ruleconfig/DialogEditRuleConfig.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ruleconfig/DialogEditRuleConfig.java
@@ -28,6 +28,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.utils.ZapTextArea;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class DialogEditRuleConfig extends StandardFieldsDialog {
 
     private static final String FIELD_KEY = "ruleconfig.dialog.label.key";

--- a/zap/src/main/java/org/zaproxy/zap/extension/ruleconfig/OptionsRuleConfigPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ruleconfig/OptionsRuleConfigPanel.java
@@ -35,6 +35,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.MultipleOptionsTablePanel;
 
+@SuppressWarnings("serial")
 public class OptionsRuleConfigPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/ruleconfig/RuleConfigTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ruleconfig/RuleConfigTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 
+@SuppressWarnings("serial")
 public class RuleConfigTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/OptionsScriptPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/OptionsScriptPanel.java
@@ -34,6 +34,7 @@ import org.parosproxy.paros.view.AbstractParamPanel;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.AbstractMultipleOptionsBaseTablePanel;
 
+@SuppressWarnings("serial")
 public class OptionsScriptPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/OptionsScriptTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/OptionsScriptTableModel.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.view.AbstractMultipleOptionsBaseTableModel;
 
+@SuppressWarnings("serial")
 public class OptionsScriptTableModel extends AbstractMultipleOptionsBaseTableModel<File> {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptNode.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptNode.java
@@ -28,6 +28,7 @@ import org.parosproxy.paros.Constant;
  * @since 2.2.0
  * @see ScriptTreeModel
  */
+@SuppressWarnings("serial")
 public class ScriptNode extends DefaultMutableTreeNode {
     private static final long serialVersionUID = 1L;
     private String nodeName = null;

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptTreeModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptTreeModel.java
@@ -35,6 +35,7 @@ import javax.swing.tree.DefaultTreeModel;
  * @see #addScript(ScriptWrapper)
  * @see #addTemplate(ScriptWrapper)
  */
+@SuppressWarnings("serial")
 public class ScriptTreeModel extends DefaultTreeModel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/search/SearchPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/search/SearchPanel.java
@@ -49,6 +49,7 @@ import org.zaproxy.zap.utils.TableExportButton;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.ZapToggleButton;
 
+@SuppressWarnings("serial")
 public class SearchPanel extends AbstractPanel implements SearchListenner {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/search/SearchResultsTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/search/SearchResultsTableModel.java
@@ -36,6 +36,7 @@ import org.zaproxy.zap.view.table.AbstractCustomColumnHistoryReferencesTableMode
 import org.zaproxy.zap.view.table.AbstractHistoryReferencesTableEntry;
 import org.zaproxy.zap.view.table.DefaultHistoryReferencesTableEntry;
 
+@SuppressWarnings("serial")
 public class SearchResultsTableModel
         extends AbstractCustomColumnHistoryReferencesTableModel<
                 SearchResultsTableModel.SearchResultTableEntry>

--- a/zap/src/main/java/org/zaproxy/zap/extension/sessions/ContextSessionManagementPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/sessions/ContextSessionManagementPanel.java
@@ -43,6 +43,7 @@ import org.zaproxy.zap.view.AbstractContextPropertiesPanel;
 import org.zaproxy.zap.view.LayoutHelper;
 
 /** The Context Panel shown for configuring a Context's session management method. */
+@SuppressWarnings("serial")
 public class ContextSessionManagementPanel extends AbstractContextPropertiesPanel {
 
     /** The Constant PANEL NAME. */

--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/DialogAddDomainAlwaysInScope.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/DialogAddDomainAlwaysInScope.java
@@ -33,6 +33,7 @@ import org.zaproxy.zap.spider.DomainAlwaysInScopeMatcher;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 class DialogAddDomainAlwaysInScope extends AbstractFormDialog {
 
     private static final long serialVersionUID = -7356390753317082681L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/DomainsAlwaysInScopeTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/DomainsAlwaysInScopeTableModel.java
@@ -25,6 +25,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.spider.DomainAlwaysInScopeMatcher;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+@SuppressWarnings("serial")
 class DomainsAlwaysInScopeTableModel
         extends AbstractMultipleOptionsTableModel<DomainAlwaysInScopeMatcher> {
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/PopupMenuItemSpiderDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/PopupMenuItemSpiderDialog.java
@@ -30,6 +30,7 @@ import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
  *
  * @see org.zaproxy.zap.extension.spider.ExtensionSpider#showSpiderDialog(SiteNode)
  */
+@SuppressWarnings("serial")
 public class PopupMenuItemSpiderDialog extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderDialog.java
@@ -44,6 +44,7 @@ import org.zaproxy.zap.spider.filters.HttpPrefixFetchFilter;
 import org.zaproxy.zap.users.User;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class SpiderDialog extends StandardFieldsDialog {
 
     private static final String FIELD_START = "spider.custom.label.start";

--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderMessagesTable.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderMessagesTable.java
@@ -39,6 +39,7 @@ import org.parosproxy.paros.model.HistoryReference;
 import org.zaproxy.zap.extension.spider.SpiderMessagesTableModel.ProcessedCellItem;
 import org.zaproxy.zap.view.table.HistoryReferencesTable;
 
+@SuppressWarnings("serial")
 class SpiderMessagesTable extends HistoryReferencesTable {
 
     private static final long serialVersionUID = -1910120966638329368L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderMessagesTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderMessagesTableModel.java
@@ -38,6 +38,7 @@ import org.zaproxy.zap.view.table.AbstractCustomColumnHistoryReferencesTableMode
 import org.zaproxy.zap.view.table.AbstractHistoryReferencesTableEntry;
 import org.zaproxy.zap.view.table.DefaultHistoryReferencesTableEntry;
 
+@SuppressWarnings("serial")
 class SpiderMessagesTableModel
         extends AbstractCustomColumnHistoryReferencesTableModel<
                 SpiderMessagesTableModel.SpiderTableEntry> {

--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderPanel.java
@@ -61,6 +61,7 @@ import org.zaproxy.zap.view.table.decorator.AbstractTableCellItemIconHighlighter
  * The Class SpiderPanel implements the Panel that is shown to the users when selecting the Spider
  * Scan Tab.
  */
+@SuppressWarnings("serial")
 public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderScan>>
         implements ScanListenner2 {
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderPanelTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/SpiderPanelTableModel.java
@@ -25,6 +25,7 @@ import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 
 /** The Class HttpSessionsTableModel that is used as a TableModel for the Http Sessions Panel. */
+@SuppressWarnings("serial")
 public class SpiderPanelTableModel extends AbstractTableModel {
 
     /** The Constant serialVersionUID. */

--- a/zap/src/main/java/org/zaproxy/zap/extension/stats/StatsdClient.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stats/StatsdClient.java
@@ -107,7 +107,7 @@ public class StatsdClient extends TimerTask {
 	}
 
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     // XXX Deprecated in Java 9, use Cleaner instead?
     protected void finalize() {
             flush();

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupContextMenuItemFactory.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupContextMenuItemFactory.java
@@ -29,6 +29,7 @@ import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.model.Context;
 
+@SuppressWarnings("serial")
 public abstract class PopupContextMenuItemFactory extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 2282358266003940700L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupContextMenuItemHolder.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupContextMenuItemHolder.java
@@ -36,6 +36,7 @@ import org.zaproxy.zap.view.popup.PopupMenuItemContext;
  * PopupMenuItemContext}. Depending on the initialization, it can be shown by itself containing the
  * Popup Menus for each Context or it can just place the Popup Menus in its parent.
  */
+@SuppressWarnings("serial")
 public abstract class PopupContextMenuItemHolder extends ExtensionPopupMenuMessageContainer {
 
     /** The Constant serialVersionUID. */

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupContextTreeMenu.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupContextTreeMenu.java
@@ -31,6 +31,7 @@ import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.SiteMapPanel;
 import org.zaproxy.zap.model.Target;
 
+@SuppressWarnings("serial")
 public class PopupContextTreeMenu extends ExtensionPopupMenuItem {
     private static final long serialVersionUID = 1L;
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanCustom.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanCustom.java
@@ -27,6 +27,7 @@ import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuActiveScanCustom extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanNode.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanNode.java
@@ -27,6 +27,7 @@ import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuActiveScanNode extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanScope.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanScope.java
@@ -27,6 +27,7 @@ import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuActiveScanScope extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanSite.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanSite.java
@@ -27,6 +27,7 @@ import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuActiveScanSite extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanURL.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuActiveScanURL.java
@@ -27,6 +27,7 @@ import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuActiveScanURL extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuResendMessage.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuResendMessage.java
@@ -26,6 +26,7 @@ import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
 /** @deprecated (2.12.0) Replaced by Requester add-on. */
 @Deprecated
+@SuppressWarnings("serial")
 public class PopupMenuResendMessage extends PopupMenuItemHttpMessageContainer {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuShowInHistory.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuShowInHistory.java
@@ -24,6 +24,7 @@ import org.parosproxy.paros.model.HistoryReference;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuShowInHistory extends PopupMenuItemHistoryReferenceContainer {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupUserMenu.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupUserMenu.java
@@ -26,6 +26,7 @@ import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
 
 /** The PopupMenu corresponding to a User valid in a Context. */
+@SuppressWarnings("serial")
 public abstract class PopupUserMenu extends PopupMenuItemSiteNodeContainer {
 
     /** The Constant serialVersionUID. */

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupUserMenuItemHolder.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupUserMenuItemHolder.java
@@ -40,6 +40,7 @@ import org.zaproxy.zap.view.popup.ExtensionPopupMenuMessageContainer;
  * Depending on the initialization, it can be shown by itself containing the Popup Menus for each
  * User or it can just place the Popup Menus in its parent.
  */
+@SuppressWarnings("serial")
 public abstract class PopupUserMenuItemHolder extends ExtensionPopupMenuMessageContainer {
 
     /** The Constant serialVersionUID. */

--- a/zap/src/main/java/org/zaproxy/zap/extension/users/ContextUsersPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/users/ContextUsersPanel.java
@@ -34,6 +34,7 @@ import org.zaproxy.zap.view.AbstractContextPropertiesPanel;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTablePanel;
 import org.zaproxy.zap.view.LayoutHelper;
 
+@SuppressWarnings("serial")
 public class ContextUsersPanel extends AbstractContextPropertiesPanel {
 
     private UsersMultipleOptionsPanel usersOptionsPanel;
@@ -78,6 +79,7 @@ public class ContextUsersPanel extends AbstractContextPropertiesPanel {
         return "ui.dialogs.contexts";
     }
 
+    @SuppressWarnings("serial")
     public static class UsersMultipleOptionsPanel extends AbstractMultipleOptionsTablePanel<User> {
 
         private static final long serialVersionUID = -7216673905642941770L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/users/DialogAddUser.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/users/DialogAddUser.java
@@ -41,6 +41,7 @@ import org.zaproxy.zap.view.AbstractFormDialog;
 import org.zaproxy.zap.view.LayoutHelper;
 
 /** The Dialog for adding and configuring a new {@link User}. */
+@SuppressWarnings("serial")
 public class DialogAddUser extends AbstractFormDialog {
 
     /** The Constant serialVersionUID. */

--- a/zap/src/main/java/org/zaproxy/zap/extension/users/UsersTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/users/UsersTableModel.java
@@ -27,6 +27,7 @@ import org.zaproxy.zap.users.User;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
 /** A table model for holding a set of Users, for a {@link Context}. */
+@SuppressWarnings("serial")
 public class UsersTableModel extends AbstractMultipleOptionsTableModel<User> {
 
     /** The Constant defining the table column names. */

--- a/zap/src/main/java/org/zaproxy/zap/session/ScriptBasedSessionManagementMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/session/ScriptBasedSessionManagementMethodType.java
@@ -263,6 +263,7 @@ public class ScriptBasedSessionManagementMethodType extends SessionManagementMet
         return method instanceof ScriptBasedSessionManagementMethod;
     }
 
+    @SuppressWarnings("serial")
     public static class ScriptBasedSessionManagementMethodOptionsPanel
             extends AbstractSessionManagementMethodOptionsPanel {
 

--- a/zap/src/main/java/org/zaproxy/zap/utils/PagingTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/PagingTableModel.java
@@ -58,6 +58,7 @@ import org.apache.logging.log4j.Logger;
  * @see javax.swing.JTable
  * @see javax.swing.JScrollPane
  */
+@SuppressWarnings("serial")
 public abstract class PagingTableModel<T> extends AbstractTableModel {
     private static final long serialVersionUID = -6353414328926478100L;
 

--- a/zap/src/main/java/org/zaproxy/zap/view/BackgroundImagePanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/BackgroundImagePanel.java
@@ -32,6 +32,7 @@ import javax.swing.JPanel;
 import org.zaproxy.zap.utils.DisplayUtils;
 
 /** @author yhawke (2014) */
+@SuppressWarnings("serial")
 public class BackgroundImagePanel extends JPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/view/ContextListTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ContextListTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 
+@SuppressWarnings("serial")
 public class ContextListTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/view/ContextStructurePanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ContextStructurePanel.java
@@ -43,6 +43,7 @@ import org.zaproxy.zap.model.StandardParameterParser;
 import org.zaproxy.zap.model.StructuralNodeModifier;
 import org.zaproxy.zap.utils.ZapTextField;
 
+@SuppressWarnings("serial")
 public class ContextStructurePanel extends AbstractContextPropertiesPanel {
 
     private static final String PANEL_NAME = Constant.messages.getString("context.struct.title");

--- a/zap/src/main/java/org/zaproxy/zap/view/DynamicFieldsPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/DynamicFieldsPanel.java
@@ -30,6 +30,7 @@ import javax.swing.JPanel;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.utils.ZapTextField;
 
+@SuppressWarnings("serial")
 public class DynamicFieldsPanel extends JPanel {
 
     private static final String[] NO_FIELDS = new String[0];

--- a/zap/src/main/java/org/zaproxy/zap/view/HighlighterManager.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/HighlighterManager.java
@@ -130,6 +130,7 @@ public class HighlighterManager {
         void highlighterChanged(HighlighterManagerEvent e);
     }
 
+    @SuppressWarnings("serial")
     public static final class HighlighterManagerEvent extends EventObject {
 
         private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/view/LocaleDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/LocaleDialog.java
@@ -33,6 +33,7 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
 import org.zaproxy.zap.extension.option.OptionsLocalePanel;
 
+@SuppressWarnings("serial")
 public class LocaleDialog extends AbstractDialog {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/view/MultipleOptionsTablePanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/MultipleOptionsTablePanel.java
@@ -34,6 +34,7 @@ import org.jdesktop.swingx.JXTreeTable;
 import org.jdesktop.swingx.VerticalLayout;
 import org.jdesktop.swingx.treetable.TreeTableModel;
 
+@SuppressWarnings("serial")
 public class MultipleOptionsTablePanel extends JPanel {
 
     private static final long serialVersionUID = 5282581470011033565L;

--- a/zap/src/main/java/org/zaproxy/zap/view/MultipleRegexesOptionsPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/MultipleRegexesOptionsPanel.java
@@ -51,6 +51,7 @@ import org.zaproxy.zap.view.widgets.WritableFileChooser;
  *
  * @since 2.5.0
  */
+@SuppressWarnings("serial")
 public class MultipleRegexesOptionsPanel extends AbstractMultipleOptionsBaseTablePanel<String> {
 
     private static final long serialVersionUID = 1041782873016590998L;

--- a/zap/src/main/java/org/zaproxy/zap/view/NodeSelectDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/NodeSelectDialog.java
@@ -47,6 +47,7 @@ import org.zaproxy.zap.utils.DisplayUtils;
  *
  * @author psiinon
  */
+@SuppressWarnings("serial")
 public class NodeSelectDialog extends AbstractDialog {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/view/OverlayIcon.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/OverlayIcon.java
@@ -30,6 +30,7 @@ import javax.swing.ImageIcon;
  *
  * @author psiinon
  */
+@SuppressWarnings("serial")
 public class OverlayIcon extends ImageIcon {
     private static final long serialVersionUID = 1L;
     private ImageIcon base;

--- a/zap/src/main/java/org/zaproxy/zap/view/ProxyDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ProxyDialog.java
@@ -34,6 +34,7 @@ import org.parosproxy.paros.model.OptionsParam;
 
 /** @deprecated (2.12.0) No longer in use. */
 @Deprecated
+@SuppressWarnings("serial")
 public class ProxyDialog extends AbstractDialog {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/view/ScanPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ScanPanel.java
@@ -62,6 +62,7 @@ import org.zaproxy.zap.users.User;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.SortedComboBoxModel;
 
+@SuppressWarnings("serial")
 public abstract class ScanPanel extends AbstractPanel {
     private static final long serialVersionUID = 1L;
 

--- a/zap/src/main/java/org/zaproxy/zap/view/ScanPanel2.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ScanPanel2.java
@@ -55,6 +55,7 @@ import org.zaproxy.zap.utils.SortedComboBoxModel;
  * This is a cleaner version of ScanPanel which doesn't mix functionality and the UI.
  * Implemented as a new set of classes for backwards compatibility with existing add-ons
  */
+@SuppressWarnings("serial")
 public abstract class ScanPanel2<GS extends GenericScanner2, SC extends ScanController<GS>>
         extends AbstractPanel {
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/view/SingleColumnTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/SingleColumnTableModel.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import javax.swing.table.AbstractTableModel;
 
+@SuppressWarnings("serial")
 public class SingleColumnTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/view/SiteMapTreeCellRenderer.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/SiteMapTreeCellRenderer.java
@@ -42,6 +42,7 @@ import org.zaproxy.zap.utils.DisplayUtils;
  * you have to enable them via: <code>ToolTipManager.sharedInstance().registerComponent(tree);
  * </code>
  */
+@SuppressWarnings("serial")
 public class SiteMapTreeCellRenderer extends DefaultTreeCellRenderer {
 
     private static final ImageIcon ROOT_ICON =

--- a/zap/src/main/java/org/zaproxy/zap/view/SplashScreen.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/SplashScreen.java
@@ -61,6 +61,7 @@ import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.utils.ZapTextArea;
 
+@SuppressWarnings("serial")
 public class SplashScreen extends JFrame {
 
     private static final String TIPS_PREFIX = "tips";

--- a/zap/src/main/java/org/zaproxy/zap/view/StandardFieldsDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/StandardFieldsDialog.java
@@ -80,6 +80,7 @@ import org.zaproxy.zap.view.widgets.ContextSelectComboBox;
  *
  * @author psiinon
  */
+@SuppressWarnings("serial")
 public abstract class StandardFieldsDialog extends AbstractDialog {
 
     private static final Logger logger = LogManager.getLogger(StandardFieldsDialog.class);

--- a/zap/src/main/java/org/zaproxy/zap/view/StructuralNodeModifiersTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/StructuralNodeModifiersTableModel.java
@@ -30,6 +30,7 @@ import org.zaproxy.zap.model.StructuralNodeModifier;
  *
  * @since 2.4.3
  */
+@SuppressWarnings("serial")
 public class StructuralNodeModifiersTableModel
         extends AbstractMultipleOptionsTableModel<StructuralNodeModifier> {
 

--- a/zap/src/main/java/org/zaproxy/zap/view/TabbedPanel2.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/TabbedPanel2.java
@@ -50,6 +50,7 @@ import org.zaproxy.zap.utils.DisplayUtils;
  *
  * @since 2.2.0
  */
+@SuppressWarnings("serial")
 public class TabbedPanel2 extends TabbedPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/view/ZapTable.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ZapTable.java
@@ -63,6 +63,7 @@ import org.zaproxy.zap.utils.TableExportAction;
  * @see #setComponentPopupMenu(JPopupMenu)
  * @see #setAutoScrollOnNewValues(boolean)
  */
+@SuppressWarnings("serial")
 public class ZapTable extends JXTable {
 
     private static final long serialVersionUID = 8303870012122236918L;
@@ -315,6 +316,7 @@ public class ZapTable extends JXTable {
         return new ZapColumnControlButton(this);
     }
 
+    @SuppressWarnings("serial")
     protected static class ZapColumnControlButton extends ColumnControlButton {
 
         private static final long serialVersionUID = -2888568545235496369L;

--- a/zap/src/main/java/org/zaproxy/zap/view/ZapToggleButton.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ZapToggleButton.java
@@ -34,6 +34,7 @@ import javax.swing.JToggleButton;
  * @see #setDisabledToolTipText(String)
  * @see #setDisabledSelectedToolTipText(String)
  */
+@SuppressWarnings("serial")
 public class ZapToggleButton extends JToggleButton {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/view/messagelocation/AbstractMessageLocationsPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/messagelocation/AbstractMessageLocationsPanel.java
@@ -47,6 +47,7 @@ import org.zaproxy.zap.view.AbstractMultipleOptionsBaseTablePanel;
  * @see MessageLocationTableEntry
  * @see MessageLocationsTableModel
  */
+@SuppressWarnings("serial")
 public abstract class AbstractMessageLocationsPanel<
                 T extends MessageLocationTableEntry, S extends MessageLocationsTableModel<T>>
         extends AbstractMultipleOptionsBaseTablePanel<T> {

--- a/zap/src/main/java/org/zaproxy/zap/view/messagelocation/HighlightChangedEvent.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/messagelocation/HighlightChangedEvent.java
@@ -29,6 +29,7 @@ import java.util.EventObject;
  * @see HighlightChangedEvent
  * @see MessageLocationHighlight
  */
+@SuppressWarnings("serial")
 public class HighlightChangedEvent<T> extends EventObject {
 
     private static final long serialVersionUID = 2706344550718757343L;

--- a/zap/src/main/java/org/zaproxy/zap/view/messagelocation/MessageLocationsTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/messagelocation/MessageLocationsTableModel.java
@@ -34,6 +34,7 @@ import org.zaproxy.zap.view.AbstractMultipleOptionsBaseTableModel;
  * @see AbstractMultipleOptionsBaseTableModel
  * @see MessageLocationTableEntry
  */
+@SuppressWarnings("serial")
 public class MessageLocationsTableModel<T extends MessageLocationTableEntry>
         extends AbstractMultipleOptionsBaseTableModel<T> {
 

--- a/zap/src/main/java/org/zaproxy/zap/view/messagelocation/SelectMessageLocationsPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/messagelocation/SelectMessageLocationsPanel.java
@@ -40,6 +40,7 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
  * @see MessageLocationProducer
  * @see MessageLocationHighlighter
  */
+@SuppressWarnings("serial")
 public class SelectMessageLocationsPanel extends HttpPanel
         implements MessageLocationProducer, MessageLocationHighlighter {
 

--- a/zap/src/main/java/org/zaproxy/zap/view/messagelocation/TextMessageLocationHighlightRenderer.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/messagelocation/TextMessageLocationHighlightRenderer.java
@@ -35,6 +35,7 @@ import javax.swing.table.TableCellRenderer;
  * @see TextMessageLocationHighlight
  * @see TextMessageLocationHighlightEditor
  */
+@SuppressWarnings("serial")
 public class TextMessageLocationHighlightRenderer extends JLabel implements TableCellRenderer {
 
     private static final long serialVersionUID = -2552011824130705284L;

--- a/zap/src/main/java/org/zaproxy/zap/view/panels/AbstractScanToolbarStatusPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/panels/AbstractScanToolbarStatusPanel.java
@@ -60,6 +60,7 @@ import org.zaproxy.zap.view.ZapToggleButton;
  * @see BaseScannerThreadManager
  * @see ScanStartOptions
  */
+@SuppressWarnings("serial")
 public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSelectToolbarStatusPanel
         implements ScanListener {
 

--- a/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemContext.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemContext.java
@@ -24,6 +24,7 @@ import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 
 /** @since 2.3.0 */
+@SuppressWarnings("serial")
 public abstract class PopupMenuItemContext extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 2282358266003940700L;

--- a/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemContextDataDriven.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemContextDataDriven.java
@@ -31,6 +31,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.model.Context;
 
 /** @since 2.4.3 */
+@SuppressWarnings("serial")
 public class PopupMenuItemContextDataDriven extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 3790264690466717219L;

--- a/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemContextDataDrivenNode.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemContextDataDrivenNode.java
@@ -31,6 +31,7 @@ import org.zaproxy.zap.model.StructuralNodeModifier;
 import org.zaproxy.zap.view.ContextStructurePanel;
 
 /** @since 2.4.3 */
+@SuppressWarnings("serial")
 public class PopupMenuItemContextDataDrivenNode extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 990419495607725846L;

--- a/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemContextExclude.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemContextExclude.java
@@ -31,6 +31,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.model.Context;
 
 /** @since 2.3.0 */
+@SuppressWarnings("serial")
 public class PopupMenuItemContextExclude extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 2282358266003940700L;

--- a/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemContextInclude.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemContextInclude.java
@@ -31,6 +31,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.model.Context;
 
 /** @since 2.3.0 */
+@SuppressWarnings("serial")
 public class PopupMenuItemContextInclude extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 3790264690466717219L;

--- a/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemExcludeFromContext.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemExcludeFromContext.java
@@ -32,6 +32,7 @@ import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.view.ContextExcludePanel;
 
 /** @since 2.3.0 */
+@SuppressWarnings("serial")
 public class PopupMenuItemExcludeFromContext extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 2766535157899537709L;

--- a/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemHttpMessageContainer.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemHttpMessageContainer.java
@@ -47,6 +47,7 @@ import org.zaproxy.zap.view.messagecontainer.http.SingleHttpMessageContainer;
  * @see HttpMessageContainer
  * @see #isEnableForMessageContainer(MessageContainer)
  */
+@SuppressWarnings("serial")
 public abstract class PopupMenuItemHttpMessageContainer
         extends ExtensionPopupMenuItemMessageContainer {
 

--- a/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemIncludeInContext.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemIncludeInContext.java
@@ -32,6 +32,7 @@ import org.zaproxy.zap.model.StructuralSiteNode;
 import org.zaproxy.zap.view.ContextIncludePanel;
 
 /** @since 2.3.0 */
+@SuppressWarnings("serial")
 public class PopupMenuItemIncludeInContext extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 990419495607725846L;

--- a/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemSiteNodeContextMenuFactory.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemSiteNodeContextMenuFactory.java
@@ -30,6 +30,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.model.Context;
 
 /** @since 2.3.0 */
+@SuppressWarnings("serial")
 public abstract class PopupMenuItemSiteNodeContextMenuFactory
         extends PopupMenuItemSiteNodeContainer {
 

--- a/zap/src/main/java/org/zaproxy/zap/view/table/AbstractCustomColumnHistoryReferencesTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/table/AbstractCustomColumnHistoryReferencesTableModel.java
@@ -29,6 +29,7 @@ import java.util.TreeMap;
  *
  * @param <T> the type of table model entries
  */
+@SuppressWarnings("serial")
 public abstract class AbstractCustomColumnHistoryReferencesTableModel<
                 T extends HistoryReferencesTableEntry>
         extends AbstractHistoryReferencesTableModel<T> {

--- a/zap/src/main/java/org/zaproxy/zap/view/table/AbstractHistoryReferencesTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/table/AbstractHistoryReferencesTableModel.java
@@ -32,6 +32,7 @@ import org.parosproxy.paros.Constant;
  *
  * @param <T> the type of table model entries
  */
+@SuppressWarnings("serial")
 public abstract class AbstractHistoryReferencesTableModel<T extends HistoryReferencesTableEntry>
         extends AbstractTableModel implements HistoryReferencesTableModel<T> {
 

--- a/zap/src/main/java/org/zaproxy/zap/view/table/DefaultHistoryReferencesTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/table/DefaultHistoryReferencesTableModel.java
@@ -33,6 +33,7 @@ import org.parosproxy.paros.model.HistoryReference;
  *
  * @see HistoryReferencesTableModel
  */
+@SuppressWarnings("serial")
 public class DefaultHistoryReferencesTableModel
         extends AbstractHistoryReferencesTableModel<DefaultHistoryReferencesTableEntry> {
 

--- a/zap/src/main/java/org/zaproxy/zap/view/table/HistoryReferencesTable.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/table/HistoryReferencesTable.java
@@ -68,6 +68,7 @@ import org.zaproxy.zap.view.table.decorator.NoteTableCellItemIconHighlighter;
  * A table specialised in showing data from {@code HistoryReference}s obtained from {@code
  * HistoryReferencesTableModel}s.
  */
+@SuppressWarnings("serial")
 public class HistoryReferencesTable extends ZapTable {
 
     private static final long serialVersionUID = -6988769961088738602L;

--- a/zap/src/main/java/org/zaproxy/zap/view/widgets/PopupButton.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/widgets/PopupButton.java
@@ -31,6 +31,7 @@ import javax.swing.JPopupMenu;
 /**
  * A button that shows a dynamic popup menu when pressed. The menu items can be changed as required.
  */
+@SuppressWarnings("serial")
 public abstract class PopupButton extends JButton {
     private static final long serialVersionUID = 1L;
     private ActionListener actionListener;

--- a/zap/src/main/java/org/zaproxy/zap/view/widgets/UsersListModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/widgets/UsersListModel.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang.ArrayUtils;
 import org.zaproxy.zap.extension.users.UsersTableModel;
 import org.zaproxy.zap.users.User;
 
+@SuppressWarnings("serial")
 class UsersListModel extends AbstractListModel<User> implements ComboBoxModel<User> {
 
     private static final long serialVersionUID = 5648260449088479312L;

--- a/zap/src/main/java/org/zaproxy/zap/view/widgets/UsersMultiSelectTable.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/widgets/UsersMultiSelectTable.java
@@ -36,6 +36,7 @@ import org.zaproxy.zap.users.User;
  * <p><strong>NOTE:</strong> Does not automatically refresh when the Users have changed. For this,
  * make sure you manually call {@link #reloadUsers(int)}.
  */
+@SuppressWarnings("serial")
 public class UsersMultiSelectTable extends JTable {
 
     private static final long serialVersionUID = 7473652413044348214L;

--- a/zap/src/test/java/org/zaproxy/zap/view/AbstractMultipleOptionsBaseTableModelUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/view/AbstractMultipleOptionsBaseTableModelUnitTest.java
@@ -136,6 +136,7 @@ class AbstractMultipleOptionsBaseTableModelUnitTest extends TableModelTestUtils 
         assertThat(listener.isDataChanged(), is(equalTo(true)));
     }
 
+    @SuppressWarnings("serial")
     private static class MultipleOptionsBaseTableModelImpl
             extends AbstractMultipleOptionsBaseTableModel<Object> {
 

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -49,6 +49,10 @@ crowdin {
     }
 }
 
+jacoco {
+    toolVersion = "0.8.8"
+}
+
 tasks.named<JacocoReport>("jacocoTestReport") {
     reports {
         xml.required.set(true)


### PR DESCRIPTION
Suppress the serialisation warnings in UI related classes, they are not
expected to be serialised.
Update JaCoCo to latest version which fully supports Java 18.

Part of #7389.