### PR TITLE
Postpone uninstallation tasks

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/control/NullUninstallationProgressCallBack.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/NullUninstallationProgressCallBack.java
@@ -1,0 +1,72 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.control;
+
+/**
+ * An {@code UninstallationProgressCallback} that does nothing.
+ *
+ * <p>A "{@code null}" object, for use when no callback is needed during the uninstallation process.
+ */
+class NullUninstallationProgressCallBack implements AddOnUninstallationProgressCallback {
+
+    private static final NullUninstallationProgressCallBack SINGLETON =
+            new NullUninstallationProgressCallBack();
+
+    private NullUninstallationProgressCallBack() {}
+
+    /**
+     * Gets the singleton.
+     *
+     * @return the {@code NullUninstallationProgressCallBack}.
+     */
+    public static NullUninstallationProgressCallBack getSingleton() {
+        return SINGLETON;
+    }
+
+    @Override
+    public void uninstallingAddOn(AddOn addOn, boolean updating) {}
+
+    @Override
+    public void activeScanRulesWillBeRemoved(int numberOfRules) {}
+
+    @Override
+    public void activeScanRuleRemoved(String name) {}
+
+    @Override
+    public void passiveScanRulesWillBeRemoved(int numberOfRules) {}
+
+    @Override
+    public void passiveScanRuleRemoved(String name) {}
+
+    @Override
+    public void filesWillBeRemoved(int numberOfFiles) {}
+
+    @Override
+    public void fileRemoved() {}
+
+    @Override
+    public void extensionsWillBeRemoved(int numberOfExtensions) {}
+
+    @Override
+    public void extensionRemoved(String name) {}
+
+    @Override
+    public void addOnUninstalled(boolean uninstalled) {}
+}

