### PR TITLE
Sonar Cloud workflow remove setting GITHUB_TOKEN into env

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -29,6 +29,5 @@ jobs:
       run: ./gradlew test jacocoTestReport -Dorg.gradle.jvmargs=-Xmx4096m
     - name: Sonarcloud Scan
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.ZAPBOT_SONARCLOUD_TOKEN }}
       run: ./gradlew -Dorg.gradle.jvmargs=-Xmx4g sonarqube --stacktrace


### PR DESCRIPTION
We believe this is not necessary for the job.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>