### PR TITLE
Include Database add-on in weekly releases

### DIFF
--- a/zap/src/main/weekly-add-ons.json
+++ b/zap/src/main/weekly-add-ons.json
@@ -11,6 +11,7 @@
       ":addOns:callhome",
       ":addOns:commonlib",
       ":addOns:coreLang",
+      ":addOns:database",
       ":addOns:diff",
       ":addOns:directorylistv1",
       ":addOns:domxss",


### PR DESCRIPTION
The add-on is required by add-ons already included (e.g. spider).