### PR TITLE
Add details to logged API exception messages

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ApiException.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ApiException.java
@@ -96,7 +96,7 @@ public class ApiException extends Exception {
          */
         BAD_EXTERNAL_DATA,
         /**
-         * Indicates that the request could not fulfilled with the current API state.
+         * Indicates that the request could not be fulfilled with the current API state.
          *
          * <p>The actual reason should be provided in {@code detail} of the exception.
          *
@@ -106,6 +106,7 @@ public class ApiException extends Exception {
     }
 
     private final Type type;
+    private final String code;
     private final String detail;
 
     private static final Logger logger = LogManager.getLogger(ApiException.class);
@@ -123,8 +124,9 @@ public class ApiException extends Exception {
     }
 
     public ApiException(Type type, String detail, Throwable cause) {
-        super(type.name().toLowerCase(Locale.ROOT), cause);
+        super(type.name() + (detail != null ? " (" + detail + ')' : ""), cause);
         this.type = type;
+        code = type.name().toLowerCase(Locale.ROOT);
         this.detail = detail;
     }
 
@@ -139,18 +141,11 @@ public class ApiException extends Exception {
 
     public String toString(boolean incDetails) {
         if (!incDetails) {
-            return Constant.messages.getString("api.error." + super.getMessage());
+            return Constant.messages.getString("api.error." + code);
         } else if (detail != null) {
-            return Constant.messages.getString("api.error." + super.getMessage())
-                    + " ("
-                    + super.getMessage()
-                    + ") : "
-                    + detail;
+            return Constant.messages.getString("api.error." + code) + " (" + code + "): " + detail;
         } else {
-            return Constant.messages.getString("api.error." + super.getMessage())
-                    + " ("
-                    + super.getMessage()
-                    + ")";
+            return Constant.messages.getString("api.error." + code) + " (" + code + ")";
         }
     }
 
@@ -170,7 +165,7 @@ public class ApiException extends Exception {
                     doc.appendChild(rootElement);
 
                     rootElement.setAttribute("type", "exception");
-                    rootElement.setAttribute("code", this.getMessage());
+                    rootElement.setAttribute("code", code);
                     if (incDetails && detail != null) {
                         rootElement.setAttribute(
                                 "detail", XMLStringUtil.escapeControlChrs(this.detail));
@@ -206,8 +201,8 @@ public class ApiException extends Exception {
 
     private JSONObject toJSON(boolean incDetails) {
         JSONObject ja = new JSONObject();
-        ja.put("code", super.getMessage());
-        ja.put("message", Constant.messages.getString("api.error." + super.getMessage()));
+        ja.put("code", code);
+        ja.put("message", Constant.messages.getString("api.error." + code));
         if (incDetails && detail != null) {
             ja.put("detail", detail);
         }

--- a/zap/src/test/java/org/zaproxy/zap/extension/api/APIUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/api/APIUnitTest.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.extension.api;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -552,7 +551,7 @@ class APIUnitTest {
         ApiException e =
                 assertThrows(ApiException.class, () -> API.responseToXml(endpointName, response));
         // Then
-        assertThat(e.getMessage(), containsString("internal_error"));
+        assertThat(e.getType(), is(equalTo(ApiException.Type.INTERNAL_ERROR)));
     }
 
     @Test
@@ -564,7 +563,7 @@ class APIUnitTest {
         ApiException e =
                 assertThrows(ApiException.class, () -> API.responseToXml(endpointName, response));
         // Then
-        assertThat(e.getMessage(), containsString("internal_error"));
+        assertThat(e.getType(), is(equalTo(ApiException.Type.INTERNAL_ERROR)));
     }
 
     @Test
@@ -576,7 +575,7 @@ class APIUnitTest {
         ApiException e =
                 assertThrows(ApiException.class, () -> API.responseToXml(endpointName, response));
         // Then
-        assertThat(e.getMessage(), containsString("internal_error"));
+        assertThat(e.getType(), is(equalTo(ApiException.Type.INTERNAL_ERROR)));
     }
 
     @Test
@@ -588,7 +587,7 @@ class APIUnitTest {
         ApiException e =
                 assertThrows(ApiException.class, () -> API.responseToXml(endpointName, response));
         // Then
-        assertThat(e.getMessage(), containsString("internal_error"));
+        assertThat(e.getType(), is(equalTo(ApiException.Type.INTERNAL_ERROR)));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/extension/ascan/ActiveScanAPIUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/ascan/ActiveScanAPIUnitTest.java
@@ -105,7 +105,7 @@ class ActiveScanAPIUnitTest {
         // When / Then
         ApiException exception =
                 assertThrows(ApiException.class, () -> api.handleApiAction(name, params));
-        assertThat(exception.getMessage(), is(equalTo("illegal_parameter")));
+        assertThat(exception.getType(), is(equalTo(ApiException.Type.ILLEGAL_PARAMETER)));
         assertThat(exception.toString(true), containsString("a"));
         verify(scanRule1).setEnabled(anyBoolean());
         verifyNoInteractions(scanRule3);
@@ -140,7 +140,7 @@ class ActiveScanAPIUnitTest {
         // When / Then
         ApiException exception =
                 assertThrows(ApiException.class, () -> api.handleApiAction(name, params));
-        assertThat(exception.getMessage(), is(equalTo("does_not_exist")));
+        assertThat(exception.getType(), is(equalTo(ApiException.Type.DOES_NOT_EXIST)));
         assertThat(exception.toString(true), containsString("IDs: [1, 3]"));
     }
 }


### PR DESCRIPTION
Before:
```
WARN  org.zaproxy.zap.extension.api.API - Bad request to API endpoint [/JSON/openapi/action/importFile/] from [127.0.0.1]:
org.zaproxy.zap.extension.api.ApiException: does_not_exist
        at ...
```

After:
```
WARN  org.zaproxy.zap.extension.api.API - Bad request to API endpoint [/JSON/openapi/action/importFile/] from [127.0.0.1]:
org.zaproxy.zap.extension.api.ApiException: DOES_NOT_EXIST (/non/existent/path)
        at ...
