### PR TITLE
Logging. Classes starting A and B. Format specifiers vs concatenation

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/common/AbstractParam.java
+++ b/zap/src/main/java/org/parosproxy/paros/common/AbstractParam.java
@@ -34,6 +34,7 @@
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
+// ZAP: 2022/09/08 Use format specifiers instead of concatenation when logging.
 package org.parosproxy.paros.common;
 
 import java.util.Map.Entry;
@@ -87,12 +88,10 @@ public abstract class AbstractParam implements Cloneable {
             if (overrides != null) {
                 for (Entry<String, String> entry : overrides.getOrderedConfigs().entrySet()) {
                     logger.info(
-                            "Setting config "
-                                    + entry.getKey()
-                                    + " = "
-                                    + entry.getValue()
-                                    + " was "
-                                    + config.getString(entry.getKey()));
+                            "Setting config {} = {} was {}",
+                            entry.getKey(),
+                            entry.getValue(),
+                            config.getString(entry.getKey()));
                     config.setProperty(entry.getKey(), entry.getValue());
                 }
             }
@@ -168,7 +167,7 @@ public abstract class AbstractParam implements Cloneable {
      * @since 2.7.0
      */
     protected static void logConversionException(String key, ConversionException e) {
-        logger.warn("Failed to read '" + key + "'", e);
+        logger.warn("Failed to read '{}'", key, e);
     }
 
     /**

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractAppParamPlugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractAppParamPlugin.java
@@ -41,6 +41,7 @@
 // ZAP: 2020/08/27 Moved variants into VariantFactory
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2021/06/16 Add support for updating multiple parameters in HttpMessage.
+// ZAP: 2022/09/08 Use format specifiers instead of concatenation when logging.
 package org.parosproxy.paros.core.scanner;
 
 import java.util.ArrayList;
@@ -87,8 +88,8 @@ public abstract class AbstractAppParamPlugin extends AbstractAppPlugin {
                 this.scan(this.variant.getParamList());
             } catch (Exception e) {
                 logger.error(
-                        "Error occurred while scanning with variant "
-                                + variant.getClass().getCanonicalName(),
+                        "Error occurred while scanning with variant {}",
+                        variant.getClass().getCanonicalName(),
                         e);
             }
 

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -73,6 +73,7 @@
 // ZAP: 2022/06/11 Add functionality for custom pages AUTHN/AUTHZ handling.
 // ZAP: 2022/06/05 Remove usage of HttpException.
 // ZAP: 2022/08/03 Keep enabled state when setting default alert threshold (Issue 7400).
+// ZAP: 2022/09/08 Use format specifiers instead of concatenation when logging.
 package org.parosproxy.paros.core.scanner;
 
 import java.io.IOException;
@@ -1542,15 +1543,11 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
             }
 
             Alert alert = build();
-            if (plugin.logger.isDebugEnabled()) {
-                plugin.logger.debug(
-                        "New alert pluginid="
-                                + alert.getPluginId()
-                                + " "
-                                + alert.getName()
-                                + " uri="
-                                + alert.getUri());
-            }
+            plugin.logger.debug(
+                    "New alert pluginid={} {} uri={}",
+                    alert.getPluginId(),
+                    alert.getName(),
+                    alert.getUri());
             plugin.parent.alertFound(alert);
         }
     }

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Analyser.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Analyser.java
@@ -47,6 +47,7 @@
 // ZAP: 2022/06/09 Quote the query component used in the regular expression.
 // ZAP: 2022/06/09 Use Analyser in more circumstances.
 // ZAP: 2022/09/07 Remove unnecessary comments and address SonarLint issues
+// ZAP: 2022/09/08 Use format specifiers instead of concatenation when logging.
 package org.parosproxy.paros.core.scanner;
 
 import java.io.IOException;

--- a/zap/src/main/java/org/parosproxy/paros/view/AbstractFrame.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/AbstractFrame.java
@@ -29,6 +29,7 @@
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/02/03 Removed deprecated loadIconImages()
 // ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
+// ZAP: 2022/09/08 Use format specifiers instead of concatenation when logging.
 package org.parosproxy.paros.view;
 
 import java.awt.Dimension;
@@ -127,28 +128,16 @@ public class AbstractFrame extends JFrame {
         if ((windowstate & Frame.ICONIFIED) == Frame.ICONIFIED) {
             preferences.put(
                     prefnzPrefix + PREF_WINDOW_STATE, SimpleWindowState.ICONIFIED.toString());
-            if (logger.isDebugEnabled())
-                logger.debug(
-                        "Saving preference "
-                                + PREF_WINDOW_STATE
-                                + "="
-                                + SimpleWindowState.ICONIFIED);
+            logger.debug("Saving preference {}={}", PREF_WINDOW_STATE, SimpleWindowState.ICONIFIED);
         }
         if ((windowstate & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH) {
             preferences.put(
                     prefnzPrefix + PREF_WINDOW_STATE, SimpleWindowState.MAXIMIZED.toString());
-            if (logger.isDebugEnabled())
-                logger.debug(
-                        "Saving preference "
-                                + PREF_WINDOW_STATE
-                                + "="
-                                + SimpleWindowState.MAXIMIZED);
+            logger.debug("Saving preference {}={}", PREF_WINDOW_STATE, SimpleWindowState.MAXIMIZED);
         }
         if (windowstate == Frame.NORMAL) { // hint: Frame.NORMAL = 0, thats why no masking
             preferences.put(prefnzPrefix + PREF_WINDOW_STATE, SimpleWindowState.NORMAL.toString());
-            if (logger.isDebugEnabled())
-                logger.debug(
-                        "Saving preference " + PREF_WINDOW_STATE + "=" + SimpleWindowState.NORMAL);
+            logger.debug("Saving preference {}={}", PREF_WINDOW_STATE, SimpleWindowState.NORMAL);
         }
     }
 
@@ -161,8 +150,7 @@ public class AbstractFrame extends JFrame {
     private SimpleWindowState restoreWindowState() {
         SimpleWindowState laststate = null;
         final String statestr = preferences.get(prefnzPrefix + PREF_WINDOW_STATE, null);
-        if (logger.isDebugEnabled())
-            logger.debug("Restoring preference " + PREF_WINDOW_STATE + "=" + statestr);
+        logger.debug("Restoring preference {}={}", PREF_WINDOW_STATE, statestr);
         if (statestr != null) {
             SimpleWindowState state = null;
             try {
@@ -182,7 +170,8 @@ public class AbstractFrame extends JFrame {
                         this.setExtendedState(Frame.MAXIMIZED_BOTH);
                         break;
                     default:
-                        logger.error("Invalid window state (nothing will changed): " + statestr);
+                        logger.error(
+                                "Invalid window state (nothing will be changed): {}", statestr);
                 }
             }
             laststate = state;
@@ -199,22 +188,14 @@ public class AbstractFrame extends JFrame {
     private void saveWindowSize(Dimension size) {
         if (size != null) {
             if (getExtendedState() == Frame.NORMAL) {
-                if (logger.isDebugEnabled())
-                    logger.debug(
-                            "Saving preference "
-                                    + PREF_WINDOW_SIZE
-                                    + "="
-                                    + size.width
-                                    + ","
-                                    + size.height);
+                logger.debug(
+                        "Saving preference {}={},{}", PREF_WINDOW_SIZE, size.width, size.height);
                 this.preferences.put(
                         prefnzPrefix + PREF_WINDOW_SIZE, size.width + "," + size.height);
             } else {
-                if (logger.isDebugEnabled())
-                    logger.debug(
-                            "Preference "
-                                    + PREF_WINDOW_SIZE
-                                    + " not saved, cause window state is not 'normal'.");
+                logger.debug(
+                        "Preference {} not saved, cause window state is not 'normal'.",
+                        PREF_WINDOW_SIZE);
             }
         }
     }
@@ -239,14 +220,11 @@ public class AbstractFrame extends JFrame {
             }
             if (width > 0 && height > 0) {
                 result = new Dimension(width, height);
-                if (logger.isDebugEnabled())
-                    logger.debug(
-                            "Restoring preference "
-                                    + PREF_WINDOW_SIZE
-                                    + "="
-                                    + result.width
-                                    + ","
-                                    + result.height);
+                logger.debug(
+                        "Restoring preference {}={},{}",
+                        PREF_WINDOW_SIZE,
+                        result.width,
+                        result.height);
                 this.setSize(result);
             }
         }
@@ -262,21 +240,12 @@ public class AbstractFrame extends JFrame {
     private void saveWindowLocation(Point point) {
         if (point != null) {
             if (getExtendedState() == Frame.NORMAL) {
-                if (logger.isDebugEnabled())
-                    logger.debug(
-                            "Saving preference "
-                                    + PREF_WINDOW_POSITION
-                                    + "="
-                                    + point.x
-                                    + ","
-                                    + point.y);
+                logger.debug("Saving preference {}={},{}", PREF_WINDOW_POSITION, point.x, point.y);
                 this.preferences.put(prefnzPrefix + PREF_WINDOW_POSITION, point.x + "," + point.y);
             } else {
-                if (logger.isDebugEnabled())
-                    logger.debug(
-                            "Preference "
-                                    + PREF_WINDOW_POSITION
-                                    + " not saved, cause window state is not 'normal'.");
+                logger.debug(
+                        "Preference {} not saved, cause window state is not 'normal'.",
+                        PREF_WINDOW_POSITION);
             }
         }
     }
@@ -301,14 +270,8 @@ public class AbstractFrame extends JFrame {
             }
             if (x > 0 && y > 0) {
                 result = new Point(x, y);
-                if (logger.isDebugEnabled())
-                    logger.debug(
-                            "Restoring preference "
-                                    + PREF_WINDOW_POSITION
-                                    + "="
-                                    + result.x
-                                    + ","
-                                    + result.y);
+                logger.debug(
+                        "Restoring preference {}={},{}", PREF_WINDOW_POSITION, result.x, result.y);
                 this.setLocation(result);
             }
         }

--- a/zap/src/main/java/org/parosproxy/paros/view/AbstractParamDialog.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/AbstractParamDialog.java
@@ -222,9 +222,7 @@ public class AbstractParamDialog extends AbstractDialog {
                                 AbstractParamDialog.this.setVisible(false);
 
                             } catch (Exception ex) {
-                                if (LOGGER.isDebugEnabled()) {
-                                    LOGGER.debug("Failed to validate or save the panels: ", ex);
-                                }
+                                LOGGER.debug("Failed to validate or save the panels: ", ex);
                                 View.getSingleton()
                                         .showWarningDialog(
                                                 AbstractParamDialog.this,

--- a/zap/src/main/java/org/zaproxy/zap/authentication/AuthenticationHelper.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/AuthenticationHelper.java
@@ -184,7 +184,9 @@ public class AuthenticationHelper {
             msg.getRequestHeader().setURI(new URI(uri, true));
         } catch (Exception e) {
             log.error(
-                    "Failed to replace user data in request " + msg.getRequestHeader().getURI(), e);
+                    "Failed to replace user data in request {}",
+                    msg.getRequestHeader().getURI(),
+                    e);
         }
         if (msg.getRequestBody().length() > 0) {
             msg.setRequestBody(

--- a/zap/src/main/java/org/zaproxy/zap/authentication/AuthenticationMethod.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/AuthenticationMethod.java
@@ -331,7 +331,7 @@ public abstract class AuthenticationMethod {
                     HttpMessage pollMsg = pollAsUser(user);
                     msgToTest = pollMsg;
                 } catch (Exception e1) {
-                    LOGGER.warn("Failed sending poll request to " + this.getPollUrl(), e1);
+                    LOGGER.warn("Failed sending poll request to {}", this.getPollUrl(), e1);
                     return false;
                 }
                 break;
@@ -417,10 +417,9 @@ public abstract class AuthenticationMethod {
                             .addHeader(headerValue[0].trim(), headerValue[1].trim());
                 } else {
                     LOGGER.error(
-                            "Invalid header '"
-                                    + header
-                                    + "' for poll request to "
-                                    + this.getPollUrl());
+                            "Invalid header '{}' for poll request to {}",
+                            header,
+                            this.getPollUrl());
                 }
             }
         }

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
@@ -415,12 +415,11 @@ public class AddOn {
                         e -> {
                             ZipEntry libEntry = zip.getEntry(e);
                             if (libEntry == null) {
-                                logger.warn("The add-on " + file + " does not have the lib: " + e);
+                                logger.warn("The add-on {} does not have the lib: {}", file, e);
                                 return true;
                             }
                             if (libEntry.isDirectory()) {
-                                logger.warn(
-                                        "The add-on " + file + " does not have a file lib: " + e);
+                                logger.warn("The add-on {} does not have a file lib: {}", file, e);
                                 return true;
                             }
                             return false;
@@ -446,10 +445,10 @@ public class AddOn {
             if (logger.isDebugEnabled() || Constant.isDevMode()) {
                 logger.warn(logMessage, e);
             } else {
-                logger.warn(logMessage + " " + e.getMessage());
+                logger.warn("{} {}", logMessage, e.getMessage());
             }
         } catch (Exception e) {
-            logger.error("Failed to create an add-on from: " + file.toString(), e);
+            logger.error("Failed to create an add-on from: {}", file, e);
         }
         return Optional.empty();
     }
@@ -588,7 +587,7 @@ public class AddOn {
             try {
                 return new URL(url);
             } catch (Exception e) {
-                logger.warn("Invalid URL for add-on \"" + id + "\": " + url, e);
+                logger.warn("Invalid URL for add-on \"{}\": {}", id, url, e);
             }
         }
         return null;
@@ -781,15 +780,8 @@ public class AddOn {
                 try {
                     this.loadManifestFile();
                 } catch (IOException e) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug(
-                                "Failed to read the "
-                                        + AddOn.MANIFEST_FILE_NAME
-                                        + " file of "
-                                        + id
-                                        + ":",
-                                e);
-                    }
+                    logger.debug(
+                            "Failed to read the {} file of {}:", AddOn.MANIFEST_FILE_NAME, id, e);
                 }
             }
         }
@@ -1273,18 +1265,15 @@ public class AddOn {
         if (installedVersion != null && !addOn.equals(installedVersion)) {
             requirements.setIssue(
                     BaseRunRequirements.DependencyIssue.OLDER_VERSION, installedVersion);
-            if (logger.isDebugEnabled()) {
-                logger.debug(
-                        "Add-on "
-                                + addOn
-                                + " not runnable, old version still installed: "
-                                + installedVersion);
-            }
+            logger.debug(
+                    "Add-on {} not runnable, old version still installed: {}",
+                    addOn,
+                    installedVersion);
             return;
         }
 
         if (!requirements.addDependency(parent, addOn)) {
-            logger.warn("Cyclic dependency detected with: " + requirements.getDependencies());
+            logger.warn("Cyclic dependency detected with: {}", requirements.getDependencies());
             requirements.setIssue(
                     BaseRunRequirements.DependencyIssue.CYCLIC, requirements.getDependencies());
             return;

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnCollection.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnCollection.java
@@ -71,10 +71,9 @@ public class AddOnCollection {
                 if (requirements.hasDependencyIssue()) {
                     if (logger.isDebugEnabled()) {
                         logger.debug(
-                                "Ignoring add-on  "
-                                        + addOn.getName()
-                                        + " because of dependency issue: "
-                                        + AddOnRunIssuesUtils.getDependencyIssue(requirements));
+                                "Ignoring add-on {} because of dependency issue: {}",
+                                addOn.getName(),
+                                AddOnRunIssuesUtils.getDependencyIssue(requirements));
                     }
                     if (AddOn.AddOnRunRequirements.DependencyIssue.CYCLIC
                             == requirements.getDependencyIssue()) {
@@ -86,10 +85,9 @@ public class AddOnCollection {
                 } else if (requirements.hasExtensionsWithRunningIssues()) {
                     if (logger.isDebugEnabled()) {
                         logger.debug(
-                                "Ignoring add-on  "
-                                        + addOn.getName()
-                                        + " because of dependency issue in an extension: "
-                                        + AddOnRunIssuesUtils.getDependencyIssue(requirements));
+                                "Ignoring add-on {} because of dependency issue in an extension: {}",
+                                addOn.getName(),
+                                AddOnRunIssuesUtils.getDependencyIssue(requirements));
                     }
                 } else {
                     runnableAddOns.add(addOn);
@@ -136,21 +134,21 @@ public class AddOnCollection {
             // And then load the addons
             String[] addOnIds = config.getStringArray("addon");
             for (String id : addOnIds) {
-                logger.debug("Found addon " + id);
+                logger.debug("Found add-on {}", id);
 
                 AddOn ao;
                 try {
                     ao = new AddOn(id, downloadDir, config.configurationAt("addon_" + id));
                     ao.setInstallationStatus(AddOn.InstallationStatus.AVAILABLE);
                 } catch (Exception e) {
-                    logger.warn("Failed to create add-on for " + id, e);
+                    logger.warn("Failed to create add-on for {}", id, e);
                     continue;
                 }
                 if (ao.canLoadInCurrentVersion()) {
                     // Ignore ones that dont apply to this version
                     this.addOns.add(ao);
                 } else {
-                    logger.debug("Ignoring addon " + ao.getName() + " cant load in this version");
+                    logger.debug("Ignoring add-on {} can't load in this version", ao.getName());
                 }
             }
 
@@ -178,12 +176,12 @@ public class AddOnCollection {
         }
         if (!dir.exists()) {
             logger.warn(
-                    "Skipping enumeration of add-ons, the directory does not exist: "
-                            + dir.getAbsolutePath());
+                    "Skipping enumeration of add-ons, the directory does not exist: {}",
+                    dir.getAbsolutePath());
             return;
         }
         if (!dir.isDirectory()) {
-            logger.warn("Not a directory: " + dir.getAbsolutePath());
+            logger.warn("Not a directory: {}", dir.getAbsolutePath());
             return;
         }
 
@@ -202,37 +200,27 @@ public class AddOnCollection {
                                                     // Replace in situ so we're not changing a list
                                                     // we're iterating through
                                                     logger.debug(
-                                                            "Addon "
-                                                                    + addOn.getId()
-                                                                    + " version "
-                                                                    + addOn.getVersion()
-                                                                    + " superseded by "
-                                                                    + ao.getVersion());
+                                                            "Add-on {} version {} superseded by {}",
+                                                            addOn.getId(),
+                                                            addOn.getVersion(),
+                                                            ao.getVersion());
                                                     addOns.remove(addOn);
                                                 } else {
-                                                    if (logger.isDebugEnabled()) {
-                                                        logger.debug(
-                                                                "Ignoring newer addon "
-                                                                        + ao.getId()
-                                                                        + " version "
-                                                                        + ao.getVersion()
-                                                                        + " because of ZAP version constraints; Not before="
-                                                                        + ao.getNotBeforeVersion()
-                                                                        + " Not from="
-                                                                        + ao.getNotFromVersion()
-                                                                        + " Current Version="
-                                                                        + Constant.PROGRAM_VERSION);
-                                                    }
+                                                    logger.debug(
+                                                            "Ignoring newer add-on {} version {} because of ZAP version constraints; Not before={} Not from={} Current Version={}",
+                                                            ao.getId(),
+                                                            ao.getVersion(),
+                                                            ao.getNotBeforeVersion(),
+                                                            ao.getNotFromVersion(),
+                                                            Constant.PROGRAM_VERSION);
                                                     add = false;
                                                 }
                                             } else {
                                                 // Same or older version, don't include
                                                 logger.debug(
-                                                        "Addon "
-                                                                + ao.getId()
-                                                                + " version "
-                                                                + ao.getVersion()
-                                                                + " not latest.");
+                                                        "Add-on {} version {} not latest.",
+                                                        ao.getId(),
+                                                        ao.getVersion());
                                                 add = false;
                                             }
                                             break;
@@ -240,10 +228,9 @@ public class AddOnCollection {
                                     }
                                     if (add) {
                                         logger.debug(
-                                                "Found addon "
-                                                        + ao.getId()
-                                                        + " version "
-                                                        + ao.getVersion());
+                                                "Found add-on {} version {}",
+                                                ao.getId(),
+                                                ao.getVersion());
                                         this.addOns.add(ao);
                                     }
                                 });

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnInstaller.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnInstaller.java
@@ -125,10 +125,9 @@ public final class AddOnInstaller {
                 ext.postInstall();
             } catch (Exception e) {
                 logger.error(
-                        "Post install method failed for add-on "
-                                + addOn.getId()
-                                + " extension "
-                                + ext.getName());
+                        "Post install method failed for add-on {} extension {}",
+                        addOn.getId(),
+                        ext.getName());
             }
         }
     }
@@ -203,7 +202,7 @@ public final class AddOnInstaller {
 
             return uninstalledWithoutErrors;
         } catch (Throwable e) {
-            logger.error("An error occurred while uninstalling the add-on: " + addOn.getId(), e);
+            logger.error("An error occurred while uninstalling the add-on: {}", addOn.getId(), e);
             return false;
         }
     }
@@ -241,7 +240,7 @@ public final class AddOnInstaller {
 
             return uninstalledWithoutErrors;
         } catch (Throwable e) {
-            logger.error("An error occurred while uninstalling the add-on: " + addOn.getId(), e);
+            logger.error("An error occurred while uninstalling the add-on: {}", addOn.getId(), e);
             return false;
         }
     }
@@ -273,7 +272,7 @@ public final class AddOnInstaller {
                 Constant.messages.addMessageBundle(bundlePrefix, resourceBundle);
             }
         } catch (MissingResourceException e) {
-            logger.error("Declared bundle not found in " + addOn.getId() + " add-on:", e);
+            logger.error("Declared bundle not found in {} add-on:", addOn.getId(), e);
         }
     }
 
@@ -308,13 +307,13 @@ public final class AddOnInstaller {
     private static void installAddOnExtensionImpl(
             AddOn addOn, Extension ext, ExtensionLoader extensionLoader) {
         if (ext.isEnabled()) {
-            logger.debug("Starting extension " + ext.getName());
+            logger.debug("Starting extension {}", ext.getName());
             try {
                 extensionLoader.startLifeCycle(ext);
             } catch (Throwable e) {
                 // Catch Throwable to (try) prevent extensions' issues from breaking the
                 // installation process.
-                logger.error("An error occurred while installing the add-on: " + addOn.getId(), e);
+                logger.error("An error occurred while installing the add-on: {}", addOn.getId(), e);
             }
         }
     }
@@ -349,23 +348,21 @@ public final class AddOnInstaller {
         if (extension.isEnabled()) {
             String extUiName = extension.getUIName();
             if (extension.canUnload()) {
-                logger.debug("Unloading ext: " + extension.getName());
+                logger.debug("Unloading extension: {}", extension.getName());
                 try {
                     extension.unload();
                     Control.getSingleton().getExtensionLoader().removeExtension(extension);
                     ExtensionFactory.unloadAddOnExtension(extension);
                 } catch (Exception e) {
                     logger.error(
-                            "An error occurred while uninstalling the extension \""
-                                    + extension.getName()
-                                    + "\" bundled in the add-on \""
-                                    + addOn.getId()
-                                    + "\":",
+                            "An error occurred while uninstalling the extension \"{}\" bundled in the add-on \"{}\":",
+                            extension.getName(),
+                            addOn.getId(),
                             e);
                     uninstalledWithoutErrors = false;
                 }
             } else {
-                logger.debug("Cant dynamically unload ext: " + extension.getName());
+                logger.debug("Can't dynamically unload extension: {}", extension.getName());
                 uninstalledWithoutErrors = false;
             }
             callback.extensionRemoved(extUiName);
@@ -384,10 +381,10 @@ public final class AddOnInstaller {
         if (!ascanrules.isEmpty()) {
             for (AbstractPlugin ascanrule : ascanrules) {
                 String name = ascanrule.getClass().getCanonicalName();
-                logger.debug("Install ascanrule: " + name);
+                logger.debug("Install ascanrule: {}", name);
                 PluginFactory.loadedPlugin(ascanrule);
                 if (!PluginFactory.isPluginLoaded(ascanrule)) {
-                    logger.error("Failed to install ascanrule: " + name);
+                    logger.error("Failed to install ascanrule: {}", name);
                 }
             }
         }
@@ -399,14 +396,14 @@ public final class AddOnInstaller {
 
         List<AbstractPlugin> loadedAscanrules = addOn.getLoadedAscanrules();
         if (!loadedAscanrules.isEmpty()) {
-            logger.debug("Uninstall ascanrules: " + addOn.getAscanrules());
+            logger.debug("Uninstall ascanrules: {}", addOn.getAscanrules());
             callback.activeScanRulesWillBeRemoved(loadedAscanrules.size());
             for (AbstractPlugin ascanrule : loadedAscanrules) {
                 String name = ascanrule.getClass().getCanonicalName();
-                logger.debug("Uninstall ascanrule: " + name);
+                logger.debug("Uninstall ascanrule: {}", name);
                 PluginFactory.unloadedPlugin(ascanrule);
                 if (PluginFactory.isPluginLoaded(ascanrule)) {
-                    logger.error("Failed to uninstall ascanrule: " + name);
+                    logger.error("Failed to uninstall ascanrule: {}", name);
                     uninstalledWithoutErrors = false;
                 }
                 callback.activeScanRuleRemoved(name);
@@ -430,9 +427,9 @@ public final class AddOnInstaller {
         if (!pscanrules.isEmpty() && extPscan != null) {
             for (PluginPassiveScanner pscanrule : pscanrules) {
                 String name = pscanrule.getClass().getCanonicalName();
-                logger.debug("Install pscanrule: " + name);
+                logger.debug("Install pscanrule: {}", name);
                 if (!extPscan.addPassiveScanner(pscanrule)) {
-                    logger.error("Failed to install pscanrule: " + name);
+                    logger.error("Failed to install pscanrule: {}", name);
                 }
             }
         }
@@ -448,13 +445,13 @@ public final class AddOnInstaller {
                         .getExtensionLoader()
                         .getExtension(ExtensionPassiveScan.class);
         if (!loadedPscanrules.isEmpty()) {
-            logger.debug("Uninstall pscanrules: " + addOn.getPscanrules());
+            logger.debug("Uninstall pscanrules: {}", addOn.getPscanrules());
             callback.passiveScanRulesWillBeRemoved(loadedPscanrules.size());
             for (PluginPassiveScanner pscanrule : loadedPscanrules) {
                 String name = pscanrule.getClass().getCanonicalName();
-                logger.debug("Uninstall pscanrule: " + name);
+                logger.debug("Uninstall pscanrule: {}", name);
                 if (!extPscan.removePassiveScanner(pscanrule)) {
-                    logger.error("Failed to uninstall pscanrule: " + name);
+                    logger.error("Failed to uninstall pscanrule: {}", name);
                     uninstalledWithoutErrors = false;
                 }
                 callback.passiveScanRuleRemoved(name);
@@ -493,23 +490,22 @@ public final class AddOnInstaller {
         try {
             Files.createDirectories(targetDir);
         } catch (IOException e) {
-            logger.warn("Failed to create libs directory for " + addOn.getId(), e);
+            logger.warn("Failed to create libs directory for {}", addOn.getId(), e);
             return false;
         }
 
         try (ZipFile zip = new ZipFile(addOn.getFile())) {
             for (AddOn.Lib lib : libs) {
                 String name = lib.getName();
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Installing library for " + addOn + ": " + name);
-                }
+                logger.debug("Installing library for {}: {}", addOn, name);
 
                 Path targetFile = targetDir.resolve(name);
                 try {
                     lib.setFileSystemUrl(targetFile.toUri().toURL());
                 } catch (MalformedURLException e) {
                     logger.warn(
-                            "Failed to convert lib's filesystem path to URL for " + addOn.getId(),
+                            "Failed to convert lib's filesystem path to URL for {}",
+                            addOn.getId(),
                             e);
                     return false;
                 }
@@ -520,19 +516,19 @@ public final class AddOnInstaller {
 
                 ZipEntry libZipEntry = zip.getEntry(lib.getJarPath());
                 if (libZipEntry == null) {
-                    logger.warn("Library not found in " + addOn + " add-on: " + lib);
+                    logger.warn("Library not found in {} add-on: {}", addOn, lib);
                     return false;
                 }
 
                 try (InputStream in = zip.getInputStream(libZipEntry)) {
                     Files.copy(in, targetFile, StandardCopyOption.REPLACE_EXISTING);
                 } catch (IOException e) {
-                    logger.warn("Failed to copy the library for " + addOn + ": " + targetFile, e);
+                    logger.warn("Failed to copy the library for {}: {}", addOn, targetFile, e);
                     return false;
                 }
             }
         } catch (IOException e) {
-            logger.error("An error occurred while installing libraries for " + addOn, e);
+            logger.error("An error occurred while installing libraries for {}", addOn, e);
             return false;
         }
 
@@ -597,7 +593,7 @@ public final class AddOnInstaller {
         try {
             deleteDir(addOnLibsDir);
         } catch (IOException e) {
-            logger.error("An error occurred while uninstalling libraries for " + addOn, e);
+            logger.error("An error occurred while uninstalling libraries for {}", addOn, e);
             return false;
         }
 
@@ -607,7 +603,7 @@ public final class AddOnInstaller {
                 Files.delete(addOnDataDir);
             }
         } catch (IOException e) {
-            logger.warn("An error occurred while removing the directory " + addOnDataDir, e);
+            logger.warn("An error occurred while removing the directory {}", addOnDataDir, e);
             return false;
         }
 
@@ -686,17 +682,16 @@ public final class AddOnInstaller {
             }
             if (!outfile.getParentFile().exists() && !outfile.getParentFile().mkdirs()) {
                 logger.error(
-                        "Failed to create directories for add-on "
-                                + addOn
-                                + ": "
-                                + outfile.getAbsolutePath());
+                        "Failed to create directories for add-on {}: {}",
+                        addOn,
+                        outfile.getAbsolutePath());
                 continue;
             }
 
-            logger.debug("Installing file: " + name);
+            logger.debug("Installing file: {}", name);
             URL fileURL = addOnClassLoader.findResource(name);
             if (fileURL == null) {
-                logger.error("File not found in add-on " + addOn + ": " + name);
+                logger.error("File not found in add-on {}: {}", addOn, name);
                 continue;
             }
             try (InputStream in = fileURL.openStream();
@@ -708,10 +703,9 @@ public final class AddOnInstaller {
                 }
             } catch (IOException e) {
                 logger.error(
-                        "Failed to install a file from add-on "
-                                + addOn
-                                + ": "
-                                + outfile.getAbsolutePath(),
+                        "Failed to install a file from add-on {}: {}",
+                        addOn,
+                        outfile.getAbsolutePath(),
                         e);
             }
         }
@@ -770,25 +764,25 @@ public final class AddOnInstaller {
             if (name == null) {
                 continue;
             }
-            logger.debug("Uninstall file: " + name);
+            logger.debug("Uninstall file: {}", name);
             File file = new File(Constant.getZapHome(), name);
             try {
                 File parent = file.getParentFile();
                 if (file.exists() && !file.delete()) {
-                    logger.error("Failed to delete: " + file.getAbsolutePath());
+                    logger.error("Failed to delete: {}", file.getAbsolutePath());
                     uninstalledWithoutErrors = false;
                 }
                 callback.fileRemoved();
                 if (parent.isDirectory() && parent.list().length == 0) {
-                    logger.debug("Deleting: " + parent.getAbsolutePath());
+                    logger.debug("Deleting: {}", parent.getAbsolutePath());
                     if (!parent.delete()) {
                         // Ignore - check for <= 2 as on *nix '.' and '..' are returned
-                        logger.debug("Failed to delete: " + parent.getAbsolutePath());
+                        logger.debug("Failed to delete: {}", parent.getAbsolutePath());
                     }
                 }
                 deleteEmptyDirsCreatedForAddOnFiles(file);
             } catch (Exception e) {
-                logger.error("Failed to uninstall file " + file.getAbsolutePath(), e);
+                logger.error("Failed to uninstall file {}", file.getAbsolutePath(), e);
             }
         }
 
@@ -850,14 +844,14 @@ public final class AddOnInstaller {
     }
 
     private static void deleteEmptyDirs(File dir) {
-        logger.debug("Deleting dir " + dir.getAbsolutePath());
+        logger.debug("Deleting dir {}", dir.getAbsolutePath());
         for (File d : dir.listFiles()) {
             if (d.isDirectory()) {
                 deleteEmptyDirs(d);
             }
         }
         if (!dir.delete()) {
-            logger.debug("Failed to delete: " + dir.getAbsolutePath());
+            logger.debug("Failed to delete: {}", dir.getAbsolutePath());
         }
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnLoader.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnLoader.java
@@ -262,27 +262,20 @@ public class AddOnLoader extends URLClassLoader {
 
     private boolean canLoadAddOn(AddOn ao) {
         if (blockList.contains(ao.getId())) {
-            if (logger.isDebugEnabled()) {
-                logger.debug(
-                        "Can't load add-on "
-                                + ao.getName()
-                                + " it's on the block list (add-on uninstalled but the file couldn't be removed).");
-            }
+            logger.debug(
+                    "Can't load add-on {} it is on the block list (add-on uninstalled but the file couldn't be removed).",
+                    ao.getName());
             return false;
         }
 
         if (!ao.canLoadInCurrentVersion()) {
-            if (logger.isDebugEnabled()) {
-                logger.debug(
-                        "Can't load add-on "
-                                + ao.getName()
-                                + " because of ZAP version constraints; Not before="
-                                + ao.getNotBeforeVersion()
-                                + " Not from="
-                                + ao.getNotFromVersion()
-                                + " Current Version="
-                                + Constant.PROGRAM_VERSION);
-            }
+            logger.debug(
+                    "Can't load add-on {} because of ZAP version constraints; Not before={} Not from={} Current Version={}",
+                    ao.getName(),
+                    ao.getNotBeforeVersion(),
+                    ao.getNotFromVersion(),
+                    Constant.PROGRAM_VERSION);
+
             return false;
         }
         return true;
@@ -294,10 +287,9 @@ public class AddOnLoader extends URLClassLoader {
         if (!reqs.isRunnable()) {
             if (logger.isDebugEnabled()) {
                 logger.debug(
-                        "Can't run add-on "
-                                + ao.getName()
-                                + " because of missing requirements: "
-                                + AddOnRunIssuesUtils.getRunningIssues(reqs));
+                        "Can't run add-on {} because of missing requirements: {}",
+                        ao.getName(),
+                        AddOnRunIssuesUtils.getRunningIssues(reqs));
             }
         }
         return reqs;
@@ -420,11 +412,11 @@ public class AddOnLoader extends URLClassLoader {
             return;
         }
         if (!dir.exists()) {
-            logger.debug("No such directory: " + dir.getAbsolutePath());
+            logger.debug("No such directory: {}", dir.getAbsolutePath());
             return;
         }
         if (!dir.isDirectory()) {
-            logger.warn("Not a directory: " + dir.getAbsolutePath());
+            logger.warn("Not a directory: {}", dir.getAbsolutePath());
             return;
         }
 
@@ -642,7 +634,7 @@ public class AddOnLoader extends URLClassLoader {
         }
 
         if (!this.aoc.includesAddOn(ao.getId())) {
-            logger.warn("Trying to uninstall an add-on that is not installed: " + ao.getId());
+            logger.warn("Trying to uninstall an add-on that is not installed: {}", ao.getId());
             return false;
         }
 
@@ -700,7 +692,7 @@ public class AddOnLoader extends URLClassLoader {
 
         if (addOn.getFile() != null && addOn.getFile().exists()) {
             if (!addOn.getFile().delete() && !upgrading) {
-                logger.debug("Cant delete " + addOn.getFile().getAbsolutePath());
+                logger.debug("Can't delete {}", addOn.getFile().getAbsolutePath());
                 this.blockList.add(addOn.getId());
                 this.saveBlockList();
             }
@@ -715,8 +707,7 @@ public class AddOnLoader extends URLClassLoader {
                 }
                 ResourceBundle.clearCache(addOnClassLoader);
             } catch (Exception e) {
-                logger.error(
-                        "Failure while closing class loader of " + addOn.getId() + " add-on:", e);
+                logger.error("Failure while closing class loader of {} add-on:", addOn.getId(), e);
             }
             addOn.setClassLoader(null);
         }
@@ -738,9 +729,8 @@ public class AddOnLoader extends URLClassLoader {
                         ResourceBundle.clearCache(extensionClassLoader);
                     } catch (Exception e) {
                         logger.error(
-                                "Failure while closing class loader of extension '"
-                                        + classname
-                                        + "':",
+                                "Failure while closing class loader of extension '{}':",
+                                classname,
                                 e);
                     }
                     runnableAddOns.get(runningAddOn).remove(classname);
@@ -875,12 +865,10 @@ public class AddOnLoader extends URLClassLoader {
                     }
                 } else if (logger.isDebugEnabled()) {
                     logger.debug(
-                            "Can't run extension '"
-                                    + extReqs.getClassname()
-                                    + "' of add-on '"
-                                    + addOn.getName()
-                                    + "' because of missing requirements: "
-                                    + AddOnRunIssuesUtils.getRunningIssues(extReqs));
+                            "Can't run extension '{}' of add-on '{}' because of missing requirements: {}",
+                            extReqs.getClassname(),
+                            addOn.getName(),
+                            AddOnRunIssuesUtils.getRunningIssues(extReqs));
                 }
             }
         }
@@ -1128,7 +1116,7 @@ public class AddOnLoader extends URLClassLoader {
                 }
             }
         } catch (Exception e) {
-            logger.error("Failed to open file: " + file.getAbsolutePath(), e);
+            logger.error("Failed to open file: {}", file.getAbsolutePath(), e);
         }
         return classNames;
     }
@@ -1151,7 +1139,7 @@ public class AddOnLoader extends URLClassLoader {
                 }
             }
         } catch (Exception e) {
-            logger.error("Failed to open file: " + ao.getFile().getAbsolutePath(), e);
+            logger.error("Failed to open file: {}", ao.getFile().getAbsolutePath(), e);
         }
         return classNames;
     }
@@ -1231,7 +1219,7 @@ public class AddOnLoader extends URLClassLoader {
         try {
             config.save();
         } catch (ConfigurationException e) {
-            logger.error("Failed to save list [" + key + "]: " + sb.toString(), e);
+            logger.error("Failed to save list [{}]: {}", key, sb, e);
         }
     }
 
@@ -1284,29 +1272,21 @@ public class AddOnLoader extends URLClassLoader {
         try {
             return new Version(version);
         } catch (IllegalArgumentException e) {
-            if (logger.isDebugEnabled()) {
-                logger.debug(
-                        "Failed to create (legacy?) version with ["
-                                + version
-                                + "] for runnable add-on ["
-                                + addOnName
-                                + "]",
-                        e);
-            }
+            logger.debug(
+                    "Failed to create (legacy?) version with [{}] for runnable add-on [{}]",
+                    version,
+                    addOnName,
+                    e);
         }
 
         try {
             return new Version(version + ".0.0");
         } catch (IllegalArgumentException e) {
-            if (logger.isDebugEnabled()) {
-                logger.debug(
-                        "Failed to create legacy version with ["
-                                + version
-                                + ".0.0] for runnable add-on ["
-                                + addOnName
-                                + "]",
-                        e);
-            }
+            logger.debug(
+                    "Failed to create legacy version with [{}.0.0] for runnable add-on [{}]",
+                    version,
+                    addOnName,
+                    e);
         }
 
         return null;

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnLoaderUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnLoaderUtils.java
@@ -89,26 +89,21 @@ final class AddOnLoaderUtils {
         try {
             cls = addOnClassLoader.loadClass(classname);
         } catch (ClassNotFoundException e) {
-            LOGGER.error("Declared \"" + type + "\" was not found: " + classname, e);
+            LOGGER.error("Declared \"{}\" was not found: {}", type, classname, e);
             return null;
         } catch (LinkageError e) {
-            LOGGER.error("Declared \"" + type + "\" could not be loaded: " + classname, e);
+            LOGGER.error("Declared \"{}\" could not be loaded: {}", type, classname, e);
             return null;
         }
 
         if (Modifier.isAbstract(cls.getModifiers()) || Modifier.isInterface(cls.getModifiers())) {
-            LOGGER.error("Declared \"" + type + "\" is abstract or an interface: " + classname);
+            LOGGER.error("Declared \"{}\" is abstract or an interface: {}", type, classname);
             return null;
         }
 
         if (!clazz.isAssignableFrom(cls)) {
             LOGGER.error(
-                    "Declared \""
-                            + type
-                            + "\" is not of type \""
-                            + clazz.getName()
-                            + "\": "
-                            + classname);
+                    "Declared \"{}\" is not of type \"{}\": {}", type, clazz.getName(), classname);
             return null;
         }
 
@@ -117,7 +112,7 @@ final class AddOnLoaderUtils {
             Constructor<T> c = (Constructor<T>) cls.getConstructor();
             return c.newInstance();
         } catch (LinkageError | Exception e) {
-            LOGGER.error("Failed to initialise: " + classname, e);
+            LOGGER.error("Failed to initialise: {}", classname, e);
         }
         return null;
     }

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnRunIssuesUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnRunIssuesUtils.java
@@ -250,10 +250,9 @@ public final class AddOnRunIssuesUtils {
                             Constant.messages.getString(
                                     "cfu.warn.addon.with.missing.requirements.unknown");
                     LOGGER.warn(
-                            "Failed to handle dependency issue with name \""
-                                    + requirements.getDependencyIssue().name()
-                                    + "\" and details: "
-                                    + issueDetails);
+                            "Failed to handle dependency issue with name \"{}\" and details: {}",
+                            requirements.getDependencyIssue().name(),
+                            issueDetails);
                     break;
             }
 
@@ -422,10 +421,9 @@ public final class AddOnRunIssuesUtils {
                         addOn.getSemVer() != null ? addOn.getSemVer() : addOn.getVersion());
             default:
                 LOGGER.warn(
-                        "Failed to handle dependency issue with name \""
-                                + requirements.getDependencyIssue().name()
-                                + "\" and details: "
-                                + issueDetails);
+                        "Failed to handle dependency issue with name \"{}\" and details: {}",
+                        requirements.getDependencyIssue().name(),
+                        issueDetails);
                 return null;
         }
     }

--- a/zap/src/main/java/org/zaproxy/zap/control/BaseZapAddOnXmlData.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/BaseZapAddOnXmlData.java
@@ -200,9 +200,7 @@ public abstract class BaseZapAddOnXmlData {
         try {
             version = new Version(v);
         } catch (IllegalArgumentException e) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Falling back to integer version [" + v + "] for add-on " + name);
-            }
+            LOGGER.debug("Falling back to integer version [{}] for add-on {}", v, name);
             version = new Version(Integer.parseInt(v) + ".0.0");
         }
 
@@ -210,9 +208,8 @@ public abstract class BaseZapAddOnXmlData {
         if (status == null) {
             LOGGER.log(
                     Constant.isDevMode() ? Level.ERROR : Level.WARN,
-                    "No status specified for "
-                            + name
-                            + ", defaulting to \"alpha\". Add-ons should declare its status in the manifest.");
+                    "No status specified for {}, defaulting to \"alpha\". Add-ons should declare its status in the manifest.",
+                    name);
             status = "alpha";
         } else if (!ADDON_STATUSES.contains(status)) {
             throw new IllegalArgumentException(
@@ -354,8 +351,7 @@ public abstract class BaseZapAddOnXmlData {
             if (!field.isEmpty()) {
                 strings.add(field);
             } else {
-                LOGGER.warn(
-                        "Ignoring empty \"" + elementName + "\" entry in add-on \"" + name + "\".");
+                LOGGER.warn("Ignoring empty \"{}\" entry in add-on \"{}\".", elementName, name);
             }
         }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/AntiCsrfParam.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/AntiCsrfParam.java
@@ -93,7 +93,7 @@ public class AntiCsrfParam extends AbstractParam {
                 }
             }
         } catch (ConversionException e) {
-            logger.error("Error while loading anti CSRF tokens: " + e.getMessage(), e);
+            logger.error("Error while loading anti CSRF tokens: {}", e.getMessage(), e);
             this.tokens = new ArrayList<>(DEFAULT_TOKENS_NAMES.length);
             this.enabledTokensNames = new ArrayList<>(DEFAULT_TOKENS_NAMES.length);
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/API.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/API.java
@@ -168,15 +168,15 @@ public class API {
     public void registerApiImplementor(ApiImplementor impl) {
         if (implementors.get(impl.getPrefix()) != null) {
             logger.error(
-                    "Second attempt to register API implementor with prefix of "
-                            + impl.getPrefix());
+                    "Second attempt to register API implementor with prefix of {}",
+                    impl.getPrefix());
             return;
         }
         implementors.put(impl.getPrefix(), impl);
         for (String shortcut : impl.getApiShortcuts()) {
-            logger.debug("Registering API shortcut: " + shortcut);
+            logger.debug("Registering API shortcut: {}", shortcut);
             if (this.shortcuts.containsKey(shortcut)) {
-                logger.error("Duplicate API shortcut: " + shortcut);
+                logger.error("Duplicate API shortcut: {}", shortcut);
             }
             this.shortcuts.put("/" + shortcut, impl);
         }
@@ -195,15 +195,15 @@ public class API {
     public void removeApiImplementor(ApiImplementor impl) {
         if (!implementors.containsKey(impl.getPrefix())) {
             logger.warn(
-                    "Attempting to remove an API implementor not registered, with prefix: "
-                            + impl.getPrefix());
+                    "Attempting to remove an API implementor not registered, with prefix: {}",
+                    impl.getPrefix());
             return;
         }
         implementors.remove(impl.getPrefix());
         for (String shortcut : impl.getApiShortcuts()) {
             String key = "/" + shortcut;
             if (this.shortcuts.containsKey(key)) {
-                logger.debug("Removing registered API shortcut: " + shortcut);
+                logger.debug("Removing registered API shortcut: {}", shortcut);
                 this.shortcuts.remove(key);
             }
         }
@@ -265,19 +265,15 @@ public class API {
                 return true;
             }
             logger.warn(
-                    "Request to API URL "
-                            + requestHeader.getURI().toString()
-                            + " with host header "
-                            + requestHeader.getHostName()
-                            + " not permitted");
+                    "Request to API URL {} with host header {} not permitted",
+                    requestHeader.getURI(),
+                    requestHeader.getHostName());
             return false;
         }
         logger.warn(
-                "Request to API URL "
-                        + requestHeader.getURI().toString()
-                        + " from "
-                        + requestHeader.getSenderAddress().getHostAddress()
-                        + " not permitted");
+                "Request to API URL {} from {} not permitted",
+                requestHeader.getURI(),
+                requestHeader.getSenderAddress().getHostAddress());
         return false;
     }
 
@@ -306,7 +302,7 @@ public class API {
 
         // Check for callbacks
         if (url.contains(CALL_BACK_URL)) {
-            logger.debug("handleApiRequest Callback: " + url);
+            logger.debug("handleApiRequest Callback: {}", url);
             for (Entry<String, ApiImplementor> callback : callBacks.entrySet()) {
                 if (url.startsWith(callback.getKey())) {
                     callbackImpl = callback.getValue();
@@ -315,11 +311,9 @@ public class API {
             }
             if (callbackImpl == null) {
                 logger.warn(
-                        "Request to callback URL "
-                                + requestHeader.getURI().toString()
-                                + " from "
-                                + requestHeader.getSenderAddress().getHostAddress()
-                                + " not found - this could be a callback url from a previous session or possibly an attempt to attack ZAP");
+                        "Request to callback URL {} from {} not found - this could be a callback url from a previous session or possibly an attempt to attack ZAP",
+                        requestHeader.getURI(),
+                        requestHeader.getSenderAddress().getHostAddress());
                 return new HttpMessage();
             }
         }
@@ -349,7 +343,7 @@ public class API {
             return new HttpMessage();
         }
 
-        logger.debug("handleApiRequest " + url);
+        logger.debug("handleApiRequest {}", url);
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader(requestHeader);
@@ -687,7 +681,7 @@ public class API {
                 return responseToHtml(res);
             default:
                 // Should not happen, format validation should prevent this case...
-                logger.error("Unhandled format: " + format);
+                logger.error("Unhandled format: {}", format);
                 throw new ApiException(ApiException.Type.INTERNAL_ERROR);
         }
     }
@@ -829,7 +823,7 @@ public class API {
             return sw.toString();
 
         } catch (Exception e) {
-            logger.error("Failed to convert API response to XML: " + e.getMessage(), e);
+            logger.error("Failed to convert API response to XML: {}", e.getMessage(), e);
             throw new ApiException(ApiException.Type.INTERNAL_ERROR, e);
         }
     }
@@ -893,7 +887,7 @@ public class API {
     public String getCallBackUrl(ApiImplementor impl, String site) {
         String url = site + CALL_BACK_URL + random.nextLong();
         this.callBacks.put(url, impl);
-        logger.debug("Callback " + url + " registered for " + impl.getClass().getCanonicalName());
+        logger.debug("Callback {} registered for {}", url, impl.getClass().getCanonicalName());
         return url;
     }
 
@@ -907,7 +901,7 @@ public class API {
      * @see #removeApiImplementor(ApiImplementor)
      */
     public void removeCallBackUrl(String url) {
-        logger.debug("Callback " + url + " removed");
+        logger.debug("Callback {} removed", url);
         this.callBacks.remove(url);
     }
 
@@ -925,7 +919,7 @@ public class API {
         if (impl == null) {
             throw new IllegalArgumentException("Parameter impl must not be null.");
         }
-        logger.debug("All callbacks removed for " + impl.getClass().getCanonicalName());
+        logger.debug("All callbacks removed for {}", impl.getClass().getCanonicalName());
         this.callBacks.values().removeIf(impl::equals);
     }
 
@@ -999,33 +993,28 @@ public class API {
                 Nonce nonce = nonces.get(nonceParam);
                 if (nonce == null) {
                     logger.warn(
-                            "API nonce "
-                                    + nonceParam
-                                    + " not found in request from "
-                                    + reqHeader.getSenderAddress().getHostAddress());
+                            "API nonce {} not found in request from {}",
+                            nonceParam,
+                            reqHeader.getSenderAddress().getHostAddress());
                     return false;
                 } else if (nonce.isOneTime()) {
                     nonces.remove(nonceParam);
                 }
                 if (!nonce.isValid()) {
                     logger.warn(
-                            "API nonce "
-                                    + nonce.getNonceKey()
-                                    + " expired at "
-                                    + nonce.getExpires().toString()
-                                    + " in request from "
-                                    + reqHeader.getSenderAddress().getHostAddress());
+                            "API nonce {} expired at {} in request from {}",
+                            nonce.getNonceKey(),
+                            nonce.getExpires(),
+                            reqHeader.getSenderAddress().getHostAddress());
                     return false;
                 }
 
                 if (!apiPath.equals(nonce.getApiPath())) {
                     logger.warn(
-                            "API nonce path was "
-                                    + nonce.getApiPath()
-                                    + " but call was for "
-                                    + apiPath
-                                    + " in request from "
-                                    + reqHeader.getSenderAddress().getHostAddress());
+                            "API nonce path was {} but call was for {} in request from {}",
+                            nonce.getApiPath(),
+                            apiPath,
+                            reqHeader.getSenderAddress().getHostAddress());
                     return false;
                 }
             } else {
@@ -1035,10 +1024,9 @@ public class API {
                 }
                 if (!getOptionsParamApi().getKey().equals(keyParam)) {
                     logger.warn(
-                            "API key incorrect or not supplied: "
-                                    + keyParam
-                                    + " in request from "
-                                    + reqHeader.getSenderAddress().getHostAddress());
+                            "API key incorrect or not supplied: {} in request from {}",
+                            keyParam,
+                            reqHeader.getSenderAddress().getHostAddress());
                     return false;
                 }
             }
