### PR TITLE
Add GitHub workflow to release the snap

### DIFF
--- a/.github/workflows/release-snap.yml
+++ b/.github/workflows/release-snap.yml
@@ -1,0 +1,21 @@
+name: Release Snap
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: snapcore/action-build@v1
+      id: build
+      with:
+        path: snap
+    - uses: snapcore/action-publish@v1
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.ZAPBOT_SNAP_STORE_LOGIN }}
+      with:
+        snap: ${{ steps.build.outputs.snap }}
+        release: stable

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,6 +29,7 @@ These tasks use checkboxes so that they can be copied into an issue.
      - [ ] Remove add-ons no longer needed.
      - [ ] Update add-ons with the task mentioned in `main-add-ons.yml`.
   - [ ] Update [SECURITY.md](https://github.com/zaproxy/zaproxy/blob/main/SECURITY.md) to mention the latest version.
+  - [ ] Update the version of the snap and the source file in [snapcraft.yaml](https://github.com/zaproxy/zaproxy/blob/main/snap/snapcraft.yaml).
 - [ ] Merge the pull request, to create the tag and the draft release (done by [Release Main Version](https://github.com/zaproxy/zaproxy/actions/workflows/release-main-version.yml));
 - [ ] Create the macOS release on a Mac (requires `hdiutil`):
   - [ ] Check out the tag: e.g. `git checkout tags/v2.12.0`
@@ -68,6 +69,7 @@ The resulting localized resources are added/updated in the repository periodical
   - [ ] Kali - [new issue](https://bugs.kali.org/)
   - [ ] [Flathub](https://github.com/flathub/org.zaproxy.ZAP)
   - [ ] [Snap](https://github.com/zaproxy/zaproxy/tree/main/snap)
+    - [ ] Run the workflow [Release Snap](https://github.com/zaproxy/zaproxy/actions/workflows/release-snap.yml).
 - [ ] Update 3rd Party Package Managers 
   - [ ] Homebrew - [owasp-zap.rb](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/owasp-zap.rb)
   - [ ] Scoop - [zaproxy.json](https://github.com/ScoopInstaller/Extras/blob/master/bucket/zaproxy.json)

--- a/snap/README.md
+++ b/snap/README.md
@@ -1,10 +1,6 @@
 This directory contains all of the files required to build a ZAP [snap].
 
-Docker is used to build the snap as `snapcraft` is only supported on a limited number of Linux distros.
-
-In order to build the snap run:
-
-`./build-snap.sh`
+In order to manually build the snap run `snapcraft` in the current directory.
 
 To install the snap you've built locally run:
 
@@ -17,7 +13,7 @@ You should then be able to run the ZAP snap using:
 
 `zaproxy`
 
-In order to publish the snap you will need appropriate permissions.
+In order to manually publish the snap you will need appropriate permissions.
 Those people who have then can upload the snap using:
 
 ```

--- a/snap/build-snap.sh
+++ b/snap/build-snap.sh
@@ -1,3 +1,0 @@
-export DOCKER=snapcore/snapcraft:stable
-docker pull $DOCKER
-docker run -it -v "$PWD:$PWD" -w "$PWD" $DOCKER /bin/sh -c 'apt update && snapcraft clean && snapcraft'

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: zaproxy
-version: '2.11.1' 
+version: '2.12.0'
 summary: OWASP ZAP, a tool for finding vulnerabilities in web applications
 description: |
   The OWASP Zed Attack Proxy (ZAP) is one of the world’s most popular free security tools
@@ -25,7 +25,7 @@ apps:
 
 parts:
   zaproxy:
-    source: https://github.com/zaproxy/zaproxy/releases/download/v2.11.1/ZAP_2.11.1_Linux.tar.gz
+    source: https://github.com/zaproxy/zaproxy/releases/download/v2.12.0/ZAP_2.12.0_Linux.tar.gz
     plugin: dump
     filesets:
       pkg-contents: [ ./* ]
@@ -40,6 +40,7 @@ parts:
     override-build: |
       cp /etc/ssl/certs/java/cacerts $SNAPCRAFT_PART_INSTALL/usr/lib/jvm/java-11-openjdk-$SNAPCRAFT_TARGET_ARCH/lib/security/cacerts
       cp /etc/ssl/certs/java/cacerts $SNAPCRAFT_PART_INSTALL/etc/ssl/certs/java/cacerts
+      rm $SNAPCRAFT_PART_INSTALL/usr/lib/jvm/java-11-openjdk-$SNAPCRAFT_TARGET_ARCH/lib/security/blacklisted.certs
   desktop-glib-only:
     build-packages:
       - libglib2.0-dev


### PR DESCRIPTION
Add workflow to publish and release the snap.
Update documents accordingly.
Remove file no longer needed.
Update snap version to match the released version.

---
zapbot credentials need to be added as secret `ZAPBOT_SNAP_STORE_LOGIN`.