### PR TITLE
Docker: Use curl for the health check

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to the docker containers will be documented in this file.
 
 ### 2022-09-27
  - Fixed problem where python-owasp-zap-v2.4 was getting an older version.
+ - Use curl for the weekly/live health checks.
 
 ### 2022-09-26
  - Changed weekly image to use debian:unstable-slim.

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -114,4 +114,4 @@ RUN chown zap:zap /zap/* && \
 WORKDIR /zap
 
 USER zap
-HEALTHCHECK --retries=5 --interval=5s CMD zap-cli status
+HEALTHCHECK CMD curl --silent --output /dev/null --fail http://localhost:$ZAP_PORT/ || exit 1

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -103,5 +103,4 @@ RUN chown zap:zap /zap/* CHANGELOG.md && \
 
 #Change back to zap at the end
 USER zap
-
-HEALTHCHECK --retries=5 --interval=5s CMD zap-cli status
+HEALTHCHECK CMD curl --silent --output /dev/null --fail http://localhost:$ZAP_PORT/ || exit 1


### PR DESCRIPTION
Default port example:
```
docker run -d owasp/zap2docker-weekly zap.sh -daemon                                                             
d42b6a016d2d4381d5cbcb0e9509c756068d232063a967efa65b69a469e43b39

docker inspect --format='{{json .State.Health}}' d42b6a016d2d4381d5cbcb0e9509c756068d232063a967efa65b69a469e43b39
{"Status":"starting","FailingStreak":0,"Log":[]}

docker inspect --format='{{json .State.Health}}' d42b6a016d2d4381d5cbcb0e9509c756068d232063a967efa65b69a469e43b39
{"Status":"healthy","FailingStreak":0,"Log":[{"Start":"2022-09-27T09:39:44.940408829Z","End":"2022-09-27T09:39:45.068881904Z","ExitCode":0,"Output":""}]}
```

Non default port example:
```
docker run -e ZAP_PORT=9090 -d owasp/zap2docker-weekly zap.sh -daemon -port 9090                                 
c4cf2ea3145c6bb56ae80b7f4eb28fac88811a946c412f66461365f8408d6ee7

docker inspect --format='{{json .State.Health}}' c4cf2ea3145c6bb56ae80b7f4eb28fac88811a946c412f66461365f8408d6ee7
{"Status":"starting","FailingStreak":0,"Log":[]}

docker inspect --format='{{json .State.Health}}' c4cf2ea3145c6bb56ae80b7f4eb28fac88811a946c412f66461365f8408d6ee7
{"Status":"healthy","FailingStreak":0,"Log":[{"Start":"2022-09-27T09:41:40.167098753Z","End":"2022-09-27T09:41:40.292437476Z","ExitCode":0,"Output":""}]}
```

C/o https://howchoo.com/devops/how-to-add-a-health-check-to-your-docker-container

I've used the `--silent --output /dev/null` curl options as otherwise the output looks like this:
```
docker inspect --format='{{json .State.Health}}' c3a6358c1cffc5a09c2e51fcd0a96f01ac0834d29c3a537d73fb7dd3d2582919
{"Status":"healthy","FailingStreak":0,"Log":[{"Start":"2022-09-27T09:34:12.794926814Z","End":"2022-09-27T09:34:12.913428613Z","ExitCode":0,"Output":"  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100  1518  100  1518    0     0  31490      0 --:--:-- --:--:-- --:--:-- 31625\n<head>\n<title>ZAP API UI</title>\n</head>\n<body>\n<h1>Welcome to the OWASP Zed Attack Proxy (ZAP)</h1><p>ZAP is an easy to use integrated penetration testing tool for finding vulnerabilities in web applications.</p><p></p><p>Please be aware that you should only attack applications that you have been specifically been given permission to test.</p><h2>Proxy Configuration</h2><p>To use ZAP effectively it is recommended that you configure your browser to proxy via ZAP.</p><p></p><p>The easiest way to do this is to launch your browser from ZAP via the \"Quick Start / Manual Explore\" panel - it will be configured to proxy via ZAP and ignore any certificate warnings.<br>Alternatively you can configure your browser manually or use the generated <a href=\"/OTHER/network/other/proxy.pac/?apinonce=4e9f772aca0bdb69\">PAC file</a>.</p><h2>HTTPS Warnings Prevention</h2><p>To avoid HTTPS Warnings <a href=\"/OTHER/network/other/rootCaCert/?apinonce=d9c0a47cd91d090b\">download</a> and <a href=\"https://www.zaproxy.org/docs/desktop/ui/dialogs/options/dynsslcert/#install\" target=\"_blank\">install CA root Certificate</a> in your Mobile device or computer.</p><h2>Links</h2><li><a href=\"/UI\">Local API</a></li><li><a href=\"https://www.zaproxy.org/\">ZAP Website</a></li><li><a href=\"https://groups.google.com/group/zaproxy-users\">ZAP User Group</a></li><li><a href=\"https://groups.google.com/group/zaproxy-develop\">ZAP Developer Group</a></li><li><a href=\"https://github.com/zaproxy/zaproxy/issues\">Report an issue</a></li></body>\n"}]}

```


Signed-off-by: Simon Bennetts <psiinon@gmail.com>