### PR TITLE
Remove SQLite dependency

### DIFF
--- a/LEGALNOTICE.md
+++ b/LEGALNOTICE.md
@@ -64,7 +64,5 @@ and subject to their respective licenses.
 | log4j-api-2.19.0.jar                | Apache 2.0                |
 | log4j-core-2.19.0.jar               | Apache 2.0                |
 | rsyntaxtextarea-3.2.0.jar           | BSD-3 clause              |
-| sqlite-jdbc-3.39.3.0.jar            | BSD-2 clause              |
-| - NestedVM                          | Apache 2.0                |
 | swingx-all-1.6.5-1.jar              | LGPL 2.1                  |
 | xom-1.3.8.jar                       | LGPL                      |

--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderSVNEntriesParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderSVNEntriesParser.java
@@ -128,21 +128,6 @@ public class SpiderSVNEntriesParser extends SpiderParser {
                 fos.write(message.getResponseBody().getBytes());
                 fos.close();
 
-                if (getLogger().isDebugEnabled()) {
-                    org.sqlite.JDBC jdbcDriver = new org.sqlite.JDBC();
-                    getLogger()
-                            .debug(
-                                    "Created a temporary SQLite database file '"
-                                            + tempSqliteFile
-                                            + "'");
-                    getLogger()
-                            .debug(
-                                    "SQLite JDBC Driver is version "
-                                            + jdbcDriver.getMajorVersion()
-                                            + "."
-                                            + jdbcDriver.getMinorVersion());
-                }
-
                 // now load the temporary SQLite file using JDBC, and query the file entries within.
                 Class.forName("org.sqlite.JDBC");
                 String sqliteConnectionUrl = "jdbc:sqlite:" + tempSqliteFile.getAbsolutePath();

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -89,7 +89,6 @@ dependencies {
     api("org.jfree:jfreechart:1.5.3")
     api("org.jgrapht:jgrapht-core:0.9.0")
     api("org.swinglabs.swingx:swingx-all:1.6.5-1")
-    api("org.xerial:sqlite-jdbc:3.39.3.0")
 
     implementation("commons-validator:commons-validator:1.7")
     // Don't need its dependencies, for now.


### PR DESCRIPTION
Core no longer needs it (deprecated and unused code) and the other two
add-ons that need it will be changed to no longer rely on core.
Remove code that was instantiating the JDBC driver just for logging.

Part of https://github.com/zaproxy/zaproxy/issues/3113.

---
See also zaproxy/zap-extensions#4067.