### PR TITLE
Remove Apache Commons XPath dependency

### DIFF
--- a/LEGALNOTICE.md
+++ b/LEGALNOTICE.md
@@ -36,10 +36,8 @@ and subject to their respective licenses.
 | commons-collections-3.2.2.jar       | Apache 2.0                |
 | commons-configuration-1.10.jar      | Apache 2.0                |
 | commons-csv-1.9.0.jar               | Apache 2.0                |
-| commons-digester-1.8.1.jar          | Apache 2.0                |
 | commons-httpclient-3.1.jar          | Apache 2.0                |
 | commons-io-2.11.0.jar               | Apache 2.0                |
-| commons-jxpath-1.3.jar              | Apache 2.0                |
 | commons-lang-2.6.jar                | Apache 2.0                |
 | commons-lang3-3.12.0.jar            | Apache 2.0                |
 | commons-logging-1.2.jar             | Apache 2.0                |

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
@@ -543,9 +543,6 @@ public class AddOn {
      * Constructs an {@code AddOn} from an add-on entry of {@code ZapVersions.xml} file. The
      * installation status of the add-on is 'not installed'.
      *
-     * <p>The given {@code SubnodeConfiguration} must have a {@code XPathExpressionEngine}
-     * installed.
-     *
      * <p>The {@value #MANIFEST_FILE_NAME} ZIP file entry is read, if the add-on file exists
      * locally.
      *
@@ -554,7 +551,6 @@ public class AddOn {
      * @param xmlData the source of add-on entry of {@code ZapVersions.xml} file
      * @throws MalformedURLException if the {@code URL} of the add-on is malformed
      * @throws IOException if an error occurs while reading the XML data
-     * @see org.apache.commons.configuration.tree.xpath.XPathExpressionEngine
      */
     public AddOn(String id, File baseDir, SubnodeConfiguration xmlData)
             throws MalformedURLException, IOException {

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnCollection.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnCollection.java
@@ -27,7 +27,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import org.apache.commons.configuration.tree.xpath.XPathExpressionEngine;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -98,33 +97,33 @@ public class AddOnCollection {
     }
 
     private void load(ZapXmlConfiguration config) {
-        config.setExpressionEngine(new XPathExpressionEngine());
         try {
             // See if theres a ZAP release defined
-            String version = config.getString("core/version");
+            String version = config.getString("core.version");
             if (Platform.daily.equals(platform)) {
                 // Daily releases take precedence even if running on Kali as they will have been
                 // manually installed
-                version = config.getString("core/daily-version", version);
+                version = config.getString("core.daily-version", version);
             } else if (Constant.isKali()) {
-                version = config.getString("core/kali-version", version);
+                version = config.getString("core.kali-version", version);
             }
             if (version != null && version.length() > 0) {
-                String relUrlStr = config.getString("core/relnotes-url", null);
+                String relUrlStr = config.getString("core.relnotes-url", null);
                 URL relUrl = null;
                 if (relUrlStr != null) {
                     relUrl = new URL(relUrlStr);
                 }
 
+                String platformPrefix = "core." + platform.name() + ".";
                 this.zapRelease =
                         new ZapRelease(
                                 version,
-                                new URL(config.getString("core/" + platform.name() + "/url")),
-                                config.getString("core/" + platform.name() + "/file"),
-                                config.getLong("core/" + platform.name() + "/size"),
-                                config.getString("core/relnotes"),
+                                new URL(config.getString(platformPrefix + "url")),
+                                config.getString(platformPrefix + "file"),
+                                config.getLong(platformPrefix + "size"),
+                                config.getString("core.relnotes"),
                                 relUrl,
-                                config.getString("core/" + platform.name() + "/hash"));
+                                config.getString(platformPrefix + "hash"));
             }
         } catch (Exception e) {
             logger.error(e.getMessage(), e);

--- a/zap/src/main/java/org/zaproxy/zap/control/ZapAddOnXmlFile.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/ZapAddOnXmlFile.java
@@ -32,17 +32,17 @@ import org.apache.commons.configuration.HierarchicalConfiguration;
 public class ZapAddOnXmlFile extends BaseZapAddOnXmlData {
 
     private static final String ASCANRULE_ELEMENT = "ascanrule";
-    private static final String ASCANRULES_ALL_ELEMENTS = "ascanrules/" + ASCANRULE_ELEMENT;
+    private static final String ASCANRULES_ALL_ELEMENTS = "ascanrules." + ASCANRULE_ELEMENT;
     private static final String PSCANRULE_ELEMENT = "pscanrule";
-    private static final String PSCANRULES_ALL_ELEMENTS = "pscanrules/" + PSCANRULE_ELEMENT;
+    private static final String PSCANRULES_ALL_ELEMENTS = "pscanrules." + PSCANRULE_ELEMENT;
     private static final String FILE_ELEMENT = "file";
-    private static final String FILES_ALL_ELEMENTS = "files/" + FILE_ELEMENT;
+    private static final String FILES_ALL_ELEMENTS = "files." + FILE_ELEMENT;
     private static final String LIB_ELEMENT = "lib";
-    private static final String LIBS_ALL_ELEMENTS = "libs/" + LIB_ELEMENT;
+    private static final String LIBS_ALL_ELEMENTS = "libs." + LIB_ELEMENT;
     private static final String BUNDLE_ELEMENT = "bundle";
-    private static final String BUNDLE_PREFIX_ATT = "bundle/@prefix";
+    private static final String BUNDLE_PREFIX_ATT = "bundle[@prefix]";
     private static final String HELPSET_ELEMENT = "helpset";
-    private static final String HELPSET_LOCALE_TOKEN_ATT = "helpset/@localetoken";
+    private static final String HELPSET_LOCALE_TOKEN_ATT = "helpset[@localetoken]";
 
     private List<String> ascanrules;
     private List<String> pscanrules;

--- a/zap/src/test/java/org/zaproxy/zap/control/AddOnUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/AddOnUnitTest.java
@@ -47,7 +47,6 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-import org.apache.commons.configuration.tree.xpath.XPathExpressionEngine;
 import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.control.AddOn.BundleData;
 import org.zaproxy.zap.control.AddOn.HelpSetData;
@@ -973,7 +972,6 @@ class AddOnUnitTest extends AddOnTestUtils {
 
     private static ZapXmlConfiguration createZapVersionsXml() throws Exception {
         ZapXmlConfiguration zapVersionsXml = new ZapXmlConfiguration(ZAP_VERSIONS_XML);
-        zapVersionsXml.setExpressionEngine(new XPathExpressionEngine());
         return zapVersionsXml;
     }
 }

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -88,7 +88,6 @@ dependencies {
 
     implementation("com.formdev:flatlaf:2.5")
 
-    runtimeOnly("commons-jxpath:commons-jxpath:1.3")
     runtimeOnly("commons-logging:commons-logging:1.2")
     runtimeOnly("xom:xom:1.3.8") {
         setTransitive(false)


### PR DESCRIPTION
The dependency was used in a subset of functionality which can be easily replaced with the usage of default expression engine.
Update notations used to read the properties and code accordingly.
Remove also Commons Digester from legalnotice, a transitive dependency of Commons Validator removed earlier.