### PR TITLE
Handle invalid session paths

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/GuiBootstrap.java
+++ b/zap/src/main/java/org/zaproxy/zap/GuiBootstrap.java
@@ -249,10 +249,20 @@ public class GuiBootstrap extends ZapBootstrap {
                                             Constant.getZapHome()));
 
                         } else if (getArgs().isEnabled(CommandLine.SESSION)) {
-                            Path sessionPath =
-                                    SessionUtils.getSessionPath(
-                                            getArgs().getArgument(CommandLine.SESSION));
-                            if (!Files.exists(sessionPath)) {
+                            String path = getArgs().getArgument(CommandLine.SESSION);
+                            Path sessionPath = null;
+                            try {
+                                sessionPath = SessionUtils.getSessionPath(path);
+                            } catch (IllegalArgumentException e) {
+                                logger.warn(
+                                        "An error occurred while resolving the session path:", e);
+                            }
+
+                            if (sessionPath == null) {
+                                view.showWarningDialog(
+                                        Constant.messages.getString(
+                                                "start.gui.cmdline.session.path.invalid", path));
+                            } else if (!Files.exists(sessionPath)) {
                                 view.showWarningDialog(
                                         Constant.messages.getString(
                                                 "start.gui.cmdline.session.does.not.exist",
@@ -266,10 +276,20 @@ public class GuiBootstrap extends ZapBootstrap {
                             }
 
                         } else if (getArgs().isEnabled(CommandLine.NEW_SESSION)) {
-                            Path sessionPath =
-                                    SessionUtils.getSessionPath(
-                                            getArgs().getArgument(CommandLine.NEW_SESSION));
-                            if (Files.exists(sessionPath)) {
+                            String path = getArgs().getArgument(CommandLine.NEW_SESSION);
+                            Path sessionPath = null;
+                            try {
+                                sessionPath = SessionUtils.getSessionPath(path);
+                            } catch (IllegalArgumentException e) {
+                                logger.warn(
+                                        "An error occurred while resolving the session path:", e);
+                            }
+
+                            if (sessionPath == null) {
+                                view.showWarningDialog(
+                                        Constant.messages.getString(
+                                                "start.gui.cmdline.session.path.invalid", path));
+                            } else if (Files.exists(sessionPath)) {
                                 view.showWarningDialog(
                                         Constant.messages.getString(
                                                 "start.gui.cmdline.newsession.already.exist",

--- a/zap/src/main/java/org/zaproxy/zap/HeadlessBootstrap.java
+++ b/zap/src/main/java/org/zaproxy/zap/HeadlessBootstrap.java
@@ -87,9 +87,14 @@ abstract class HeadlessBootstrap extends ZapBootstrap {
         }
 
         if (getArgs().isEnabled(CommandLine.SESSION)) {
-            Path sessionPath =
-                    SessionUtils.getSessionPath(getArgs().getArgument(CommandLine.SESSION));
-
+            String path = getArgs().getArgument(CommandLine.SESSION);
+            Path sessionPath;
+            try {
+                sessionPath = SessionUtils.getSessionPath(path);
+            } catch (IllegalArgumentException e) {
+                System.err.println("Failed to open session, file path is not valid: " + path);
+                return false;
+            }
             String absolutePath = sessionPath.toAbsolutePath().toString();
             try {
                 control.runCommandLineOpenSession(absolutePath);
@@ -102,8 +107,15 @@ abstract class HeadlessBootstrap extends ZapBootstrap {
             }
 
         } else if (getArgs().isEnabled(CommandLine.NEW_SESSION)) {
-            Path sessionPath =
-                    SessionUtils.getSessionPath(getArgs().getArgument(CommandLine.NEW_SESSION));
+            String path = getArgs().getArgument(CommandLine.NEW_SESSION);
+            Path sessionPath;
+            try {
+                sessionPath = SessionUtils.getSessionPath(path);
+            } catch (IllegalArgumentException e) {
+                System.err.println(
+                        "Failed to create a new session, file path is not valid: " + path);
+                return false;
+            }
 
             String absolutePath = sessionPath.toAbsolutePath().toString();
             if (Files.exists(sessionPath)) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -545,7 +545,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 
         } else if (ACTION_SAVE_SESSION.equalsIgnoreCase(
                 name)) { // Ignore case for backwards compatibility
-            Path sessionPath = SessionUtils.getSessionPath(params.getString(PARAM_SESSION));
+            Path sessionPath = getSessionPath(params.getString(PARAM_SESSION));
             String filename = sessionPath.toAbsolutePath().toString();
 
             final boolean overwrite = getParam(params, PARAM_OVERWRITE_SESSION, false);
@@ -608,7 +608,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                 }
                 fileName += "-" + dateFormat.format(new Date()) + ".session";
             } else {
-                Path sessionPath = SessionUtils.getSessionPath(fileName);
+                Path sessionPath = getSessionPath(fileName);
                 fileName = sessionPath.toAbsolutePath().toString();
 
                 if (Files.exists(sessionPath)) {
@@ -649,7 +649,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 
         } else if (ACTION_LOAD_SESSION.equalsIgnoreCase(
                 name)) { // Ignore case for backwards compatibility
-            Path sessionPath = SessionUtils.getSessionPath(params.getString(PARAM_SESSION));
+            Path sessionPath = getSessionPath(params.getString(PARAM_SESSION));
             String filename = sessionPath.toAbsolutePath().toString();
 
             if (!Files.exists(sessionPath)) {
@@ -680,7 +680,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                     throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
                 }
             } else {
-                Path sessionPath = SessionUtils.getSessionPath(sessionName);
+                Path sessionPath = getSessionPath(sessionName);
                 String filename = sessionPath.toAbsolutePath().toString();
 
                 final boolean overwrite = getParam(params, PARAM_OVERWRITE_SESSION, false);
@@ -878,6 +878,14 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
             throw new ApiException(ApiException.Type.BAD_ACTION);
         }
         return ApiResponseElement.OK;
+    }
+
+    private static Path getSessionPath(String path) throws ApiException {
+        try {
+            return SessionUtils.getSessionPath(path);
+        } catch (IllegalArgumentException e) {
+            throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_SESSION, e);
+        }
     }
 
     private static ApiImplementor getNetworkImplementor() throws ApiException {

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -3084,6 +3084,7 @@ start.cmdline.noread		= File is not readable ''{0}''
 start.db.error      = Could not access database\nMaybe another ZAP process is running?\n
 start.gui.cmdline.invalid.session.options = Invalid command line session options:\noption ''{0}'' not allowed with option ''{1}''\n\nA new empty session will be created in {2}
 start.gui.cmdline.session.does.not.exist = Session given at command line does not exist.\n\nA new empty session will be created in {0}
+start.gui.cmdline.session.path.invalid = Session path given at command line is invalid:\n{0}
 start.gui.cmdline.newsession.already.exist = New session given at command line already exists.\n\nA new empty session will be created in {0}
 start.gui.dialog.fatal.error.title = Failed to start ZAP
 start.gui.dialog.fatal.error.message = A fatal error occurred that prevents ZAP from start.\nConsider reporting the error with following details:


### PR DESCRIPTION
Catch and handle the exception thrown when unable to create the session path.

Fix #7436.