### PR TITLE
Docker: ZAP API fix

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2022-09-27
+ - Fixed problem where python-owasp-zap-v2.4 was getting an older version.
+
 ### 2022-09-26
  - Changed weekly image to use debian:unstable-slim.
 

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -58,9 +58,9 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	chown zap /zap-src && \
 	chgrp zap /zap-src
 
-RUN pip3 install --upgrade awscli pip python-owasp-zap-v2.4 pyyaml urllib3 zapcli
+RUN pip3 install --upgrade awscli pip pyyaml urllib3 zapcli
 # This apparently must be run separately so the packaged scans will run, don't know why
-RUN pip3 install --upgrade requests
+RUN pip3 install --upgrade python-owasp-zap-v2.4 requests
 
 #Change to the zap user so things get done as the right person (apart from copy)
 USER zap

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -48,9 +48,9 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --upgrade awscli pip python-owasp-zap-v2.4 pyyaml urllib3 zapcli
+RUN pip3 install --upgrade awscli pip pyyaml urllib3 zapcli
 # This apparently must be run separately so the packaged scans will run, don't know why
-RUN pip3 install --upgrade requests
+RUN pip3 install --upgrade python-owasp-zap-v2.4 requests
 
 RUN useradd -d /home/zap -m -s /bin/bash zap
 RUN echo zap:zap | chpasswd


### PR DESCRIPTION
The ZAP python API package 0.0.12 was getting installed instead of the latest.
No idea why, or why this fixes it .. but it does 😒 

Fixes #7483

Signed-off-by: Simon Bennetts <psiinon@gmail.com>