@@ -1159,11 +1147,9 @@ public class API {
 
     private static void logBadRequest(HttpMessage msg, Exception cause) {
         logger.warn(
-                "Bad request to API endpoint ["
-                        + msg.getRequestHeader().getURI().getEscapedPath()
-                        + "] from ["
-                        + msg.getRequestHeader().getSenderAddress().getHostAddress()
-                        + "]:",
+                "Bad request to API endpoint [{}] from [{}]:",
+                msg.getRequestHeader().getURI().getEscapedPath(),
+                msg.getRequestHeader().getSenderAddress().getHostAddress(),
                 cause);
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ApiResponseConversionUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ApiResponseConversionUtils.java
@@ -89,7 +89,7 @@ public final class ApiResponseConversionUtils {
         try {
             tags = HistoryReference.getTags(historyId);
         } catch (DatabaseException e) {
-            LOGGER.warn("Failed to obtain the tags for message with ID " + historyId, e);
+            LOGGER.warn("Failed to obtain the tags for message with ID {}", historyId, e);
         }
         return new HttpMessageResponseSet(map, tags);
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
@@ -293,7 +293,7 @@ public class ActiveScanAPI extends ApiImplementor {
     @SuppressWarnings({"fallthrough"})
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiAction " + name + " " + params.toString());
+        log.debug("handleApiAction {} {}", name, params);
         ScanPolicy policy;
         int categoryId;
 
@@ -351,7 +351,7 @@ public class ActiveScanAPI extends ApiImplementor {
                     try {
                         if (policyName != null && policyName.length() > 0) {
                             // Not specified, use the default one
-                            log.debug("handleApiAction scan policy =" + policyName);
+                            log.debug("handleApiAction scan policy ={}", policyName);
                             policy = controller.getPolicyManager().getPolicy(policyName);
                         }
                     } catch (ConfigurationException e) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanController.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanController.java
@@ -146,7 +146,7 @@ public class ActiveScanController implements ScanController<ActiveScan> {
                         ascan.setScannerParam((ScannerParam) obj);
                     } else if (obj instanceof ScanPolicy) {
                         policy = (ScanPolicy) obj;
-                        logger.debug("Setting custom policy " + policy.getName());
+                        logger.debug("Setting custom policy {}", policy.getName());
                         ascan.setScanPolicy(policy);
                     } else if (obj instanceof TechSet) {
                         ascan.setTechSet((TechSet) obj);
@@ -157,15 +157,15 @@ public class ActiveScanController implements ScanController<ActiveScan> {
                         ascan.addScanFilter((ScanFilter) obj);
                     } else {
                         logger.error(
-                                "Unexpected contextSpecificObject: "
-                                        + obj.getClass().getCanonicalName());
+                                "Unexpected contextSpecificObject: {}",
+                                obj.getClass().getCanonicalName());
                     }
                 }
             }
             if (policy == null) {
                 // use the default
                 policy = extension.getPolicyManager().getDefaultScanPolicy();
-                logger.debug("Setting default policy " + policy.getName());
+                logger.debug("Setting default policy {}", policy.getName());
                 ascan.setScanPolicy(policy);
             }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanPanel.java
@@ -308,7 +308,7 @@ public class ActiveScanPanel extends ScanPanel2<ActiveScan, ScanController<Activ
                             }
                         });
             } catch (InvocationTargetException | InterruptedException e) {
-                LOGGER.error("Failed to switch view: " + e.getMessage(), e);
+                LOGGER.error("Failed to switch view: {}", e.getMessage(), e);
             }
             return;
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/AttackModeScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/AttackModeScanner.java
@@ -99,7 +99,7 @@ public class AttackModeScanner implements EventConsumer {
         if (this.rescanOnChange) {
             this.nodeStack.addAll(Model.getSingleton().getSession().getNodesInScopeFromSiteTree());
             log.debug(
-                    "Added existing in scope nodes to attack mode stack " + this.nodeStack.size());
+                    "Added existing in scope nodes to attack mode stack {}", this.nodeStack.size());
             updateCount();
         }
     }
