### PR TITLE
Set/remove the Content-Type when mutating the method

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/network/HttpMessage.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpMessage.java
@@ -1016,6 +1016,8 @@ public class HttpMessage implements Message {
                 }
                 // Clear the body
                 body = "";
+                // Remove Content-Type if present
+                getRequestHeader().setHeader(HttpRequestHeader.CONTENT_TYPE, null);
 
             } else if (method.equals(HttpRequestHeader.POST)) {
                 // To be a port, move all URL query params into the body
@@ -1035,6 +1037,10 @@ public class HttpMessage implements Message {
                             sb.append('=');
                         }
                     }
+                    getRequestHeader()
+                            .setHeader(
+                                    HttpRequestHeader.CONTENT_TYPE,
+                                    HttpRequestHeader.FORM_URLENCODED_CONTENT_TYPE);
                     body = sb.toString();
                     uri.setQuery(null);
                 }


### PR DESCRIPTION
Opening a GET request with the request editor and switching the method with the dropdown from GET to POST moves the query parameters to the request body but it is not adding the correct content-type header, making the call silently fail.
This PR sets correctly the content-type header when switching methods in the requester add-on.

Fix zaproxy/zaproxy#7440

Signed-off-by: Leyart [leyart@gmail.com](mailto:leyart@gmail.com)