--- a/zap/src/main/java/org/zaproxy/zap/control/PostponedTasksRunner.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/PostponedTasksRunner.java
@@ -1,0 +1,299 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.control;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Runner of postponed tasks, e.g. uninstallating an add-on. */
+class PostponedTasksRunner {
+
+    private static final Logger LOGGER = LogManager.getLogger(PostponedTasksRunner.class);
+
+    private static final String TASKS_BASE_KEY = "postponedTasks";
+    private static final String TASKS_KEY = TASKS_BASE_KEY + ".task";
+
+    private final ZapXmlConfiguration config;
+    private final AddOnCollection aoc;
+    private final List<Task> tasks;
+
+    PostponedTasksRunner(ZapXmlConfiguration config, AddOnCollection aoc) {
+        this.config = config;
+        this.aoc = aoc;
+        this.tasks = readTasks(config);
+    }
+
+    List<Task> getTasks() {
+        return tasks;
+    }
+
+    private static List<Task> readTasks(ZapXmlConfiguration config) {
+        List<HierarchicalConfiguration> savedTasks = config.configurationsAt(TASKS_KEY);
+
+        List<Task> tasks = new ArrayList<>(0);
+        for (HierarchicalConfiguration savedTask : savedTasks) {
+            Task task = createTask(savedTask);
+            if (task != null) {
+                tasks.add(task);
+            }
+        }
+
+        return tasks;
+    }
+
+    public void run() {
+        for (Iterator<Task> it = tasks.iterator(); it.hasNext(); ) {
+            it.next().execute(aoc);
+            it.remove();
+        }
+
+        saveTasks();
+    }
+
+    public void addUninstallAddOnTask(AddOn addOn) {
+        tasks.add(new UninstallAddOnTask(addOn));
+
+        saveTasks();
+    }
+
+    public void addDeleteFileTask(Path path) {
+        tasks.add(new DeleteFileTask(path));
+
+        saveTasks();
+    }
+
+    private void saveTasks() {
+        config.clearTree(TASKS_BASE_KEY);
+
+        try {
+            int i = 0;
+            for (Task task : tasks) {
+                task.save(config, TASKS_KEY + "(" + i + ").");
+
+                i++;
+            }
+
+            config.save();
+        } catch (Exception e) {
+            LOGGER.error("Failed to save the postponed tasks:", e);
+        }
+    }
+
+    private static Task createTask(HierarchicalConfiguration data) {
+        Task.Type type = readType(data);
+        if (type == null) {
+            return null;
+        }
+
+        switch (type) {
+            case UNINSTALL_ADD_ON:
+                return UninstallAddOnTask.create(data);
+
+            case DELETE_FILE:
+                return DeleteFileTask.create(data);
+
+            default:
+                LOGGER.error("Ignoring unsupported postponed task type: {}", type);
+                return null;
+        }
+    }
+
+    private static Task.Type readType(HierarchicalConfiguration savedData) {
+        String typeName = savedData.getString(Task.TYPE_KEY, "");
+        if (typeName.isBlank()) {
+            return null;
+        }
+
+        try {
+            return Task.Type.valueOf(typeName);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to create postponed task type: {}", typeName);
+        }
+        return null;
+    }
+
+    abstract static class Task {
+
+        private static final String TYPE_KEY = "type";
+
+        enum Type {
+            UNINSTALL_ADD_ON,
+            DELETE_FILE
+        }
+
+        private final Type type;
+
+        protected Task(Type type) {
+            this.type = type;
+        }
+
+        Type getType() {
+            return type;
+        }
+
+        abstract void execute(AddOnCollection aoc);
+
+        final void save(ZapXmlConfiguration config, String keyPrefix) {
+            config.setProperty(keyPrefix + TYPE_KEY, type.name());
+
+            saveData(config, keyPrefix);
+        }
+
+        protected abstract void saveData(ZapXmlConfiguration config, String keyPrefix);
+    }
+
+    static class UninstallAddOnTask extends Task {
+
+        private static final String ADD_ON_KEY = "addOn";
+
+        private final AddOn addOn;
+
+        private UninstallAddOnTask(AddOn addOn) {
+            super(Task.Type.UNINSTALL_ADD_ON);
+
+            this.addOn = addOn;
+        }
+
+        AddOn getAddOn() {
+            return addOn;
+        }
+
+        @Override
+        void execute(AddOnCollection aoc) {
+            LOGGER.info("Executing postponed task, uninstalling add-on: {}", addOn);
+
+            AddOnInstaller.uninstallAddOnFiles(
+                    addOn,
+                    NullUninstallationProgressCallBack.getSingleton(),
+                    Collections.emptySet(),
+                    null);
+            AddOnInstaller.uninstallAddOnLibs(addOn);
+
+            AddOn presentAddOn = aoc.getAddOn(addOn.getId());
+            if (presentAddOn != null && addOn.getFile().equals(presentAddOn.getFile())) {
+                aoc.removeAddOn(presentAddOn);
+            }
+
+            Path path = addOn.getFile().toPath();
+            try {
+                Files.delete(path);
+            } catch (IOException e) {
+                LOGGER.warn("Failed to delete add-on file: {}", path, e);
+            }
+        }
+
+        @Override
+        protected void saveData(ZapXmlConfiguration config, String keyPrefix) {
+            config.setProperty(
+                    keyPrefix + ADD_ON_KEY,
+                    addOn.getFile().toPath().toAbsolutePath().normalize().toString());
+        }
+
+        static UninstallAddOnTask create(HierarchicalConfiguration data) {
+            String path = data.getString(ADD_ON_KEY, "");
+            if (path.isBlank()) {
+                return null;
+            }
+
+            Path file = Paths.get(path);
+            if (Files.notExists(file)) {
+                LOGGER.warn("Ignoring postponed task, add-on file no longer exists: {}", path);
+                return null;
+            }
+
+            AddOn addOn;
+            try {
+                addOn = new AddOn(file);
+            } catch (IOException e) {
+                LOGGER.warn("Ignoring postponed task, add-on file is not valid: {}", path, e);
+                return null;
+            }
+            return new UninstallAddOnTask(addOn);
+        }
+    }
+
+    static class DeleteFileTask extends Task {
+
+        private static final String FILE_KEY = "file";
+
+        private final Path file;
+
+        private DeleteFileTask(Path file) {
+            super(Task.Type.DELETE_FILE);
+
+            this.file = file;
+        }
+
+        Path getFile() {
+            return file;
+        }
+
+        @Override
+        void execute(AddOnCollection aoc) {
+            LOGGER.info("Executing postponed task, deleting bundled add-on file: {}", file);
+
+            try {
+                Files.delete(file);
+            } catch (IOException e) {
+                LOGGER.warn("Failed to delete the file: {}", file, e);
+            }
+        }
+
+        @Override
+        protected void saveData(ZapXmlConfiguration config, String keyPrefix) {
+            config.setProperty(keyPrefix + FILE_KEY, file.toAbsolutePath().normalize().toString());
+        }
+
+        static DeleteFileTask create(HierarchicalConfiguration data) {
+            String path = data.getString(FILE_KEY, "");
+            if (path == null || path.isBlank()) {
+                return null;
+            }
+
+            Path file = Paths.get(path);
+            if (Files.notExists(file)) {
+                LOGGER.warn(
+                        "Ignoring postponed task, add-on bundled file no longer exists: {}", path);
+                return null;
+            }
+
+            Path homeDir = Paths.get(Constant.getZapHome());
+            if (!file.startsWith(homeDir)) {
+                LOGGER.warn(
+                        "Ignoring postponed task, add-on bundled file is not under the home directory: {}",
+                        path);
+                return null;
+            }
+
+            return new DeleteFileTask(file);
+        }
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/control/AddOnInstallerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/AddOnInstallerUnitTest.java
@@ -179,30 +179,6 @@ class AddOnInstallerUnitTest extends AddOnTestUtils {
         assertInstalledLibs(addOn, "lib1", "lib2");
     }
 
-    private static Path addOnDataLibsDir(AddOn addOn) {
-        return AddOnInstaller.getAddOnDataDir(addOn).resolve("libs");
-    }
-
-    private static Path installLib(AddOn addOn, String name) throws IOException {
-        return installLib(addOn, name, null);
-    }
-
-    private static Path installLib(AddOn addOn, String name, String contents) throws IOException {
-        Path addOnLibsDir = addOnDataLibsDir(addOn);
-        return createFile(addOnLibsDir.resolve(name), contents);
-    }
-
-    private static Path createFile(Path file) throws IOException {
-        return createFile(file, null);
-    }
-
-    private static Path createFile(Path file, String contents) throws IOException {
-        Files.createDirectories(file.getParent());
-        String data = contents != null ? contents : DEFAULT_LIB_CONTENTS;
-        Files.write(file, data.getBytes(StandardCharsets.UTF_8));
-        return file;
-    }
-
     private static void assertInstalledLibs(AddOn addOn, String... fileNames) throws IOException {
         Path addOnLibsDir = addOnDataLibsDir(addOn);
 

--- a/zap/src/test/java/org/zaproxy/zap/control/PostponedTasksRunnerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/PostponedTasksRunnerUnitTest.java
@@ -1,0 +1,294 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.control;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.control.PostponedTasksRunner.DeleteFileTask;
+import org.zaproxy.zap.control.PostponedTasksRunner.Task;
+import org.zaproxy.zap.control.PostponedTasksRunner.UninstallAddOnTask;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link PostponedTasksRunner}. */
+class PostponedTasksRunnerUnitTest extends AddOnTestUtils {
+
+    private ZapXmlConfiguration config;
+    private AddOnCollection aoc;
+    private PostponedTasksRunner postponedTasks;
+
+    @BeforeEach
+    void setup() throws Exception {
+        Constant.setZapHome(newTempDir("home").toAbsolutePath().toString());
+
+        config = new ZapXmlConfiguration();
+        config.setFile(createHomeFile("tasks.xml").toFile());
+        aoc = mock(AddOnCollection.class);
+        postponedTasks = new PostponedTasksRunner(config, aoc);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "   ", "NOT_VALID"})
+    void shouldIgnoreUnsupportedTask(String type) throws Exception {
+        // Given
+        config.setProperty("postponedTasks.task(0).type", type);
+        config.setProperty("postponedTasks.task(0).field", "value");
+        // When
+        postponedTasks = new PostponedTasksRunner(config, aoc);
+        // Then
+        assertThat(postponedTasks.getTasks(), hasSize(0));
+    }
+
+    @Test
+    void shouldAddUninstallAddOnTask() throws Exception {
+        // Given
+        Path file = createAddOnFile("addOnId.zap");
+        AddOn addOn = new AddOn(file);
+        // When
+        postponedTasks.addUninstallAddOnTask(addOn);
+        // Then
+        assertPersistedUninstallAddOnTask(0, file);
+    }
+
+    @Test
+    void shouldRunUninstallAddOnTask() throws Exception {
+        // Given
+        Path homeFile1 = createHomeFile("file1.txt");
+        Path homeFile2 = createHomeFile("a/file2.txt");
+        AddOn addOn =
+                new AddOn(
+                        createAddOnWithLibs(
+                                manifest -> {
+                                    manifest.append("<files>");
+                                    manifest.append("<file>file1.txt</file>");
+                                    manifest.append("<file>a/file2.txt</file>");
+                                    manifest.append("</files>");
+                                },
+                                "lib1",
+                                "lib2"));
+        Path file = addOn.getFile().toPath();
+        installLib(addOn, "lib1");
+        installLib(addOn, "lib2");
+        postponedTasks.addUninstallAddOnTask(addOn);
+        // When
+        postponedTasks.run();
+        // Then
+        assertThat(Files.notExists(file), is(equalTo(true)));
+        assertThat(Files.notExists(homeFile1), is(equalTo(true)));
+        assertThat(Files.notExists(homeFile2), is(equalTo(true)));
+        assertThat(Files.notExists(AddOnInstaller.getAddOnDataDir(addOn)), is(equalTo(true)));
+        verify(aoc).getAddOn("addon");
+        verifyNoMoreInteractions(aoc);
+        assertNoPersistedTasks();
+    }
+
+    @Test
+    void shouldRemoveExistingAddOnFromAddOnCollectionOnUninstallAddOnTask() throws Exception {
+        // Given
+        String addOnId = "addOnId";
+        Path file = createAddOnFile(addOnId + ".zap");
+        AddOn existingAddOn = new AddOn(file);
+        given(aoc.getAddOn(addOnId)).willReturn(existingAddOn);
+        AddOn addOn = new AddOn(file);
+        postponedTasks.addUninstallAddOnTask(addOn);
+        // When
+        postponedTasks.run();
+        // Then
+        assertThat(Files.notExists(file), is(equalTo(true)));
+        verify(aoc).getAddOn(addOnId);
+        verify(aoc).removeAddOn(existingAddOn);
+        verifyNoMoreInteractions(aoc);
+        assertNoPersistedTasks();
+    }
+
+    @Test
+    void shouldNotRemoveExistingAddOnFromAddOnCollectionIfNotSameFileOnUninstallAddOnTask()
+            throws Exception {
+        // Given
+        String addOnId = "addOnId";
+        Path existingFile = createAddOnFile(addOnId + ".zap", "release", "1.4.2");
+        AddOn existingAddOn = new AddOn(existingFile);
+        given(aoc.getAddOn(addOnId)).willReturn(existingAddOn);
+        Path file = createAddOnFile(addOnId + ".zap");
+        AddOn addOn = new AddOn(file);
+        postponedTasks.addUninstallAddOnTask(addOn);
+        // When
+        postponedTasks.run();
+        // Then
+        assertThat(Files.notExists(file), is(equalTo(true)));
+        verify(aoc).getAddOn(addOnId);
+        verify(aoc, times(0)).removeAddOn(existingAddOn);
+        assertThat(Files.exists(existingFile), is(equalTo(true)));
+        verifyNoMoreInteractions(aoc);
+        assertNoPersistedTasks();
+    }
+
+    @Test
+    void shouldReadUninstallAddOnTask() throws Exception {
+        // Given
+        Path file = createAddOnFile("addOnId.zap");
+        config.setProperty("postponedTasks.task(0).type", "UNINSTALL_ADD_ON");
+        config.setProperty("postponedTasks.task(0).addOn", file.toString());
+        // When
+        postponedTasks = new PostponedTasksRunner(config, aoc);
+        // Then
+        assertUninstallAddOnTask(0, file);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "   ", "/not/path/to/file"})
+    void shouldIgnoreUninstallAddOnTaskWithInvalidPath(String path) throws Exception {
+        // Given
+        config.setProperty("postponedTasks.task(0).type", "UNINSTALL_ADD_ON");
+        config.setProperty("postponedTasks.task(0).addOn", path);
+        // When
+        postponedTasks = new PostponedTasksRunner(config, aoc);
+        // Then
+        assertThat(postponedTasks.getTasks(), hasSize(0));
+    }
+
+    @Test
+    void shouldIgnoreUninstallAddOnTaskWithInvalidAddOn() throws Exception {
+        // Given
+        Path file = createHomeFile("not-add-on.zap");
+        config.setProperty("postponedTasks.task(0).type", "UNINSTALL_ADD_ON");
+        config.setProperty("postponedTasks.task(0).addOn", file.toString());
+        // When
+        postponedTasks = new PostponedTasksRunner(config, aoc);
+        // Then
+        assertThat(postponedTasks.getTasks(), hasSize(0));
+    }
+
+    @Test
+    void shouldAddDeleteFileTask() throws Exception {
+        // Given
+        Path file = createHomeFile("file.txt");
+        // When
+        postponedTasks.addDeleteFileTask(file);
+        // Then
+        assertPersistedDeleteFileTask(0, file);
+    }
+
+    @Test
+    void shouldRunDeleteFileTask() throws Exception {
+        // Given
+        Path file = createHomeFile("file.txt");
+        postponedTasks.addDeleteFileTask(file);
+        // When
+        postponedTasks.run();
+        // Then
+        assertThat(Files.notExists(file), is(equalTo(true)));
+        verifyNoInteractions(aoc);
+        assertNoPersistedTasks();
+    }
+
+    @Test
+    void shouldReadDeleteFileTask() throws Exception {
+        // Given
+        Path file = createHomeFile("file.txt");
+        config.setProperty("postponedTasks.task(0).type", "DELETE_FILE");
+        config.setProperty("postponedTasks.task(0).file", file.toString());
+        // When
+        postponedTasks = new PostponedTasksRunner(config, aoc);
+        // Then
+        assertDeleteFileTask(0, file);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "   ", "/not/path/to/file"})
+    void shouldIgnoreDeleteFileTaskWithInvalidPath(String path) throws Exception {
+        // Given
+        config.setProperty("postponedTasks.task(0).type", "DELETE_FILE");
+        config.setProperty("postponedTasks.task(0).file", path);
+        // When
+        postponedTasks = new PostponedTasksRunner(config, aoc);
+        // Then
+        assertThat(postponedTasks.getTasks(), hasSize(0));
+    }
+
+    @Test
+    void shouldIgnoreDeleteFileTaskWithFileNotUnderHomeDir() throws Exception {
+        // Given
+        Path file = createFile();
+        config.setProperty("postponedTasks.task(0).type", "DELETE_FILE");
+        config.setProperty("postponedTasks.task(0).file", file.toString());
+        // When
+        postponedTasks = new PostponedTasksRunner(config, aoc);
+        // Then
+        assertThat(postponedTasks.getTasks(), hasSize(0));
+    }
+
+    private static Path createFile() throws IOException {
+        return createFile(newTempDir().resolve("file.txt"));
+    }
+
+    private void assertUninstallAddOnTask(int idx, Path file) {
+        Task task = postponedTasks.getTasks().get(idx);
+        assertThat(task, is(instanceOf(UninstallAddOnTask.class)));
+        UninstallAddOnTask uninstallAddOnTask = (UninstallAddOnTask) task;
+        assertThat(uninstallAddOnTask.getType(), is(equalTo(Task.Type.UNINSTALL_ADD_ON)));
+        assertThat(uninstallAddOnTask.getAddOn(), is(notNullValue()));
+        assertThat(uninstallAddOnTask.getAddOn().getFile(), is(equalTo(file.toFile())));
+    }
+
+    private void assertDeleteFileTask(int idx, Path file) {
+        Task task = postponedTasks.getTasks().get(idx);
+        assertThat(task, is(instanceOf(DeleteFileTask.class)));
+        DeleteFileTask deleteFileTask = (DeleteFileTask) task;
+        assertThat(deleteFileTask.getType(), is(equalTo(Task.Type.DELETE_FILE)));
+        assertThat(deleteFileTask.getFile(), is(equalTo(file)));
+    }
+
+    private void assertPersistedUninstallAddOnTask(int idx, Path file) {
+        assertPersistedTask(idx, "UNINSTALL_ADD_ON", "addOn", file);
+    }
+
+    private void assertPersistedDeleteFileTask(int idx, Path file) {
+        assertPersistedTask(idx, "DELETE_FILE", "file", file);
+    }
+
+    private void assertPersistedTask(int idx, String type, String propertyName, Path file) {
+        String baseKey = "postponedTasks.task(" + idx + ").";
+        assertThat(config.getProperty(baseKey + "type"), is(equalTo(type)));
+        assertThat(config.getProperty(baseKey + propertyName), is(equalTo(file.toString())));
+    }
+
+    private void assertNoPersistedTasks() {
+        assertThat(config.getProperties("postponedTasks.task").size(), is(equalTo(0)));
+    }
+}


### PR DESCRIPTION
Do not attempt to uninstall the add-on that has extensions that can't be unloaded, instead postpone the uninstallation for the next start.
Fix #7593.

Postpone the deletion of the add-on bundled files that were not successfully deleted (e.g. they are in use) during the uninstallation.
Part of #7589.