### PR TITLE
Install/update add-ons first in automation

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/CommandLineListener.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/CommandLineListener.java
@@ -25,6 +25,7 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2022/05/02 Document usage of ShutdownRequestedException.
+// ZAP: 2022/08/17 Added preExecute.
 package org.parosproxy.paros.extension;
 
 import java.io.File;
@@ -33,12 +34,22 @@ import org.zaproxy.zap.ShutdownRequestedException;
 
 public interface CommandLineListener {
     /**
-     * execute the command line using the argument provided.
+     * Execute the command line using the argument provided.
      *
      * @param args the command line arguments
      * @throws ShutdownRequestedException (since 2.12.0) if ZAP should shutdown immediately.
      */
     void execute(CommandLineArgument[] args);
+
+    /**
+     * Execute any command line args that need to be run before the others. This should typically
+     * only be done by specific core add-ons, such as ExtensionAutoUpdate.
+     *
+     * @since 2.12.0
+     * @param args the command line arguments
+     * @throws ShutdownRequestedException if ZAP should shutdown immediately.
+     */
+    default void preExecute(CommandLineArgument[] args) {}
 
     /**
      * Handle the specified file (in whatever way is appropriate). This will only be called for

--- a/zap/src/main/java/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -992,6 +992,8 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
     @Override
     public void destroy() {
         super.destroy();
-        this.getHistoryReferencesTable().persistColumnConfiguration();
+        if (hasView()) {
+            this.getHistoryReferencesTable().persistColumnConfiguration();
+        }
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/DaemonBootstrap.java
+++ b/zap/src/main/java/org/zaproxy/zap/DaemonBootstrap.java
@@ -84,6 +84,8 @@ class DaemonBootstrap extends HeadlessBootstrap {
                                     return;
                                 }
 
+                                HeadlessBootstrap.checkForUpdates();
+
                                 try {
                                     // Allow extensions to pick up command line args in daemon mode
                                     control.getExtensionLoader().hookCommandLineListener(getArgs());
@@ -95,8 +97,6 @@ class DaemonBootstrap extends HeadlessBootstrap {
                                 } catch (Exception e) {
                                     logger.error(e.getMessage(), e);
                                 }
-
-                                HeadlessBootstrap.checkForUpdates();
 
                                 // This is the only non-daemon thread, so should keep running
                                 // CoreAPI.handleApiAction uses System.exit to shutdown

--- a/zap/src/test/java/org/parosproxy/paros/CommandLineUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/CommandLineUnitTest.java
@@ -253,6 +253,19 @@ class CommandLineUnitTest {
     }
 
     @Test
+    void shouldNotFailIfGivenUnsupportedArgumentAndNotReportUnsupported() throws Exception {
+        // Given
+        cmdLine = new CommandLine(new String[] {"-unsupported"});
+        // When / Then
+        assertDoesNotThrow(
+                () ->
+                        cmdLine.parse(
+                                NO_EXTENSIONS_CUSTOM_ARGUMENTS,
+                                NO_SUPPORTED_FILE_EXTENSIONS,
+                                false));
+    }
+
+    @Test
     void claWithoutArgs() throws Exception {
         cmdLine = new CommandLine(new String[] {"-a", "-b"});
         Vector<CommandLineArgument[]> customArguments = new Vector<>();

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -235,6 +235,7 @@ val japicmp by tasks.registering(JapicmpTask::class) {
         "org.parosproxy.paros.db.paros.ParosTableHistory#unsetHistoryTypeAsTemporary(int)",
         "org.parosproxy.paros.db.RecordAlert#getReliability()",
         "org.parosproxy.paros.db.RecordAlert#setReliability(int)",
+        "org.parosproxy.paros.extension.CommandLineListener#preExecute(org.parosproxy.paros.extension.CommandLineArgument[])",
         "org.parosproxy.paros.extension.ExtensionPopupMenuItem#isSuperMenu()",
         "org.parosproxy.paros.extension.history.ExtensionHistory#clearLogPanelDisplayQueue()",
         "org.parosproxy.paros.extension.history.LogPanel#clearDisplayQueue()",


### PR DESCRIPTION
Always install / update add-ons synchronously in cmdline / daemon modes before running any other command line args.
The GUI will still act as know, updating add-ons in the background.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>