### PR TITLE
Disable use of cached history references

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/model/SiteMap.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/SiteMap.java
@@ -479,8 +479,10 @@ public class SiteMap extends SortedTreeModel {
     }
 
     private boolean isReferenceCached(HistoryReference ref) {
-        return ref.getHistoryType() != HistoryReference.TYPE_TEMPORARY
-                && hrefMap.containsKey(ref.getHistoryId());
+        // FIXME Use of cache leads to missing alerts in the tree nodes.
+        // return ref.getHistoryType() != HistoryReference.TYPE_TEMPORARY
+        //        && hrefMap.containsKey(ref.getHistoryId());
+        return false;
     }
 
     private SiteNode findAndAddChild(

--- a/zap/src/test/java/org/parosproxy/paros/model/SiteMapUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/model/SiteMapUnitTest.java
@@ -238,7 +238,7 @@ class SiteMapUnitTest {
     }
 
     @Test
-    void shouldReturnCachedHistoryReference() throws Exception {
+    void shouldNotReturnCachedHistoryReference() throws Exception {
         // Given
         String uri = "http://example.com";
         HistoryReference href = createHistoryReference(uri);
@@ -249,7 +249,7 @@ class SiteMapUnitTest {
         siteMap.addPath(href);
         siteMap.addPath(href, href.getHttpMessage(), false);
         // Then
-        verify(session).getUrlParamParser(anyString());
+        verify(session, times(3)).getUrlParamParser(anyString());
     }
 
     @Test


### PR DESCRIPTION
The use of cache leads to missing alerts in the tree.