### PR TITLE
zap-x.sh returns the exit code from zap.sh

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2022-11-04
+  - Fixed `zap-x.sh` to return the exit code from `zap.sh` instead of `rm -f`
+
 ### 2022-10-27
  - Updated to use Webswing 22.2
 

--- a/docker/zap-x.sh
+++ b/docker/zap-x.sh
@@ -1,11 +1,20 @@
 #!/bin/sh
+
 export DISPLAY=:1.0
 if [ ! -f /tmp/.X1-lock ]
 then
   Xvfb :1 -screen 0 1024x768x16 -ac -nolisten tcp -nolisten unix &
 fi
-/zap/zap.sh "$@"
 
-# Shutdown xvfb
-kill -9 `cat /tmp/.X1-lock`
-rm -f /tmp/.X1-lock
+# Run ZAP and capture the exit code
+/zap/zap.sh "$@"
+exit_code=$?
+
+if [ -f /tmp/.X1-lock ]
+then
+  # Shutdown xvfb
+  kill -9 `cat /tmp/.X1-lock`
+  rm -f /tmp/.X1-lock
+fi
+
+exit $exit_code


### PR DESCRIPTION
* Return the exit code from `zap.sh` instead of `rm -f`
* Check for file existence prior to attempting to `cat` it

Closes: #7576