### PR TITLE
Disable/deprecate the Manual Request Editor

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -99,6 +99,7 @@
 // the exim add-on.
 // ZAP: 2022/06/12 Deprecate getResendDialog().
 // ZAP: 2022/06/27 Make delete more consistent and protective (Issue 7336).
+// ZAP: 2022/09/14 Address deprecation warnings.
 package org.parosproxy.paros.extension.history;
 
 import java.awt.EventQueue;
@@ -122,8 +123,6 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.ExtensionHookView;
 import org.parosproxy.paros.extension.SessionChangedListener;
-import org.parosproxy.paros.extension.manualrequest.ManualRequestEditorDialog;
-import org.parosproxy.paros.extension.manualrequest.http.impl.ManualHttpRequestEditorDialog;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.HistoryReferenceEventPublisher;
 import org.parosproxy.paros.model.Model;
@@ -577,9 +576,11 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
      * @deprecated (2.12.0) Replaced by Requester add-on.
      */
     @Deprecated
-    public ManualRequestEditorDialog getResendDialog() {
-        ManualRequestEditorDialog resendDialog =
-                new ManualHttpRequestEditorDialog(true, "resend", "ui.dialogs.manreq");
+    public org.parosproxy.paros.extension.manualrequest.ManualRequestEditorDialog
+            getResendDialog() {
+        org.parosproxy.paros.extension.manualrequest.ManualRequestEditorDialog resendDialog =
+                new org.parosproxy.paros.extension.manualrequest.http.impl
+                        .ManualHttpRequestEditorDialog(true, "resend", "ui.dialogs.manreq");
         resendDialog.setTitle(Constant.messages.getString("manReq.dialog.title")); // ZAP: i18n
         return resendDialog;
     }

--- a/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/ExtensionManualRequestEditor.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/ExtensionManualRequestEditor.java
@@ -48,6 +48,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2019/10/04 Add dialog/menu icon.
 // ZAP: 2022/06/13 Add HrefTypeInfo on hook.
+// ZAP: 2022/09/14 Deprecate the class.
 package org.parosproxy.paros.extension.manualrequest;
 
 import java.awt.EventQueue;
@@ -63,17 +64,19 @@ import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.extension.SessionChangedListener;
 import org.parosproxy.paros.extension.ViewDelegate;
-import org.parosproxy.paros.extension.manualrequest.http.impl.ManualHttpRequestEditorDialog;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Session;
 import org.zaproxy.zap.extension.httppanel.Message;
 import org.zaproxy.zap.view.HrefTypeInfo;
 
+/** @deprecated (2.12.0) Replaced by Requester add-on. */
+@Deprecated
 public class ExtensionManualRequestEditor extends ExtensionAdaptor
         implements SessionChangedListener {
 
     private Map<Class<? extends Message>, ManualRequestEditorDialog> dialogues = new HashMap<>();
-    private ManualHttpRequestEditorDialog httpSendEditorDialog;
+    private org.parosproxy.paros.extension.manualrequest.http.impl.ManualHttpRequestEditorDialog
+            httpSendEditorDialog;
 
     /** Name of this extension. */
     public static final String NAME = "ExtensionManualRequest";
@@ -94,7 +97,8 @@ public class ExtensionManualRequestEditor extends ExtensionAdaptor
 
         // add default manual request editor
         httpSendEditorDialog =
-                new ManualHttpRequestEditorDialog(true, "manual", "ui.dialogs.manreq");
+                new org.parosproxy.paros.extension.manualrequest.http.impl
+                        .ManualHttpRequestEditorDialog(true, "manual", "ui.dialogs.manreq");
         httpSendEditorDialog.setTitle(Constant.messages.getString("manReq.dialog.title"));
 
         addManualSendEditor(httpSendEditorDialog);

--- a/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/ManualRequestEditorDialog.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/ManualRequestEditorDialog.java
@@ -43,6 +43,7 @@
 // ZAP: 2021/02/12 Add shortcut key to Send button (Issue 6448).
 // ZAP: 2022/06/08 Fix resizing issues.
 // ZAP: 2022/06/23 Do not implement Tab.
+// ZAP: 2022/09/14 Deprecate the class.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
 package org.parosproxy.paros.extension.manualrequest;
 
@@ -72,7 +73,12 @@ import org.zaproxy.zap.extension.httppanel.Message;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.ZapMenuItem;
 
-/** Send custom crafted messages via HTTP or other TCP based protocols. */
+/**
+ * Send custom crafted messages via HTTP or other TCP based protocols.
+ *
+ * @deprecated (2.12.0) Replaced by Requester add-on.
+ */
+@Deprecated
 public abstract class ManualRequestEditorDialog extends AbstractFrame {
     private static final long serialVersionUID = 1L;
 

--- a/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/MessageSender.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/MessageSender.java
@@ -21,7 +21,12 @@ package org.parosproxy.paros.extension.manualrequest;
 
 import org.zaproxy.zap.extension.httppanel.Message;
 
-/** A message sender knows how to send a given message object. */
+/**
+ * A message sender knows how to send a given message object.
+ *
+ * @deprecated (2.12.0) Replaced by Requester add-on.
+ */
+@Deprecated
 public interface MessageSender {
 
     void handleSendMessage(Message aMessage) throws Exception;

--- a/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/HttpPanelSender.java
@@ -37,7 +37,6 @@ import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.control.Control.Mode;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
-import org.parosproxy.paros.extension.manualrequest.MessageSender;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
@@ -56,8 +55,13 @@ import org.zaproxy.zap.model.SessionStructure;
 import org.zaproxy.zap.network.HttpRedirectionValidator;
 import org.zaproxy.zap.network.HttpRequestConfig;
 
-/** Knows how to send {@link HttpMessage} objects. */
-public class HttpPanelSender implements MessageSender {
+/**
+ * Knows how to send {@link HttpMessage} objects.
+ *
+ * @deprecated (2.12.0) Replaced by Requester add-on.
+ */
+@Deprecated
+public class HttpPanelSender implements org.parosproxy.paros.extension.manualrequest.MessageSender {
 
     private static final Logger logger = LogManager.getLogger(HttpPanelSender.class);
 

--- a/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/ManualHttpRequestEditorDialog.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/manualrequest/http/impl/ManualHttpRequestEditorDialog.java
@@ -35,6 +35,7 @@
 // ZAP: 2021/02/12 Add shortcut key to Send button (Issue 6448).
 // ZAP: 2022/04/28 Call the new message sender method.
 // ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
+// ZAP: 2022/09/14 Deprecate the class.
 package org.parosproxy.paros.extension.manualrequest.http.impl;
 
 import java.awt.BorderLayout;
@@ -59,8 +60,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.OptionsChangedListener;
-import org.parosproxy.paros.extension.manualrequest.ExtensionManualRequestEditor;
-import org.parosproxy.paros.extension.manualrequest.ManualRequestEditorDialog;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.network.HttpHeader;
@@ -76,8 +75,11 @@ import org.zaproxy.zap.extension.httppanel.HttpPanelResponse;
 import org.zaproxy.zap.extension.httppanel.Message;
 import org.zaproxy.zap.view.ZapMenuItem;
 
+/** @deprecated (2.12.0) Replaced by Requester add-on. */
+@Deprecated
 @SuppressWarnings("serial")
-public class ManualHttpRequestEditorDialog extends ManualRequestEditorDialog
+public class ManualHttpRequestEditorDialog
+        extends org.parosproxy.paros.extension.manualrequest.ManualRequestEditorDialog
         implements OptionsChangedListener {
 
     private static final long serialVersionUID = -5830450800029295419L;
@@ -295,7 +297,9 @@ public class ManualHttpRequestEditorDialog extends ManualRequestEditorDialog
                     new ZapMenuItem(
                             "menu.tools.manReq",
                             View.getSingleton().getMenuShortcutKeyStroke(KeyEvent.VK_M, 0, false));
-            menuItem.setIcon(ExtensionManualRequestEditor.getIcon());
+            menuItem.setIcon(
+                    org.parosproxy.paros.extension.manualrequest.ExtensionManualRequestEditor
+                            .getIcon());
             menuItem.addActionListener(
                     new ActionListener() {
                         @Override
@@ -441,8 +445,9 @@ public class ManualHttpRequestEditorDialog extends ManualRequestEditorDialog
             tabsButtonView =
                     new JToggleButton(
                             new ImageIcon(
-                                    ManualRequestEditorDialog.class.getResource(
-                                            "/resource/icon/layout_tabbed.png")));
+                                    org.parosproxy.paros.extension.manualrequest
+                                            .ManualRequestEditorDialog.class
+                                            .getResource("/resource/icon/layout_tabbed.png")));
             tabsButtonView.setToolTipText(TABS_VIEW_TOOL_TIP);
 
             tabsButtonView.addActionListener(
@@ -458,8 +463,10 @@ public class ManualHttpRequestEditorDialog extends ManualRequestEditorDialog
             aboveButtonView =
                     new JToggleButton(
                             new ImageIcon(
-                                    ManualRequestEditorDialog.class.getResource(
-                                            "/resource/icon/layout_vertical_split.png")));
+                                    org.parosproxy.paros.extension.manualrequest
+                                            .ManualRequestEditorDialog.class
+                                            .getResource(
+                                                    "/resource/icon/layout_vertical_split.png")));
             aboveButtonView.setToolTipText(ABOVE_VIEW_TOOL_TIP);
 
             aboveButtonView.addActionListener(
@@ -475,8 +482,10 @@ public class ManualHttpRequestEditorDialog extends ManualRequestEditorDialog
             sideBySideButtonView =
                     new JToggleButton(
                             new ImageIcon(
-                                    ManualRequestEditorDialog.class.getResource(
-                                            "/resource/icon/layout_horizontal_split.png")));
+                                    org.parosproxy.paros.extension.manualrequest
+                                            .ManualRequestEditorDialog.class
+                                            .getResource(
+                                                    "/resource/icon/layout_horizontal_split.png")));
             sideBySideButtonView.setToolTipText(SIDE_BY_SIDE_VIEW_TOOL_TIP);
 
             sideBySideButtonView.addActionListener(

--- a/zap/src/main/java/org/zaproxy/zap/control/CoreFunctionality.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/CoreFunctionality.java
@@ -81,9 +81,6 @@ public final class CoreFunctionality {
             ArrayList<Extension> extensions = new ArrayList<>();
             extensions.add(new org.parosproxy.paros.extension.edit.ExtensionEdit());
             extensions.add(new org.parosproxy.paros.extension.history.ExtensionHistory());
-            extensions.add(
-                    new org.parosproxy.paros.extension.manualrequest
-                            .ExtensionManualRequestEditor());
             extensions.add(new org.parosproxy.paros.extension.option.ExtensionOption());
             extensions.add(new org.zaproxy.zap.extension.alert.ExtensionAlert());
             extensions.add(new org.zaproxy.zap.extension.anticsrf.ExtensionAntiCSRF());

--- a/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuResendMessage.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuResendMessage.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.history;
 
 import org.parosproxy.paros.extension.history.ExtensionHistory;
-import org.parosproxy.paros.extension.manualrequest.ManualRequestEditorDialog;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
@@ -39,7 +38,8 @@ public class PopupMenuResendMessage extends PopupMenuItemHttpMessageContainer {
 
     @Override
     public void performAction(HttpMessage msg) {
-        ManualRequestEditorDialog dialog = extension.getResendDialog();
+        org.parosproxy.paros.extension.manualrequest.ManualRequestEditorDialog dialog =
+                extension.getResendDialog();
 
         dialog.setMessage(msg.cloneRequest());
         dialog.setVisible(true);

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuResendMessage.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuResendMessage.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.stdmenus;
 
 import org.parosproxy.paros.extension.history.ExtensionHistory;
-import org.parosproxy.paros.extension.manualrequest.ManualRequestEditorDialog;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
@@ -40,7 +39,8 @@ public class PopupMenuResendMessage extends PopupMenuItemHttpMessageContainer {
 
     @Override
     public void performAction(HttpMessage msg) {
-        ManualRequestEditorDialog dialog = extension.getResendDialog();
+        org.parosproxy.paros.extension.manualrequest.ManualRequestEditorDialog dialog =
+                extension.getResendDialog();
 
         dialog.setMessage(msg.cloneRequest());
         dialog.setVisible(true);


### PR DESCRIPTION
Deprecate all related classes and remove the extension from core
functionality, it will be provided by the requester add-on.
Address deprecation warnings in other classes.

---
WIP pending changes in the add-on.