### PR TITLE
Use full path to zap-x.sh in Docker packaged scans

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2022-11-07
+ - Updated `zap-x.sh` to use full path
+
 ### 2022-11-04
   - Fixed `zap-x.sh` to return the exit code from `zap.sh` instead of `rm -f`
 

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to the docker containers will be documented in this file.
 
 ### 2022-11-07
- - Updated `zap-x.sh` to use full path
+ - Updated packaged scans to use full path to `zap-x.sh`.
 
 ### 2022-11-04
   - Fixed `zap-x.sh` to return the exit code from `zap.sh` instead of `rm -f`

--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -274,7 +274,7 @@ def add_zap_options(params, zap_options):
 
 def create_start_options(mode, port, extra_params):
     params = [
-        'zap-x.sh', mode,
+        '/zap/zap-x.sh', mode,
         '-port', str(port),
         '-host', '0.0.0.0',
         '-config', 'database.recoverylog=false',


### PR DESCRIPTION
This fixes an issue where depending in the shell context / runner that the zap scan is being executed it could not be able to locate the `zap-x.sh` shell script without the parent folder.

How I've troubleshooted the issue:
1 - Have a wrapper image that uses zap as base and modified  https://github.com/zaproxy/zaproxy/blob/main/docker/zap-baseline.py#L428 this line to throw a general error (https://github.com/soos-io/soos-dast)
2 - Have Github Action that uses that wrapper (https://github.com/soos-io/soos-dast-github-action)
3 - Run the github action and see what the issue is 
![image](https://user-images.githubusercontent.com/92373106/199231551-bc2c5b3a-e5b4-46e8-b43b-e229e85fb666.png)
4 - Modify image once again to find proper location of `zap-x.sh`, with `os.system('find / -name zap-x.sh').`, wich turns out to be `/zap/zap-x.sh`
5 - Added /zap/ to  https://github.com/zaproxy/zaproxy/blob/main/docker/zap_common.py#L277
6 - Succesfully able to run the wrapper from the Github Action now and executing the wrapper from everywhere else still works.

This started as a google group thread 
https://groups.google.com/g/zaproxy-users/c/im19A4tPFos

