### PR TITLE
Allow to restore HttpSenderImpl state

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
@@ -109,6 +109,7 @@
 // ZAP: 2022/06/05 Remove usage of HttpException.
 // ZAP: 2022/06/07 Address deprecation warnings with HttpSenderParos.
 // ZAP: 2022/06/13 Added param digger initiator.
+// ZAP: 2022/12/09 Allow to restore HttpSenderImpl state.
 package org.parosproxy.paros.network;
 
 import java.io.IOException;
@@ -152,12 +153,24 @@ public class HttpSender {
     @SuppressWarnings("rawtypes")
     private static HttpSenderImpl impl = PAROS_IMPL;
 
-    private final HttpSenderContext ctx;
+    private static Object implState;
+
+    private HttpSenderContext ctx;
+
     private final int initiator;
 
     /** <strong>Note:</strong> Not part of the public API. */
     public static <T extends HttpSenderContext> void setImpl(HttpSenderImpl<T> impl) {
+        if (HttpSender.impl != PAROS_IMPL) {
+            implState = HttpSender.impl.saveState();
+        }
+
         HttpSender.impl = impl == null ? PAROS_IMPL : impl;
+
+        if (HttpSender.impl != PAROS_IMPL) {
+            HttpSender.impl.restoreState(implState);
+            implState = null;
+        }
     }
 
     /**
@@ -199,10 +212,20 @@ public class HttpSender {
 
     private HttpSender(boolean useGlobalState, int initiator) {
         this.initiator = initiator;
-        ctx = impl.createContext(this, initiator);
+        HttpSenderContext createdCtx = impl.createContext(this, initiator);
+        if (impl.getContext(this) == null) {
+            ctx = createdCtx;
+        }
 
         setUseGlobalState(useGlobalState);
         setUseCookies(true);
+    }
+
+    private HttpSenderContext getContext() {
+        if (ctx != null) {
+            return ctx;
+        }
+        return impl.getContext(this);
     }
 
     /**
@@ -234,7 +257,7 @@ public class HttpSender {
      * @see #setUseCookies(boolean)
      */
     public void setUseGlobalState(boolean enableGlobalState) {
-        ctx.setUseGlobalState(enableGlobalState);
+        getContext().setUseGlobalState(enableGlobalState);
     }
 
     /**
@@ -256,7 +279,7 @@ public class HttpSender {
      * @see #setUseGlobalState(boolean)
      */
     public void setUseCookies(boolean shouldUseCookies) {
-        ctx.setUseCookies(shouldUseCookies);
+        getContext().setUseCookies(shouldUseCookies);
     }
 
     /**
@@ -271,7 +294,7 @@ public class HttpSender {
      */
     @Deprecated
     public int executeMethod(HttpMethod method, HttpState state) throws IOException {
-        HttpSenderContext ctxTemp = ctx;
+        HttpSenderContext ctxTemp = getContext();
         if (!(ctxTemp instanceof HttpSenderContextParos)) {
             ctxTemp = PAROS_IMPL.createContext(this, initiator);
         }
@@ -293,14 +316,12 @@ public class HttpSender {
      * @since 2.12.0
      * @see #setFollowRedirect(boolean)
      */
-    @SuppressWarnings("unchecked")
     public void sendAndReceive(HttpMessage message, Path file) throws IOException {
-        impl.sendAndReceive(ctx, null, message, file);
+        sendImpl(null, message, file);
     }
 
-    @SuppressWarnings("unchecked")
     public void sendAndReceive(HttpMessage msg) throws IOException {
-        impl.sendAndReceive(ctx, null, msg, null);
+        sendImpl(null, msg, null);
     }
 
     /**
@@ -311,9 +332,8 @@ public class HttpSender {
      * @throws IOException
      * @see #sendAndReceive(HttpMessage, HttpRequestConfig)
      */
-    @SuppressWarnings("unchecked")
     public void sendAndReceive(HttpMessage msg, boolean isFollowRedirect) throws IOException {
-        impl.sendAndReceive(ctx, isFollowRedirect ? FOLLOW_REDIRECTS : NO_REDIRECTS, msg, null);
+        sendImpl(isFollowRedirect ? FOLLOW_REDIRECTS : NO_REDIRECTS, msg, null);
     }
 
     /**
@@ -329,11 +349,11 @@ public class HttpSender {
      * @see HttpMessage#getRequestingUser()
      */
     public User getUser(HttpMessage msg) {
-        return ctx.getUser(msg);
+        return getContext().getUser(msg);
     }
 
     public void setFollowRedirect(boolean followRedirect) {
-        ctx.setFollowRedirects(followRedirect);
+        getContext().setFollowRedirects(followRedirect);
     }
 
     /**
@@ -385,7 +405,7 @@ public class HttpSender {
      * @param user
      */
     public void setUser(User user) {
-        ctx.setUser(user);
+        getContext().setUser(user);
     }
 
     /**
@@ -416,7 +436,7 @@ public class HttpSender {
      *     removed when challenged, {@code false} otherwise
      */
     public void setRemoveUserDefinedAuthHeaders(boolean removeHeaders) {
-        ctx.setRemoveUserDefinedAuthHeaders(removeHeaders);
+        getContext().setRemoveUserDefinedAuthHeaders(removeHeaders);
     }
 
     /**
@@ -429,7 +449,7 @@ public class HttpSender {
      * @since 2.4.0
      */
     public void setMaxRetriesOnIOError(int retries) {
-        ctx.setMaxRetriesOnIoError(retries);
+        getContext().setMaxRetriesOnIoError(retries);
     }
 
     /**
@@ -442,7 +462,7 @@ public class HttpSender {
      * @since 2.4.0
      */
     public void setMaxRedirects(int maxRedirects) {
-        ctx.setMaxRedirects(maxRedirects);
+        getContext().setMaxRedirects(maxRedirects);
     }
 
     /**
@@ -472,9 +492,18 @@ public class HttpSender {
      * @since 2.6.0
      * @see #sendAndReceive(HttpMessage, boolean)
      */
-    @SuppressWarnings("unchecked")
     public void sendAndReceive(HttpMessage message, HttpRequestConfig requestConfig)
             throws IOException {
-        impl.sendAndReceive(ctx, requestConfig, message, null);
+        sendImpl(requestConfig, message, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void sendImpl(HttpRequestConfig requestConfig, HttpMessage message, Path file)
+            throws IOException {
+        if (ctx == null) {
+            impl.sendAndReceive(this, requestConfig, message, file);
+        } else {
+            impl.sendAndReceive(ctx, requestConfig, message, file);
+        }
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/network/HttpSenderImpl.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/HttpSenderImpl.java
@@ -35,6 +35,20 @@ public interface HttpSenderImpl<T extends HttpSenderContext> {
 
     T createContext(HttpSender parent, int initiator);
 
-    void sendAndReceive(T ctx, HttpRequestConfig config, HttpMessage msg, Path file)
-            throws IOException;
+    default T getContext(HttpSender httpSender) {
+        return null;
+    }
+
+    default void sendAndReceive(T ctx, HttpRequestConfig config, HttpMessage msg, Path file)
+            throws IOException {}
+
+    default void sendAndReceive(
+            HttpSender parent, HttpRequestConfig config, HttpMessage msg, Path file)
+            throws IOException {}
+
+    default Object saveState() {
+        return null;
+    }
+
+    default void restoreState(Object implState) {}
 }

--- a/zap/src/test/java/org/parosproxy/paros/network/HttpSenderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/network/HttpSenderUnitTest.java
@@ -1,0 +1,103 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.network;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zaproxy.zap.network.HttpSenderContext;
+import org.zaproxy.zap.network.HttpSenderImpl;
+
+/** Unit test for {@link HttpSender}. */
+class HttpSenderUnitTest {
+
+    private HttpMessage msg;
+    private HttpSenderImpl<HttpSenderContext> impl;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setup() {
+        impl = mock(HttpSenderImpl.class);
+        HttpSender.setImpl(impl);
+    }
+
+    @Test
+    void shouldRestoreSavedStateAfterRemovingImplementation() {
+        // Given
+        Object state = mock(Object.class);
+        given(impl.saveState()).willReturn(state);
+        HttpSenderImpl<?> otherImpl = mock(HttpSenderImpl.class);
+        // When
+        HttpSender.setImpl(null);
+        HttpSender.setImpl(otherImpl);
+        // Then
+        verify(otherImpl).restoreState(state);
+    }
+
+    @Test
+    void shouldRestoreSavedStateReplacingImplementation() {
+        // Given
+        Object state = mock(Object.class);
+        given(impl.saveState()).willReturn(state);
+        HttpSenderImpl<?> otherImpl = mock(HttpSenderImpl.class);
+        // When
+        HttpSender.setImpl(otherImpl);
+        // Then
+        verify(otherImpl).restoreState(state);
+    }
+
+    @Test
+    void shouldUseAndSendWithCreatedContext() throws IOException {
+        // Given
+        HttpSenderContext createdCtx = mock(HttpSenderContext.class);
+        given(impl.createContext(any(), anyInt())).willReturn(createdCtx);
+        // When
+        HttpSender httpSender = new HttpSender(1);
+        httpSender.sendAndReceive(msg);
+        // Then
+        verify(impl).createContext(httpSender, 1);
+        verify(impl).getContext(httpSender);
+        verify(impl).sendAndReceive(eq(createdCtx), any(), eq(msg), eq(null));
+    }
+
+    @Test
+    void shouldUseAndSendWithGetContext() throws IOException {
+        // Given
+        HttpSenderContext createdCtx = mock(HttpSenderContext.class);
+        given(impl.createContext(any(), anyInt())).willReturn(createdCtx);
+        HttpSenderContext getCtx = mock(HttpSenderContext.class);
+        given(impl.getContext(any())).willReturn(getCtx);
+        // When
+        HttpSender httpSender = new HttpSender(1);
+        httpSender.sendAndReceive(msg);
+        // Then
+        verify(impl).createContext(httpSender, 1);
+        verify(impl, times(3)).getContext(httpSender);
+        verify(impl).sendAndReceive(eq(httpSender), any(), eq(msg), eq(null));
+    }
+}

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -147,7 +147,11 @@ val japicmp by tasks.registering(JapicmpTask::class) {
 
     fieldExcludes.set(listOf())
 
-    classExcludes.set(listOf())
+    classExcludes.set(
+        listOf(
+            "org.zaproxy.zap.network.HttpSenderImpl"
+        )
+    )
 
     methodExcludes.set(
         listOf(


### PR DESCRIPTION
Save and restore the implementation state when changed, to allow to properly replace the implementations at runtime.
Obtain the contexts when needed to not keep a reference to the implementation class (with newer implementations), thus not prevent them from being GC'ed.