### PR TITLE
Fix buildWeeklyAddOns task

### DIFF
--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/GradleBuildWithGitRepos.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/GradleBuildWithGitRepos.java
@@ -51,7 +51,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.TaskAction;
-import org.zaproxy.zap.internal.RepoData;
+import org.zaproxy.zap.tasks.internal.RepoData;
 
 /** A task that clones Git repositories and runs Gradle tasks contained in them. */
 public class GradleBuildWithGitRepos extends DefaultTask {

--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/internal/RepoData.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/internal/RepoData.java
@@ -3,7 +3,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 The ZAP Development Team
+ * Copyright 2022 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.internal
+package org.zaproxy.zap.tasks.internal;
 
-data class RepoData(val cloneUrl: String, val branch: String?, val projects: List<String>)
+import java.util.List;
+
+public class RepoData {
+
+    private String cloneUrl;
+    private String branch;
+    private List<String> projects;
+
+    public String getCloneUrl() {
+        return cloneUrl;
+    }
+
+    public String getBranch() {
+        return branch;
+    }
+
+    public List<String> getProjects() {
+        return projects;
+    }
+}


### PR DESCRIPTION
Provide the `RepoData` with a default constructor, needed per the use of the different JSON parser.