### PR TITLE
Do not attempt to load extension with errors

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnLoader.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnLoader.java
@@ -574,9 +574,11 @@ public class AddOnLoader extends URLClassLoader {
                         Extension ext =
                                 loadAddOnExtension(
                                         runningAddOn, extReqs.getClassname(), extAddOnClassLoader);
-                        AddOnInstaller.installAddOnExtension(runningAddOn, ext);
-                        runnableAddOns.get(runningAddOn).add(extReqs.getClassname());
-                        changed = true;
+                        if (ext != null) {
+                            AddOnInstaller.installAddOnExtension(runningAddOn, ext);
+                            runnableAddOns.get(runningAddOn).add(extReqs.getClassname());
+                            changed = true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Add null check as the extension is null if there were errors loading
it.