@@ -122,7 +122,8 @@ public class AttackModeScanner implements EventConsumer {
                         != HistoryReference.TYPE_TEMPORARY) {
                     // Add to the stack awaiting attack
                     log.debug(
-                            "Adding node to attack mode stack " + event.getTarget().getStartNode());
+                            "Adding node to attack mode stack {}",
+                            event.getTarget().getStartNode());
                     nodeStack.add(event.getTarget().getStartNode());
                     updateCount();
                 }
@@ -302,7 +303,7 @@ public class AttackModeScanner implements EventConsumer {
                 }
                 while (nodeStack.size() > 0 && scanners.size() < scannerCount) {
                     SiteNode node = nodeStack.remove(0);
-                    log.debug("Attacking node " + node.getNodeName());
+                    log.debug("Attacking node {}", node.getNodeName());
 
                     Scanner scanner =
                             new Scanner(
@@ -340,7 +341,7 @@ public class AttackModeScanner implements EventConsumer {
                     if (scanner.isStop()) {
                         SiteNode node = scanner.getStartNode();
                         if (node != null) {
-                            log.debug("Finished attacking node " + node.getNodeName());
+                            log.debug("Finished attacking node {}", node.getNodeName());
                             if (View.isInitialised()) {
                                 // Remove the icon
                                 node.removeCustomIcon(ATTACK_ICON_RESOURCE);

--- a/zap/src/main/java/org/zaproxy/zap/extension/authentication/AuthenticationAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authentication/AuthenticationAPI.java
@@ -116,7 +116,7 @@ public class AuthenticationAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiView(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiView " + name + " " + params.toString());
+        log.debug("handleApiView {} {}", name, params);
 
         switch (name) {
             case VIEW_GET_AUTHENTICATION:
@@ -149,7 +149,7 @@ public class AuthenticationAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiAction " + name + " " + params.toString());
+        log.debug("handleApiAction {} {}", name, params);
 
         Context context;
         switch (name) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/authorization/AuthorizationAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authorization/AuthorizationAPI.java
@@ -73,7 +73,7 @@ public class AuthorizationAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiView(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiView " + name + " " + params.toString());
+        log.debug("handleApiView {} {}", name, params);
 
         switch (name) {
             case VIEW_GET_AUTHORIZATION_METHOD:
@@ -87,7 +87,7 @@ public class AuthorizationAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiAction " + name + " " + params.toString());
+        log.debug("handleApiAction {} {}", name, params);
         Context context;
         switch (name) {
             case ACTION_SET_AUTHORIZATION_METHOD:
@@ -108,12 +108,12 @@ public class AuthorizationAPI extends ApiImplementor {
                                 PARAM_STATUS_CODE,
                                 BasicAuthorizationDetectionMethod.NO_STATUS_CODE);
 
-                if (log.isDebugEnabled()) {
-                    log.debug(
-                            String.format(
-                                    "Setting basic authorization detection to: %s / %s / %d / %s",
-                                    headerRegex, bodyRegex, statusCode, logicalOperator));
-                }
+                log.debug(
+                        "Setting basic authorization detection to: {} / {} / {} / {}",
+                        headerRegex,
+                        bodyRegex,
+                        statusCode,
+                        logicalOperator);
 
                 BasicAuthorizationDetectionMethod method =
                         new BasicAuthorizationDetectionMethod(

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/AddOnsTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/AddOnsTableModel.java
@@ -225,9 +225,7 @@ public abstract class AddOnsTableModel extends AbstractTableModel {
                         rows.add(idx);
                     }
                 } catch (Exception e) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Error on " + url, e);
-                    }
+                    logger.debug("Error on {}", url, e);
                     setFailed(aow, addOn);
                     try {
                         final int row = idx;
@@ -258,9 +256,7 @@ public abstract class AddOnsTableModel extends AbstractTableModel {
                             }
                         });
             } catch (InvocationTargetException | InterruptedException e) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Failed to update all the progresses: ", e);
-                }
+                logger.debug("Failed to update all the progresses: ", e);
             }
         }
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/AutoUpdateAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/AutoUpdateAPI.java
@@ -87,7 +87,7 @@ public class AutoUpdateAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiAction " + name + " " + params.toString());
+        log.debug("handleApiAction {} {}", name, params);
         if (ACTION_DOWNLOAD_LATEST_RELEASE.equals(name)) {
             if (this.downloadLatestRelease()) {
                 return ApiResponseElement.OK;

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakpointsPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakpointsPanel.java
@@ -295,15 +295,8 @@ public class BreakpointsPanel extends AbstractPanel {
 
     private void saveColumnWidth(String prefix, int width) {
         if (width > 0) {
-            if (log.isDebugEnabled())
-                log.debug(
-                        "Saving preference "
-                                + prefnzPrefix
-                                + prefix
-                                + "."
-                                + PREF_COLUMN_WIDTH
-                                + "="
-                                + width);
+            log.debug(
+                    "Saving preference {}{}.{}={}", prefnzPrefix, prefix, PREF_COLUMN_WIDTH, width);
             this.preferences.put(
                     prefnzPrefix + prefix + "." + PREF_COLUMN_WIDTH, Integer.toString(width));
             // immediate flushing
@@ -328,15 +321,12 @@ public class BreakpointsPanel extends AbstractPanel {
             }
             if (width > 0) {
                 result = width;
-                if (log.isDebugEnabled())
-                    log.debug(
-                            "Restoring preference "
-                                    + prefnzPrefix
-                                    + prefix
-                                    + "."
-                                    + PREF_COLUMN_WIDTH
-                                    + "="
-                                    + width);
+                log.debug(
+                        "Restoring preference {}{}.{}={}",
+                        prefnzPrefix,
+                        prefix,
+                        PREF_COLUMN_WIDTH,
+                        width);
             }
         }
         return result;
@@ -356,14 +346,7 @@ public class BreakpointsPanel extends AbstractPanel {
         public void propertyChange(PropertyChangeEvent evt) {
             TableColumn column = (TableColumn) evt.getSource();
             if (column != null) {
-                if (log.isDebugEnabled())
-                    log.debug(
-                            prefnzPrefix
-                                    + prefix
-                                    + "."
-                                    + PREF_COLUMN_WIDTH
-                                    + "="
-                                    + column.getWidth());
+                log.debug("{}{}.{}={}", prefnzPrefix, prefix, PREF_COLUMN_WIDTH, column.getWidth());
                 saveColumnWidth(prefix, column.getWidth());
             }
         }

--- a/zap/src/main/java/org/zaproxy/zap/utils/ByteBuilder.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/ByteBuilder.java
@@ -229,9 +229,7 @@ public class ByteBuilder {
                 | IllegalAccessException
                 | InvocationTargetException e) {
             // shouldn't happen but in case it does log it.
-            if (logger.isDebugEnabled()) {
-                logger.debug(e.getMessage(), e);
-            }
+            logger.debug(e.getMessage(), e);
         } catch (NoSuchMethodException e) {
             // will happen, a lot
         }

--- a/zap/src/main/java/org/zaproxy/zap/view/panels/AbstractContextSelectToolbarStatusPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/panels/AbstractContextSelectToolbarStatusPanel.java
@@ -229,7 +229,7 @@ public abstract class AbstractContextSelectToolbarStatusPanel extends AbstractPa
      * @param context the context that was selected
      */
     protected void contextSelected(Context context) {
-        log.debug("Selected new context: " + context);
+        log.debug("Selected new context: {}", context);
         switchViewForContext(context);
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/view/panels/AbstractScanToolbarStatusPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/panels/AbstractScanToolbarStatusPanel.java
@@ -313,7 +313,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
      * @param context the context whose scan should be paused
      */
     protected void pauseScan(Context context) {
-        log.debug("Access Control pause on Context: " + context);
+        log.debug("Access Control pause on Context: {}", context);
         threadManager.getScannerThread(context.getId()).pauseScan();
     }
 
@@ -325,7 +325,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
      * @param context the context whose scan should be resumed
      */
     protected void resumeScan(Context context) {
-        log.debug("Access Control resume on Context: " + context);
+        log.debug("Access Control resume on Context: {}", context);
         threadManager.getScannerThread(context.getId()).resumeScan();
     }
 
@@ -337,7 +337,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
      * @param context the context whose scan should be stopped
      */
     protected void stopScan(Context context) {
-        log.debug("Access Control stop on Context: " + context);
+        log.debug("Access Control stop on Context: {}", context);
         threadManager.getScannerThread(context.getId()).stopScan();
     }
 
@@ -395,7 +395,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
                 new Runnable() {
                     @Override
                     public void run() {
-                        log.debug("ScanStarted " + panelPrefix + " on context" + contextId);
+                        log.debug("ScanStarted {} on context {}", panelPrefix, contextId);
                         if (getSelectedContext() != null
                                 && contextId == getSelectedContext().getId()) {
                             setScanButtonsAndProgressBarStates(true, false, false);
@@ -407,7 +407,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
         try {
             ThreadUtils.invokeAndWait(handler);
         } catch (InvocationTargetException | InterruptedException e) {
-            log.error("Error while starting scan: " + e.getMessage(), e);
+            log.error("Error while starting scan: {}", e.getMessage(), e);
         }
     }
 
@@ -417,7 +417,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
                 new Runnable() {
                     @Override
                     public void run() {
-                        log.debug("ScanFinished " + panelPrefix + " on context" + contextId);
+                        log.debug("ScanFinished {} on context {}", panelPrefix, contextId);
                         if (getSelectedContext() != null
                                 && contextId == getSelectedContext().getId()) {
                             setScanButtonsAndProgressBarStates(false, false, true);
@@ -428,7 +428,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
         try {
             ThreadUtils.invokeAndWait(handler);
         } catch (InvocationTargetException | InterruptedException e) {
-            log.error("Error while finishing scan: " + e.getMessage(), e);
+            log.error("Error while finishing scan: {}", e.getMessage(), e);
         }
     }
 
@@ -439,12 +439,10 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
                     @Override
                     public void run() {
                         log.debug(
-                                "scanProgress "
-                                        + panelPrefix
-                                        + " on context "
-                                        + contextId
-                                        + " "
-                                        + progress);
+                                "scanProgress {} on context {} {}",
+                                panelPrefix,
+                                contextId,
+                                progress);
                         if (getSelectedContext() != null
                                 && contextId == getSelectedContext().getId()) {
                             getProgressBar().setValue(progress);
@@ -456,7 +454,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
         try {
             ThreadUtils.invokeAndWait(handler);
         } catch (InvocationTargetException | InterruptedException e) {
-            log.error("Error while updating progress: " + e.getMessage(), e);
+            log.error("Error while updating progress: {}", e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
Update logging statements to use format specifiers vs concatenation. Removed isDebugEnabled conditionals where no longer needed. Add ZAP comment to paros classes.

Started with 731 occurrences, now at 582 (delta 149)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>