### PR TITLE
Avoid tab focus on Alert selection in Full layout

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertPanel.java
@@ -63,6 +63,7 @@ import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
+import org.parosproxy.paros.view.WorkbenchPanel.Layout;
 import org.zaproxy.zap.extension.httppanel.HttpPanel;
 import org.zaproxy.zap.extension.search.SearchMatch;
 import org.zaproxy.zap.utils.DisplayUtils;
@@ -691,6 +692,7 @@ public class AlertPanel extends AbstractPanel {
             SearchMatch sm = null;
             int start;
 
+            HttpPanel focusPanel = null;
             // Highlight the 'attack' / evidence
             if (highlight == null || highlight.length() == 0) {
                 // ignore
@@ -702,7 +704,7 @@ public class AlertPanel extends AbstractPanel {
                                 start,
                                 start + highlight.length());
                 responsePanel.highlightHeader(sm);
-                responsePanel.setTabFocus();
+                focusPanel = responsePanel;
 
             } else if ((start = msg.getResponseBody().toString().indexOf(highlight)) >= 0) {
                 sm =
@@ -712,7 +714,7 @@ public class AlertPanel extends AbstractPanel {
                                 start,
                                 start + highlight.length());
                 responsePanel.highlightBody(sm);
-                responsePanel.setTabFocus();
+                focusPanel = responsePanel;
 
             } else if ((start = msg.getRequestHeader().toString().indexOf(highlight)) >= 0) {
                 sm =
@@ -722,7 +724,7 @@ public class AlertPanel extends AbstractPanel {
                                 start,
                                 start + highlight.length());
                 requestPanel.highlightHeader(sm);
-                requestPanel.setTabFocus();
+                focusPanel = requestPanel;
 
             } else if ((start = msg.getRequestBody().toString().indexOf(highlight)) >= 0) {
                 sm =
@@ -732,7 +734,12 @@ public class AlertPanel extends AbstractPanel {
                                 start,
                                 start + highlight.length());
                 requestPanel.highlightBody(sm);
-                requestPanel.setTabFocus();
+                focusPanel = requestPanel;
+            }
+
+            if (focusPanel != null
+                    && getView().getMainFrame().getWorkbenchLayout() != Layout.FULL) {
+                focusPanel.setTabFocus();
             }
         }
     }


### PR DESCRIPTION
Do not focus the Request/Response tabs when highlighting the evidence of the selected alert in Full layout, otherwise one has to manually reselect the Alerts tab to continue reading the alerts.

Fix #7559.