### PR TITLE
Install Network add-on async through the API

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -261,6 +261,15 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
         }
 
         AddOn installedAddOn = this.getLocalVersionInfo().getAddOn(ao.getId());
+        if ("network".equals(ao.getId())) {
+            new Thread(() -> installLocalAddOnQuietly(installedAddOn, ao), "ZAP-AddOnAsyncInstall")
+                    .start();
+            return true;
+        }
+        return installLocalAddOnQuietly(installedAddOn, ao);
+    }
+
+    private boolean installLocalAddOnQuietly(AddOn installedAddOn, AddOn ao) {
         if (installedAddOn != null) {
             try {
                 if (Files.isSameFile(installedAddOn.getFile().toPath(), ao.getFile().toPath())) {


### PR DESCRIPTION
Install asynchronously to return a proper response, as the API is being served by the add-on which will be uninstalled.