### PR TITLE
Build releases with Java 11

### DIFF
--- a/.github/workflows/release-main-version.yml
+++ b/.github/workflows/release-main-version.yml
@@ -25,4 +25,6 @@ jobs:
       env:
         INSTALL4J_LICENSE: ${{ secrets.INSTALL4J_LICENSE }}
         ZAPBOT_TOKEN: ${{ secrets.ZAPBOT_TOKEN }}
+        ZAP_RELEASE: 1
+        ZAP_JAVA_VERSION: 11
       run: ./gradlew "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m" :zap:createMainRelease

--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -19,4 +19,6 @@ jobs:
     - name: Build and Release
       env:
         ZAPBOT_TOKEN: ${{ secrets.ZAPBOT_TOKEN }}
+        ZAP_RELEASE: 1
+        ZAP_JAVA_VERSION: 11
       run: ./gradlew "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m" :zap:createWeeklyRelease

--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/GradleBuildWithGitRepos.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/GradleBuildWithGitRepos.java
@@ -214,7 +214,6 @@ public class GradleBuildWithGitRepos extends DefaultTask {
         getProject()
                 .exec(
                         spec -> {
-                            spec.environment("ZAP_RELEASE", "1");
                             spec.setWorkingDir(repoDir);
                             spec.setExecutable(gradleWrapper());
                             spec.args(execArgs);

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -28,10 +28,10 @@ val creationDate by extra { project.findProperty("creationDate") ?: LocalDate.no
 val distDir = file("src/main/dist/")
 
 java {
-    // Compile ZAP with Java 8 when building releases.
-    if (System.getenv("GITHUB_REF")?.contains("refs/tags/") ?: false) {
+    // Compile with appropriate Java version when building ZAP releases.
+    if (System.getenv("ZAP_RELEASE") != null) {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(8))
+            languageVersion.set(JavaLanguageVersion.of(System.getenv("ZAP_JAVA_VERSION")))
         }
     } else {
         sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Update workflows and build to use Java 11 when building the releases,
version is defined with a env var to also be used by other repos.