### PR TITLE
Remove tasks from release pull request

### DIFF
--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/github-releases.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/github-releases.gradle.kts
@@ -82,14 +82,7 @@ val createPullRequestMainRelease by tasks.registering(CreatePullRequest::class) 
     commitDescription.set("Remove `-SNAPSHOT` from the version.")
 
     pullRequestTitle.set("Release version ${project.version}")
-    pullRequestDescription.set("""
-    Pending tasks, update:
-      - [ ] `Constant#VERSION_TAG`
-      - [ ] CFU links (`ExtensionAutoUpdate#ZAP_VERSIONS_REL_XML_DESKTOP_SHORT`, `ZAP_VERSIONS_REL_XML_DAEMON_SHORT`, and `ZAP_VERSIONS_REL_XML_FULL`)
-      - [ ] Add-ons
-      - [ ] macOS JRE
-      - [ ] JavaDoc link in `README`
-    """.trimIndent())
+    pullRequestDescription.set("")
 }
 
 tasks.register<CreateMainRelease>("createMainRelease") {


### PR DESCRIPTION
Keep the release tasks/steps in a single place (`RELEASING.md`) and avoid duplication.