### PR TITLE
Include the version in add-ons' data dir

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnInstaller.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnInstaller.java
@@ -505,7 +505,7 @@ public final class AddOnInstaller {
      * Installs the libraries declared by the given add-on.
      *
      * <p>The libraries are copied to the directory with the following path: {@code
-     * <zapHome>/addOnData/<addOnId>/libs/}
+     * <zapHome>/addOnData/<addOnId>/<version>/libs/}
      *
      * @param addOn the add-on that will have the declared libraries installed.
      * @return {@code true} if no error occurred while installing the libraries, {@code false}
@@ -576,20 +576,43 @@ public final class AddOnInstaller {
     /**
      * Gets the path to the data directory of the given add-on.
      *
-     * <p>The path is built as: {@code <zapHome>/addOnData/<addOnId>/}
+     * <p>The path is built as: {@code <zapHome>/addOnData/<addOnId>/<version>/}
      *
      * @param addOn the add-on.
      * @return the path to the directory.
      * @see #ADD_ON_DATA_DIR
      */
     static Path getAddOnDataDir(AddOn addOn) {
-        return Paths.get(Constant.getZapHome(), ADD_ON_DATA_DIR, addOn.getId());
+        return Paths.get(
+                Constant.getZapHome(),
+                ADD_ON_DATA_DIR,
+                addOn.getId(),
+                addOn.getVersion().toString());
+    }
+
+    static void deleteLegacyAddOnLibsDir(List<AddOn> addOns) {
+        for (AddOn addOn : addOns) {
+            Path libsDir =
+                    Paths.get(
+                            Constant.getZapHome(),
+                            ADD_ON_DATA_DIR,
+                            addOn.getId(),
+                            ADD_ON_DATA_LIBS_DIR);
+            try {
+                deleteDir(libsDir);
+            } catch (IOException e) {
+                logger.warn(
+                        "An error occurred while removing legacy add-on libs directory {}",
+                        libsDir,
+                        e);
+            }
+        }
     }
 
     /**
      * Gets the path to the libraries directory of the given add-on.
      *
-     * <p>The path is built as: {@code <zapHome>/addOnData/<addOnId>/libs/}
+     * <p>The path is built as: {@code <zapHome>/addOnData/<addOnId>/<version>/libs/}
      *
      * @param addOn the add-on.
      * @return the path to the directory.

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnLoader.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnLoader.java
@@ -191,6 +191,8 @@ public class AddOnLoader extends URLClassLoader {
     }
 
     private void loadAllAddOns() {
+        AddOnInstaller.deleteLegacyAddOnLibsDir(aoc.getAddOns());
+
         for (Iterator<AddOn> iterator = aoc.getAddOns().iterator(); iterator.hasNext(); ) {
             AddOn addOn = iterator.next();
             if (canLoadAddOn(addOn)) {

--- a/zap/src/test/java/org/zaproxy/zap/control/AddOnInstallerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/AddOnInstallerUnitTest.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,7 +53,7 @@ class AddOnInstallerUnitTest extends AddOnTestUtils {
         // Then
         assertThat(
                 Paths.get(Constant.getZapHome()).relativize(addOnDataDir),
-                is(equalTo(Paths.get("addOnData/addOnId"))));
+                is(equalTo(Paths.get("addOnData/addOnId/1.0.0"))));
     }
 
     @Test
@@ -64,7 +65,26 @@ class AddOnInstallerUnitTest extends AddOnTestUtils {
         // Then
         assertThat(
                 Paths.get(Constant.getZapHome()).relativize(addOnLibsDir),
-                is(equalTo(Paths.get("addOnData/addOnId/libs"))));
+                is(equalTo(Paths.get("addOnData/addOnId/1.0.0/libs"))));
+    }
+
+    @Test
+    void shouldDeleteLegacyAddOnLibsDir() throws Exception {
+        // Given
+        AddOn addOnA = new AddOn(createAddOnFile("addOnA.zap"));
+        Path addOnALibsDir = Paths.get(Constant.getZapHome(), "addOnData/addOnA/libs");
+        createFile(addOnALibsDir.resolve("a_a.jar"));
+        createFile(addOnALibsDir.resolve("a_b.jar"));
+        AddOn addOnB = new AddOn(createAddOnFile("addOnB.zap"));
+        Path addOnBLibsDir = Paths.get(Constant.getZapHome(), "addOnData/addOnB/libs");
+        createFile(addOnBLibsDir.resolve("b_a.jar"));
+        createFile(addOnBLibsDir.resolve("b_b.jar"));
+        List<AddOn> addOns = List.of(addOnA, addOnB);
+        // When
+        AddOnInstaller.deleteLegacyAddOnLibsDir(addOns);
+        // Then
+        assertThat(Files.notExists(addOnALibsDir), is(equalTo(true)));
+        assertThat(Files.notExists(addOnBLibsDir), is(equalTo(true)));
     }
 
     @Test


### PR DESCRIPTION
Allow to deploy the libraries of the newer version without requiring to delete the libraries of the older version.

Part of #7589.