### PR TITLE
Prevent Toolkit initialisation without view

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
@@ -56,7 +56,6 @@ import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.authentication.GenericAuthenticationCredentials.GenericAuthenticationCredentialsOptionsPanel;
 import org.zaproxy.zap.extension.api.ApiDynamicActionImplementor;
 import org.zaproxy.zap.extension.api.ApiException;
@@ -93,10 +92,6 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
     public static final String SCRIPT_TYPE_AUTH = "authentication";
 
     private static final String API_METHOD_NAME = "scriptBasedAuthentication";
-
-    /** The SCRIPT ICON. */
-    private static final ImageIcon SCRIPT_ICON_AUTH =
-            new ImageIcon(ZAP.class.getResource("/resource/icon/16/script-auth.png"));
 
     /** The Authentication method's name. */
     private static final String METHOD_NAME =
@@ -589,7 +584,12 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
                             new ScriptType(
                                     SCRIPT_TYPE_AUTH,
                                     "authentication.method.script.type",
-                                    SCRIPT_ICON_AUTH,
+                                    getScriptsExtension().getView() != null
+                                            ? new ImageIcon(
+                                                    getClass()
+                                                            .getResource(
+                                                                    "/resource/icon/16/script-auth.png"))
+                                            : null,
                                     false,
                                     new String[] {ScriptType.CAPABILITY_APPEND}));
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -434,7 +434,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
                             extensionLoader.getExtension(ExtensionHistory.class),
                             extensionLoader.getExtension(ExtensionAlert.class),
                             getPassiveScanParam(),
-                            getScanStatus());
+                            hasView() ? getScanStatus() : null);
             psc.setSession(Model.getSingleton().getSession());
             psc.start();
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanController.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanController.java
@@ -33,7 +33,6 @@ import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.utils.Stats;
 import org.zaproxy.zap.view.ScanStatus;
@@ -137,7 +136,7 @@ public class PassiveScanController extends Thread implements ProxyListener {
                 }
                 int recordsToScan = this.getRecordsToScan();
                 Stats.setHighwaterMark("stats.pscan.recordsToScan", recordsToScan);
-                if (View.isInitialised()) {
+                if (scanStatus != null) {
                     scanStatus.setScanCount(recordsToScan);
                 }
 

--- a/zap/src/main/java/org/zaproxy/zap/session/ScriptBasedSessionManagementMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/session/ScriptBasedSessionManagementMethodType.java
@@ -98,11 +98,6 @@ public class ScriptBasedSessionManagementMethodType extends SessionManagementMet
 
     public static final String SCRIPT_TYPE_SESSION = "session";
 
-    private static final ImageIcon SCRIPT_ICON_SESSION =
-            new ImageIcon(
-                    ScriptBasedSessionManagementMethodType.class.getResource(
-                            "/resource/icon/16/script-session.png"));
-
     private static ExtensionScript extensionScript;
 
     public class ScriptBasedSessionManagementMethod implements SessionManagementMethod {
@@ -462,7 +457,12 @@ public class ScriptBasedSessionManagementMethodType extends SessionManagementMet
                             new ScriptType(
                                     SCRIPT_TYPE_SESSION,
                                     "session.method.script.type",
-                                    SCRIPT_ICON_SESSION,
+                                    getScriptsExtension().getView() != null
+                                            ? new ImageIcon(
+                                                    getClass()
+                                                            .getResource(
+                                                                    "/resource/icon/16/script-session.png"))
+                                            : null,
                                     false,
                                     new String[] {ScriptType.CAPABILITY_APPEND}));
         }


### PR DESCRIPTION
Do not initialise icons and other UI components if there's no view.

Part of #3798.