### PR TITLE
Allow arbitrary HTTP versions

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/network/HttpHeader.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpHeader.java
@@ -44,6 +44,7 @@
 // ZAP: 2019/12/09 Added getHeaderValues(String) method (returning List) and deprecated
 // getHeaders(String) method (returning Vector).
 // ZAP: 2022/03/11 Added headers: Content-Location, Link, Refresh
+// ZAP: 2022/09/12 Allow only major HTTP version.
 package org.parosproxy.paros.network;
 
 import java.util.ArrayList;
@@ -121,7 +122,7 @@ public abstract class HttpHeader implements java.io.Serializable {
     // protected static final String p_URI			= "(\\S+)";
     // allow space in URI for encoding to %20
     protected static final String p_URI = "([^\\r\\n]+)";
-    protected static final String p_VERSION = "(HTTP/\\d+\\.\\d+)";
+    protected static final String p_VERSION = "(HTTP/\\d+(?:\\.\\d+)?)";
     protected static final String p_STATUS_CODE = "(\\d{3})";
     protected static final String p_REASON_PHRASE = "(" + p_TEXT + ")";
     protected String mStartLine;

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpRequestHeader.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpRequestHeader.java
@@ -62,6 +62,7 @@
 // ZAP: 2021/05/10 Use authority for CONNECT requests.
 // ZAP: 2021/07/16 Issue 6691: Do not add zero Content-Length by default in GET requests
 // ZAP: 2021/07/19 Include SVG in isImage().
+// ZAP: 2022/09/12 Allow arbitrary HTTP versions.
 package org.parosproxy.paros.network;
 
 import java.io.UnsupportedEncodingException;
@@ -454,13 +455,6 @@ public class HttpRequestHeader extends HttpHeader {
         mMethod = matcher.group(1);
         String sUri = matcher.group(2);
         mVersion = matcher.group(3);
-
-        if (!mVersion.equalsIgnoreCase(HTTP09)
-                && !mVersion.equalsIgnoreCase(HTTP10)
-                && !mVersion.equalsIgnoreCase(HTTP11)) {
-            mMalformedHeader = true;
-            throw new HttpMalformedHeaderException("Unexpected version: " + mVersion);
-        }
 
         if (mMethod.equalsIgnoreCase(CONNECT)) {
             parseHostName(sUri);

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpResponseHeader.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpResponseHeader.java
@@ -42,6 +42,7 @@
 // ZAP: 2020/11/10 Add convenience method isCss().
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2021/05/14 Remove redundant type arguments.
+// ZAP: 2022/09/12 Allow arbitrary HTTP versions.
 package org.parosproxy.paros.network;
 
 import java.net.HttpCookie;
@@ -211,12 +212,6 @@ public class HttpResponseHeader extends HttpHeader {
         mVersion = matcher.group(1);
         mStatusCodeString = matcher.group(2);
         setReasonPhrase(matcher.group(3));
-
-        if (!mVersion.equalsIgnoreCase(HTTP10) && !mVersion.equalsIgnoreCase(HTTP11)) {
-            mMalformedHeader = true;
-            throw new HttpMalformedHeaderException("Unexpected version: " + mVersion);
-            // return false;
-        }
 
         try {
             mStatusCode = Integer.parseInt(mStatusCodeString);

--- a/zap/src/test/java/org/parosproxy/paros/network/HttpRequestHeaderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/network/HttpRequestHeaderUnitTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /** Unit test for {@link HttpRequestHeader}. */
 class HttpRequestHeaderUnitTest {
@@ -72,6 +73,27 @@ class HttpRequestHeaderUnitTest {
         boolean empty = header.isEmpty();
         // Then
         assertThat(empty, is(equalTo(false)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "HTTP/0.9",
+                "HTTP/1.0",
+                "HTTP/1.1",
+                "HTTP/1.2",
+                "HTTP/2",
+                "HTTP/3.0",
+                "HTTP/4.5"
+            })
+    void shouldParseWithArbitraryHttpVersions(String version) throws Exception {
+        // Given
+        HttpRequestHeader header =
+                new HttpRequestHeader("GET http://example.com/ " + version + "\r\n\r\n");
+        // When
+        String parsedVersion = header.getVersion();
+        // Then
+        assertThat(parsedVersion, is(equalTo(version)));
     }
 
     @Test

--- a/zap/src/test/java/org/parosproxy/paros/network/HttpResponseHeaderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/network/HttpResponseHeaderUnitTest.java
@@ -65,6 +65,26 @@ class HttpResponseHeaderUnitTest {
         assertThat(empty, is(equalTo(false)));
     }
 
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "HTTP/0.9",
+                "HTTP/1.0",
+                "HTTP/1.1",
+                "HTTP/1.2",
+                "HTTP/2",
+                "HTTP/3.0",
+                "HTTP/4.5"
+            })
+    void shouldParseWithArbitraryHttpVersions(String version) throws Exception {
+        // Given
+        HttpResponseHeader header = new HttpResponseHeader(version + " 200 OK\r\n\r\n");
+        // When
+        String parsedVersion = header.getVersion();
+        // Then
+        assertThat(parsedVersion, is(equalTo(version)));
+    }
+
     @Test
     void shouldSetValidStatusCode() throws Exception {
         // Given


### PR DESCRIPTION
Remove the validation of the HTTP version in request/response headers.
Tweak the HTTP version regular expression to allow only major version.
Does not add support for newer HTTP versions (though the messages can
still be sent) but allows to represent newer versions in plain text.