### PR TITLE
Build multi-platform Docker images

### DIFF
--- a/.github/workflows/release-live-docker.yml
+++ b/.github/workflows/release-live-docker.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           context: docker
           file: docker/Dockerfile-live
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             owasp/zap2docker-live:latest

--- a/.github/workflows/release-main-docker.yml
+++ b/.github/workflows/release-main-docker.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           context: docker
           file: docker/Dockerfile-bare
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             owasp/zap2docker-bare:b${{ env.REL_DATE }}

--- a/.github/workflows/release-weekly-docker.yml
+++ b/.github/workflows/release-weekly-docker.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           context: docker
           file: docker/Dockerfile-weekly
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             owasp/zap2docker-weekly:w${{ env.REL_DATE }}

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to the docker containers will be documented in this file.
 
 ### 2022-12-05
- - Changed all images to use debian:stable-slim instead of unstable-slim
+ - Changed all images to use debian:bullseye-slim instead of unstable-slim.
 
 ### 2022-11-07
  - Updated packaged scans to use full path to `zap-x.sh`.

--- a/docker/Dockerfile-bare
+++ b/docker/Dockerfile-bare
@@ -1,5 +1,6 @@
+# syntax=docker/dockerfile:1
 # This dockerfile builds the zap bare release
-FROM debian:stable-slim AS builder
+FROM --platform=linux/amd64 debian:bullseye-slim AS builder
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
 	wget \
