### PR TITLE
Restore component/view on configuration load

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/HttpPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/HttpPanel.java
@@ -601,6 +601,11 @@ public abstract class HttpPanel extends AbstractPanel {
             while (it.hasNext()) {
                 it.next().loadConfig(fileConfiguration);
             }
+
+            if (savedLastSelectedComponentName != null
+                    && components.containsKey(savedLastSelectedComponentName)) {
+                switchComponent(savedLastSelectedComponentName);
+            }
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/component/HttpPanelComponentViewsManager.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/component/HttpPanelComponentViewsManager.java
@@ -488,6 +488,10 @@ public class HttpPanelComponentViewsManager implements ItemListener, MessageLoca
         while (it.hasNext()) {
             it.next().loadConfiguration(fileConfiguration);
         }
+
+        if (savedSelectedViewName != null && views.containsKey(savedSelectedViewName)) {
+            switchView(savedSelectedViewName);
+        }
     }
 
     public void saveConfig(FileConfiguration fileConfiguration) {


### PR DESCRIPTION
Show the component/view previously saved when loading the configuration
to properly restore the state when the panels are dynamically loaded.