### PR TITLE
Do not allow invalid number of active scan threads

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/ScannerParam.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/ScannerParam.java
@@ -53,6 +53,7 @@
 // ZAP: 2021/04/13 Issue 6469: Add option to scan null JSON values.
 // ZAP: 2021/09/14 Enable Anti CSRF handling by default.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
+// ZAP: 2022/11/04 Prevent invalid number of hosts/threads.
 package org.parosproxy.paros.core.scanner;
 
 import java.util.ArrayList;
@@ -220,9 +221,9 @@ public class ScannerParam extends AbstractParam {
     protected void parse() {
         removeOldOptions();
 
-        this.threadPerHost = getInt(THREAD_PER_HOST, 2);
+        this.threadPerHost = Math.max(1, getInt(THREAD_PER_HOST, 2));
 
-        this.hostPerScan = getInt(HOST_PER_SCAN, 2);
+        this.hostPerScan = Math.max(1, getInt(HOST_PER_SCAN, 2));
 
         this.delayInMs = getInt(DELAY_IN_MS, 0);
 
@@ -370,7 +371,7 @@ public class ScannerParam extends AbstractParam {
 
     /** @param threadPerHost */
     public void setThreadPerHost(int threadPerHost) {
-        this.threadPerHost = threadPerHost;
+        this.threadPerHost = Math.max(1, threadPerHost);
         getConfig().setProperty(THREAD_PER_HOST, Integer.toString(this.threadPerHost));
     }
 
@@ -381,7 +382,7 @@ public class ScannerParam extends AbstractParam {
 
     /** @param hostPerScan The thread to set. */
     public void setHostPerScan(int hostPerScan) {
-        this.hostPerScan = hostPerScan;
+        this.hostPerScan = Math.max(1, hostPerScan);
         getConfig().setProperty(HOST_PER_SCAN, Integer.toString(this.hostPerScan));
     }
 

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/ScannerParamUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/ScannerParamUnitTest.java
@@ -57,6 +57,94 @@ class ScannerParamUnitTest {
         param.load(configuration);
     }
 
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10})
+    void shouldLoadThreadPerHostFromConfig(int threadPerHost) {
+        // Given
+        configuration.setProperty("scanner.threadPerHost", threadPerHost);
+        // When
+        param.load(configuration);
+        // Then
+        assertThat(param.getThreadPerHost(), is(equalTo(threadPerHost)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0})
+    void shouldUseOneIfLoadingInvalidThreadPerHostFromConfig(int threadPerHost) {
+        // Given
+        configuration.setProperty("scanner.threadPerHost", threadPerHost);
+        // When
+        param.load(configuration);
+        // Then
+        assertThat(param.getThreadPerHost(), is(equalTo(1)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10})
+    void shouldSetThreadPerHost(int threadPerHost) {
+        // Given / When
+        param.setThreadPerHost(threadPerHost);
+        // Then
+        assertThat(param.getThreadPerHost(), is(equalTo(threadPerHost)));
+        assertThat(
+                configuration.getProperty("scanner.threadPerHost"),
+                is(equalTo(String.valueOf(threadPerHost))));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0})
+    void shouldUseOneIfSettingInvalidNumberOfThreadPerHost(int threadPerHost) {
+        // Given / When
+        param.setThreadPerHost(threadPerHost);
+        // Then
+        assertThat(param.getThreadPerHost(), is(equalTo(1)));
+        assertThat(configuration.getProperty("scanner.threadPerHost"), is(equalTo("1")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10})
+    void shouldLoadHostPerScanFromConfig(int hostPerScan) {
+        // Given
+        configuration.setProperty("scanner.hostPerScan", hostPerScan);
+        // When
+        param.load(configuration);
+        // Then
+        assertThat(param.getHostPerScan(), is(equalTo(hostPerScan)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0})
+    void shouldUseOneIfLoadingInvalidHostPerScanFromConfig(int hostPerScan) {
+        // Given
+        configuration.setProperty("scanner.hostPerScan", hostPerScan);
+        // When
+        param.load(configuration);
+        // Then
+        assertThat(param.getHostPerScan(), is(equalTo(1)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 10})
+    void shouldSetHostPerScan(int hostPerScan) {
+        // Given / When
+        param.setHostPerScan(hostPerScan);
+        // Then
+        assertThat(param.getHostPerScan(), is(equalTo(hostPerScan)));
+        assertThat(
+                configuration.getProperty("scanner.hostPerScan"),
+                is(equalTo(String.valueOf(hostPerScan))));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0})
+    void shouldUseOneIfSettingInvalidNumberOfHostPerScan(int hostPerScan) {
+        // Given / When
+        param.setHostPerScan(hostPerScan);
+        // Then
+        assertThat(param.getHostPerScan(), is(equalTo(1)));
+        assertThat(configuration.getProperty("scanner.hostPerScan"), is(equalTo("1")));
+    }
+
     @Test
     void shouldHaveScanJsonNullValuesDisabledByDefault() {
         // Given / When


### PR DESCRIPTION
Always use 1 as minimum for the number of host and scan threads, otherwise the scan would get stuck as no threads would be available to run the scan.

---
Reported in IRC channel.