### PR TITLE
Fix StackOverflow in Analyser

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/model/StructuralSiteNode.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/StructuralSiteNode.java
@@ -115,4 +115,21 @@ public class StructuralSiteNode implements StructuralNode {
     public boolean isDataDriven() {
         return this.node.isDataDriven();
     }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(node);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof StructuralSiteNode)) {
+            return false;
+        }
+        StructuralSiteNode other = (StructuralSiteNode) obj;
+        return Objects.equals(node, other.node);
+    }
 }

--- a/zap/src/main/java/org/zaproxy/zap/model/StructuralTableNode.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/StructuralTableNode.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.model;
 
 import java.security.InvalidParameterException;
 import java.util.Iterator;
+import java.util.Objects;
 import org.apache.commons.httpclient.URI;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.db.DatabaseException;
@@ -154,5 +155,22 @@ public class StructuralTableNode implements StructuralNode {
             name = name.substring(slashIndex + 1);
         }
         return name.startsWith(SessionStructure.DATA_DRIVEN_NODE_PREFIX);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rs);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof StructuralTableNode)) {
+            return false;
+        }
+        StructuralTableNode other = (StructuralTableNode) obj;
+        return Objects.equals(rs, other.rs);
     }
 }


### PR DESCRIPTION
Keep track of the nodes traversed instead of using the ones analysed as not all of them might be (e.g. nodes not in context).
Use a `Set` to track them, override `equals` and `hashCode` on the node implementations.