### PR TITLE
Update Sites Tree Restructuring Logic

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/model/Session.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/Session.java
@@ -89,6 +89,7 @@
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/02/09 Remove code no longer needed and deprecate a method.
 // ZAP: 2022/02/28 Remove code deprecated in 2.6.0
+// ZAP: 2022/08/12 Use SiteMap#createTree to create a new Sites Tree when loading a session.
 package org.parosproxy.paros.model;
 
 import java.awt.EventQueue;
@@ -309,8 +310,7 @@ public class Session {
         }
 
         if (!Constant.isLowMemoryOptionSet()) {
-            SiteNode newRoot = new SiteNode(siteTree, -1, Constant.messages.getString("tab.sites"));
-            siteTree.setRoot(newRoot);
+            siteTree = SiteMap.createTree(model);
         }
 
         // update history reference

--- a/zap/src/main/java/org/parosproxy/paros/model/SiteMap.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/SiteMap.java
@@ -75,6 +75,7 @@
 // ZAP: 2022/07/27 Use hrefMap to return early from addPath and findAndAddChild. Remove getHostName
 // and use SessionStructure#getHostName in its place.
 // ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
+// ZAP: 2022/08/12 Make hrefMap an instance variable.
 package org.parosproxy.paros.model;
 
 import java.awt.EventQueue;
@@ -114,7 +115,7 @@ public class SiteMap extends SortedTreeModel {
         REMOVE
     }
 
-    private static Map<Integer, SiteNode> hrefMap = new HashMap<>();
+    private final Map<Integer, SiteNode> hrefMap;
 
     private Model model = null;
 
@@ -127,13 +128,13 @@ public class SiteMap extends SortedTreeModel {
         SiteMap siteMap = new SiteMap(null, model);
         SiteNode root = new SiteNode(siteMap, -1, Constant.messages.getString("tab.sites"));
         siteMap.setRoot(root);
-        hrefMap = new HashMap<>();
         return siteMap;
     }
 
     public SiteMap(SiteNode root, Model model) {
         super(root);
         this.model = model;
+        this.hrefMap = new HashMap<>();
     }
 
     /**


### PR DESCRIPTION
Also fix a bug introduced in #7394 where loading 2 sessions back to back resulted in the second session having no sites tree.
It was happening because `hrefMap` was not being cleared upon loading a session.