### PR TITLE
Fix PII Disclosure FP by treating PDF as an image

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/network/HttpRequestHeader.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpRequestHeader.java
@@ -125,7 +125,7 @@ public class HttpRequestHeader extends HttpHeader {
     //	= Pattern.compile("([^:]+)\\s*?:?\\s*?(\\d*?)");
     private static final Pattern patternImage =
             Pattern.compile(
-                    "\\.(bmp|ico|jpg|jpeg|gif|tiff|tif|png|svg)\\z", Pattern.CASE_INSENSITIVE);
+                    "\\.(bmp|ico|jpg|jpeg|gif|tiff|tif|pdf|png|svg)\\z", Pattern.CASE_INSENSITIVE);
     private static final Pattern patternPartialRequestLine =
             Pattern.compile(
                     "\\A *(OPTIONS|GET|HEAD|POST|PUT|DELETE|TRACE|CONNECT)\\b",


### PR DESCRIPTION
https://cloud.gov/assets/pages/documents/Pages-Proposal.pdf is triggering the PII Scan rule, https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/PiiScanRule.java, resulting in a "High" false positive.

The supposed evidence is: 569534536645515786

Since a regex against a PDF is not going to match real content, we should treat PDFs as images. 

Signed-off-by: Peter Burkholder (@pburkholder) <peter.burkholder@gsa.gov>

---

[Pages-Proposal.pdf](https://github.com/zaproxy/zaproxy/files/10365255/Pages-Proposal.pdf)