@@ -21,7 +22,7 @@ RUN ./zap.sh -cmd -silent -addonupdate
 # Copy them to installation directory
 RUN cp /root/.ZAP/plugin/*.zap plugin/ || :
 
-FROM eclipse-temurin:11-jre-alpine
+FROM eclipse-temurin:11-jre-alpine AS final
 LABEL maintainer="psiinon@gmail.com"
 
 RUN apk update && apk add bash curl 
@@ -29,18 +30,13 @@ RUN apk update && apk add bash curl
 USER root
 
 WORKDIR /zap
-COPY --from=builder /zap .
-COPY policies /home/zap/.ZAP/policies/
+COPY --from=builder --link --chown=zap:zap /zap .
+COPY --link --chown=zap:zap policies /home/zap/.ZAP/policies/
 
 RUN echo "zap2docker-bare" > /zap/container
 
 RUN /usr/sbin/adduser -h /home/zap -s /bin/bash -D zap && \
-    rm -rf /var/cache/apk/* && \
-    chown zap /zap && \
-    chgrp zap /zap && \
-    chown -R zap:zap /zap && \
-    chown -R zap:zap /home/zap/ && \
-    chown -R zap:zap /home/zap/.ZAP/
+    rm -rf /var/cache/apk/*
 
 #Change to the zap user so things get done as the right person (apart from copy)
 USER zap

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -1,11 +1,25 @@
+# syntax=docker/dockerfile:1
 # This dockerfile builds a 'live' zap docker image using the latest files in the repos
-FROM debian:stable-slim AS builder
+FROM --platform=linux/amd64 debian:bullseye-slim AS builder
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
+	openjdk-11-jdk \
 	wget \
 	curl \
-	unzip && \
-	apt-get clean
+	unzip \
+	git && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/* && \
+	mkdir /zap-src
+
+WORKDIR /zap-src
+
+# Pull the ZAP repo and build ZAP with weekly add-ons
+RUN git clone --depth 1 https://github.com/zaproxy/zaproxy.git && \
+	cd zaproxy && \
+	ZAP_WEEKLY_ADDONS_NO_TEST=true ./gradlew :zap:prepareDistWeekly
 
 WORKDIR /zap
 
@@ -21,7 +35,7 @@ RUN if [ -z "$WEBSWING_URL" ] ; \
 	# Remove Webswing bundled examples
 	rm -Rf webswing/apps/
 
-FROM debian:stable-slim
+FROM debian:bullseye-slim AS final
 LABEL maintainer="psiinon@gmail.com"
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -43,7 +57,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	net-tools \
 	python3-pip \
 	python-is-python3 \
-	firefox \
+	firefox-esr \
 	vim \
 	xvfb \
 	x11vnc && \
@@ -52,13 +66,9 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	useradd -d /home/zap -m -s /bin/bash zap && \
 	echo zap:zap | chpasswd && \
 	mkdir /zap  && \
-	chown zap /zap && \
-	chgrp zap /zap && \
-	mkdir /zap-src  && \
-	chown zap /zap-src && \
-	chgrp zap /zap-src
+	chown zap:zap /zap
 
-RUN pip3 install --upgrade awscli pip python-owasp-zap-v2.4 pyyaml requests urllib3 
+RUN pip3 install --upgrade awscli pip python-owasp-zap-v2.4 pyyaml requests urllib3
 
 #Change to the zap user so things get done as the right person (apart from copy)
 USER zap
@@ -66,18 +76,8 @@ USER zap
 RUN mkdir /home/zap/.vnc
 
 ARG TARGETARCH
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-$TARGETARCH/
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-$TARGETARCH
 ENV PATH $JAVA_HOME/bin:/zap/:$PATH
-
-WORKDIR /zap-src
-
-# Pull the ZAP repo
-RUN git clone --depth 1 https://github.com/zaproxy/zaproxy.git && \
-	# Build ZAP with weekly add-ons
-	cd zaproxy && \
-	ZAP_WEEKLY_ADDONS_NO_TEST=true ./gradlew :zap:prepareDistWeekly && \
-	cp -R /zap-src/zaproxy/zap/build/distFilesWeekly/* /zap/ && \
-	rm -rf /zap-src/*
 
 ENV ZAP_PATH /zap/zap.sh
 # Default port for use with health check
@@ -87,30 +87,20 @@ ENV HOME /home/zap/
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
-COPY zap* CHANGELOG.md /zap/
-COPY --from=builder /zap/webswing /zap/webswing
-COPY webswing.config /zap/webswing/
-COPY webswing.properties /zap/webswing/
-COPY policies /home/zap/.ZAP_D/policies/
-COPY policies /root/.ZAP_D/policies/
-COPY scripts /home/zap/.ZAP_D/scripts/
-COPY .xinitrc /home/zap/
+COPY --link --from=builder --chown=zap:zap /zap-src/zaproxy/zap/build/distFilesWeekly/ /zap/
+COPY --link --chown=zap:zap zap* CHANGELOG.md /zap/
+COPY --link --from=builder --chown=zap:zap /zap/webswing /zap/webswing
+COPY --link --chown=zap:zap webswing.config /zap/webswing/
+COPY --link --chown=zap:zap webswing.properties /zap/webswing/
+COPY --link --chown=zap:zap policies /home/zap/.ZAP_D/policies/
+COPY --link --chown=zap:zap policies /root/.ZAP_D/policies/
+COPY --link --chown=zap:zap scripts /home/zap/.ZAP_D/scripts/
+COPY --link --chown=zap:zap .xinitrc /home/zap/
 
-RUN echo "zap2docker-live" > /zap/container
-
-#Copy doesn't respect USER directives so we need to chown and to do that we need to be root
-USER root
-
-RUN chown zap:zap /zap/* && \
-	chown zap:zap /zap/webswing/webswing.config && \
-	chown zap:zap /zap/webswing/webswing.properties && \
-	chown zap:zap -R /home/zap/.ZAP_D/ && \
-	chown zap:zap /home/zap/.xinitrc && \
-	chmod a+x /home/zap/.xinitrc && \
-	chmod +x /zap/zap.sh && \
-	rm -rf /zap-src
+RUN echo "zap2docker-live" > /zap/container && \
+    chmod a+x /home/zap/.xinitrc && \
+    chmod +x /zap/zap.sh
 
 WORKDIR /zap
 
-USER zap
 HEALTHCHECK CMD curl --silent --output /dev/null --fail http://localhost:$ZAP_PORT/ || exit 1

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -1,5 +1,6 @@
+# syntax=docker/dockerfile:1
 # This dockerfile builds the zap stable release
-FROM debian:stable-slim AS builder
+FROM --platform=linux/amd64 debian:bullseye-slim AS builder
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
 	wget \
@@ -33,7 +34,7 @@ RUN if [ -z "$WEBSWING_URL" ] ; \
 	# Remove Webswing bundled examples
 	rm -Rf webswing/apps/
 
-FROM debian:stable-slim
+FROM debian:bullseye-slim AS final
 LABEL maintainer="psiinon@gmail.com"
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -54,7 +55,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	net-tools \
 	python3-pip \
 	python-is-python3 \
-	firefox \
+	firefox-esr \
 	xvfb \
 	x11vnc && \
 	apt-get clean && \
@@ -74,12 +75,12 @@ USER zap
 RUN mkdir /home/zap/.vnc
 
 # Copy stable release
-COPY --from=builder /zap .
+COPY --link --from=builder --chown=zap:zap /zap .
 
-COPY --from=builder /zap/webswing /zap/webswing
+COPY --link --from=builder --chown=zap:zap /zap/webswing /zap/webswing
 
 ARG TARGETARCH
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-$TARGETARCH/
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-$TARGETARCH
 ENV PATH $JAVA_HOME/bin:/zap/:$PATH
 ENV ZAP_PATH /zap/zap.sh
 
@@ -90,29 +91,16 @@ ENV HOME /home/zap/
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
-COPY zap* CHANGELOG.md /zap/
-COPY webswing.config /zap/webswing/
-COPY webswing.properties /zap/webswing/
-COPY policies /home/zap/.ZAP/policies/
-COPY policies /root/.ZAP/policies/
+COPY --link --chown=zap:zap zap* CHANGELOG.md /zap/
+COPY --link --chown=zap:zap webswing.config /zap/webswing/
+COPY --link --chown=zap:zap webswing.properties /zap/webswing/
+COPY --link --chown=zap:zap policies /home/zap/.ZAP/policies/
+COPY --link --chown=zap:zap policies /root/.ZAP/policies/
 # The scan script loads the scripts from dev home dir.
-COPY scripts /home/zap/.ZAP_D/scripts/
-COPY .xinitrc /home/zap/
+COPY --link --chown=zap:zap scripts /home/zap/.ZAP_D/scripts/
+COPY --link --chown=zap:zap .xinitrc /home/zap/
 
-RUN echo "zap2docker-stable" > /zap/container
-
-#Copy doesn't respect USER directives so we need to chown and to do that we need to be root
-USER root
-
-RUN chown zap:zap /zap/* && \
-	chown zap:zap /zap/webswing/webswing.config && \
-	chown zap:zap /zap/webswing/webswing.properties && \
-	chown zap:zap -R /home/zap/.ZAP/ && \
-	chown zap:zap /home/zap/.xinitrc && \
-	chmod a+x /home/zap/.xinitrc
-
-#Change back to zap at the end
-USER zap
+RUN echo "zap2docker-stable" > /zap/container && \
+    chmod a+x /home/zap/.xinitrc
 
 HEALTHCHECK CMD curl --silent --output /dev/null --fail http://localhost:$ZAP_PORT/ || exit 1
-

--- a/docker/Dockerfile-tests
+++ b/docker/Dockerfile-tests
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # This dockerfile builds a ZAP docker image used for integration tests
 FROM owasp/zap2docker-live
 LABEL maintainer="psiinon@gmail.com"
@@ -7,18 +8,11 @@ ARG DEBIAN_FRONTEND=noninteractive
 #Change to the zap user so things get done as the right person (apart from copy)
 USER zap
 
-COPY integration_tests /zap/wrk/
+COPY --link --chown=zap:zap integration_tests /zap/wrk/
 
 # Pick up any local changes
-COPY zap* CHANGELOG.md /zap/
+COPY --link --chown=zap:zap zap* CHANGELOG.md /zap/
 
-#Copy doesn't respect USER directives so we need to chown and to do that we need to be root
-USER root
-
-RUN chown zap:zap -R /zap/ && \
-	chmod +x /zap/wrk/*.sh
-
+RUN chmod +x /zap/wrk/*.sh
 
 WORKDIR /zap
-
-USER zap

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -1,6 +1,6 @@
+# syntax=docker/dockerfile:1
 # This dockerfile builds the zap weekly release
-FROM debian:stable-slim AS builder
-
+FROM --platform=linux/amd64 debian:bullseye-slim AS builder
 RUN apt-get update && apt-get install -q -y --fix-missing \
 	wget \
 	curl \
@@ -21,11 +21,10 @@ RUN if [ -z "$WEBSWING_URL" ] ; \
 	# Remove Webswing bundled examples
 	rm -Rf webswing/apps/
 
-FROM debian:stable-slim
+FROM debian:bullseye-slim AS final
 LABEL maintainer="psiinon@gmail.com"
 
 ARG DEBIAN_FRONTEND=noninteractive
-
 RUN apt-get update && apt-get install -q -y --fix-missing \
 	make \
 	automake \
@@ -42,17 +41,17 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	net-tools \
 	python3-pip \
 	python-is-python3 \
-	firefox \
+	firefox-esr \
 	xvfb \
 	x11vnc && \
 	apt-get clean && \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* && \
+    useradd -d /home/zap -m -s /bin/bash zap && \
+    echo zap:zap | chpasswd && \
+    mkdir /zap  && \
+    chown zap:zap /zap
 
 RUN pip3 install --upgrade awscli pip python-owasp-zap-v2.4 pyyaml requests urllib3 
-
-RUN useradd -d /home/zap -m -s /bin/bash zap
-RUN echo zap:zap | chpasswd
-RUN mkdir /zap && chown zap:zap /zap
 
 WORKDIR /zap
 
@@ -68,7 +67,7 @@ RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersio
 	rm -R ZAP*
 
 ARG TARGETARCH
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-$TARGETARCH/
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-$TARGETARCH
 ENV PATH $JAVA_HOME/bin:/zap/:$PATH
 ENV ZAP_PATH /zap/zap.sh
 
@@ -79,27 +78,16 @@ ENV HOME /home/zap/
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
-COPY zap* CHANGELOG.md /zap/
-COPY --from=builder /zap/webswing /zap/webswing
-COPY webswing.config /zap/webswing/
-COPY webswing.properties /zap/webswing/
-COPY policies /home/zap/.ZAP_D/policies/
-COPY policies /root/.ZAP_D/policies/
-COPY scripts /home/zap/.ZAP_D/scripts/
-COPY .xinitrc /home/zap/
+COPY --link --chown=zap:zap zap* CHANGELOG.md /zap/
+COPY --link --from=builder --chown=zap:zap /zap/webswing /zap/webswing
+COPY --link --chown=zap:zap webswing.config /zap/webswing/
+COPY --link --chown=zap:zap webswing.properties /zap/webswing/
+COPY --link --chown=zap:zap policies /home/zap/.ZAP_D/policies/
+COPY --link --chown=zap:zap policies /root/.ZAP_D/policies/
+COPY --link --chown=zap:zap scripts /home/zap/.ZAP_D/scripts/
+COPY --link --chown=zap:zap .xinitrc /home/zap/
 
-RUN echo "zap2docker-weekly" > /zap/container
+RUN echo "zap2docker-weekly" > /zap/container && \
+    chmod a+x /home/zap/.xinitrc
 
-#Copy doesn't respect USER directives so we need to chown and to do that we need to be root
-USER root
-
-RUN chown zap:zap /zap/* CHANGELOG.md && \
-	chown zap:zap /zap/webswing/webswing.config && \
-	chown zap:zap /zap/webswing/webswing.properties && \
-	chown zap:zap -R /home/zap/.ZAP_D/ && \
-	chown zap:zap /home/zap/.xinitrc && \
-	chmod a+x /home/zap/.xinitrc
-
-#Change back to zap at the end
-USER zap
 HEALTHCHECK CMD curl --silent --output /dev/null --fail http://localhost:$ZAP_PORT/ || exit 1

--- a/docker/integration_tests/baseline_tests.sh
+++ b/docker/integration_tests/baseline_tests.sh
@@ -17,7 +17,7 @@ check_results() {
     
     if [ $expected -ne $code ] 
     then
-        echo "ERROR: exited with $? instead of $code"
+        echo "ERROR: exited with $code instead of $expected"
         RES=1
     else
         files=`ls /zap/wrk/results/$base-*`


### PR DESCRIPTION
 - Changed all images to use debian:bullseye-slim instead of unstable-slim.  
 - Updated live and weekly GitHub workflows to build multi-platform images (linux/amd64, linux/arm64).  
 - Optimized multi-platform builds by using the same builder stage across platforms ([Ref.](https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/)).  
 - Use the `docker/dockerfile:1` image to build containers with BuildKit ([Ref.](https://docs.docker.com/build/buildkit/dockerfile-frontend/)).  
 - Replaced usage of `COPY` with `COPY --link` ([Ref.](https://docs.docker.com/engine/reference/builder/#copy---link)).  
 - Replaced `COPY` then `RUN chown` with `COPY --chown` ([Ref.](https://docs.docker.com/engine/reference/builder/#copy)).