### PR TITLE
Carry add-ons' update state when uninstalling

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -1629,7 +1629,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
 
         final Set<AddOn> failedUninstallations = new HashSet<>();
         for (AddOn addOn : addOns) {
-            if (!uninstall(addOn, false, null)) {
+            if (!uninstall(addOn, updates, null)) {
                 failedUninstallations.add(addOn);
             }
         }


### PR DESCRIPTION
Use the flag that indicates if the add-ons are being updated when uninstalling them.

Fix #7590.