### PR TITLE
Use correct path for proxy.pac API nonce

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/WebUI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/WebUI.java
@@ -34,6 +34,8 @@ public class WebUI {
 
     private API api;
     private boolean isDevTestNonce = false; // Manually change here to test nonces with the web UI
+    private static final String PAC_FILE_API_PATH = "/OTHER/network/other/proxy.pac/";
+    private static final String ROOT_CA_CERT_API_PATH = "/OTHER/network/other/rootCaCert/";
 
     public WebUI(API api) {
         this.api = api;
@@ -474,20 +476,10 @@ public class WebUI {
         sb.append(Constant.messages.getString("api.home.topmsg"));
         sb.append(
                 Constant.messages.getString(
-                        "api.home.proxypac",
-                        "/?"
-                                + API.API_NONCE_PARAM
-                                + "="
-                                + API.getInstance()
-                                        .getLongLivedNonce("/OTHER/core/other/proxy.pac/")));
+                        "api.home.proxypac", getApiPathWithNonceParam(PAC_FILE_API_PATH)));
         sb.append(
                 Constant.messages.getString(
-                        "api.home.cacert",
-                        "/?"
-                                + API.API_NONCE_PARAM
-                                + "="
-                                + API.getInstance()
-                                        .getLongLivedNonce("/OTHER/network/other/rootCaCert/")));
+                        "api.home.cacert", getApiPathWithNonceParam(ROOT_CA_CERT_API_PATH)));
         sb.append(Constant.messages.getString("api.home.links.header"));
         if (apiEnabled) {
             sb.append(Constant.messages.getString("api.home.links.api.enabled"));
@@ -498,6 +490,10 @@ public class WebUI {
         sb.append("</body>\n");
 
         return sb.toString();
+    }
+
+    private static String getApiPathWithNonceParam(String path) {
+        return path + '?' + API.API_NONCE_PARAM + '=' + API.getInstance().getLongLivedNonce(path);
     }
 
     private OptionsParamApi getOptionsParamApi() {

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -212,13 +212,13 @@ api.home.links.online		= <li><a href="https://www.zaproxy.org/">ZAP Website</a><
 <li><a href="https://groups.google.com/group/zaproxy-develop">ZAP Developer Group</a></li>\
 <li><a href="https://github.com/zaproxy/zaproxy/issues">Report an issue</a></li>
 api.home.cacert	= <h2>HTTPS Warnings Prevention</h2>\
-<p>To avoid HTTPS Warnings <a href="/OTHER/network/other/rootCaCert{0}">download</a> and \
-<a href="https://www.zaproxy.org/docs/desktop/ui/dialogs/options/dynsslcert/#install" target="_blank">\
+<p>To avoid HTTPS Warnings <a href="{0}">download</a> and \
+<a href="https://www.zaproxy.org/docs/desktop/addons/network/options/servercertificates/#install" target="_blank">\
  install CA root Certificate</a> in your Mobile device or computer.</p>
 api.home.proxypac			= <h2>Proxy Configuration</h2>\
 <p>To use ZAP effectively it is recommended that you configure your browser to proxy via ZAP.</p><p></p>\
 <p>The easiest way to do this is to launch your browser from ZAP via the "Quick Start / Manual Explore" panel - it will be configured to proxy via ZAP and ignore any certificate warnings.<br>\
-Alternatively you can configure your browser manually or use the generated <a href="/OTHER/network/other/proxy.pac{0}">PAC file</a>.</p>
+Alternatively, you can configure your browser manually, or use the generated <a href="{0}">PAC file</a>.</p>
 api.home.topmsg				= <h1>Welcome to the OWASP Zed Attack Proxy (ZAP)</h1>\
 <p>ZAP is an easy to use integrated penetration testing tool for finding vulnerabilities in web applications.</p><p></p>\
 <p>Please be aware that you should only attack applications that you have been specifically been given permission to test.</p>


### PR DESCRIPTION
This fixes the cause of the following warning that is logged when `PAC file` is clicked on the API web UI homepage.

```
WARN  org.zaproxy.zap.extension.api.API - API nonce path was /OTHER/core/other/proxy.pac/ 
but call was for /OTHER/network/other/proxy.pac/ in request from 127.0.0.1
```

![image](https://user-images.githubusercontent.com/16446369/204108653-2f807f1a-396d-4d2e-af4a-d8d62ab8b629.png)