### PR TITLE
ci: add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group:  ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/crowdin-upload-files.yml
+++ b/.github/workflows/crowdin-upload-files.yml
@@ -3,6 +3,9 @@ name: Crowdin Upload Files
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   upload:
     name: Upload Files

--- a/.github/workflows/handle-release.yml
+++ b/.github/workflows/handle-release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   handle-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/prepare-release-main-version.yml
+++ b/.github/workflows/prepare-release-main-version.yml
@@ -3,6 +3,9 @@ name: Prepare Release Main Version
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   prepare-release:
     name: Prepare Release

--- a/.github/workflows/release-live-docker.yml
+++ b/.github/workflows/release-live-docker.yml
@@ -5,6 +5,9 @@ on:
     # Every day at the start of the day
     - cron:  '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Build and Push Docker Image

--- a/.github/workflows/release-main-docker.yml
+++ b/.github/workflows/release-main-docker.yml
@@ -5,6 +5,9 @@ on:
   repository_dispatch:
     types: 'release-main-docker'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Build and Push Docker Images

--- a/.github/workflows/release-main-version.yml
+++ b/.github/workflows/release-main-version.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'zap/zap.gradle.kts'
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Build and Release

--- a/.github/workflows/release-weekly-docker.yml
+++ b/.github/workflows/release-weekly-docker.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: 'release-weekly-docker'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Build and Push Docker Image

--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -3,6 +3,9 @@ name: Release Weekly
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Build and Release

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -5,6 +5,9 @@ on:
     # Every day at the 1am
     - cron:  '0 1 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Build, Push and Run Docker Image

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -5,6 +5,9 @@ on:
     - cron: '30 15 * * SAT'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sonar:
     runs-on: [ubuntu-latest]

--- a/.github/workflows/test-packaged-scans.yml
+++ b/.github/workflows/test-packaged-scans.yml
@@ -5,6 +5,9 @@ on:
     paths:
     - docker/**
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows.

GitHub Actions workflows have a GITHUB_TOKEN with write access to multiple scopes.
Here is an example of the permissions in one of the workflows:
https://github.com/zaproxy/zaproxy/runs/8252201162?check_suite_focus=true#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflows:

- ci.yml
- crowdin-upload-files.yml
- handle-release.yml
- prepare-release-main-version.yml
- release-live-docker.yml
- release-main-docker.yml
- release-main-version.yml
- release-weekly-docker.yml
- release-weekly.yml
- run-integration-tests.yml
- sonar.yml
- test-packaged-scans.yml

The following workflow files already have the least privileged token permission set:

- lock.yml

### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- GitHub recommends defining minimum GITHUB_TOKEN permissions.
   https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>