### PR TITLE
Restore Session title and Persist Session's state

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/view/MainMenuBar.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/MainMenuBar.java
@@ -287,9 +287,6 @@ public class MainMenuBar extends JMenuBar {
                         public void actionPerformed(java.awt.event.ActionEvent e) {
                             try {
                                 getMenuFileControl().newSession(true);
-                                if (Model.getSingleton().getSession().isNewState()) {
-                                    toggleSnapshotState(false);
-                                }
                             } catch (Exception e1) {
                                 View.getSingleton()
                                         .showWarningDialog(
@@ -314,9 +311,6 @@ public class MainMenuBar extends JMenuBar {
                         @Override
                         public void actionPerformed(java.awt.event.ActionEvent e) {
                             getMenuFileControl().openSession();
-                            if (!Model.getSingleton().getSession().isNewState()) {
-                                toggleSnapshotState(true);
-                            }
                         }
                     });
         }
@@ -337,9 +331,6 @@ public class MainMenuBar extends JMenuBar {
                                         .showWarningDialog(
                                                 Constant.messages.getString(
                                                         "menu.file.sessionExists.error"));
-                            }
-                            if (!Model.getSingleton().getSession().isNewState()) {
-                                toggleSnapshotState(true);
                             }
                         }
                     });
@@ -557,7 +548,7 @@ public class MainMenuBar extends JMenuBar {
     public void sessionChanged(Session session) {
         if (session != null) {
             this.getMenuFileSaveAs().setEnabled(session.isNewState());
-            this.getMenuFileSnapshot().setEnabled(!session.isNewState());
+            toggleSnapshotState(!session.isNewState());
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
@@ -59,6 +59,8 @@ public class ExtensionUiUtils extends ExtensionAdaptor implements SessionChanged
 
     @Override
     public void initView(ViewDelegate view) {
+        super.initView(view);
+
         Arrays.asList(
                         new LookAndFeelInfo("Flat Light", "com.formdev.flatlaf.FlatLightLaf"),
                         new LookAndFeelInfo("Flat Dark", "com.formdev.flatlaf.FlatDarkLaf"),

--- a/zap/src/test/java/org/zaproxy/zap/extension/uiutils/ExtensionUiUtilsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/uiutils/ExtensionUiUtilsUnitTest.java
@@ -1,0 +1,59 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.uiutils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.extension.ViewDelegate;
+
+/** Unit test for {@link ExtensionUiUtils}. */
+class ExtensionUiUtilsUnitTest {
+
+    private ExtensionUiUtils extension;
+
+    @BeforeEach
+    void setup() {
+        extension = new ExtensionUiUtils();
+    }
+
+    @Test
+    void shouldNotHaveViewByDefault() {
+        // Given / When
+        ViewDelegate view = extension.getView();
+        // When
+        assertThat(view, is(nullValue()));
+    }
+
+    @Test
+    void shouldHaveViewAfterInitView() {
+        // Given
+        ViewDelegate view = mock(ViewDelegate.class);
+        // When
+        extension.initView(view);
+        // When
+        assertThat(extension.getView(), is(equalTo(view)));
+    }
+}


### PR DESCRIPTION
Properly initialise the view in `ExtensionUiUtils` to have the session changed listener added on hook, which sets the main title to the session's name and controls the state of Persist Session menu/button.
Remove statements no longer needed in `MainMenuBar` that updated the button state, now done in a single method.

Fix #7423.