### PR TITLE
Use rendered content when finding plain URLs

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderHtmlParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderHtmlParser.java
@@ -307,7 +307,9 @@ public class SpiderHtmlParser extends SpiderParser {
         for (String tag : elementsWithText) {
             elements = source.getAllElements(tag);
             for (Element el : elements) {
-                Matcher matcher = INLINE_CONTENT_URL_PATTERN.matcher(el.getContent().toString());
+                Matcher matcher =
+                        INLINE_CONTENT_URL_PATTERN.matcher(
+                                el.getContent().getRenderer().setMaxLineLength(0).toString());
                 while (matcher.find()) {
                     String foundMatch = matcher.group().trim();
                     if (baseTagSet) {

--- a/zap/src/test/resources/org/zaproxy/zap/spider/parser/html/StringSpiderHtmlParser.html
+++ b/zap/src/test/resources/org/zaproxy/zap/spider/parser/html/StringSpiderHtmlParser.html
@@ -11,5 +11,7 @@
 <p>The test contains an inline string - /with/base/tag</p>
 <p>The test contains an inline string - //meta.example.com:8443/inline/string/scheme</p>
 
+<p>No URLs <strong>here</strong>.</p>
+
 </body>
 </html>


### PR DESCRIPTION
Render the content to remove the HTML tags the elements might have,
which could match a URL (e.g. `/a` would be found in `</a>`).

---
Thanks to the integration tests and someone that was looking at them ;)