### PR TITLE
Tidy up loggers

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/CommandLine.java
+++ b/zap/src/main/java/org/parosproxy/paros/CommandLine.java
@@ -52,6 +52,7 @@
 // ZAP: 2022/02/28 Remove code deprecated in 2.6.0
 // ZAP: 2022/04/11 Remove -nouseragent option.
 // ZAP: 2022/08/18 Support parameters supplied to newly installed or updated add-ons.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros;
 
 import java.io.File;
@@ -73,7 +74,7 @@ import org.zaproxy.zap.extension.autoupdate.ExtensionAutoUpdate;
 
 public class CommandLine {
 
-    private static final Logger logger = LogManager.getLogger(CommandLine.class);
+    private static final Logger LOGGER = LogManager.getLogger(CommandLine.class);
 
     // ZAP: Made public
     public static final String SESSION = "-session";
@@ -627,7 +628,7 @@ public class CommandLine {
             default: // Ignore
         }
         // Always write to the log
-        logger.info(str);
+        LOGGER.info(str);
     }
 
     /**
@@ -645,7 +646,7 @@ public class CommandLine {
             default: // Ignore
         }
         // Always write to the log
-        logger.error(str);
+        LOGGER.error(str);
     }
 
     /**
@@ -664,6 +665,6 @@ public class CommandLine {
             default: // Ignore
         }
         // Always write to the log
-        logger.error(str, e);
+        LOGGER.error(str, e);
     }
 }

--- a/zap/src/main/java/org/parosproxy/paros/Constant.java
+++ b/zap/src/main/java/org/parosproxy/paros/Constant.java
@@ -119,6 +119,7 @@
 // ZAP: 2022/05/20 Remove usage of ConnectionParam.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
 // ZAP: 2022/12/22 Issue 7663: Default threads based on number of processors.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros;
 
 import java.io.File;
@@ -389,7 +390,7 @@ public final class Constant {
     public static final URL SPIDER_IMAGE_URL =
             Constant.class.getResource("/resource/icon/10/spider.png");
 
-    private static Logger LOG = LogManager.getLogger(Constant.class);
+    private static final Logger LOGGER = LogManager.getLogger(Constant.class);
 
     public static String getEyeCatcher() {
         return staticEyeCatcher;
@@ -458,7 +459,7 @@ public final class Constant {
                 && oldf.exists()
                 && Paths.get(zapHome).equals(Paths.get(getDefaultHomeDirectory(true)))) {
             // Dont copy old configs if forcedReset or they've specified a non std directory
-            LOG.info("Copying defaults from {} to {}", oldf.getAbsolutePath(), FILE_CONFIG);
+            LOGGER.info("Copying defaults from {} to {}", oldf.getAbsolutePath(), FILE_CONFIG);
             copier.copy(oldf, f);
 
             if (isDevMode() || isDailyBuild()) {
@@ -468,7 +469,7 @@ public final class Constant {
                 newConfig.save();
             }
         } else {
-            LOG.info("Copying default configuration to {}", FILE_CONFIG);
+            LOGGER.info("Copying default configuration to {}", FILE_CONFIG);
             copyDefaultConfigFile();
         }
     }
@@ -515,7 +516,7 @@ public final class Constant {
             try {
                 return path.toUri().toURL();
             } catch (MalformedURLException e) {
-                LOG.debug("Failed to convert file system path:", e);
+                LOGGER.debug("Failed to convert file system path:", e);
             }
         }
         return Constant.class.getResource(PATH_BUNDLED_CONFIG_XML);
@@ -582,7 +583,7 @@ public final class Constant {
 
             f = new File(FOLDER_SESSION);
             if (!f.isDirectory()) {
-                LOG.info("Creating directory {}", FOLDER_SESSION);
+                LOGGER.info("Creating directory {}", FOLDER_SESSION);
                 if (!f.mkdir()) {
                     // ZAP: report failure to create directory
                     System.out.println("Failed to create directory " + f.getAbsolutePath());
@@ -590,7 +591,7 @@ public final class Constant {
             }
             f = new File(DIRBUSTER_CUSTOM_DIR);
             if (!f.isDirectory()) {
-                LOG.info("Creating directory {}", DIRBUSTER_CUSTOM_DIR);
+                LOGGER.info("Creating directory {}", DIRBUSTER_CUSTOM_DIR);
                 if (!f.mkdir()) {
                     // ZAP: report failure to create directory
                     System.out.println("Failed to create directory " + f.getAbsolutePath());
@@ -598,7 +599,7 @@ public final class Constant {
             }
             f = new File(FUZZER_DIR);
             if (!f.isDirectory()) {
-                LOG.info("Creating directory {}", FUZZER_DIR);
+                LOGGER.info("Creating directory {}", FUZZER_DIR);
                 if (!f.mkdir()) {
                     // ZAP: report failure to create directory
                     System.out.println("Failed to create directory " + f.getAbsolutePath());
@@ -606,7 +607,7 @@ public final class Constant {
             }
             f = new File(FOLDER_LOCAL_PLUGIN);
             if (!f.isDirectory()) {
-                LOG.info("Creating directory {}", FOLDER_LOCAL_PLUGIN);
+                LOGGER.info("Creating directory {}", FOLDER_LOCAL_PLUGIN);
                 if (!f.mkdir()) {
                     // ZAP: report failure to create directory
                     System.out.println("Failed to create directory " + f.getAbsolutePath());
@@ -636,7 +637,7 @@ public final class Constant {
                     // Nothing to do
                 } else {
                     // Backup the old one
-                    LOG.info("Backing up config file to {}.bak", FILE_CONFIG);
+                    LOGGER.info("Backing up config file to {}.bak", FILE_CONFIG);
                     f = new File(FILE_CONFIG);
                     try {
                         copier.copy(f, new File(FILE_CONFIG + ".bak"));
@@ -649,7 +650,7 @@ public final class Constant {
                                         + ".bak "
                                         + e.getMessage();
                         System.err.println(msg);
-                        LOG.error(msg, e);
+                        LOGGER.error(msg, e);
                     }
 
                     if (ver == V_PAROS_TAG) {
@@ -717,7 +718,7 @@ public final class Constant {
                     // Execute always to pick installer choices.
                     updateCfuFromDefaultConfig(config);
 
-                    LOG.info("Upgraded from {}", ver);
+                    LOGGER.info("Upgraded from {}", ver);
 
                     setLatestVersion(config);
                 }
@@ -812,13 +813,13 @@ public final class Constant {
     }
 
     private static void logAndPrintError(String message, Exception e) {
-        LOG.error(message, e);
+        LOGGER.error(message, e);
         System.err.println(message);
         e.printStackTrace();
     }
 
     private static void logAndPrintInfo(String message) {
-        LOG.info(message);
+        LOGGER.info(message);
         System.out.println(message);
     }
 
@@ -1017,7 +1018,7 @@ public final class Constant {
                 config.setProperty(OptionsParamCheckForUpdates.DAY_LAST_CHECKED, "");
             }
         } catch (ConversionException e) {
-            LOG.debug(
+            LOGGER.debug(
                     "The option {} is not an int.", OptionsParamCheckForUpdates.CHECK_ON_START, e);
         }
         // Clear the block list - addons were incorrectly added to this if an update failed
@@ -1030,7 +1031,7 @@ public final class Constant {
             int oldValue = config.getInt(OptionsParamCheckForUpdates.CHECK_ON_START, 1);
             config.setProperty(OptionsParamCheckForUpdates.CHECK_ON_START, oldValue != 0);
         } catch (ConversionException e) {
-            LOG.debug(
+            LOGGER.debug(
                     "The option {} is no longer an int.",
                     OptionsParamCheckForUpdates.CHECK_ON_START,
                     e);
@@ -1112,7 +1113,7 @@ public final class Constant {
             int oldValue = config.getInt(certUseKey, 0);
             config.setProperty(certUseKey, oldValue != 0);
         } catch (ConversionException e) {
-            LOG.debug("The option {} is no longer an int.", certUseKey, e);
+            LOGGER.debug("The option {} is no longer an int.", certUseKey, e);
         }
     }
 

--- a/zap/src/main/java/org/parosproxy/paros/common/AbstractParam.java
+++ b/zap/src/main/java/org/parosproxy/paros/common/AbstractParam.java
@@ -35,6 +35,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/09/08 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.common;
 
 import java.util.Map.Entry;
@@ -48,7 +49,7 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 public abstract class AbstractParam implements Cloneable {
 
-    private static final Logger logger = LogManager.getLogger(AbstractParam.class);
+    private static final Logger LOGGER = LogManager.getLogger(AbstractParam.class);
 
     private FileConfiguration config = null;
     /**
@@ -62,7 +63,7 @@ public abstract class AbstractParam implements Cloneable {
         try {
             parse();
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -87,7 +88,7 @@ public abstract class AbstractParam implements Cloneable {
             config = new ZapXmlConfiguration(filePath);
             if (overrides != null) {
                 for (Entry<String, String> entry : overrides.getOrderedConfigs().entrySet()) {
-                    logger.info(
+                    LOGGER.info(
                             "Setting config {} = {} was {}",
                             entry.getKey(),
                             entry.getValue(),
@@ -97,7 +98,7 @@ public abstract class AbstractParam implements Cloneable {
             }
             parse();
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -117,7 +118,7 @@ public abstract class AbstractParam implements Cloneable {
             clone.load((FileConfiguration) ConfigurationUtils.cloneConfiguration(config));
             return clone;
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
         return null;
     }
@@ -167,7 +168,7 @@ public abstract class AbstractParam implements Cloneable {
      * @since 2.7.0
      */
     protected static void logConversionException(String key, ConversionException e) {
-        logger.warn("Failed to read '{}'", key, e);
+        LOGGER.warn("Failed to read '{}'", key, e);
     }
 
     /**

--- a/zap/src/main/java/org/parosproxy/paros/control/MenuFileControl.java
+++ b/zap/src/main/java/org/parosproxy/paros/control/MenuFileControl.java
@@ -57,6 +57,7 @@
 // ZAP: 2021/05/14 Remove redundant type arguments.
 // ZAP: 2022/08/05 Address warns with Java 18.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.control;
 
 import java.awt.EventQueue;
@@ -90,7 +91,7 @@ import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
 public class MenuFileControl implements SessionListener {
 
-    private static Logger log = LogManager.getLogger(MenuFileControl.class);
+    private static final Logger LOGGER = LogManager.getLogger(MenuFileControl.class);
 
     private View view = null;
     private Model model = null;
@@ -241,7 +242,7 @@ public class MenuFileControl implements SessionListener {
                             } else {
                                 view.showWarningDialog(
                                         Constant.messages.getString("menu.file.newSession.error"));
-                                log.error(
+                                LOGGER.error(
                                         "Error creating session file {}",
                                         model.getSession().getFileName(),
                                         e);
@@ -277,7 +278,7 @@ public class MenuFileControl implements SessionListener {
         File sessionFile = new File(session);
         waitMessageDialog =
                 view.getWaitMessageDialog(Constant.messages.getString("menu.file.loadSession"));
-        log.info("opening session file {}", sessionFile.getAbsolutePath());
+        LOGGER.info("opening session file {}", sessionFile.getAbsolutePath());
         control.openSession(
                 sessionFile,
                 new SessionListener() {
@@ -294,7 +295,7 @@ public class MenuFileControl implements SessionListener {
                             if (e != null) {
                                 view.showWarningDialog(
                                         Constant.messages.getString("menu.file.openSession.error"));
-                                log.error(
+                                LOGGER.error(
                                         "error opening session file {}",
                                         model.getSession().getFileName(),
                                         e);
@@ -353,14 +354,14 @@ public class MenuFileControl implements SessionListener {
                     return;
                 }
                 model.getOptionsParam().setUserDirectory(chooser.getCurrentDirectory());
-                log.info("opening session file {}", file.getAbsolutePath());
+                LOGGER.info("opening session file {}", file.getAbsolutePath());
                 waitMessageDialog =
                         view.getWaitMessageDialog(
                                 Constant.messages.getString("menu.file.loadSession"));
                 control.openSession(file, this);
                 waitMessageDialog.setVisible(true);
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -384,7 +385,7 @@ public class MenuFileControl implements SessionListener {
             }
 
         } catch (DatabaseException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -401,7 +402,7 @@ public class MenuFileControl implements SessionListener {
                     view.getWaitMessageDialog(
                             Constant.messages.getString("menu.file.savingSession")); // ZAP: i18n
             control.saveSession(session.getFileName(), this);
-            log.info("saving session file {}", session.getFileName());
+            LOGGER.info("saving session file {}", session.getFileName());
             // ZAP: If the save is quick the dialog can already be null here
             if (waitMessageDialog != null) {
                 waitMessageDialog.setVisible(true);
@@ -410,8 +411,8 @@ public class MenuFileControl implements SessionListener {
         } catch (Exception e) {
             view.showWarningDialog(
                     Constant.messages.getString("menu.file.savingSession.error")); // ZAP: i18n
-            log.error("error saving session file {}", session.getFileName());
-            log.error(e.getMessage(), e);
+            LOGGER.error("error saving session file {}", session.getFileName());
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -446,10 +447,10 @@ public class MenuFileControl implements SessionListener {
                                 Constant.messages.getString(
                                         "menu.file.savingSession")); // ZAP: i18n
                 control.saveSession(fileName, this);
-                log.info("save as session file {}", session.getFileName());
+                LOGGER.info("save as session file {}", session.getFileName());
                 waitMessageDialog.setVisible(true);
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -499,10 +500,10 @@ public class MenuFileControl implements SessionListener {
                                 Constant.messages.getString(
                                         "menu.file.savingSnapshot")); // ZAP: i18n
                 control.snapshotSession(fileName, this);
-                log.info("Snapshotting: {} as {}", session.getFileName(), fileName);
+                LOGGER.info("Snapshotting: {} as {}", session.getFileName(), fileName);
                 waitMessageDialog.setVisible(true);
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -521,10 +522,10 @@ public class MenuFileControl implements SessionListener {
         } else {
             view.showWarningDialog(Constant.messages.getString("menu.file.openSession.errorFile"));
             if (file != null) {
-                log.error("Error opening session file {}", file.getAbsolutePath(), e);
+                LOGGER.error("Error opening session file {}", file.getAbsolutePath(), e);
             } else {
                 // File is null for table based sessions (i.e. non HSQLDB)
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
 
@@ -539,8 +540,8 @@ public class MenuFileControl implements SessionListener {
         if (e != null) {
             view.showWarningDialog(
                     Constant.messages.getString("menu.file.savingSession.error")); // ZAP: i18n
-            log.error("error saving session file {}", model.getSession().getFileName(), e);
-            log.error(e.getMessage(), e);
+            LOGGER.error("error saving session file {}", model.getSession().getFileName(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         if (waitMessageDialog != null) {
@@ -554,8 +555,8 @@ public class MenuFileControl implements SessionListener {
         if (e != null) {
             view.showWarningDialog(
                     Constant.messages.getString("menu.file.snapshotSession.error")); // ZAP: i18n
-            log.error("error saving snapshot file {}", model.getSession().getFileName(), e);
-            log.error(e.getMessage(), e);
+            LOGGER.error("error saving snapshot file {}", model.getSession().getFileName(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         if (waitMessageDialog != null) {
@@ -616,7 +617,7 @@ public class MenuFileControl implements SessionListener {
                         .showWarningDialog(
                                 Constant.messages.getString("context.import.error", detailError));
             } catch (Exception e1) {
-                log.error(e1.getMessage(), e1);
+                LOGGER.error(e1.getMessage(), e1);
                 View.getSingleton()
                         .showWarningDialog(
                                 Constant.messages.getString(

--- a/zap/src/main/java/org/parosproxy/paros/control/MenuToolsControl.java
+++ b/zap/src/main/java/org/parosproxy/paros/control/MenuToolsControl.java
@@ -28,6 +28,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/02/09 Remove proxy related code.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.control;
 
 import javax.swing.JOptionPane;
@@ -41,7 +42,7 @@ import org.parosproxy.paros.view.View;
 
 public class MenuToolsControl {
 
-    private static final Logger logger = LogManager.getLogger(MenuToolsControl.class);
+    private static final Logger LOGGER = LogManager.getLogger(MenuToolsControl.class);
 
     private View view = null;
     private Model model = null;
@@ -76,7 +77,7 @@ public class MenuToolsControl {
             try {
                 model.getOptionsParam().getConfig().save();
             } catch (ConfigurationException e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
                 view.showWarningDialog(
                         Constant.messages.getString("menu.tools.options.errorSavingOptions"));
                 return;

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractAppParamPlugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractAppParamPlugin.java
@@ -43,13 +43,12 @@
 // ZAP: 2021/05/06 Add input vector and param to all alerts
 // ZAP: 2021/06/16 Add support for updating multiple parameters in HttpMessage.
 // ZAP: 2022/09/08 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/01/10 Use logger provided by base class.
 package org.parosproxy.paros.core.scanner;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
@@ -59,7 +58,6 @@ import org.zaproxy.zap.extension.ascan.VariantFactory;
 
 public abstract class AbstractAppParamPlugin extends AbstractAppPlugin {
 
-    private final Logger logger = LogManager.getLogger(this.getClass());
     private List<Variant> listVariant;
     private NameValuePair originalPair = null;
     private Variant variant = null;
@@ -93,10 +91,11 @@ public abstract class AbstractAppParamPlugin extends AbstractAppPlugin {
                 variant.setMessage(msg);
                 this.scan(this.variant.getParamList());
             } catch (Exception e) {
-                logger.error(
-                        "Error occurred while scanning with variant {}",
-                        variant.getClass().getCanonicalName(),
-                        e);
+                getLogger()
+                        .error(
+                                "Error occurred while scanning with variant {}",
+                                variant.getClass().getCanonicalName(),
+                                e);
             }
 
             // ZAP: Implement pause and resume
@@ -132,7 +131,7 @@ public abstract class AbstractAppParamPlugin extends AbstractAppPlugin {
                 try {
                     scan(msg, originalPair);
                 } catch (Exception e) {
-                    logger.error("Error occurred while scanning a message:", e);
+                    getLogger().error("Error occurred while scanning a message:", e);
                 }
             }
         }

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -75,6 +75,7 @@
 // ZAP: 2022/08/03 Keep enabled state when setting default alert threshold (Issue 7400).
 // ZAP: 2022/09/08 Use format specifiers instead of concatenation when logging.
 // ZAP: 2022/09/28 Do not set the Content-Length header when the method does not require one.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.core.scanner;
 
 import java.io.IOException;
@@ -116,7 +117,7 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
     private HostProcess parent = null;
     private HttpMessage msg = null;
     private boolean enabled = true;
-    private Logger logger = LogManager.getLogger(this.getClass());
+    private final Logger logger = LogManager.getLogger(getClass());
     private Configuration config = null;
     // ZAP Added delayInMs
     private int delayInMs;

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Alert.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Alert.java
@@ -65,6 +65,7 @@
 // getReliability()
 // ZAP: 2022/02/25 Remove code deprecated in 2.5.0
 // ZAP: 2022/05/26 Add addTag and removeTag methods
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.core.scanner;
 
 import java.net.URL;
@@ -207,7 +208,7 @@ public class Alert implements Comparable<Alert> {
     private int sourceHistoryId = 0;
     private HistoryReference historyRef = null;
     // ZAP: Added logger
-    private static final Logger logger = LogManager.getLogger(Alert.class);
+    private static final Logger LOGGER = LogManager.getLogger(Alert.class);
     // Cache this info so that we dont have to keep a ref to the HttpMessage
     private String method = "";
     private String postData;
@@ -244,10 +245,10 @@ public class Alert implements Comparable<Alert> {
 
         } catch (HttpMalformedHeaderException e) {
             // ZAP: Just an indication the history record doesn't exist
-            logger.debug(e.getMessage(), e);
+            LOGGER.debug(e.getMessage(), e);
         } catch (Exception e) {
             // ZAP: Log the exception
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         init(recordAlert, hRef);
@@ -700,7 +701,7 @@ public class Alert implements Comparable<Alert> {
             try {
                 return this.historyRef.getHttpMessage();
             } catch (HttpMalformedHeaderException | DatabaseException e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
         return null;

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/HostProcess.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/HostProcess.java
@@ -104,6 +104,7 @@
 // ZAP: 2022/05/20 Address deprecation warnings with ConnectionParam.
 // ZAP: 2022/05/30 Remove deprecation usage.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.core.scanner;
 
 import java.io.IOException;
@@ -145,7 +146,7 @@ import org.zaproxy.zap.users.User;
 
 public class HostProcess implements Runnable {
 
-    private static final Logger log = LogManager.getLogger(HostProcess.class);
+    private static final Logger LOGGER = LogManager.getLogger(HostProcess.class);
     private static final DecimalFormat decimalFormat = new java.text.DecimalFormat("###0.###");
 
     private List<StructuralNode> startNodes;
@@ -336,7 +337,7 @@ public class HostProcess implements Runnable {
     /** Main execution method */
     @Override
     public void run() {
-        log.debug("HostProcess.run");
+        LOGGER.debug("HostProcess.run");
 
         try {
             hostProcessStartTime = System.currentTimeMillis();
@@ -401,7 +402,7 @@ public class HostProcess implements Runnable {
             }
             threadPool.waitAllThreadComplete(300000);
         } catch (Exception e) {
-            log.error("An error occurred while active scanning:", e);
+            LOGGER.error("An error occurred while active scanning:", e);
             stop();
         } finally {
             notifyHostProgress(null);
@@ -445,7 +446,7 @@ public class HostProcess implements Runnable {
         if (nodeInScopeCount == 0) {
             strBuilder.append(", skipping all plugins.");
         }
-        log.info(strBuilder.toString());
+        LOGGER.info(strBuilder.toString());
     }
 
     private void processPlugin(final Plugin plugin) {
@@ -465,7 +466,7 @@ public class HostProcess implements Runnable {
             return;
         }
 
-        log.info(
+        LOGGER.info(
                 "start host {} | {} strength {} threshold {}",
                 hostAndPort,
                 plugin.getCodeName(),
@@ -525,7 +526,8 @@ public class HostProcess implements Runnable {
                         if (!node.isSameAs(sibling)
                                 && nodeName.equals(
                                         SessionStructure.getCleanRelativeName(sibling, false))) {
-                            log.debug("traverse: including related sibling {}", sibling.getName());
+                            LOGGER.debug(
+                                    "traverse: including related sibling {}", sibling.getName());
                             parentNodes.add(sibling);
                         }
                     }
@@ -544,7 +546,7 @@ public class HostProcess implements Runnable {
                         traverse(iter.next(), false, action);
 
                     } catch (Exception e) {
-                        log.error(e.getMessage(), e);
+                        LOGGER.error(e.getMessage(), e);
                     }
                 }
             }
@@ -564,20 +566,20 @@ public class HostProcess implements Runnable {
                         HttpMessage msg = node.getHistoryReference().getHttpMessage();
                         parentScanner.notifyFilteredMessage(msg, filterResult.getReason());
                     } catch (HttpMalformedHeaderException | DatabaseException e) {
-                        log.warn(
+                        LOGGER.warn(
                                 "Error while getting httpmessage from history reference: {}",
                                 e.getMessage(),
                                 e);
                     }
 
-                    log.debug(
+                    LOGGER.debug(
                             "Ignoring filtered node: {} Reason: {}",
                             node.getName(),
                             filterResult.getReason());
                     return true;
                 }
             } catch (Exception ex) {
-                log.error(ex.getMessage(), ex);
+                LOGGER.error(ex.getMessage(), ex);
             }
         }
         return false;
@@ -601,7 +603,8 @@ public class HostProcess implements Runnable {
             historyReference = new HistoryReference(messageId, true);
             msg = historyReference.getHttpMessage();
         } catch (HttpMalformedHeaderException | DatabaseException e) {
-            log.warn("Failed to read message with ID [{}], cause: {}", messageId, e.getMessage());
+            LOGGER.warn(
+                    "Failed to read message with ID [{}], cause: {}", messageId, e.getMessage());
             return false;
         }
 
@@ -616,7 +619,7 @@ public class HostProcess implements Runnable {
                 }
             }
 
-            log.debug(
+            LOGGER.debug(
                     "scanSingleNode node plugin={} node={}",
                     plugin.getName(),
                     historyReference.getURI());
@@ -638,7 +641,7 @@ public class HostProcess implements Runnable {
                     plugin.getName() + ": " + msg.getRequestHeader().getURI().toString());
 
         } catch (Exception e) {
-            log.error("{} {}", e.getMessage(), historyReference.getURI(), e);
+            LOGGER.error("{} {}", e.getMessage(), historyReference.getURI(), e);
             return false;
         }
 
@@ -665,7 +668,7 @@ public class HostProcess implements Runnable {
             requestCount++;
             return true;
         } catch (IOException e) {
-            log.warn(
+            LOGGER.warn(
                     "Failed to obtain the HTTP response for href [id={}, type={}, URL={}]: {}",
                     hRef.getHistoryId(),
                     hRef.getHistoryType(),
@@ -685,18 +688,18 @@ public class HostProcess implements Runnable {
      */
     private boolean canScanNode(StructuralNode node) {
         if (node == null) {
-            log.debug("Ignoring null node");
+            LOGGER.debug("Ignoring null node");
             return false;
         }
 
         HistoryReference hRef = node.getHistoryReference();
         if (hRef == null) {
-            log.debug("Ignoring null history reference for node: {}", node.getName());
+            LOGGER.debug("Ignoring null history reference for node: {}", node.getName());
             return false;
         }
 
         if (HistoryReference.TYPE_SCANNER == hRef.getHistoryType()) {
-            log.debug(
+            LOGGER.debug(
                     "Ignoring \"scanner\" type href [id={}, URL={}]",
                     hRef.getHistoryId(),
                     hRef.getURI());
@@ -704,7 +707,7 @@ public class HostProcess implements Runnable {
         }
 
         if (!nodeInScope(node.getName())) {
-            log.debug("Ignoring node not in scope: {}", node.getName());
+            LOGGER.debug("Ignoring node not in scope: {}", node.getName());
             return false;
         }
 
@@ -811,7 +814,7 @@ public class HostProcess implements Runnable {
     private void notifyHostComplete() {
         long diffTimeMillis = System.currentTimeMillis() - hostProcessStartTime;
         String diffTimeString = decimalFormat.format(diffTimeMillis / 1000.0) + "s";
-        log.info(
+        LOGGER.info(
                 "completed host {} in {} with {} alert(s) raised.",
                 hostAndPort,
                 diffTimeString,
@@ -941,7 +944,8 @@ public class HostProcess implements Runnable {
             redirectionValidator =
                     redirection -> {
                         if (!nodeInScope(redirection.getEscapedURI())) {
-                            log.debug("Skipping redirection out of scan's scope: {}", redirection);
+                            LOGGER.debug(
+                                    "Skipping redirection out of scan's scope: {}", redirection);
                             return false;
                         }
                         return true;
@@ -1112,7 +1116,7 @@ public class HostProcess implements Runnable {
         sb.append(" and ").append(pluginStats.getAlertCount()).append(" alert(s) raised.");
 
         // Probably too verbose evaluate 4 the future
-        log.info(sb.toString());
+        LOGGER.info(sb.toString());
 
         pluginFactory.setRunningPluginCompleted(plugin);
         notifyHostProgress(null);
@@ -1209,7 +1213,7 @@ public class HostProcess implements Runnable {
                 try {
                     hook.beforeScan(msg, plugin, this.parentScanner);
                 } catch (Exception e) {
-                    log.info(
+                    LOGGER.info(
                             "An exception occurred while trying to call beforeScan(msg, plugin) for one of the ScannerHooks: {}",
                             e.getMessage(),
                             e);
@@ -1234,7 +1238,7 @@ public class HostProcess implements Runnable {
                 try {
                     hook.afterScan(msg, plugin, this.parentScanner);
                 } catch (Exception e) {
-                    log.info(
+                    LOGGER.info(
                             "An exception occurred while trying to call afterScan(msg, plugin) for one of the ScannerHooks: {}",
                             e.getMessage(),
                             e);

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Kb.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Kb.java
@@ -28,6 +28,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/02/08 Use isEmpty where applicable.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.core.scanner;
 
 import java.util.TreeMap;
@@ -48,7 +49,7 @@ import org.apache.logging.log4j.Logger;
 public class Kb {
 
     // ZAP: Added logger.
-    private static final Logger logger = LogManager.getLogger(Kb.class);
+    private static final Logger LOGGER = LogManager.getLogger(Kb.class);
 
     // KB related
     // ZAP: Added the type arguments.
@@ -122,7 +123,7 @@ public class Kb {
             uri.setQuery(null);
         } catch (URIException e) {
             // ZAP: Added logging.
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             return;
         }
         // ZAP: Moved to after the try catch block.
@@ -151,7 +152,7 @@ public class Kb {
             uri.setQuery(null);
         } catch (URIException e) {
             // ZAP: Added logging.
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             return null;
         }
         // ZAP: Moved to after the try catch block.

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/PluginFactory.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/PluginFactory.java
@@ -59,6 +59,7 @@
 // ZAP: 2021/05/14 Remove redundant type arguments.
 // ZAP: 2022/02/03 Removed loadedPlugin and unloadedPlugin.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.core.scanner;
 
 import java.util.ArrayList;
@@ -81,7 +82,7 @@ import org.zaproxy.zap.control.ExtensionFactory;
 
 public class PluginFactory {
 
-    private static Logger log = LogManager.getLogger(PluginFactory.class);
+    private static final Logger LOGGER = LogManager.getLogger(PluginFactory.class);
     private static List<AbstractPlugin> loadedPlugins = null;
     private static Map<Integer, Plugin> mapLoadedPlugins;
 
@@ -128,7 +129,7 @@ public class PluginFactory {
 
     private static void checkPluginId(Plugin plugin) {
         if (plugin.getId() == -1) {
-            log.error(
+            LOGGER.error(
                     "The active scan rule [{}] does not have a defined ID.",
                     plugin.getClass().getCanonicalName());
         }
@@ -297,7 +298,7 @@ public class PluginFactory {
         } else {
             plugin.setEnabled(false);
             plugin.setAlertThreshold(Plugin.AlertThreshold.OFF);
-            log.warn(
+            LOGGER.warn(
                     "Disabled scanner '{}' because of unfulfilled dependencies.", plugin.getName());
         }
     }
@@ -364,7 +365,7 @@ public class PluginFactory {
 
     /** @param config */
     public synchronized void loadAllPlugin(Configuration config) {
-        log.debug("loadAllPlugin");
+        LOGGER.debug("loadAllPlugin");
         this.config = config;
 
         // mapAllPlugin is ordered by insertion order, so the ordering of plugins in listTest is
@@ -380,13 +381,13 @@ public class PluginFactory {
                 try {
                     Plugin loadedPlugin = getLoadedPlugins().get(i);
                     if (!loadedPlugin.isVisible()) {
-                        log.info("Plugin {} not visible", loadedPlugin.getName());
+                        LOGGER.info("Plugin {} not visible", loadedPlugin.getName());
                         continue;
                     }
 
                     if (loadedPlugin.isDepreciated()) {
                         // ZAP: ignore all depreciated plugins
-                        log.info("Plugin {} deprecated", loadedPlugin.getName());
+                        LOGGER.info("Plugin {} deprecated", loadedPlugin.getName());
                         continue;
                     }
 
@@ -395,7 +396,7 @@ public class PluginFactory {
                     }
 
                     Plugin plugin = createNewPlugin(loadedPlugin, config);
-                    log.debug(
+                    LOGGER.debug(
                             "loaded plugin {} with: Threshold={} Strength={}",
                             plugin.getName(),
                             plugin.getAlertThreshold().name(),
@@ -406,7 +407,7 @@ public class PluginFactory {
                     mapAllPluginOrderCodeName.put(plugin.getCodeName(), plugin);
 
                 } catch (Exception e) {
-                    log.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
             Iterator<Plugin> iterator = mapAllPlugin.values().iterator();
@@ -437,7 +438,7 @@ public class PluginFactory {
         // Check if it has also the same name, might be the same scanner but a newer/older version
         if (existingPlugin.getName().equals(plugin.getName())) {
             if (existingPlugin.getStatus().compareTo(plugin.getStatus()) > 0) {
-                log.info(
+                LOGGER.info(
                         "Ignoring (apparently) less stable scanner version, id={}, ExistingPlugin[Status={}, Class={}], LessStablePlugin[Status={}, Class={}]",
                         plugin.getId(),
                         existingPlugin.getStatus(),
@@ -448,7 +449,7 @@ public class PluginFactory {
             }
 
             if (existingPlugin.getStatus() != plugin.getStatus()) {
-                log.info(
+                LOGGER.info(
                         "Replacing existing scanner with (apparently) stabler version, id={}, ExistingPlugin[Status={}, Class={}], StablerPlugin[Status={}, Class={}]",
                         plugin.getId(),
                         existingPlugin.getStatus(),
@@ -459,7 +460,7 @@ public class PluginFactory {
             }
         }
 
-        log.error(
+        LOGGER.error(
                 "Duplicate id {} {} {}",
                 plugin.getId(),
                 plugin.getClass().getCanonicalName(),
@@ -468,7 +469,7 @@ public class PluginFactory {
     }
 
     public synchronized void loadFrom(PluginFactory pf) {
-        log.debug("loadFrom {}", pf.listAllPlugin.size());
+        LOGGER.debug("loadFrom {}", pf.listAllPlugin.size());
         for (Plugin plugin : pf.listAllPlugin) {
             Plugin p = this.mapAllPlugin.get(plugin.getId());
             if (p != null) {
@@ -492,7 +493,7 @@ public class PluginFactory {
                 plugin.cloneInto(pluginCopy);
                 clone.addPlugin(pluginCopy);
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
         return clone;
@@ -505,9 +506,9 @@ public class PluginFactory {
 
             boolean duplicatedId = mapAllPlugin.get(plugin.getId()) != null;
             if (this.addPlugin(plugin)) {
-                log.info("loaded plugin {}", plugin.getName());
+                LOGGER.info("loaded plugin {}", plugin.getName());
                 if (duplicatedId) {
-                    log.error(
+                    LOGGER.error(
                             "Duplicate id {} {}",
                             plugin.getName(),
                             mapAllPlugin.get(plugin.getId()).getName());
@@ -516,17 +517,17 @@ public class PluginFactory {
             }
 
             if (!plugin.isVisible()) {
-                log.info("Plugin {} not visible", plugin.getName());
+                LOGGER.info("Plugin {} not visible", plugin.getName());
                 return false;
             }
 
             if (plugin.isDepreciated()) {
-                log.info("Plugin {} deprecated", plugin.getName());
+                LOGGER.info("Plugin {} deprecated", plugin.getName());
                 return false;
             }
             return false;
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             return false;
         }
     }

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Scanner.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Scanner.java
@@ -56,6 +56,7 @@
 // ZAP: 2022/05/20 Address deprecation warnings with ConnectionParam.
 // ZAP: 2022/06/09 Name the threads.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.core.scanner;
 
 import java.security.InvalidParameterException;
@@ -106,7 +107,7 @@ public class Scanner implements Runnable {
     public static final String TIME_POSTFIX = ".time";
     public static final String URLS_POSTFIX = ".urls";
 
-    private static Logger log = LogManager.getLogger(Scanner.class);
+    private static final Logger LOGGER = LogManager.getLogger(Scanner.class);
     private static DecimalFormat decimalFormat = new java.text.DecimalFormat("###0.###");
 
     private Vector<ScannerListener> listenerList = new Vector<>();
@@ -197,7 +198,7 @@ public class Scanner implements Runnable {
 
     public void start(Target target) {
         isStop = false;
-        log.info("scanner started");
+        LOGGER.info("scanner started");
         startTimeMillis = System.currentTimeMillis();
         this.target = target;
         Thread thread = new Thread(this);
@@ -210,7 +211,7 @@ public class Scanner implements Runnable {
 
     public void stop() {
         if (!isStop) {
-            log.info("scanner stopped");
+            LOGGER.info("scanner stopped");
 
             isStop = true;
 
@@ -251,7 +252,7 @@ public class Scanner implements Runnable {
             //	    }
             pool.waitAllThreadComplete(0);
         } catch (Exception e) {
-            log.error("An error occurred while active scanning:", e);
+            LOGGER.error("An error occurred while active scanning:", e);
         } finally {
             notifyScannerComplete();
         }
@@ -401,7 +402,7 @@ public class Scanner implements Runnable {
     void notifyScannerComplete() {
         long diffTimeMillis = System.currentTimeMillis() - startTimeMillis;
         String diffTimeString = decimalFormat.format(diffTimeMillis / 1000.0) + "s";
-        log.info("scanner completed in {}", diffTimeString);
+        LOGGER.info("scanner completed in {}", diffTimeString);
         isStop = true;
 
         ActiveScanEventPublisher.publishScanEvent(
@@ -420,7 +421,7 @@ public class Scanner implements Runnable {
                 ScannerHook hook = hookList.get(i);
                 hook.scannerComplete();
             } catch (Exception e) {
-                log.info(
+                LOGGER.info(
                         "An exception occurred while notifying a ScannerHook about scanner completion: {}",
                         e.getMessage(),
                         e);
@@ -502,7 +503,7 @@ public class Scanner implements Runnable {
         if (excludeUrls != null) {
             for (Pattern p : excludeUrls) {
                 if (p.matcher(nodeName).matches()) {
-                    log.debug("URL excluded: {} Regex: {}", nodeName, p.pattern());
+                    LOGGER.debug("URL excluded: {} Regex: {}", nodeName, p.pattern());
                     // Explicitly excluded
                     return false;
                 }

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/ScannerParam.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/ScannerParam.java
@@ -55,6 +55,7 @@
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
 // ZAP: 2022/11/04 Prevent invalid number of hosts/threads.
 // ZAP: 2022/12/22 Issue 7663: Default thread to number of processors.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.core.scanner;
 
 import java.util.ArrayList;
@@ -215,7 +216,7 @@ public class ScannerParam extends AbstractParam {
     private final Map<Integer, List<ScannerParamFilter>> excludedParamsMap = new HashMap<>();
 
     // ZAP: internal Logger
-    private static final Logger logger = LogManager.getLogger(ScannerParam.class);
+    private static final Logger LOGGER = LogManager.getLogger(ScannerParam.class);
 
     public ScannerParam() {}
 
@@ -290,7 +291,7 @@ public class ScannerParam extends AbstractParam {
             }
 
         } catch (ConversionException e) {
-            logger.error("Error while loading the excluded parameter list: {}", e.getMessage(), e);
+            LOGGER.error("Error while loading the excluded parameter list: {}", e.getMessage(), e);
         }
 
         // If the list is null probably we've to use defaults!!!

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantODataFilterQuery.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantODataFilterQuery.java
@@ -50,7 +50,7 @@ import org.parosproxy.paros.network.HttpMessage;
  */
 public class VariantODataFilterQuery implements Variant {
 
-    private static final Logger LOG = LogManager.getLogger(VariantODataFilterQuery.class);
+    private static final Logger LOGGER = LogManager.getLogger(VariantODataFilterQuery.class);
 
     // Extract the content of the $filter parameter
     private static final Pattern patternFilterParameters =
@@ -136,7 +136,7 @@ public class VariantODataFilterQuery implements Variant {
             }
 
         } catch (URIException e) {
-            LOG.error("{} {}", e.getMessage(), uri, e);
+            LOGGER.error("{} {}", e.getMessage(), uri, e);
         }
     }
 
@@ -171,7 +171,7 @@ public class VariantODataFilterQuery implements Variant {
                 msg.getRequestHeader().getURI().setQuery(modifiedQuery);
 
             } catch (URIException | NullPointerException e) {
-                LOG.error("Exception with the modified query {}", modifiedQuery, e);
+                LOGGER.error("Exception with the modified query {}", modifiedQuery, e);
             }
 
             return newfilter;

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantODataIdQuery.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantODataIdQuery.java
@@ -46,7 +46,7 @@ import org.parosproxy.paros.network.HttpMessage;
  */
 public class VariantODataIdQuery implements Variant {
 
-    private static final Logger LOG = LogManager.getLogger(VariantODataIdQuery.class);
+    private static final Logger LOGGER = LogManager.getLogger(VariantODataIdQuery.class);
 
     /** In order to identify the unnamed id we add this prefix to the resource name * */
     public static final String RESOURCE_ID_PREFIX = "__ID__";
@@ -160,7 +160,7 @@ public class VariantODataIdQuery implements Variant {
             }
 
         } catch (URIException e) {
-            LOG.error("{} {}", e.getMessage(), uri, e);
+            LOGGER.error("{} {}", e.getMessage(), uri, e);
         }
     }
 

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantURLPath.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantURLPath.java
@@ -39,7 +39,7 @@ import org.parosproxy.paros.network.HttpMessage;
  */
 public class VariantURLPath implements Variant {
 
-    private final Logger LOGGER = LogManager.getLogger(this.getClass());
+    private static final Logger LOGGER = LogManager.getLogger(VariantURLPath.class);
 
     private static final char ESCAPE = '%';
 

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantURLQuery.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantURLQuery.java
@@ -30,6 +30,7 @@
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2021/05/06 Add method to get a short name of the variant
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.core.scanner;
 
 import org.apache.commons.httpclient.URIException;
@@ -41,7 +42,7 @@ import org.parosproxy.paros.network.HttpMessage;
 
 public class VariantURLQuery extends VariantAbstractQuery {
 
-    private static final Logger LOG = LogManager.getLogger(VariantURLQuery.class);
+    private static final Logger LOGGER = LogManager.getLogger(VariantURLQuery.class);
 
     private static final String SHORT_NAME = "querystring";
 
@@ -91,7 +92,7 @@ public class VariantURLQuery extends VariantAbstractQuery {
             msg.getRequestHeader().getURI().setEscapedQuery(query);
 
         } catch (URIException e) {
-            LOG.error("{} {}", e.getMessage(), query, e);
+            LOGGER.error("{} {}", e.getMessage(), query, e);
         }
     }
 }

--- a/zap/src/main/java/org/parosproxy/paros/db/DbUtils.java
+++ b/zap/src/main/java/org/parosproxy/paros/db/DbUtils.java
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.Logger;
 
 public class DbUtils {
 
-    private static final Logger logger = LogManager.getLogger(DbUtils.class);
+    private static final Logger LOGGER = LogManager.getLogger(DbUtils.class);
 
     private DbUtils() {}
 
@@ -57,7 +57,7 @@ public class DbUtils {
                     rs.close();
                 }
             } catch (SQLException e) {
-                logger.debug(e.getMessage(), e);
+                LOGGER.debug(e.getMessage(), e);
             }
         }
 
@@ -92,7 +92,7 @@ public class DbUtils {
                     rs.close();
                 }
             } catch (SQLException e) {
-                logger.debug(e.getMessage(), e);
+                LOGGER.debug(e.getMessage(), e);
             }
         }
 
@@ -130,7 +130,7 @@ public class DbUtils {
                     rs.close();
                 }
             } catch (SQLException e) {
-                logger.debug(e.getMessage(), e);
+                LOGGER.debug(e.getMessage(), e);
             }
         }
 
@@ -163,7 +163,7 @@ public class DbUtils {
                     rs.close();
                 }
             } catch (SQLException e) {
-                logger.debug(e.getMessage(), e);
+                LOGGER.debug(e.getMessage(), e);
             }
         }
 
@@ -197,7 +197,7 @@ public class DbUtils {
                     rs.close();
                 }
             } catch (SQLException e) {
-                logger.debug(e.getMessage(), e);
+                LOGGER.debug(e.getMessage(), e);
             }
         }
 
@@ -222,7 +222,7 @@ public class DbUtils {
             try {
                 preparedStatement.close();
             } catch (SQLException e) {
-                logger.debug(e.getMessage(), e);
+                LOGGER.debug(e.getMessage(), e);
             }
         }
     }
@@ -259,7 +259,7 @@ public class DbUtils {
             try {
                 preparedStatement.close();
             } catch (SQLException e) {
-                logger.debug(e.getMessage(), e);
+                LOGGER.debug(e.getMessage(), e);
             }
         }
     }

--- a/zap/src/main/java/org/parosproxy/paros/db/paros/ParosDatabaseServer.java
+++ b/zap/src/main/java/org/parosproxy/paros/db/paros/ParosDatabaseServer.java
@@ -29,6 +29,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/09/21 Remove unnecessary debug level checking.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.db.paros;
 
 import java.io.File;
@@ -52,7 +53,7 @@ public class ParosDatabaseServer implements DatabaseServer {
     public static final int DEFAULT_SERVER_PORT = 9001;
 
     // ZAP: Added the class variable.
-    private static final Logger logger = LogManager.getLogger(ParosDatabaseServer.class);
+    private static final Logger LOGGER = LogManager.getLogger(ParosDatabaseServer.class);
 
     //  change the url to reflect your preferred db location and name
     //  String url = "jdbc:hsqldb:hsql://localhost/yourtest";
@@ -93,7 +94,7 @@ public class ParosDatabaseServer implements DatabaseServer {
                         propsStream.close();
                     }
                 } catch (IOException e) {
-                    logger.debug(e.getMessage(), e);
+                    LOGGER.debug(e.getMessage(), e);
                 }
             }
             String version = (String) dbProps.get("version");
@@ -153,12 +154,12 @@ public class ParosDatabaseServer implements DatabaseServer {
                 return conn;
             } catch (SQLException e) {
                 // ZAP: Changed to log the exception.
-                logger.warn(e.getMessage(), e);
+                LOGGER.warn(e.getMessage(), e);
                 if (i == 4) {
                     throw e;
                 }
                 // ZAP: Changed to log the message.
-                logger.warn("Recovering {} times.", i);
+                LOGGER.warn("Recovering {} times.", i);
             }
 
             try {
@@ -166,7 +167,7 @@ public class ParosDatabaseServer implements DatabaseServer {
                 // ZAP: Changed to catch the InterruptedException.
             } catch (InterruptedException e) {
                 // ZAP: Added the log.
-                logger.debug(e.getMessage(), e);
+                LOGGER.debug(e.getMessage(), e);
             }
         }
         return conn;

--- a/zap/src/main/java/org/parosproxy/paros/db/paros/ParosTableHistory.java
+++ b/zap/src/main/java/org/parosproxy/paros/db/paros/ParosTableHistory.java
@@ -47,6 +47,7 @@
 // ZAP: 2022/02/03 Removed getHistoryList(long, int) and getHistoryList(long)
 // ZAP: 2022/02/25 Remove code deprecated in 2.5.0
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.db.paros;
 
 import java.nio.charset.StandardCharsets;
@@ -113,7 +114,7 @@ public class ParosTableHistory extends ParosAbstractTable implements TableHistor
     private static boolean isExistStatusCode = false;
 
     // ZAP: Added logger
-    private static final Logger log = LogManager.getLogger(ParosTableHistory.class);
+    private static final Logger LOGGER = LogManager.getLogger(ParosTableHistory.class);
 
     private boolean bodiesAsBytes;
 
@@ -244,7 +245,7 @@ public class ParosTableHistory extends ParosAbstractTable implements TableHistor
                     try {
                         stmt.close();
                     } catch (SQLException e) {
-                        log.debug(e.getMessage(), e);
+                        LOGGER.debug(e.getMessage(), e);
                     }
                 }
             }
@@ -306,7 +307,7 @@ public class ParosTableHistory extends ParosAbstractTable implements TableHistor
             try {
                 if (requestbodysizeindb != this.configuredrequestbodysize
                         && this.configuredrequestbodysize > 0) {
-                    log.debug(
+                    LOGGER.debug(
                             "Extending table {} request body length from {} to {}",
                             TABLE_NAME,
                             requestbodysizeindb,
@@ -320,7 +321,7 @@ public class ParosTableHistory extends ParosAbstractTable implements TableHistor
                                     + " VARBINARY("
                                     + this.configuredrequestbodysize
                                     + ")");
-                    log.debug(
+                    LOGGER.debug(
                             "Completed extending table {} request body length from {} to {}",
                             TABLE_NAME,
                             requestbodysizeindb,
@@ -329,7 +330,7 @@ public class ParosTableHistory extends ParosAbstractTable implements TableHistor
 
                 if (responsebodysizeindb != this.configuredresponsebodysize
                         && this.configuredresponsebodysize > 0) {
-                    log.debug(
+                    LOGGER.debug(
                             "Extending table {} response body length from {} to {}",
                             TABLE_NAME,
                             responsebodysizeindb,
@@ -343,21 +344,21 @@ public class ParosTableHistory extends ParosAbstractTable implements TableHistor
                                     + " VARBINARY("
                                     + this.configuredresponsebodysize
                                     + ")");
-                    log.debug(
+                    LOGGER.debug(
                             "Completed extending table {} response body length from {} to {}",
                             TABLE_NAME,
                             responsebodysizeindb,
                             this.configuredresponsebodysize);
                 }
             } catch (SQLException e) {
-                log.error("An error occurred while modifying a column length on {}", TABLE_NAME);
-                log.error(
+                LOGGER.error("An error occurred while modifying a column length on {}", TABLE_NAME);
+                LOGGER.error(
                         "The 'Maximum Request Body Size' value in the Database Options needs to be set to at least {} to avoid this error",
                         requestbodysizeindb);
-                log.error(
+                LOGGER.error(
                         "The 'Maximum Response Body Size' value in the Database Options needs to be set to at least {} to avoid this error",
                         responsebodysizeindb);
-                log.error("The SQL Exception was:", e);
+                LOGGER.error("The SQL Exception was:", e);
                 throw e;
             }
         } catch (SQLException e) {
@@ -982,7 +983,7 @@ public class ParosTableHistory extends ParosAbstractTable implements TableHistor
                     psReadCache.close();
                 } catch (Exception e) {
                     // ZAP: Log exceptions
-                    log.warn(e.getMessage(), e);
+                    LOGGER.warn(e.getMessage(), e);
                 }
             }
 
@@ -1041,7 +1042,7 @@ public class ParosTableHistory extends ParosAbstractTable implements TableHistor
                     psReadCache.close();
                 } catch (Exception e) {
                     // ZAP: Log exceptions
-                    log.warn(e.getMessage(), e);
+                    LOGGER.warn(e.getMessage(), e);
                 }
             }
 

--- a/zap/src/main/java/org/parosproxy/paros/extension/ExtensionLoader.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/ExtensionLoader.java
@@ -98,6 +98,7 @@
 // ZAP: 2022/06/13 Hook HrefTypeInfo.
 // ZAP: 2022/08/17 Install updates before running other cmdline args.
 // ZAP: 2022/11/23 Refresh tabs menu when tabs are removed.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.extension;
 
 import java.awt.Component;
@@ -164,7 +165,7 @@ public class ExtensionLoader {
 
     private View view = null;
     private CommandLine cmdLine;
-    private static final Logger logger = LogManager.getLogger(ExtensionLoader.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionLoader.class);
 
     @SuppressWarnings("deprecation")
     private List<org.parosproxy.paros.core.proxy.ProxyServer> proxyServers;
@@ -187,7 +188,7 @@ public class ExtensionLoader {
                 getExtension(i).destroy();
 
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -303,7 +304,7 @@ public class ExtensionLoader {
         try {
             elements.stream().filter(Objects::nonNull).forEach(action);
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -365,7 +366,7 @@ public class ExtensionLoader {
                     proxy.addProxyListener(listener);
                 }
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -387,7 +388,7 @@ public class ExtensionLoader {
                     proxy.addOverrideMessageProxyListener(listener);
                 }
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -434,7 +435,7 @@ public class ExtensionLoader {
                     proxy.addPersistentConnectionListener(listener);
                 }
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -455,7 +456,7 @@ public class ExtensionLoader {
                 }
             } catch (Exception e) {
                 // ZAP: Log the exception
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -474,7 +475,7 @@ public class ExtensionLoader {
                 }
 
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -498,7 +499,7 @@ public class ExtensionLoader {
                     scan.addScannerHook(scannerHook);
 
                 } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
         }
@@ -514,7 +515,7 @@ public class ExtensionLoader {
                     }
 
                 } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
         }
@@ -539,7 +540,7 @@ public class ExtensionLoader {
     }
 
     public void sessionChangedAllPlugin(Session session) {
-        logger.debug("sessionChangedAllPlugin");
+        LOGGER.debug("sessionChangedAllPlugin");
         for (ExtensionHook hook : extensionHooks.values()) {
             List<SessionChangedListener> listenerList = hook.getSessionListenerList();
             for (SessionChangedListener listener : listenerList) {
@@ -549,7 +550,7 @@ public class ExtensionLoader {
                     }
 
                 } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
         }
@@ -562,13 +563,13 @@ public class ExtensionLoader {
             try {
                 ext.databaseOpen(db);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
 
     public void sessionAboutToChangeAllPlugin(Session session) {
-        logger.debug("sessionAboutToChangeAllPlugin");
+        LOGGER.debug("sessionAboutToChangeAllPlugin");
         for (ExtensionHook hook : extensionHooks.values()) {
             List<SessionChangedListener> listenerList = hook.getSessionListenerList();
             for (SessionChangedListener listener : listenerList) {
@@ -578,14 +579,14 @@ public class ExtensionLoader {
                     }
 
                 } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
         }
     }
 
     public void sessionScopeChangedAllPlugin(Session session) {
-        logger.debug("sessionScopeChangedAllPlugin");
+        LOGGER.debug("sessionScopeChangedAllPlugin");
         for (ExtensionHook hook : extensionHooks.values()) {
             List<SessionChangedListener> listenerList = hook.getSessionListenerList();
             for (SessionChangedListener listener : listenerList) {
@@ -595,14 +596,14 @@ public class ExtensionLoader {
                     }
 
                 } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
         }
     }
 
     public void sessionModeChangedAllPlugin(Mode mode) {
-        logger.debug("sessionModeChangedAllPlugin");
+        LOGGER.debug("sessionModeChangedAllPlugin");
         for (ExtensionHook hook : extensionHooks.values()) {
             List<SessionChangedListener> listenerList = hook.getSessionListenerList();
             for (SessionChangedListener listener : listenerList) {
@@ -612,7 +613,7 @@ public class ExtensionLoader {
                     }
 
                 } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
         }
@@ -627,7 +628,7 @@ public class ExtensionLoader {
      * @since 2.7.0
      */
     public void sessionPropertiesChangedAllPlugin(Session session) {
-        logger.debug("sessionPropertiesChangedAllPlugin");
+        LOGGER.debug("sessionPropertiesChangedAllPlugin");
         for (ExtensionHook hook : extensionHooks.values()) {
             for (SessionChangedListener listener : hook.getSessionListenerList()) {
                 try {
@@ -636,7 +637,7 @@ public class ExtensionLoader {
                     }
 
                 } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
         }
@@ -650,7 +651,7 @@ public class ExtensionLoader {
                     listener.filesAdded();
 
                 } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
         }
@@ -664,7 +665,7 @@ public class ExtensionLoader {
                     listener.filesRemoved();
 
                 } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
         }
@@ -684,7 +685,7 @@ public class ExtensionLoader {
                 try {
                     listener.addOnInstalled(addOn);
                 } catch (Exception e) {
-                    logger.error(
+                    LOGGER.error(
                             "An error occurred while notifying: {}",
                             listener.getClass().getCanonicalName(),
                             e);
@@ -709,7 +710,7 @@ public class ExtensionLoader {
                 try {
                     listener.addOnSoftUninstalled(addOn, successfully);
                 } catch (Exception e) {
-                    logger.error(
+                    LOGGER.error(
                             "An error occurred while notifying: {}",
                             listener.getClass().getCanonicalName(),
                             e);
@@ -734,7 +735,7 @@ public class ExtensionLoader {
                 try {
                     listener.addOnUninstalled(addOn, successfully);
                 } catch (Exception e) {
-                    logger.error(
+                    LOGGER.error(
                             "An error occurred while notifying: {}",
                             listener.getClass().getCanonicalName(),
                             e);
@@ -866,7 +867,7 @@ public class ExtensionLoader {
                 getExtension(i).stop();
 
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -879,7 +880,7 @@ public class ExtensionLoader {
                 dialog.addParamPanel(ROOT, panel, true);
 
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -890,7 +891,7 @@ public class ExtensionLoader {
                 dialog.removeParamPanel(panel);
 
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
         dialog.revalidate();
@@ -902,7 +903,7 @@ public class ExtensionLoader {
         for (int i = 0; i < getExtensionCount(); i++) {
             final Extension ext = getExtension(i);
             try {
-                logger.info("Initializing {} - {}", ext.getUIName(), ext.getDescription());
+                LOGGER.info("Initializing {} - {}", ext.getUIName(), ext.getDescription());
                 final ExtensionHook extHook = new ExtensionHook(model, view);
                 extensionHooks.put(ext, extHook);
                 ext.hook(extHook);
@@ -951,7 +952,7 @@ public class ExtensionLoader {
                             view.getMainFrame().validate();
                         });
             } catch (InvocationTargetException | InterruptedException e) {
-                logger.warn("An error occurred while updating the UI:", e);
+                LOGGER.warn("An error occurred while updating the UI:", e);
             }
         }
     }
@@ -966,7 +967,7 @@ public class ExtensionLoader {
         }
         strBuilder.append(", cause: ");
         strBuilder.append(ExceptionUtils.getRootCauseMessage(e));
-        logger.error(strBuilder, e);
+        LOGGER.error(strBuilder, e);
     }
 
     private void hookContextDataFactories(Extension extension, ExtensionHook extHook) {
@@ -974,7 +975,7 @@ public class ExtensionLoader {
             try {
                 model.addContextDataFactory(contextDataFactory);
             } catch (Exception e) {
-                logger.error(
+                LOGGER.error(
                         "Error while adding a ContextDataFactory from {}",
                         extension.getClass().getCanonicalName(),
                         e);
@@ -987,7 +988,7 @@ public class ExtensionLoader {
             try {
                 API.getInstance().registerApiImplementor(apiImplementor);
             } catch (Exception e) {
-                logger.error(
+                LOGGER.error(
                         "Error while adding an ApiImplementor from {}",
                         extension.getClass().getCanonicalName(),
                         e);
@@ -1000,7 +1001,7 @@ public class ExtensionLoader {
             try {
                 HttpSender.addListener(httpSenderListener);
             } catch (Exception e) {
-                logger.error(
+                LOGGER.error(
                         "Error while adding an HttpSenderListener from {}",
                         extension.getClass().getCanonicalName(),
                         e);
@@ -1015,7 +1016,7 @@ public class ExtensionLoader {
                 variant.getDeclaredConstructor().newInstance();
                 Model.getSingleton().getVariantFactory().addVariant(variant);
             } catch (Exception e) {
-                logger.error(
+                LOGGER.error(
                         "Error while adding a Variant from {}",
                         extension.getClass().getCanonicalName(),
                         e);
@@ -1028,7 +1029,7 @@ public class ExtensionLoader {
             try {
                 HrefTypeInfo.addType(hrefTypeInfo);
             } catch (Exception e) {
-                logger.error(
+                LOGGER.error(
                         "Error while adding a HrefTypeInfo from {}",
                         extension.getClass().getCanonicalName(),
                         e);
@@ -1195,7 +1196,7 @@ public class ExtensionLoader {
                 model.getOptionsParam().addParamSet(paramSet);
 
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -1208,7 +1209,7 @@ public class ExtensionLoader {
                 model.getOptionsParam().removeParamSet(paramSet);
 
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -1227,7 +1228,7 @@ public class ExtensionLoader {
             try {
                 view.addContextPanelFactory(contextPanelFactory);
             } catch (Exception e) {
-                logger.error(
+                LOGGER.error(
                         "Error while adding a ContextPanelFactory from {}",
                         extension.getClass().getCanonicalName(),
                         e);
@@ -1239,7 +1240,7 @@ public class ExtensionLoader {
             try {
                 mainToolBarPanel.addToolBarComponent(component);
             } catch (Exception e) {
-                logger.error(
+                LOGGER.error(
                         "Error while adding a component to the main tool bar panel, from {}",
                         extension.getClass().getCanonicalName(),
                         e);
@@ -1278,7 +1279,7 @@ public class ExtensionLoader {
             try {
                 view.removeContextPanelFactory(contextPanelFactory);
             } catch (Exception e) {
-                logger.error(
+                LOGGER.error(
                         "Error while removing a ContextPanelFactory from {}",
                         extension.getClass().getCanonicalName(),
                         e);
@@ -1290,7 +1291,7 @@ public class ExtensionLoader {
             try {
                 mainToolBarPanel.removeToolBarComponent(component);
             } catch (Exception e) {
-                logger.error(
+                LOGGER.error(
                         "Error while removing a component from the main tool bar panel, from {}",
                         extension.getClass().getCanonicalName(),
                         e);
@@ -1513,7 +1514,7 @@ public class ExtensionLoader {
     private void unhook(Extension extension) {
         ExtensionHook hook = extensionHooks.remove(extension);
         if (hook == null) {
-            logger.error(
+            LOGGER.error(
                     "ExtensionHook not found for: {}", extension.getClass().getCanonicalName());
             return;
         }
@@ -1528,7 +1529,7 @@ public class ExtensionLoader {
             try {
                 model.removeContextDataFactory(contextDataFactory);
             } catch (Exception e) {
-                logger.error(
+                LOGGER.error(
                         "Error while removing a ContextDataFactory from {}",
                         extension.getClass().getCanonicalName(),
                         e);
@@ -1539,7 +1540,7 @@ public class ExtensionLoader {
             try {
                 API.getInstance().removeApiImplementor(apiImplementor);
             } catch (Exception e) {
-                logger.error(
+                LOGGER.error(
                         "Error while removing an ApiImplementor from {}",
                         extension.getClass().getCanonicalName(),
                         e);
@@ -1550,7 +1551,7 @@ public class ExtensionLoader {
             try {
                 HttpSender.removeListener(httpSenderListener);
             } catch (Exception e) {
-                logger.error(
+                LOGGER.error(
                         "Error while removing an HttpSenderListener from {}",
                         extension.getClass().getCanonicalName(),
                         e);
@@ -1561,7 +1562,7 @@ public class ExtensionLoader {
             try {
                 model.getVariantFactory().removeVariant(variant);
             } catch (Exception e) {
-                logger.error(
+                LOGGER.error(
                         "Error while removing a Variant from {}",
                         extension.getClass().getCanonicalName(),
                         e);
@@ -1572,7 +1573,7 @@ public class ExtensionLoader {
             try {
                 HrefTypeInfo.removeType(hrefTypeInfo);
             } catch (Exception e) {
-                logger.error(
+                LOGGER.error(
                         "Error while removing a HrefTypeInfo from {}",
                         extension.getClass().getCanonicalName(),
                         e);
@@ -1616,7 +1617,7 @@ public class ExtensionLoader {
                                     return messages;
                                 }
                             } catch (Throwable ex) {
-                                logger.error(
+                                LOGGER.error(
                                         "Error while getting messages from {}",
                                         e.getClass().getCanonicalName(),
                                         ex);

--- a/zap/src/main/java/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -100,6 +100,7 @@
 // ZAP: 2022/06/12 Deprecate getResendDialog().
 // ZAP: 2022/06/27 Make delete more consistent and protective (Issue 7336).
 // ZAP: 2022/09/14 Address deprecation warnings.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.extension.history;
 
 import java.awt.EventQueue;
@@ -188,7 +189,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
      */
     private boolean sessionChanging;
 
-    private Logger logger = LogManager.getLogger(ExtensionHistory.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionHistory.class);
 
     public ExtensionHistory() {
         super(NAME);
@@ -383,7 +384,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
         try {
             this.addHistory(new HistoryReference(Model.getSingleton().getSession(), type, msg));
         } catch (final Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -425,7 +426,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
                 }
             }
         } catch (final Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -475,7 +476,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
 
                 buildHistory(list, historyFilter);
             } catch (DatabaseException e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -521,7 +522,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
                     historyTableModel.addHistoryReference(historyRef);
 
                 } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
             if (hasView()) {
@@ -543,7 +544,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
         try {
             dialog.setAllTags(getModel().getDb().getTableTag().getAllTags());
         } catch (DatabaseException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         int exit = dialog.showDialog();
@@ -677,7 +678,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
         try {
             manageTags.setAllTags(getModel().getDb().getTableTag().getAllTags());
         } catch (DatabaseException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
         manageTags.setTags(tags);
         manageTags.setHistoryRef(ref);
@@ -720,7 +721,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
                         });
             } catch (Exception e) {
                 // ZAP: Added logging.
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -751,7 +752,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
                     child = (SiteNode) node.getChildAt(0);
                     purge(map, child);
                 } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
 
@@ -967,7 +968,7 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
                             | HttpMalformedHeaderException
                             | NullPointerException
                             | DatabaseException e) {
-                        logger.error("Failed to create temporary node:", e);
+                        LOGGER.error("Failed to create temporary node:", e);
                     }
                 }
             }

--- a/zap/src/main/java/org/parosproxy/paros/extension/history/HistoryFilter.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/HistoryFilter.java
@@ -47,7 +47,7 @@ public class HistoryFilter {
     private List<Pattern> urlIncPatternList = new ArrayList<>();
     private List<Pattern> urlExcPatternList = new ArrayList<>();
 
-    private Logger logger = LogManager.getLogger(HistoryFilter.class);
+    private static final Logger LOGGER = LogManager.getLogger(HistoryFilter.class);
 
     public void setMethods(List<String> methods) {
         methodList.clear();
@@ -148,7 +148,7 @@ public class HistoryFilter {
                 }
             }
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
         return true;
     }

--- a/zap/src/main/java/org/parosproxy/paros/extension/history/ProxyListenerLog.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/ProxyListenerLog.java
@@ -37,6 +37,7 @@
 // ZAP: 2019/09/30 Use instance variable for view checks.
 // ZAP: 2020/08/04 Changed to use new SessionStructure method
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.extension.history;
 
 import java.awt.EventQueue;
@@ -60,7 +61,7 @@ import org.zaproxy.zap.model.StructuralNode;
 public class ProxyListenerLog implements ProxyListener, ConnectRequestProxyListener {
 
     // ZAP: Added logger
-    private static final Logger log = LogManager.getLogger(ProxyListenerLog.class);
+    private static final Logger LOGGER = LogManager.getLogger(ProxyListenerLog.class);
 
     // ZAP: Must be the last one of all listeners to be notified, as is the one that saves the
     // HttpMessage
@@ -106,7 +107,7 @@ public class ProxyListenerLog implements ProxyListener, ConnectRequestProxyListe
                 }
             }
         } catch (URIException | DatabaseException | HttpMalformedHeaderException e) {
-            log.warn("Failed to check if message already exists:", e);
+            LOGGER.warn("Failed to check if message already exists:", e);
         }
 
         // if not, make sure a new copy will be obtained
@@ -166,7 +167,7 @@ public class ProxyListenerLog implements ProxyListener, ConnectRequestProxyListe
         try {
             addToSiteMap(historyRef, historyRef.getHttpMessage());
         } catch (HttpMalformedHeaderException | DatabaseException e) {
-            log.warn("Failed to add the message to Sites tree:", e);
+            LOGGER.warn("Failed to add the message to Sites tree:", e);
         }
 
         ProxyListenerLogEventPublisher.getPublisher().publishHrefAddedEvent(historyRef);
@@ -177,7 +178,7 @@ public class ProxyListenerLog implements ProxyListener, ConnectRequestProxyListe
             return new HistoryReference(model.getSession(), type, message);
         } catch (Exception e) {
             // ZAP: Log exceptions
-            log.warn(e.getMessage(), e);
+            LOGGER.warn(e.getMessage(), e);
         }
         return null;
     }
@@ -194,7 +195,7 @@ public class ProxyListenerLog implements ProxyListener, ConnectRequestProxyListe
                         });
             } catch (Exception e) {
                 // ZAP: Log exceptions
-                log.warn(e.getMessage(), e);
+                LOGGER.warn(e.getMessage(), e);
             }
             return;
         }

--- a/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsParamView.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/option/OptionsParamView.java
@@ -51,6 +51,7 @@
 // ZAP: 2022/02/26 Remove code deprecated in 2.5.0
 // ZAP: 2022/04/28 Add set and get of the open recent menu
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.extension.option;
 
 import java.awt.Window;
@@ -83,7 +84,7 @@ import org.zaproxy.zap.utils.ZapHtmlLabel;
 
 public class OptionsParamView extends AbstractParam {
 
-    private static final Logger LOG = LogManager.getLogger(OptionsParamView.class);
+    private static final Logger LOGGER = LogManager.getLogger(OptionsParamView.class);
 
     private static final String DEFAULT_TIME_STAMP_FORMAT =
             Constant.messages.getString("timestamp.format.datetime");
@@ -638,7 +639,7 @@ public class OptionsParamView extends AbstractParam {
                                                 .getPopupList()
                                                 .forEach(SwingUtilities::updateComponentTreeUI);
                                     } catch (Exception e2) {
-                                        LOG.warn(
+                                        LOGGER.warn(
                                                 "Failed to set the look and feel: {}",
                                                 e2.getMessage());
                                     } finally {

--- a/zap/src/main/java/org/parosproxy/paros/model/HistoryReference.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/HistoryReference.java
@@ -66,6 +66,7 @@
 // ZAP: 2022/02/28 Remove code deprecated in 2.6.0
 // ZAP: 2022/06/27 Add TYPE_PARAM_DIGGER.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.model;
 
 import java.util.ArrayList;
@@ -320,7 +321,7 @@ public class HistoryReference {
     private List<String> tags = new ArrayList<>();
     private boolean webSocketUpgrade;
 
-    private static Logger log = LogManager.getLogger(HistoryReference.class);
+    private static final Logger LOGGER = LogManager.getLogger(HistoryReference.class);
 
     private HttpMessage httpMessage;
     private HttpMessageCachedData httpMessageCachedData;
@@ -515,7 +516,7 @@ public class HistoryReference {
                 staticTableHistory.delete(historyId);
                 notifyEvent(HistoryReferenceEventPublisher.EVENT_REMOVED);
             } catch (DatabaseException e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -556,7 +557,7 @@ public class HistoryReference {
             staticTableTag.insert(historyId, tag);
             return true;
         } catch (DatabaseException e) {
-            log.error("Failed to persist tag: {}", e.getMessage(), e);
+            LOGGER.error("Failed to persist tag: {}", e.getMessage(), e);
         }
         return false;
     }
@@ -588,7 +589,7 @@ public class HistoryReference {
             staticTableTag.delete(historyId, tag);
             return true;
         } catch (DatabaseException e) {
-            log.error("Failed to delete tag: {}", e.getMessage(), e);
+            LOGGER.error("Failed to delete tag: {}", e.getMessage(), e);
         }
         return false;
     }
@@ -604,7 +605,7 @@ public class HistoryReference {
             httpMessageCachedData.setNote(note != null && note.length() > 0);
             notifyEvent(HistoryReferenceEventPublisher.EVENT_NOTE_SET);
         } catch (DatabaseException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -617,7 +618,7 @@ public class HistoryReference {
                 this.addAlert(new Alert(alert, this));
             }
         } catch (DatabaseException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -833,7 +834,7 @@ public class HistoryReference {
                 requestBody = getHttpMessage().getRequestBody().toString();
                 httpMessageCachedData.setRequestBody(requestBody);
             } catch (HttpMalformedHeaderException | DatabaseException e) {
-                log.error(
+                LOGGER.error(
                         "Failed to reload request body from database with history ID: {}",
                         historyId,
                         e);

--- a/zap/src/main/java/org/parosproxy/paros/model/Model.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/Model.java
@@ -52,6 +52,7 @@
 // ZAP: 2020/10/14 Allow to set a singleton Model for tests.
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.model;
 
 import java.io.File;
@@ -92,7 +93,7 @@ public class Model {
     private Database db = null;
     private String currentDBNameUntitled = "";
     // ZAP: Added logger
-    private Logger logger = LogManager.getLogger(Model.class);
+    private static final Logger LOGGER = LogManager.getLogger(Model.class);
     private List<ContextDataFactory> contextDataFactories = new ArrayList<>();
     private VariantFactory variantFactory = new VariantFactory();
 
@@ -196,7 +197,7 @@ public class Model {
         getOptionsParam().load(Constant.getInstance().FILE_CONFIG, overrides);
 
         if (overrides.isExperimentalDb()) {
-            logger.info("Using experimental database :/");
+            LOGGER.info("Using experimental database :/");
             db = DbSQL.getSingleton().initDatabase();
         } else {
             ParosDatabase parosDb = new ParosDatabase();
@@ -326,7 +327,7 @@ public class Model {
 
     // TODO disable for non file based sessions
     protected void snapshotSessionDb(String currentFile, String destFile) throws Exception {
-        logger.debug("snapshotSessionDb {} -> {}", currentFile, destFile);
+        LOGGER.debug("snapshotSessionDb {} -> {}", currentFile, destFile);
 
         // ZAP: Changed to call the method close(boolean, boolean).
         getDb().close(false, false);
@@ -367,7 +368,7 @@ public class Model {
         }
 
         if (currentFile.length() == 0) {
-            logger.debug("snapshotSessionDb using {} -> {}", currentDBNameUntitled, destFile);
+            LOGGER.debug("snapshotSessionDb using {} -> {}", currentDBNameUntitled, destFile);
             currentFile = currentDBNameUntitled;
         }
 
@@ -396,7 +397,7 @@ public class Model {
         for (int i = 0; i < listFile.length; i++) {
             if (!listFile[i].delete()) {
                 // ZAP: Log failure to delete file
-                logger.error("Failed to delete file {}", listFile[i].getAbsolutePath());
+                LOGGER.error("Failed to delete file {}", listFile[i].getAbsolutePath());
             }
         }
 
@@ -409,7 +410,7 @@ public class Model {
             File fileOut = new File(currentDBNameUntitled + ".data");
             if (fileOut.exists() && !fileOut.delete()) {
                 // ZAP: Log failure to delete file
-                logger.error("Failed to delete file {}", fileOut.getAbsolutePath());
+                LOGGER.error("Failed to delete file {}", fileOut.getAbsolutePath());
             }
 
             copier.copy(fileIn, fileOut);
@@ -420,7 +421,7 @@ public class Model {
             File fileOut = new File(currentDBNameUntitled + ".properties");
             if (fileOut.exists() && !fileOut.delete()) {
                 // ZAP: Log failure to delete file
-                logger.error("Failed to delete file {}", fileOut.getAbsolutePath());
+                LOGGER.error("Failed to delete file {}", fileOut.getAbsolutePath());
             }
 
             copier.copy(fileIn, fileOut);
@@ -431,7 +432,7 @@ public class Model {
             File fileOut = new File(currentDBNameUntitled + ".script");
             if (fileOut.exists() && !fileOut.delete()) {
                 // ZAP: Log failure to delete file
-                logger.error("Failed to delete file {}", fileOut.getAbsolutePath());
+                LOGGER.error("Failed to delete file {}", fileOut.getAbsolutePath());
             }
 
             copier.copy(fileIn, fileOut);
@@ -450,7 +451,7 @@ public class Model {
         if (fileIn.exists()) {
             if (!fileIn.delete()) {
                 // ZAP: Log failure to delete file
-                logger.error("Failed to delete file {}", fileIn.getAbsolutePath());
+                LOGGER.error("Failed to delete file {}", fileIn.getAbsolutePath());
             }
         }
 
@@ -458,7 +459,7 @@ public class Model {
         fileIn = new File(currentDBNameUntitled + ".lobs");
         if (fileIn.exists()) {
             if (!fileIn.delete()) {
-                logger.error("Failed to delete file {}", fileIn.getAbsolutePath());
+                LOGGER.error("Failed to delete file {}", fileIn.getAbsolutePath());
             }
         }
 

--- a/zap/src/main/java/org/parosproxy/paros/model/OptionsParam.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/OptionsParam.java
@@ -46,6 +46,7 @@
 // ZAP: 2022/02/09 Deprecate methods related to core proxy options.
 // ZAP: 2022/05/20 Deprecate methods related to core connection options.
 // ZAP: 2022/05/29 Deprecate methods related to core client certificates.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.model;
 
 import java.io.File;
@@ -67,7 +68,7 @@ import org.zaproxy.zap.extension.globalexcludeurl.GlobalExcludeURLParam;
 
 public class OptionsParam extends AbstractParam {
 
-    private static final Logger logger = LogManager.getLogger(OptionsParam.class);
+    private static final Logger LOGGER = LogManager.getLogger(OptionsParam.class);
 
     //	private static final String ROOT = "Options";
     // ZAP: User directory now stored in the config file
@@ -224,7 +225,7 @@ public class OptionsParam extends AbstractParam {
                     this.userDirectory = file;
                 }
             } catch (Exception e1) {
-                logger.error(e1.getMessage(), e1);
+                LOGGER.error(e1.getMessage(), e1);
             }
         }
     }
@@ -262,7 +263,7 @@ public class OptionsParam extends AbstractParam {
         try {
             getConfig().save();
         } catch (ConfigurationException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 

--- a/zap/src/main/java/org/parosproxy/paros/model/Session.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/Session.java
@@ -91,6 +91,7 @@
 // ZAP: 2022/02/28 Remove code deprecated in 2.6.0
 // ZAP: 2022/08/23 Use SiteMap#createTree to create a new Sites Tree when loading a session.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.model;
 
 import java.awt.EventQueue;
@@ -139,7 +140,7 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
 public class Session {
 
     // ZAP: Added logger
-    private static Logger log = LogManager.getLogger(Session.class);
+    private static final Logger LOGGER = LogManager.getLogger(Session.class);
 
     private static final String ROOT = "session";
 
@@ -207,7 +208,7 @@ public class Session {
             model.getDb().discardSession(getSessionId());
         } catch (DatabaseException e) {
             // ZAP: Log exceptions
-            log.warn(e.getMessage(), e);
+            LOGGER.warn(e.getMessage(), e);
         }
         discardContexts();
     }
@@ -381,7 +382,7 @@ public class Session {
                 if (i % 100 == 99) Thread.yield();
             } catch (Exception e) {
                 // ZAP: Log exceptions
-                log.warn(e.getMessage(), e);
+                LOGGER.warn(e.getMessage(), e);
             }
         }
 
@@ -424,7 +425,7 @@ public class Session {
 
             } catch (Exception e) {
                 // ZAP: Log exceptions
-                log.warn(e.getMessage(), e);
+                LOGGER.warn(e.getMessage(), e);
             }
         }
         List<RecordContext> contextData = model.getDb().getTableContext().getAllData();
@@ -474,7 +475,7 @@ public class Session {
                 if (strs.size() == 1) {
                     Class<?> c = ExtensionFactory.getAddOnLoader().loadClass(strs.get(0));
                     if (c == null) {
-                        log.error(
+                        LOGGER.error(
                                 "Failed to load URL parser for context {} : {}",
                                 ctx.getId(),
                                 strs.get(0));
@@ -491,7 +492,7 @@ public class Session {
                     }
                 }
             } catch (Exception e) {
-                log.error("Failed to load URL parser for context {}", ctx.getId(), e);
+                LOGGER.error("Failed to load URL parser for context {}", ctx.getId(), e);
             }
             try {
                 // Set up the URL parameter parser
@@ -501,7 +502,7 @@ public class Session {
                 if (strs.size() == 1) {
                     Class<?> c = ExtensionFactory.getAddOnLoader().loadClass(strs.get(0));
                     if (c == null) {
-                        log.error(
+                        LOGGER.error(
                                 "Failed to load POST parser for context {} : {}",
                                 ctx.getId(),
                                 strs.get(0));
@@ -518,7 +519,7 @@ public class Session {
                     }
                 }
             } catch (Exception e) {
-                log.error("Failed to load POST parser for context {}", ctx.getId(), e);
+                LOGGER.error("Failed to load POST parser for context {}", ctx.getId(), e);
             }
 
             try {
@@ -530,7 +531,7 @@ public class Session {
                     ctx.addDataDrivenNodes(new StructuralNodeModifier(str));
                 }
             } catch (Exception e) {
-                log.error("Failed to load data driven nodes for context {}", ctx.getId(), e);
+                LOGGER.error("Failed to load data driven nodes for context {}", ctx.getId(), e);
             }
 
             ctx.restructureSiteTree();
@@ -592,7 +593,7 @@ public class Session {
                                     save(fileName);
                                 } catch (Exception e) {
                                     // ZAP: Log exceptions
-                                    log.warn(e.getMessage(), e);
+                                    LOGGER.warn(e.getMessage(), e);
                                     thrownException = e;
                                 }
                                 if (callback != null) {
@@ -669,7 +670,7 @@ public class Session {
                                     snapshot(fileName);
                                 } catch (Exception e) {
                                     // ZAP: Log exceptions
-                                    log.warn(e.getMessage(), e);
+                                    LOGGER.warn(e.getMessage(), e);
                                     thrownException = e;
                                 }
                                 if (callback != null) {
@@ -730,7 +731,7 @@ public class Session {
                 saveSiteTree((SiteNode) node.getChildAt(i));
             } catch (Exception e) {
                 // ZAP: Log exceptions
-                log.warn(e.getMessage(), e);
+                LOGGER.warn(e.getMessage(), e);
             }
         }
     }
@@ -808,7 +809,7 @@ public class Session {
                             }
                         });
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -869,7 +870,7 @@ public class Session {
         try {
             return this.isInScope(href.getURI().toString());
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
         return false;
     }
@@ -1182,7 +1183,7 @@ public class Session {
             try {
                 return Integer.parseInt(dataList.get(0).getData());
             } catch (NumberFormatException e) {
-                log.error("Failed to parse context value type {}", type, e);
+                LOGGER.error("Failed to parse context value type {}", type, e);
             }
         }
         return defaultValue;
@@ -1265,7 +1266,7 @@ public class Session {
 
             model.saveContext(c);
         } catch (DatabaseException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         if (View.isInitialised()) {
@@ -1363,7 +1364,7 @@ public class Session {
         try {
             this.clearContextData(c.getId());
         } catch (DatabaseException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         for (OnContextsChangedListener l : contextsChangedListeners) {

--- a/zap/src/main/java/org/parosproxy/paros/model/SiteMap.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/SiteMap.java
@@ -77,6 +77,7 @@
 // ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
 // ZAP: 2022/08/23 Make hrefMap an instance variable.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.model;
 
 import java.awt.EventQueue;
@@ -123,7 +124,7 @@ public class SiteMap extends SortedTreeModel {
     private SiteTreeFilter filter = null;
 
     // ZAP: Added log
-    private static Logger log = LogManager.getLogger(SiteMap.class);
+    private static final Logger LOGGER = LogManager.getLogger(SiteMap.class);
 
     public static SiteMap createTree(Model model) {
         SiteMap siteMap = new SiteMap(null, model);
@@ -180,7 +181,7 @@ public class SiteMap extends SortedTreeModel {
             }
         } catch (URIException e) {
             // ZAP: Added error
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         if (resultNode == null || resultNode.getHistoryReference() == null) {
@@ -192,7 +193,7 @@ public class SiteMap extends SortedTreeModel {
             nodeMsg = resultNode.getHistoryReference().getHttpMessage();
         } catch (Exception e) {
             // ZAP: Added error
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
         return nodeMsg;
     }
@@ -248,7 +249,7 @@ public class SiteMap extends SortedTreeModel {
                 }
             }
         } catch (URIException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         return resultNode;
@@ -298,7 +299,7 @@ public class SiteMap extends SortedTreeModel {
                 }
             }
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         return resultNode;
@@ -351,7 +352,7 @@ public class SiteMap extends SortedTreeModel {
                 }
             }
         } catch (URIException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         return lastParent;
@@ -378,7 +379,7 @@ public class SiteMap extends SortedTreeModel {
             msg = ref.getHttpMessage();
         } catch (Exception e) {
             // ZAP: Added error
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             return null;
         }
 
@@ -417,7 +418,7 @@ public class SiteMap extends SortedTreeModel {
         if (View.isInitialised() && Constant.isDevMode() && !EventQueue.isDispatchThread()) {
             // In developer mode log an error if we're not on the EDT
             // Adding to the site tree on GUI ('initial') threads causes problems
-            log.error(
+            LOGGER.error(
                     "SiteMap.addPath not on EDT {}",
                     Thread.currentThread().getName(),
                     new Exception());
@@ -428,7 +429,7 @@ public class SiteMap extends SortedTreeModel {
         }
 
         URI uri = msg.getRequestHeader().getURI();
-        log.debug("addPath {}", uri);
+        LOGGER.debug("addPath {}", uri);
 
         SiteNode parent = getRoot();
         SiteNode leaf = null;
@@ -469,7 +470,7 @@ public class SiteMap extends SortedTreeModel {
 
         } catch (Exception e) {
             // ZAP: Added error
-            log.error("Exception adding {} {}", uri, e.getMessage(), e);
+            LOGGER.error("Exception adding {} {}", uri, e.getMessage(), e);
         }
 
         hrefMap.putIfAbsent(ref.getHistoryId(), leaf);
@@ -491,7 +492,7 @@ public class SiteMap extends SortedTreeModel {
             SiteNode parent, String nodeName, HistoryReference baseRef, HttpMessage baseMsg)
             throws URIException, HttpMalformedHeaderException, NullPointerException,
                     DatabaseException {
-        log.debug("findAndAddChild {} / {}", parent.getNodeName(), nodeName);
+        LOGGER.debug("findAndAddChild {} / {}", parent.getNodeName(), nodeName);
         if (isReferenceCached(baseRef)) {
             return hrefMap.get(baseRef.getHistoryId());
         }
@@ -545,7 +546,7 @@ public class SiteMap extends SortedTreeModel {
 
     private SiteNode findChild(SiteNode parent, String nodeName) {
         // ZAP: Added debug
-        log.debug("findChild {} / {}", parent.getNodeName(), nodeName);
+        LOGGER.debug("findChild {} / {}", parent.getNodeName(), nodeName);
 
         for (int i = 0; i < parent.getChildCount(); i++) {
             SiteNode child = (SiteNode) parent.getChildAt(i);
@@ -559,7 +560,7 @@ public class SiteMap extends SortedTreeModel {
     private SiteNode findAndAddLeaf(
             SiteNode parent, String nodeName, HistoryReference ref, HttpMessage msg) {
         // ZAP: Added debug
-        log.debug("findAndAddLeaf {} / {}", parent.getNodeName(), nodeName);
+        LOGGER.debug("findAndAddLeaf {} / {}", parent.getNodeName(), nodeName);
 
         String leafName = SessionStructure.getLeafName(model, nodeName, msg);
         SiteNode node = findChild(parent, leafName);
@@ -638,10 +639,11 @@ public class SiteMap extends SortedTreeModel {
             if (((SiteNode) path[i]).isDataDriven()) {
                 // Retrieve original name..
                 if (origPath.length > i - 1) {
-                    log.debug("Replace Data Driven element {} with {}", nodeName, origPath[i - 1]);
+                    LOGGER.debug(
+                            "Replace Data Driven element {} with {}", nodeName, origPath[i - 1]);
                     sb.append(origPath[i - 1]);
                 } else {
-                    log.error(
+                    LOGGER.error(
                             "Failed to determine original node name for element {} {} original request: {}",
                             i,
                             nodeName,

--- a/zap/src/main/java/org/parosproxy/paros/model/SiteNode.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/SiteNode.java
@@ -62,6 +62,7 @@
 // ZAP: 2022/09/21 Use a contains check for DDN prefix. Tweak if conditions in setIncludedFromScope
 // and setExcludedFromScope to short-circuit && operator earlier.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.model;
 
 import java.awt.EventQueue;
@@ -101,7 +102,7 @@ public class SiteNode extends DefaultMutableTreeNode {
     private ArrayList<String> icons = null;
     private ArrayList<Boolean> clearIfManual = null;
 
-    private static Logger log = LogManager.getLogger(SiteNode.class);
+    private static final Logger LOGGER = LogManager.getLogger(SiteNode.class);
     private boolean isIncludedInScope = false;
     private boolean isExcludedFromScope = false;
     private boolean filtered = false;
@@ -180,7 +181,7 @@ public class SiteNode extends DefaultMutableTreeNode {
                     if (url == null) {
                         url = ExtensionFactory.getAddOnLoader().getResource(icon);
                         if (url == null) {
-                            log.warn("Failed to find icon: {}", icon);
+                            LOGGER.warn("Failed to find icon: {}", icon);
                             it.remove();
                         }
                     }
@@ -414,7 +415,7 @@ public class SiteNode extends DefaultMutableTreeNode {
                             }
                         });
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpBody.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpBody.java
@@ -29,6 +29,7 @@
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2020/12/09 Add content encoding.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.network;
 
 import java.io.IOException;
@@ -53,7 +54,7 @@ import org.zaproxy.zap.network.HttpEncoding;
  */
 public abstract class HttpBody {
 
-    private static final Logger log = LogManager.getLogger(HttpBody.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpBody.class);
 
     /**
      * The name of the default charset ({@code ISO-8859-1}) used for {@code String} related
@@ -198,7 +199,7 @@ public abstract class HttpBody {
             contentEncodingErrors = false;
             return decoded;
         } catch (IOException e) {
-            log.warn("An error occurred while encoding the body: {}", e.getMessage());
+            LOGGER.warn("An error occurred while encoding the body: {}", e.getMessage());
         }
         contentEncodingErrors = true;
         return value;
@@ -410,7 +411,7 @@ public abstract class HttpBody {
             contentEncodingErrors = false;
             return decoded;
         } catch (IOException e) {
-            log.warn("An error occurred while decoding the body: {}", e.getMessage());
+            LOGGER.warn("An error occurred while decoding the body: {}", e.getMessage());
         }
         contentEncodingErrors = true;
         return value;
@@ -566,7 +567,7 @@ public abstract class HttpBody {
                 setCharsetImpl(newCharset);
             }
         } catch (IllegalCharsetNameException | UnsupportedCharsetException e) {
-            log.error("Failed to set charset: {}", charsetName, e);
+            LOGGER.error("Failed to set charset: {}", charsetName, e);
         }
     }
 

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpInputStream.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpInputStream.java
@@ -40,7 +40,7 @@ import org.zaproxy.zap.network.HttpRequestBody;
 import org.zaproxy.zap.network.HttpResponseBody;
 
 public class HttpInputStream extends BufferedInputStream {
-    private static Logger log = LogManager.getLogger(HttpInputStream.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpInputStream.class);
 
     static final int BUFFER_SIZE = 4096;
     private static final String CRLF = "\r\n";
@@ -65,7 +65,7 @@ public class HttpInputStream extends BufferedInputStream {
 
         msg = readHeader();
         if (msg.length() == 0) {
-            log.debug("Read 0 bytes from upstream. Could not read header!");
+            LOGGER.debug("Read 0 bytes from upstream. Could not read header!");
             throw new IOException();
         }
 

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpMessage.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpMessage.java
@@ -61,6 +61,7 @@
 // ZAP: 2021/05/11 Fixed conversion of Request Method to/from CONNECT
 // ZAP: 2021/05/14 Add missing override annotation.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.network;
 
 import java.net.HttpCookie;
@@ -119,7 +120,7 @@ public class HttpMessage implements Message {
     // ZAP: Added historyRef
     private HistoryReference historyRef = null;
     // ZAP: Added logger
-    private static Logger log = LogManager.getLogger(HttpMessage.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpMessage.class);
     // ZAP: Added HttpSession
     private HttpSession httpSession = null;
     // ZAP: Added support for requesting the message to be sent as a particular User
@@ -583,7 +584,7 @@ public class HttpMessage implements Message {
                                 .equalsIgnoreCase(msg.getRequestHeader().getURI().toString());
             } catch (Exception e1) {
                 // ZAP: log error
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
 
@@ -606,7 +607,7 @@ public class HttpMessage implements Message {
                                         ? 0
                                         : uri.getHost().toLowerCase(Locale.ROOT).hashCode());
             } catch (URIException e) {
-                log.error("Failed to obtain the host for hashCode calculation: {}", uri, e);
+                LOGGER.error("Failed to obtain the host for hashCode calculation: {}", uri, e);
             }
             result =
                     prime * result
@@ -681,7 +682,7 @@ public class HttpMessage implements Message {
 
         } catch (URIException e) {
             // ZAP: log error
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         return result;
@@ -931,7 +932,7 @@ public class HttpMessage implements Message {
             try {
                 newMsg.getRequestHeader().setMessage(this.getRequestHeader().toString());
             } catch (HttpMalformedHeaderException e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
             newMsg.setRequestBody(this.getRequestBody().getBytes());
         }
@@ -1062,9 +1063,9 @@ public class HttpMessage implements Message {
             getRequestBody().setBody(body);
         } catch (HttpMalformedHeaderException e) {
             // Ignore?
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         } catch (URIException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpRequestHeader.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpRequestHeader.java
@@ -65,6 +65,7 @@
 // ZAP: 2022/09/12 Allow arbitrary HTTP versions.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
 // ZAP: 2022/11/22 Lower case the HTTP field names for compatibility with HTTP/2.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.network;
 
 import java.io.UnsupportedEncodingException;
@@ -100,7 +101,7 @@ public class HttpRequestHeader extends HttpHeader {
     public static final String ORIGIN = "origin";
 
     private static final long serialVersionUID = 4156598327921777493L;
-    private static final Logger log = LogManager.getLogger(HttpRequestHeader.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpRequestHeader.class);
 
     // method list
     public static final String CONNECT = "CONNECT";
@@ -231,7 +232,7 @@ public class HttpRequestHeader extends HttpHeader {
                             + (uri.getPort() > 0 ? ":" + Integer.toString(uri.getPort()) : ""));
 
         } catch (URIException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         setHeader(USER_AGENT, defaultUserAgent);
@@ -293,12 +294,12 @@ public class HttpRequestHeader extends HttpHeader {
 
         } catch (HttpMalformedHeaderException e) {
             mMalformedHeader = true;
-            log.debug("Malformed header: {}", data, e);
+            LOGGER.debug("Malformed header: {}", data, e);
 
             throw e;
 
         } catch (Exception e) {
-            log.error("Failed to parse:\n{}", data, e);
+            LOGGER.error("Failed to parse:\n{}", data, e);
             mMalformedHeader = true;
             throw new HttpMalformedHeaderException(e.getMessage());
         }
@@ -513,8 +514,8 @@ public class HttpRequestHeader extends HttpHeader {
             hostName = ((mUri.getHost() != null) ? mUri.getHost() : mHostName);
 
         } catch (URIException e) {
-            if (log.isDebugEnabled()) {
-                log.warn(e);
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.warn(e);
             }
         }
 
@@ -580,7 +581,7 @@ public class HttpRequestHeader extends HttpHeader {
             }
 
         } catch (URIException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         return false;
@@ -683,7 +684,7 @@ public class HttpRequestHeader extends HttpHeader {
                 mUri.setQuery("");
 
             } catch (URIException e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
 
             return;
@@ -706,7 +707,7 @@ public class HttpRequestHeader extends HttpHeader {
                 mUri.setQuery("");
 
             } catch (URIException e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
 
             return;
@@ -720,7 +721,7 @@ public class HttpRequestHeader extends HttpHeader {
             mUri.setQuery(query);
 
         } catch (URIException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -831,7 +832,7 @@ public class HttpRequestHeader extends HttpHeader {
 
                 } catch (IllegalArgumentException e) {
                     // Occurs while scanning ;)
-                    log.debug("{} {}", e.getMessage(), htmlParameter.getName());
+                    LOGGER.debug("{} {}", e.getMessage(), htmlParameter.getName());
                 }
             }
         }

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpResponseHeader.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpResponseHeader.java
@@ -45,6 +45,7 @@
 // ZAP: 2022/09/12 Allow arbitrary HTTP versions.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
 // ZAP: 2022/11/22 Lower case the HTTP field names for compatibility with HTTP/2.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.network;
 
 import java.net.HttpCookie;
@@ -97,7 +98,7 @@ public class HttpResponseHeader extends HttpHeader {
     public static final String SERVER = "server";
 
     private static final long serialVersionUID = 2812716126742059785L;
-    private static final Logger log = LogManager.getLogger(HttpResponseHeader.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpResponseHeader.class);
 
     public static final String HTTP_CLIENT_BAD_REQUEST = "HTTP/1.0 400 Bad request" + CRLF + CRLF;
     private static final String _CONTENT_TYPE_CSS = "css";
@@ -349,7 +350,7 @@ public class HttpResponseHeader extends HttpHeader {
                     }
                     return parsedCookies;
                 } catch (IllegalArgumentException e2) {
-                    log.error("Failed to parse cookie: {}", c, e);
+                    LOGGER.error("Failed to parse cookie: {}", c, e);
                 }
             }
         }

--- a/zap/src/main/java/org/parosproxy/paros/view/AbstractFrame.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/AbstractFrame.java
@@ -30,6 +30,7 @@
 // ZAP: 2022/02/03 Removed deprecated loadIconImages()
 // ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
 // ZAP: 2022/09/08 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.view;
 
 import java.awt.Dimension;
@@ -80,7 +81,7 @@ public class AbstractFrame extends JFrame {
     private final Preferences preferences;
 
     private final String prefnzPrefix = this.getClass().getSimpleName() + ".";
-    private static final Logger logger = LogManager.getLogger(AbstractFrame.class);
+    private static final Logger LOGGER = LogManager.getLogger(AbstractFrame.class);
 
     /** This is the default constructor */
     public AbstractFrame() {
@@ -128,16 +129,16 @@ public class AbstractFrame extends JFrame {
         if ((windowstate & Frame.ICONIFIED) == Frame.ICONIFIED) {
             preferences.put(
                     prefnzPrefix + PREF_WINDOW_STATE, SimpleWindowState.ICONIFIED.toString());
-            logger.debug("Saving preference {}={}", PREF_WINDOW_STATE, SimpleWindowState.ICONIFIED);
+            LOGGER.debug("Saving preference {}={}", PREF_WINDOW_STATE, SimpleWindowState.ICONIFIED);
         }
         if ((windowstate & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH) {
             preferences.put(
                     prefnzPrefix + PREF_WINDOW_STATE, SimpleWindowState.MAXIMIZED.toString());
-            logger.debug("Saving preference {}={}", PREF_WINDOW_STATE, SimpleWindowState.MAXIMIZED);
+            LOGGER.debug("Saving preference {}={}", PREF_WINDOW_STATE, SimpleWindowState.MAXIMIZED);
         }
         if (windowstate == Frame.NORMAL) { // hint: Frame.NORMAL = 0, thats why no masking
             preferences.put(prefnzPrefix + PREF_WINDOW_STATE, SimpleWindowState.NORMAL.toString());
-            logger.debug("Saving preference {}={}", PREF_WINDOW_STATE, SimpleWindowState.NORMAL);
+            LOGGER.debug("Saving preference {}={}", PREF_WINDOW_STATE, SimpleWindowState.NORMAL);
         }
     }
 
@@ -150,7 +151,7 @@ public class AbstractFrame extends JFrame {
     private SimpleWindowState restoreWindowState() {
         SimpleWindowState laststate = null;
         final String statestr = preferences.get(prefnzPrefix + PREF_WINDOW_STATE, null);
-        logger.debug("Restoring preference {}={}", PREF_WINDOW_STATE, statestr);
+        LOGGER.debug("Restoring preference {}={}", PREF_WINDOW_STATE, statestr);
         if (statestr != null) {
             SimpleWindowState state = null;
             try {
@@ -170,7 +171,7 @@ public class AbstractFrame extends JFrame {
                         this.setExtendedState(Frame.MAXIMIZED_BOTH);
                         break;
                     default:
-                        logger.error(
+                        LOGGER.error(
                                 "Invalid window state (nothing will be changed): {}", statestr);
                 }
             }
@@ -188,12 +189,12 @@ public class AbstractFrame extends JFrame {
     private void saveWindowSize(Dimension size) {
         if (size != null) {
             if (getExtendedState() == Frame.NORMAL) {
-                logger.debug(
+                LOGGER.debug(
                         "Saving preference {}={},{}", PREF_WINDOW_SIZE, size.width, size.height);
                 this.preferences.put(
                         prefnzPrefix + PREF_WINDOW_SIZE, size.width + "," + size.height);
             } else {
-                logger.debug(
+                LOGGER.debug(
                         "Preference {} not saved, cause window state is not 'normal'.",
                         PREF_WINDOW_SIZE);
             }
@@ -220,7 +221,7 @@ public class AbstractFrame extends JFrame {
             }
             if (width > 0 && height > 0) {
                 result = new Dimension(width, height);
-                logger.debug(
+                LOGGER.debug(
                         "Restoring preference {}={},{}",
                         PREF_WINDOW_SIZE,
                         result.width,
@@ -240,10 +241,10 @@ public class AbstractFrame extends JFrame {
     private void saveWindowLocation(Point point) {
         if (point != null) {
             if (getExtendedState() == Frame.NORMAL) {
-                logger.debug("Saving preference {}={},{}", PREF_WINDOW_POSITION, point.x, point.y);
+                LOGGER.debug("Saving preference {}={},{}", PREF_WINDOW_POSITION, point.x, point.y);
                 this.preferences.put(prefnzPrefix + PREF_WINDOW_POSITION, point.x + "," + point.y);
             } else {
-                logger.debug(
+                LOGGER.debug(
                         "Preference {} not saved, cause window state is not 'normal'.",
                         PREF_WINDOW_POSITION);
             }
@@ -270,7 +271,7 @@ public class AbstractFrame extends JFrame {
             }
             if (x > 0 && y > 0) {
                 result = new Point(x, y);
-                logger.debug(
+                LOGGER.debug(
                         "Restoring preference {}={},{}", PREF_WINDOW_POSITION, result.x, result.y);
                 this.setLocation(result);
             }
@@ -284,7 +285,7 @@ public class AbstractFrame extends JFrame {
         try {
             this.preferences.flush();
         } catch (final BackingStoreException e) {
-            logger.error("Error while saving the preferences", e);
+            LOGGER.error("Error while saving the preferences", e);
         }
     }
 

--- a/zap/src/main/java/org/parosproxy/paros/view/AbstractParamContainerPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/AbstractParamContainerPanel.java
@@ -41,6 +41,7 @@
 // ZAP: 2022/05/11 Use a unique ID to identify the panels instead of their name (Issue 5637).
 // ZAP: 2022/06/08 Fix resizing issues.
 // ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.view;
 
 import java.awt.BorderLayout;
@@ -133,7 +134,7 @@ public class AbstractParamContainerPanel extends JSplitPane {
     private ShowHelpAction showHelpAction = null;
 
     // ZAP: Added logger
-    private static Logger log = LogManager.getLogger(AbstractParamContainerPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(AbstractParamContainerPanel.class);
 
     /**
      * Constructs an {@code AbstractParamContainerPanel} with a default root node's name ({@value
@@ -675,7 +676,7 @@ public class AbstractParamContainerPanel extends JSplitPane {
             try {
                 panel.validateParam(paramObject);
             } catch (NullPointerException e) {
-                log.error("Failed to validate the panel: ", e);
+                LOGGER.error("Failed to validate the panel: ", e);
                 showInternalError(e);
             } catch (Exception e) {
                 showParamPanel(panel);
@@ -712,7 +713,7 @@ public class AbstractParamContainerPanel extends JSplitPane {
             try {
                 panel.saveParam(paramObject);
             } catch (NullPointerException e) {
-                log.error("Failed to save the panel: ", e);
+                LOGGER.error("Failed to save the panel: ", e);
                 showInternalError(e);
             }
         }
@@ -808,7 +809,7 @@ public class AbstractParamContainerPanel extends JSplitPane {
 
         } catch (Exception e) {
             // ZAP: log errors
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 

--- a/zap/src/main/java/org/parosproxy/paros/view/MainMenuBar.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/MainMenuBar.java
@@ -45,6 +45,7 @@
 // disabled menu item (Issue 6938).
 // ZAP: 2022/03/12 Add open recent menu
 // ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.view;
 
 import java.awt.event.ActionEvent;
@@ -76,7 +77,7 @@ public class MainMenuBar extends JMenuBar {
 
     private static final long serialVersionUID = 8580116506279095244L;
 
-    private static final Logger logger = LogManager.getLogger(MainMenuBar.class);
+    private static final Logger LOGGER = LogManager.getLogger(MainMenuBar.class);
 
     private javax.swing.JMenu menuEdit = null;
     private javax.swing.JMenu menuTools = null;
@@ -295,7 +296,7 @@ public class MainMenuBar extends JMenuBar {
                                         .showWarningDialog(
                                                 Constant.messages.getString(
                                                         "menu.file.newSession.error")); // ZAP: i18n
-                                logger.error(e1.getMessage(), e1);
+                                LOGGER.error(e1.getMessage(), e1);
                             }
                         }
                     });

--- a/zap/src/main/java/org/parosproxy/paros/view/MainPopupMenu.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/MainPopupMenu.java
@@ -49,6 +49,7 @@
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/02/03 Removed deprecated prepareShow method
 // ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.view;
 
 import java.awt.Component;
@@ -87,7 +88,7 @@ public class MainPopupMenu extends JPopupMenu {
     // ZAP: Added support for submenus
     Map<String, JMenu> superMenus = new HashMap<>();
     View view = null;
-    private static final Logger log = LogManager.getLogger(MainPopupMenu.class);
+    private static final Logger LOGGER = LogManager.getLogger(MainPopupMenu.class);
 
     /**
      * The change listener responsible for updating the {@code pathSelectedMenu} when the path to
@@ -166,7 +167,7 @@ public class MainPopupMenu extends JPopupMenu {
                     }
                 }
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
 
@@ -261,7 +262,7 @@ public class MainPopupMenu extends JPopupMenu {
             }
 
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -295,7 +296,7 @@ public class MainPopupMenu extends JPopupMenu {
                 }
             }
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 

--- a/zap/src/main/java/org/parosproxy/paros/view/OptionsDialog.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/OptionsDialog.java
@@ -25,6 +25,7 @@
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/06/08 Fix resizing issues.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.view;
 
 import java.awt.Frame;
@@ -44,7 +45,7 @@ import org.zaproxy.zap.utils.DisplayUtils;
 public class OptionsDialog extends AbstractParamDialog {
 
     private static final long serialVersionUID = -4374132178769109917L;
-    private static final Logger logger = LogManager.getLogger(OptionsDialog.class);
+    private static final Logger LOGGER = LogManager.getLogger(OptionsDialog.class);
     private JButton[] extraButtons = null;
 
     public OptionsDialog() {
@@ -100,7 +101,7 @@ public class OptionsDialog extends AbstractParamDialog {
                                     OptionsDialog.this.initParam(params);
 
                                 } catch (Exception e1) {
-                                    logger.error("Failed to reset to defaults:", e1);
+                                    LOGGER.error("Failed to reset to defaults:", e1);
                                     View.getSingleton()
                                             .showWarningDialog(
                                                     Constant.messages.getString(
@@ -120,7 +121,7 @@ public class OptionsDialog extends AbstractParamDialog {
             try {
                 panel.reset();
             } catch (Exception e) {
-                logger.error("Failed to reset {} options panel:", panel.getName(), e);
+                LOGGER.error("Failed to reset {} options panel:", panel.getName(), e);
                 View.getSingleton()
                         .showWarningDialog(
                                 Constant.messages.getString(

--- a/zap/src/main/java/org/parosproxy/paros/view/OutputPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/OutputPanel.java
@@ -33,6 +33,7 @@
 // ZAP: 2019/06/05 Normalise format/style.
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2021/05/14 Remove empty statement.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.view;
 
 import java.awt.BorderLayout;
@@ -57,7 +58,7 @@ public class OutputPanel extends AbstractPanel {
 
     private static final long serialVersionUID = -947074835463140074L;
     // ZAP: Added logger.
-    private static final Logger logger = LogManager.getLogger(OutputPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(OutputPanel.class);
 
     private static final String CLEAR_BUTTON_LABEL =
             Constant.messages.getString("output.panel.clear.button.label");
@@ -203,7 +204,7 @@ public class OutputPanel extends AbstractPanel {
                     });
         } catch (Exception e) {
             // ZAP: Added logging.
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 

--- a/zap/src/main/java/org/parosproxy/paros/view/SiteMapPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/SiteMapPanel.java
@@ -55,6 +55,7 @@
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/07/04 Make delete more consistent and protective (Issue 7336).
 // ZAP: 2022/08/05 Address warns with Java 18 (Issue 7389).
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.view;
 
 import java.awt.Component;
@@ -128,7 +129,7 @@ public class SiteMapPanel extends AbstractPanel {
     private static final long serialVersionUID = -3161729504065679088L;
 
     // ZAP: Added logger
-    private static Logger log = LogManager.getLogger(SiteMapPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(SiteMapPanel.class);
 
     private JTree treeSite = null;
     private JTree treeContext = null;
@@ -320,7 +321,7 @@ public class SiteMapPanel extends AbstractPanel {
         try {
             dialog.setAllTags(Model.getSingleton().getDb().getTableTag().getAllTags());
         } catch (DatabaseException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         int exit = dialog.showDialog();
@@ -412,7 +413,7 @@ public class SiteMapPanel extends AbstractPanel {
                                     msg = node.getHistoryReference().getHttpMessage();
                                 } catch (Exception e1) {
                                     // ZAP: Log exceptions
-                                    log.warn(e1.getMessage(), e1);
+                                    LOGGER.warn(e1.getMessage(), e1);
                                     return;
                                 }
 
@@ -675,7 +676,7 @@ public class SiteMapPanel extends AbstractPanel {
                     });
         } catch (Exception e) {
             // ZAP: Log exceptions
-            log.warn(e.getMessage(), e);
+            LOGGER.warn(e.getMessage(), e);
         }
     }
 

--- a/zap/src/main/java/org/parosproxy/paros/view/View.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/View.java
@@ -94,6 +94,7 @@
 // ZAP: 2022/05/29 Implement getOptionsDialog().
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
 // ZAP: 2022/09/27 Added dialog methods with ZapHtmlLabel parameter.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.view;
 
 import java.awt.Component;
@@ -198,7 +199,7 @@ public class View implements ViewDelegate {
     private Map<ContextPanelFactory, List<AbstractContextPropertiesPanel>>
             contextPanelFactoriesPanels = new HashMap<>();
 
-    private static final Logger logger = LogManager.getLogger(View.class);
+    private static final Logger LOGGER = LogManager.getLogger(View.class);
 
     // ZAP: splash screen
     private SplashScreen splashScreen = null;
@@ -626,11 +627,11 @@ public class View implements ViewDelegate {
         if (view == null) {
             if (daemon) {
                 Exception e = new Exception("Attempting to initialise View in daemon mode");
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
                 return null;
             }
 
-            logger.info("Initialising View");
+            LOGGER.info("Initialising View");
             view = new View();
             view.init();
         }
@@ -1101,7 +1102,7 @@ public class View implements ViewDelegate {
         }
 
         if (!(message instanceof HttpMessage)) {
-            logger.warn("Unable to display message: {}", message.getClass().getCanonicalName());
+            LOGGER.warn("Unable to display message: {}", message.getClass().getCanonicalName());
             return;
         }
 

--- a/zap/src/main/java/org/parosproxy/paros/view/WorkbenchPanel.java
+++ b/zap/src/main/java/org/parosproxy/paros/view/WorkbenchPanel.java
@@ -41,6 +41,7 @@
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2022/02/26 Remove deprecated methods in 2.5.0
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.parosproxy.paros.view;
 
 import java.awt.BorderLayout;
@@ -229,7 +230,7 @@ public class WorkbenchPanel extends JPanel {
 
     private static final long serialVersionUID = -4610792807151921550L;
 
-    private static final Logger logger = LogManager.getLogger(WorkbenchPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(WorkbenchPanel.class);
 
     private static final String PREF_DIVIDER_LOCATION = "divider.location";
     private static final String DIVIDER_VERTICAL = "vertical";
@@ -1286,7 +1287,7 @@ public class WorkbenchPanel extends JPanel {
      */
     private void saveDividerLocation(String prefix, int location) {
         if (location > 0) {
-            logger.debug(
+            LOGGER.debug(
                     "Saving preference {}{}.{}={}",
                     prefnzPrefix,
                     prefix,
@@ -1299,7 +1300,7 @@ public class WorkbenchPanel extends JPanel {
             try {
                 this.preferences.flush();
             } catch (final BackingStoreException e) {
-                logger.error("Error while saving the preferences", e);
+                LOGGER.error("Error while saving the preferences", e);
             }
         }
     }
@@ -1322,7 +1323,7 @@ public class WorkbenchPanel extends JPanel {
             }
             if (location > 0) {
                 result = location;
-                logger.debug(
+                LOGGER.debug(
                         "Restoring preference {}{}.{}={}",
                         prefnzPrefix,
                         prefix,
@@ -1351,7 +1352,7 @@ public class WorkbenchPanel extends JPanel {
         public void propertyChange(PropertyChangeEvent evt) {
             JSplitPane component = (JSplitPane) evt.getSource();
             if (component != null) {
-                logger.debug(
+                LOGGER.debug(
                         "{}{}.location={}", prefnzPrefix, prefix, component.getDividerLocation());
                 saveDividerLocation(prefix, component.getDividerLocation());
             }

--- a/zap/src/main/java/org/zaproxy/zap/CommandLineBootstrap.java
+++ b/zap/src/main/java/org/zaproxy/zap/CommandLineBootstrap.java
@@ -35,7 +35,7 @@ import org.zaproxy.zap.utils.ZapSupportUtils;
  */
 public class CommandLineBootstrap extends HeadlessBootstrap {
 
-    private final Logger logger = LogManager.getLogger(CommandLineBootstrap.class);
+    private static final Logger LOGGER = LogManager.getLogger(CommandLineBootstrap.class);
 
     public CommandLineBootstrap(CommandLine cmdLineArgs) {
         super(cmdLineArgs);
@@ -52,7 +52,7 @@ public class CommandLineBootstrap extends HeadlessBootstrap {
             disableStdOutLog();
         }
 
-        logger.info(getStartingMessage());
+        LOGGER.info(getStartingMessage());
 
         try {
             initModel();
@@ -103,7 +103,7 @@ public class CommandLineBootstrap extends HeadlessBootstrap {
         } catch (ShutdownRequestedException e) {
             rc = 1;
         } catch (final Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             System.out.println(e.getMessage());
             System.out.println();
             // Help is kind of useful too ;)
@@ -113,7 +113,7 @@ public class CommandLineBootstrap extends HeadlessBootstrap {
         } finally {
             control.shutdown(
                     Model.getSingleton().getOptionsParam().getDatabaseParam().isCompactDatabase());
-            logger.info("{} terminated.", Constant.PROGRAM_TITLE);
+            LOGGER.info("{} terminated.", Constant.PROGRAM_TITLE);
         }
         if (rc == 0) {
             rc = control.getExitStatus();
@@ -124,6 +124,6 @@ public class CommandLineBootstrap extends HeadlessBootstrap {
 
     @Override
     protected Logger getLogger() {
-        return logger;
+        return LOGGER;
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/DaemonBootstrap.java
+++ b/zap/src/main/java/org/zaproxy/zap/DaemonBootstrap.java
@@ -34,7 +34,7 @@ import org.parosproxy.paros.view.View;
  */
 class DaemonBootstrap extends HeadlessBootstrap {
 
-    private final Logger logger = LogManager.getLogger(DaemonBootstrap.class);
+    private static final Logger LOGGER = LogManager.getLogger(DaemonBootstrap.class);
 
     public DaemonBootstrap(CommandLine cmdLineArgs) {
         super(cmdLineArgs);
@@ -49,7 +49,7 @@ class DaemonBootstrap extends HeadlessBootstrap {
 
         View.setDaemon(true); // Prevents the View ever being initialised
 
-        logger.info(getStartingMessage());
+        LOGGER.info(getStartingMessage());
 
         try {
             initModel();
@@ -59,7 +59,7 @@ class DaemonBootstrap extends HeadlessBootstrap {
                 System.out.println(e.getLocalizedMessage());
             }
 
-            logger.fatal(e.getMessage(), e);
+            LOGGER.fatal(e.getMessage(), e);
             return 1;
         }
 
@@ -92,10 +92,10 @@ class DaemonBootstrap extends HeadlessBootstrap {
                                     control.runCommandLine();
                                 } catch (ShutdownRequestedException e) {
                                     control.shutdown(false);
-                                    logger.info("{} terminated.", Constant.PROGRAM_TITLE);
+                                    LOGGER.info("{} terminated.", Constant.PROGRAM_TITLE);
                                     return;
                                 } catch (Exception e) {
-                                    logger.error(e.getMessage(), e);
+                                    LOGGER.error(e.getMessage(), e);
                                 }
 
                                 // This is the only non-daemon thread, so should keep running
@@ -119,6 +119,6 @@ class DaemonBootstrap extends HeadlessBootstrap {
 
     @Override
     protected Logger getLogger() {
-        return logger;
+        return LOGGER;
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/GuiBootstrap.java
+++ b/zap/src/main/java/org/zaproxy/zap/GuiBootstrap.java
@@ -62,7 +62,7 @@ import org.zaproxy.zap.view.LocaleDialog;
  */
 public class GuiBootstrap extends ZapBootstrap {
 
-    private static final Logger logger = LogManager.getLogger(GuiBootstrap.class);
+    private static final Logger LOGGER = LogManager.getLogger(GuiBootstrap.class);
 
     /**
      * Flag that indicates whether or not the look and feel was already set.
@@ -82,12 +82,12 @@ public class GuiBootstrap extends ZapBootstrap {
             return rc;
         }
 
-        logger.info(getStartingMessage());
+        LOGGER.info(getStartingMessage());
 
         if (GraphicsEnvironment.isHeadless()) {
             String headlessMessage =
                     Constant.messages.getString("start.gui.headless", CommandLine.HELP);
-            logger.fatal(headlessMessage);
+            LOGGER.fatal(headlessMessage);
             System.err.println(headlessMessage);
             return 1;
         }
@@ -122,7 +122,7 @@ public class GuiBootstrap extends ZapBootstrap {
                 awtAppClassName.setAccessible(true);
                 awtAppClassName.set(null, Constant.PROGRAM_NAME);
             } catch (Exception e) {
-                logger.warn("Failed to set awt app class name: {}", e.getMessage());
+                LOGGER.warn("Failed to set awt app class name: {}", e.getMessage());
             }
         }
     }
@@ -141,7 +141,7 @@ public class GuiBootstrap extends ZapBootstrap {
                         Constant.messages.getString("start.title.error"),
                         JOptionPane.ERROR_MESSAGE);
             }
-            logger.fatal("Failed to initialise: {}", e.getMessage(), e);
+            LOGGER.fatal("Failed to initialise: {}", e.getMessage(), e);
             System.err.println(e.getMessage());
             System.exit(1);
         }
@@ -201,7 +201,7 @@ public class GuiBootstrap extends ZapBootstrap {
                                     }
                                     View.getSingleton().hideSplashScreen();
 
-                                    logger.fatal("Failed to initialise GUI: ", e);
+                                    LOGGER.fatal("Failed to initialise GUI: ", e);
 
                                     // We must exit otherwise EDT would keep ZAP running.
                                     System.exit(1);
@@ -254,7 +254,7 @@ public class GuiBootstrap extends ZapBootstrap {
                             try {
                                 sessionPath = SessionUtils.getSessionPath(path);
                             } catch (IllegalArgumentException e) {
-                                logger.warn(
+                                LOGGER.warn(
                                         "An error occurred while resolving the session path:", e);
                             }
 
@@ -281,7 +281,7 @@ public class GuiBootstrap extends ZapBootstrap {
                             try {
                                 sessionPath = SessionUtils.getSessionPath(path);
                             } catch (IllegalArgumentException e) {
-                                logger.warn(
+                                LOGGER.warn(
                                         "An error occurred while resolving the session path:", e);
                             }
 
@@ -308,7 +308,7 @@ public class GuiBootstrap extends ZapBootstrap {
                             try {
                                 control.getMenuFileControl().newSession(false);
                             } catch (Exception e) {
-                                logger.error(e.getMessage(), e);
+                                LOGGER.error(e.getMessage(), e);
                                 View.getSingleton()
                                         .showWarningDialog(
                                                 Constant.messages.getString(
@@ -324,7 +324,7 @@ public class GuiBootstrap extends ZapBootstrap {
             control.runCommandLine();
 
         } catch (final Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             EventQueue.invokeLater(
                     new Runnable() {
 
@@ -406,7 +406,7 @@ public class GuiBootstrap extends ZapBootstrap {
                     | ClassNotFoundException
                     | InstantiationException
                     | IllegalAccessException e) {
-                logger.warn("Failed to set the look and feel: {}", e.getMessage());
+                LOGGER.warn("Failed to set the look and feel: {}", e.getMessage());
             }
         }
         return false;
@@ -447,7 +447,7 @@ public class GuiBootstrap extends ZapBootstrap {
             try {
                 options.getViewParam().getConfig().save();
             } catch (ConfigurationException e) {
-                logger.warn("Failed to save locale: ", e);
+                LOGGER.warn("Failed to save locale: ", e);
             }
         }
     }

--- a/zap/src/main/java/org/zaproxy/zap/ZAP.java
+++ b/zap/src/main/java/org/zaproxy/zap/ZAP.java
@@ -52,7 +52,7 @@ public class ZAP {
     private static ProcessType processType;
 
     private static final EventBus eventBus = new SimpleEventBus();
-    private static final Logger logger = LogManager.getLogger(ZAP.class);
+    private static final Logger LOGGER = LogManager.getLogger(ZAP.class);
 
     static {
         try {
@@ -97,7 +97,7 @@ public class ZAP {
             }
 
         } catch (final Exception e) {
-            logger.fatal(e.getMessage(), e);
+            LOGGER.fatal(e.getMessage(), e);
             System.exit(1);
         }
     }
@@ -147,7 +147,7 @@ public class ZAP {
 
     static final class UncaughtExceptionLogger implements Thread.UncaughtExceptionHandler {
 
-        private static final Logger logger = LogManager.getLogger(UncaughtExceptionLogger.class);
+        private static final Logger LOGGER = LogManager.getLogger(UncaughtExceptionLogger.class);
 
         private boolean loggerConfigured = false;
 
@@ -155,7 +155,7 @@ public class ZAP {
         public void uncaughtException(Thread t, Throwable e) {
             if (!(e instanceof ThreadDeath)) {
                 if (loggerConfigured || isLoggerConfigured()) {
-                    logger.error("Exception in thread \"{}\"", t.getName(), e);
+                    LOGGER.error("Exception in thread \"{}\"", t.getName(), e);
 
                 } else {
                     System.err.println("Exception in thread \"" + t.getName() + "\"");

--- a/zap/src/main/java/org/zaproxy/zap/authentication/AuthenticationHelper.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/AuthenticationHelper.java
@@ -59,7 +59,7 @@ public class AuthenticationHelper {
         this.user = user;
     }
 
-    private static final Logger log = LogManager.getLogger(AuthenticationHelper.class);
+    private static final Logger LOGGER = LogManager.getLogger(AuthenticationHelper.class);
 
     private static final String HISTORY_TAG_AUTHENTICATION = "Authentication";
     public static final String AUTH_SUCCESS_STATS = "stats.auth.success";
@@ -140,7 +140,7 @@ public class AuthenticationHelper {
                 }
             }
         } catch (Exception ex) {
-            log.error("Cannot add authentication message to History tab.", ex);
+            LOGGER.error("Cannot add authentication message to History tab.", ex);
         }
     }
 
@@ -183,7 +183,7 @@ public class AuthenticationHelper {
                             PostBasedAuthenticationMethodType::encodeParameter);
             msg.getRequestHeader().setURI(new URI(uri, true));
         } catch (Exception e) {
-            log.error(
+            LOGGER.error(
                     "Failed to replace user data in request {}",
                     msg.getRequestHeader().getURI(),
                     e);

--- a/zap/src/main/java/org/zaproxy/zap/authentication/HttpAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/HttpAuthenticationMethodType.java
@@ -71,7 +71,7 @@ public class HttpAuthenticationMethodType extends AuthenticationMethodType {
     public static final String CONTEXT_CONFIG_AUTH_HTTP_REALM = CONTEXT_CONFIG_AUTH_HTTP + ".realm";
     public static final String CONTEXT_CONFIG_AUTH_HTTP_PORT = CONTEXT_CONFIG_AUTH_HTTP + ".port";
 
-    private static final Logger log = LogManager.getLogger(HttpAuthenticationMethodType.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpAuthenticationMethodType.class);
 
     /** The unique identifier of the method. */
     private static final int METHOD_IDENTIFIER = 3;
@@ -174,7 +174,7 @@ public class HttpAuthenticationMethodType extends AuthenticationMethodType {
                 session.getHttpState().setCredentials(stateAuthScope, stateCredentials);
             } catch (UnknownHostException e1) {
                 user.getAuthenticationState().setLastAuthFailure(e1.getMessage());
-                log.error(e1.getMessage(), e1);
+                LOGGER.error(e1.getMessage(), e1);
             }
             user.getAuthenticationState().setLastAuthFailure("");
             return session;
@@ -342,7 +342,7 @@ public class HttpAuthenticationMethodType extends AuthenticationMethodType {
             try {
                 method.port = Integer.parseInt(ports.get(0));
             } catch (Exception ex) {
-                log.error("Unable to load HttpAuthenticationMethod. ", ex);
+                LOGGER.error("Unable to load HttpAuthenticationMethod. ", ex);
             }
         }
 

--- a/zap/src/main/java/org/zaproxy/zap/authentication/ManualAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/ManualAuthenticationMethodType.java
@@ -236,7 +236,7 @@ public class ManualAuthenticationMethodType extends AuthenticationMethodType {
         /** The Constant serialVersionUID. */
         private static final long serialVersionUID = -8081914793980311435L;
 
-        private static final Logger log =
+        private static final Logger LOGGER =
                 LogManager.getLogger(ManualAuthenticationCredentialsOptionsPanel.class);
         private JComboBox<HttpSession> sessionsComboBox;
         private Context uiSharedContext;
@@ -294,7 +294,7 @@ public class ManualAuthenticationMethodType extends AuthenticationMethodType {
                                 .getExtension(ExtensionHttpSessions.class);
                 List<HttpSession> sessions =
                         extensionHttpSessions.getHttpSessionsForContext(uiSharedContext);
-                log.debug("Found sessions for Manual Authentication Config: {}", sessions);
+                LOGGER.debug("Found sessions for Manual Authentication Config: {}", sessions);
                 sessionsComboBox =
                         new JComboBox<>(sessions.toArray(new HttpSession[sessions.size()]));
                 sessionsComboBox.setSelectedItem(this.getCredentials().getSelectedSession());
@@ -310,7 +310,7 @@ public class ManualAuthenticationMethodType extends AuthenticationMethodType {
 
         @Override
         public void saveCredentials() {
-            log.info(
+            LOGGER.info(
                     "Saving Manual Authentication Method: {}",
                     getSessionsComboBox().getSelectedItem());
             getCredentials()

--- a/zap/src/main/java/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
@@ -85,7 +85,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
 
     public static final int METHOD_IDENTIFIER = 4;
 
-    private static final Logger log =
+    private static final Logger LOGGER =
             LogManager.getLogger(ScriptBasedAuthenticationMethodType.class);
 
     /** The Constant SCRIPT_TYPE_AUTH. */
@@ -133,7 +133,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
                 script = getScriptInterface(scriptW);
             }
             if (script == null) {
-                log.warn(
+                LOGGER.warn(
                         "The script {} does not properly implement the Authentication Script interface.",
                         scriptW.getName());
                 throw new IllegalArgumentException(
@@ -151,8 +151,8 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
                 String[] requiredParams = script.getRequiredParamsNames();
                 String[] optionalParams = script.getOptionalParamsNames();
                 this.credentialsParamNames = script.getCredentialsParamsNames();
-                if (log.isDebugEnabled()) {
-                    log.debug(
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(
                             "Loaded authentication script - required parameters: {} - optional parameters: {}",
                             Arrays.toString(requiredParams),
                             Arrays.toString(optionalParams));
@@ -170,9 +170,10 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
                     this.paramValues.put(param, oldValues.get(param));
 
                 this.script = scriptW;
-                log.info("Successfully loaded new script for ScriptBasedAuthentication: {}", this);
+                LOGGER.info(
+                        "Successfully loaded new script for ScriptBasedAuthentication: {}", this);
             } catch (Exception e) {
-                log.error("Error while loading authentication script", e);
+                LOGGER.error("Error while loading authentication script", e);
                 getScriptsExtension().handleScriptException(this.script, e);
                 throw new IllegalArgumentException(
                         Constant.messages.getString(
@@ -283,7 +284,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
                 user.getAuthenticationState()
                         .setLastAuthFailure(
                                 "Error running authentication script " + e.getMessage());
-                log.error(
+                LOGGER.error(
                         "An error occurred while trying to authenticate using the Authentication Script: {}",
                         this.script.getName(),
                         e);
@@ -297,7 +298,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
                                 "Auth request returned by the script '%s' does not have the request-target.",
                                 this.script.getName());
                 user.getAuthenticationState().setLastAuthFailure(error);
-                log.error(error);
+                LOGGER.error(error);
                 error = "ERROR: " + error + "\n";
                 getScriptsExtension().handleScriptError(this.script, error);
                 if (View.isInitialised()) {
@@ -490,7 +491,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
             }
 
             if (script == null) {
-                log.warn(
+                LOGGER.warn(
                         "The script {} does not properly implement the Authentication Script interface.",
                         scriptW.getName());
                 warnAndResetPanel(
@@ -526,8 +527,8 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
                 String[] requiredParams = script.getRequiredParamsNames();
                 String[] optionalParams = script.getOptionalParamsNames();
                 this.loadedCredentialParams = script.getCredentialsParamsNames();
-                if (log.isDebugEnabled()) {
-                    log.debug(
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(
                             "Loaded authentication script - required parameters: {} - optional parameters: {}",
                             Arrays.toString(requiredParams),
                             Arrays.toString(optionalParams));
@@ -537,7 +538,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
                 Map<String, String> oldValues = null;
                 if (adaptOldValues && dynamicFieldsPanel != null) {
                     oldValues = dynamicFieldsPanel.getFieldValues();
-                    log.debug("Trying to adapt old values: {}", oldValues);
+                    LOGGER.debug("Trying to adapt old values: {}", oldValues);
                 }
 
                 this.dynamicFieldsPanel = new DynamicFieldsPanel(requiredParams, optionalParams);
@@ -551,7 +552,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
 
             } catch (Exception e) {
                 getScriptsExtension().handleScriptException(scriptW, e);
-                log.error("Error while calling authentication script", e);
+                LOGGER.error("Error while calling authentication script", e);
                 warnAndResetPanel(
                         Constant.messages.getString(
                                 "authentication.method.script.dialog.error.text.loading",
@@ -578,7 +579,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
     public void hook(ExtensionHook extensionHook) {
         // Hook up the Script Type
         if (getScriptsExtension() != null) {
-            log.debug("Registering Script...");
+            LOGGER.debug("Registering Script...");
             getScriptsExtension()
                     .registerScriptType(
                             new ScriptType(
@@ -663,7 +664,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
             scriptName = scripts.get(0);
             ScriptWrapper script = getScriptsExtension().getScript(scriptName);
             if (script == null) {
-                log.error(
+                LOGGER.error(
                         "Unable to find script while loading Script Based Authentication Method for name: {}",
                         scriptName);
                 if (View.isInitialised()) {
@@ -675,7 +676,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
                 }
                 return;
             }
-            log.info("Loaded script:{}", script.getName());
+            LOGGER.info("Loaded script:{}", script.getName());
             method.script = script;
 
             // Check script interface and make sure we load the credentials parameter names
@@ -684,7 +685,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
                 s = getScriptInterface(script);
             }
             if (s == null) {
-                log.error(
+                LOGGER.error(
                         "Unable to load Script Based Authentication method. The script {} does not properly implement the Authentication Script interface.",
                         scriptName);
                 return;
@@ -709,7 +710,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
             method.paramValues = paramValues;
         } else {
             method.paramValues = new HashMap<>();
-            log.error(
+            LOGGER.error(
                     "Unable to load script parameter values loading Script Based Authentication Method for name: {}",
                     scriptName);
         }
@@ -771,7 +772,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
             AuthenticationScriptV2 authScript =
                     getScriptsExtension().getInterface(script, AuthenticationScriptV2.class);
             if (authScript == null) {
-                log.debug(
+                LOGGER.debug(
                         "Script '{}' is not a AuthenticationScriptV2 interface.", script::getName);
                 return null;
             }
@@ -788,7 +789,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
             return authScript;
         } catch (Exception ignore) {
             // The interface is optional, the AuthenticationScript will be checked after this one.
-            log.debug(
+            LOGGER.debug(
                     "Script '{}' is not a AuthenticationScriptV2 interface!",
                     script.getName(),
                     ignore);
@@ -869,11 +870,11 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
                 // Load the script and make sure it exists and follows the required interface
                 ScriptWrapper script = getScriptsExtension().getScript(scriptName);
                 if (script == null) {
-                    log.error(
+                    LOGGER.error(
                             "Unable to find script while loading Script Based Authentication Method for name: {}",
                             scriptName);
                     throw new ApiException(ApiException.Type.SCRIPT_NOT_FOUND, scriptName);
-                } else log.info("Loaded script for API:{}", script.getName());
+                } else LOGGER.info("Loaded script for API:{}", script.getName());
                 method.script = script;
 
                 // Check script interface and make sure we load the credentials parameter names
@@ -882,7 +883,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
                     s = getScriptInterface(script);
                 }
                 if (s == null) {
-                    log.error(
+                    LOGGER.error(
                             "Unable to load Script Based Authentication method. The script {} does not properly implement the Authentication Script interface.",
                             script.getName());
                     throw new ApiException(
@@ -901,8 +902,8 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
                     // are there
                     String[] requiredParams = s.getRequiredParamsNames();
                     String[] optionalParams = s.getOptionalParamsNames();
-                    if (log.isDebugEnabled()) {
-                        log.debug(
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug(
                                 "Loaded authentication script - required parameters: {} - optional parameters: {}",
                                 Arrays.toString(requiredParams),
                                 Arrays.toString(optionalParams));
@@ -918,13 +919,13 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
                     for (String op : optionalParams)
                         paramValues.put(op, ApiUtils.getOptionalStringParam(params, op));
                     method.paramValues = paramValues;
-                    log.debug("Loaded authentication script parameters: {}", paramValues);
+                    LOGGER.debug("Loaded authentication script parameters: {}", paramValues);
 
                 } catch (ApiException e) {
                     throw e;
                 } catch (Exception e) {
                     getScriptsExtension().handleScriptException(script, e);
-                    log.error(
+                    LOGGER.error(
                             "Unable to load Script Based Authentication method. The script {} contains errors.",
                             script.getName());
                     throw new ApiException(ApiException.Type.BAD_SCRIPT_FORMAT, e.getMessage());

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOn.java
@@ -328,7 +328,7 @@ public class AddOn {
      */
     private boolean mandatory;
 
-    private static final Logger logger = LogManager.getLogger(AddOn.class);
+    private static final Logger LOGGER = LogManager.getLogger(AddOn.class);
 
     /**
      * Tells whether or not the given file name matches the name of a ZAP add-on.
@@ -415,11 +415,11 @@ public class AddOn {
                         e -> {
                             ZipEntry libEntry = zip.getEntry(e);
                             if (libEntry == null) {
-                                logger.warn("The add-on {} does not have the lib: {}", file, e);
+                                LOGGER.warn("The add-on {} does not have the lib: {}", file, e);
                                 return true;
                             }
                             if (libEntry.isDirectory()) {
-                                logger.warn("The add-on {} does not have a file lib: {}", file, e);
+                                LOGGER.warn("The add-on {} does not have a file lib: {}", file, e);
                                 return true;
                             }
                             return false;
@@ -442,13 +442,13 @@ public class AddOn {
             return Optional.of(new AddOn(file));
         } catch (AddOn.InvalidAddOnException e) {
             String logMessage = "Invalid add-on: " + file.toString() + ".";
-            if (logger.isDebugEnabled() || Constant.isDevMode()) {
-                logger.warn(logMessage, e);
+            if (LOGGER.isDebugEnabled() || Constant.isDevMode()) {
+                LOGGER.warn(logMessage, e);
             } else {
-                logger.warn("{} {}", logMessage, e.getMessage());
+                LOGGER.warn("{} {}", logMessage, e.getMessage());
             }
         } catch (Exception e) {
-            logger.error("Failed to create an add-on from: {}", file, e);
+            LOGGER.error("Failed to create an add-on from: {}", file, e);
         }
         return Optional.empty();
     }
@@ -583,7 +583,7 @@ public class AddOn {
             try {
                 return new URL(url);
             } catch (Exception e) {
-                logger.warn("Invalid URL for add-on \"{}\": {}", id, url, e);
+                LOGGER.warn("Invalid URL for add-on \"{}\": {}", id, url, e);
             }
         }
         return null;
@@ -776,7 +776,7 @@ public class AddOn {
                 try {
                     this.loadManifestFile();
                 } catch (IOException e) {
-                    logger.debug(
+                    LOGGER.debug(
                             "Failed to read the {} file of {}:", AddOn.MANIFEST_FILE_NAME, id, e);
                 }
             }
@@ -1261,7 +1261,7 @@ public class AddOn {
         if (installedVersion != null && !addOn.equals(installedVersion)) {
             requirements.setIssue(
                     BaseRunRequirements.DependencyIssue.OLDER_VERSION, installedVersion);
-            logger.debug(
+            LOGGER.debug(
                     "Add-on {} not runnable, old version still installed: {}",
                     addOn,
                     installedVersion);
@@ -1269,7 +1269,7 @@ public class AddOn {
         }
 
         if (!requirements.addDependency(parent, addOn)) {
-            logger.warn("Cyclic dependency detected with: {}", requirements.getDependencies());
+            LOGGER.warn("Cyclic dependency detected with: {}", requirements.getDependencies());
             requirements.setIssue(
                     BaseRunRequirements.DependencyIssue.CYCLIC, requirements.getDependencies());
             return;

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnCollection.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnCollection.java
@@ -41,7 +41,7 @@ public class AddOnCollection {
         mac
     }
 
-    private static final Logger logger = LogManager.getLogger(AddOnCollection.class);
+    private static final Logger LOGGER = LogManager.getLogger(AddOnCollection.class);
     private ZapRelease zapRelease = null;
     private List<AddOn> addOns = new ArrayList<>();
     private File downloadDir = new File(Constant.FOLDER_LOCAL_PLUGIN);
@@ -68,8 +68,8 @@ public class AddOnCollection {
                 AddOn.AddOnRunRequirements requirements =
                         addOn.calculateInstallRequirements(addOns);
                 if (requirements.hasDependencyIssue()) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug(
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug(
                                 "Ignoring add-on {} because of dependency issue: {}",
                                 addOn.getName(),
                                 AddOnRunIssuesUtils.getDependencyIssue(requirements));
@@ -82,8 +82,8 @@ public class AddOnCollection {
                         checkedAddOns.removeAll(cyclicChain);
                     }
                 } else if (requirements.hasExtensionsWithRunningIssues()) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug(
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug(
                                 "Ignoring add-on {} because of dependency issue in an extension: {}",
                                 addOn.getName(),
                                 AddOnRunIssuesUtils.getDependencyIssue(requirements));
@@ -126,33 +126,33 @@ public class AddOnCollection {
                                 config.getString(platformPrefix + "hash"));
             }
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         try {
             // And then load the addons
             String[] addOnIds = config.getStringArray("addon");
             for (String id : addOnIds) {
-                logger.debug("Found add-on {}", id);
+                LOGGER.debug("Found add-on {}", id);
 
                 AddOn ao;
                 try {
                     ao = new AddOn(id, downloadDir, config.configurationAt("addon_" + id));
                     ao.setInstallationStatus(AddOn.InstallationStatus.AVAILABLE);
                 } catch (Exception e) {
-                    logger.warn("Failed to create add-on for {}", id, e);
+                    LOGGER.warn("Failed to create add-on for {}", id, e);
                     continue;
                 }
                 if (ao.canLoadInCurrentVersion()) {
                     // Ignore ones that dont apply to this version
                     this.addOns.add(ao);
                 } else {
-                    logger.debug("Ignoring add-on {} can't load in this version", ao.getName());
+                    LOGGER.debug("Ignoring add-on {} can't load in this version", ao.getName());
                 }
             }
 
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -162,7 +162,7 @@ public class AddOnCollection {
                 try {
                     this.addDirectory(dir);
                 } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
         }
@@ -170,17 +170,17 @@ public class AddOnCollection {
 
     private void addDirectory(File dir) throws Exception {
         if (dir == null) {
-            logger.error("Null directory supplied");
+            LOGGER.error("Null directory supplied");
             return;
         }
         if (!dir.exists()) {
-            logger.warn(
+            LOGGER.warn(
                     "Skipping enumeration of add-ons, the directory does not exist: {}",
                     dir.getAbsolutePath());
             return;
         }
         if (!dir.isDirectory()) {
-            logger.warn("Not a directory: {}", dir.getAbsolutePath());
+            LOGGER.warn("Not a directory: {}", dir.getAbsolutePath());
             return;
         }
 
@@ -198,14 +198,14 @@ public class AddOnCollection {
                                                 if (ao.canLoadInCurrentVersion()) {
                                                     // Replace in situ so we're not changing a list
                                                     // we're iterating through
-                                                    logger.debug(
+                                                    LOGGER.debug(
                                                             "Add-on {} version {} superseded by {}",
                                                             addOn.getId(),
                                                             addOn.getVersion(),
                                                             ao.getVersion());
                                                     addOns.remove(addOn);
                                                 } else {
-                                                    logger.debug(
+                                                    LOGGER.debug(
                                                             "Ignoring newer add-on {} version {} because of ZAP version constraints; Not before={} Not from={} Current Version={}",
                                                             ao.getId(),
                                                             ao.getVersion(),
@@ -216,7 +216,7 @@ public class AddOnCollection {
                                                 }
                                             } else {
                                                 // Same or older version, don't include
-                                                logger.debug(
+                                                LOGGER.debug(
                                                         "Add-on {} version {} not latest.",
                                                         ao.getId(),
                                                         ao.getVersion());
@@ -226,7 +226,7 @@ public class AddOnCollection {
                                         }
                                     }
                                     if (add) {
-                                        logger.debug(
+                                        LOGGER.debug(
                                                 "Found add-on {} version {}",
                                                 ao.getId(),
                                                 ao.getVersion());
@@ -293,7 +293,7 @@ public class AddOnCollection {
                         updatedAddOns.add(ao);
                     }
                 } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
         }
@@ -320,7 +320,7 @@ public class AddOnCollection {
                         break;
                     }
                 } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
             if (isNew) {

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnInstaller.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnInstaller.java
@@ -68,7 +68,7 @@ import org.zaproxy.zap.utils.ZapResourceBundleControl;
  */
 public final class AddOnInstaller {
 
-    private static final Logger logger = LogManager.getLogger(AddOnInstaller.class);
+    private static final Logger LOGGER = LogManager.getLogger(AddOnInstaller.class);
 
     /** The base directory to where add-on data (e.g. libraries) is copied. */
     private static final String ADD_ON_DATA_DIR = "addOnData";
@@ -124,7 +124,7 @@ public final class AddOnInstaller {
             try {
                 ext.postInstall();
             } catch (Exception e) {
-                logger.error(
+                LOGGER.error(
                         "Post install method failed for add-on {} extension {}",
                         addOn.getId(),
                         ext.getName());
@@ -240,7 +240,7 @@ public final class AddOnInstaller {
 
             return uninstalledWithoutErrors;
         } catch (Throwable e) {
-            logger.error("An error occurred while uninstalling the add-on: {}", addOn.getId(), e);
+            LOGGER.error("An error occurred while uninstalling the add-on: {}", addOn.getId(), e);
             return false;
         }
     }
@@ -278,7 +278,7 @@ public final class AddOnInstaller {
 
             return uninstalledWithoutErrors;
         } catch (Throwable e) {
-            logger.error("An error occurred while uninstalling the add-on: {}", addOn.getId(), e);
+            LOGGER.error("An error occurred while uninstalling the add-on: {}", addOn.getId(), e);
             return false;
         }
     }
@@ -310,7 +310,7 @@ public final class AddOnInstaller {
                 Constant.messages.addMessageBundle(bundlePrefix, resourceBundle);
             }
         } catch (MissingResourceException e) {
-            logger.error("Declared bundle not found in {} add-on:", addOn.getId(), e);
+            LOGGER.error("Declared bundle not found in {} add-on:", addOn.getId(), e);
         }
     }
 
@@ -345,13 +345,13 @@ public final class AddOnInstaller {
     private static void installAddOnExtensionImpl(
             AddOn addOn, Extension ext, ExtensionLoader extensionLoader) {
         if (ext.isEnabled()) {
-            logger.debug("Starting extension {}", ext.getName());
+            LOGGER.debug("Starting extension {}", ext.getName());
             try {
                 extensionLoader.startLifeCycle(ext);
             } catch (Throwable e) {
                 // Catch Throwable to (try) prevent extensions' issues from breaking the
                 // installation process.
-                logger.error("An error occurred while installing the add-on: {}", addOn.getId(), e);
+                LOGGER.error("An error occurred while installing the add-on: {}", addOn.getId(), e);
             }
         }
     }
@@ -386,13 +386,13 @@ public final class AddOnInstaller {
         if (extension.isEnabled()) {
             String extUiName = extension.getUIName();
             if (extension.canUnload()) {
-                logger.debug("Unloading extension: {}", extension.getName());
+                LOGGER.debug("Unloading extension: {}", extension.getName());
                 try {
                     extension.unload();
                     Control.getSingleton().getExtensionLoader().removeExtension(extension);
                     ExtensionFactory.unloadAddOnExtension(extension);
                 } catch (Exception e) {
-                    logger.error(
+                    LOGGER.error(
                             "An error occurred while uninstalling the extension \"{}\" bundled in the add-on \"{}\":",
                             extension.getName(),
                             addOn.getId(),
@@ -400,7 +400,7 @@ public final class AddOnInstaller {
                     uninstalledWithoutErrors = false;
                 }
             } else {
-                logger.debug("Can't dynamically unload extension: {}", extension.getName());
+                LOGGER.debug("Can't dynamically unload extension: {}", extension.getName());
                 uninstalledWithoutErrors = false;
             }
             callback.extensionRemoved(extUiName);
@@ -419,10 +419,10 @@ public final class AddOnInstaller {
         if (!ascanrules.isEmpty()) {
             for (AbstractPlugin ascanrule : ascanrules) {
                 String name = ascanrule.getClass().getCanonicalName();
-                logger.debug("Install ascanrule: {}", name);
+                LOGGER.debug("Install ascanrule: {}", name);
                 PluginFactory.loadedPlugin(ascanrule);
                 if (!PluginFactory.isPluginLoaded(ascanrule)) {
-                    logger.error("Failed to install ascanrule: {}", name);
+                    LOGGER.error("Failed to install ascanrule: {}", name);
                 }
             }
         }
@@ -434,14 +434,14 @@ public final class AddOnInstaller {
 
         List<AbstractPlugin> loadedAscanrules = addOn.getLoadedAscanrules();
         if (!loadedAscanrules.isEmpty()) {
-            logger.debug("Uninstall ascanrules: {}", addOn.getAscanrules());
+            LOGGER.debug("Uninstall ascanrules: {}", addOn.getAscanrules());
             callback.activeScanRulesWillBeRemoved(loadedAscanrules.size());
             for (AbstractPlugin ascanrule : loadedAscanrules) {
                 String name = ascanrule.getClass().getCanonicalName();
-                logger.debug("Uninstall ascanrule: {}", name);
+                LOGGER.debug("Uninstall ascanrule: {}", name);
                 PluginFactory.unloadedPlugin(ascanrule);
                 if (PluginFactory.isPluginLoaded(ascanrule)) {
-                    logger.error("Failed to uninstall ascanrule: {}", name);
+                    LOGGER.error("Failed to uninstall ascanrule: {}", name);
                     uninstalledWithoutErrors = false;
                 }
                 callback.activeScanRuleRemoved(name);
@@ -465,9 +465,9 @@ public final class AddOnInstaller {
         if (!pscanrules.isEmpty() && extPscan != null) {
             for (PluginPassiveScanner pscanrule : pscanrules) {
                 String name = pscanrule.getClass().getCanonicalName();
-                logger.debug("Install pscanrule: {}", name);
+                LOGGER.debug("Install pscanrule: {}", name);
                 if (!extPscan.addPassiveScanner(pscanrule)) {
-                    logger.error("Failed to install pscanrule: {}", name);
+                    LOGGER.error("Failed to install pscanrule: {}", name);
                 }
             }
         }
@@ -483,13 +483,13 @@ public final class AddOnInstaller {
                         .getExtensionLoader()
                         .getExtension(ExtensionPassiveScan.class);
         if (!loadedPscanrules.isEmpty()) {
-            logger.debug("Uninstall pscanrules: {}", addOn.getPscanrules());
+            LOGGER.debug("Uninstall pscanrules: {}", addOn.getPscanrules());
             callback.passiveScanRulesWillBeRemoved(loadedPscanrules.size());
             for (PluginPassiveScanner pscanrule : loadedPscanrules) {
                 String name = pscanrule.getClass().getCanonicalName();
-                logger.debug("Uninstall pscanrule: {}", name);
+                LOGGER.debug("Uninstall pscanrule: {}", name);
                 if (!extPscan.removePassiveScanner(pscanrule)) {
-                    logger.error("Failed to uninstall pscanrule: {}", name);
+                    LOGGER.error("Failed to uninstall pscanrule: {}", name);
                     uninstalledWithoutErrors = false;
                 }
                 callback.passiveScanRuleRemoved(name);
@@ -528,20 +528,20 @@ public final class AddOnInstaller {
         try {
             Files.createDirectories(targetDir);
         } catch (IOException e) {
-            logger.warn("Failed to create libs directory for {}", addOn.getId(), e);
+            LOGGER.warn("Failed to create libs directory for {}", addOn.getId(), e);
             return false;
         }
 
         try (ZipFile zip = new ZipFile(addOn.getFile())) {
             for (AddOn.Lib lib : libs) {
                 String name = lib.getName();
-                logger.debug("Installing library for {}: {}", addOn, name);
+                LOGGER.debug("Installing library for {}: {}", addOn, name);
 
                 Path targetFile = targetDir.resolve(name);
                 try {
                     lib.setFileSystemUrl(targetFile.toUri().toURL());
                 } catch (MalformedURLException e) {
-                    logger.warn(
+                    LOGGER.warn(
                             "Failed to convert lib's filesystem path to URL for {}",
                             addOn.getId(),
                             e);
@@ -554,19 +554,19 @@ public final class AddOnInstaller {
 
                 ZipEntry libZipEntry = zip.getEntry(lib.getJarPath());
                 if (libZipEntry == null) {
-                    logger.warn("Library not found in {} add-on: {}", addOn, lib);
+                    LOGGER.warn("Library not found in {} add-on: {}", addOn, lib);
                     return false;
                 }
 
                 try (InputStream in = zip.getInputStream(libZipEntry)) {
                     Files.copy(in, targetFile, StandardCopyOption.REPLACE_EXISTING);
                 } catch (IOException e) {
-                    logger.warn("Failed to copy the library for {}: {}", addOn, targetFile, e);
+                    LOGGER.warn("Failed to copy the library for {}: {}", addOn, targetFile, e);
                     return false;
                 }
             }
         } catch (IOException e) {
-            logger.error("An error occurred while installing libraries for {}", addOn, e);
+            LOGGER.error("An error occurred while installing libraries for {}", addOn, e);
             return false;
         }
 
@@ -601,7 +601,7 @@ public final class AddOnInstaller {
             try {
                 deleteDir(libsDir);
             } catch (IOException e) {
-                logger.warn(
+                LOGGER.warn(
                         "An error occurred while removing legacy add-on libs directory {}",
                         libsDir,
                         e);
@@ -654,7 +654,7 @@ public final class AddOnInstaller {
         try {
             deleteDir(addOnLibsDir);
         } catch (IOException e) {
-            logger.error("An error occurred while uninstalling libraries for {}", addOn, e);
+            LOGGER.error("An error occurred while uninstalling libraries for {}", addOn, e);
             return false;
         }
 
@@ -664,7 +664,7 @@ public final class AddOnInstaller {
                 Files.delete(addOnDataDir);
             }
         } catch (IOException e) {
-            logger.warn("An error occurred while removing the directory {}", addOnDataDir, e);
+            LOGGER.warn("An error occurred while removing the directory {}", addOnDataDir, e);
             return false;
         }
 
@@ -742,17 +742,17 @@ public final class AddOnInstaller {
                 continue;
             }
             if (!outfile.getParentFile().exists() && !outfile.getParentFile().mkdirs()) {
-                logger.error(
+                LOGGER.error(
                         "Failed to create directories for add-on {}: {}",
                         addOn,
                         outfile.getAbsolutePath());
                 continue;
             }
 
-            logger.debug("Installing file: {}", name);
+            LOGGER.debug("Installing file: {}", name);
             URL fileURL = addOnClassLoader.findResource(name);
             if (fileURL == null) {
-                logger.error("File not found in add-on {}: {}", addOn, name);
+                LOGGER.error("File not found in add-on {}: {}", addOn, name);
                 continue;
             }
             try (InputStream in = fileURL.openStream();
@@ -763,7 +763,7 @@ public final class AddOnInstaller {
                     out.write(buffer, 0, bytesRead);
                 }
             } catch (IOException e) {
-                logger.error(
+                LOGGER.error(
                         "Failed to install a file from add-on {}: {}",
                         addOn,
                         outfile.getAbsolutePath(),
@@ -851,12 +851,12 @@ public final class AddOnInstaller {
             if (name == null) {
                 continue;
             }
-            logger.debug("Uninstall file: {}", name);
+            LOGGER.debug("Uninstall file: {}", name);
             File file = new File(Constant.getZapHome(), name);
             try {
                 File parent = file.getParentFile();
                 if (file.exists() && !file.delete()) {
-                    logger.error("Failed to delete: {}", file.getAbsolutePath());
+                    LOGGER.error("Failed to delete: {}", file.getAbsolutePath());
                     uninstalledWithoutErrors = false;
                     if (postponedTasks != null) {
                         postponedTasks.addDeleteFileTask(file.toPath());
@@ -864,15 +864,15 @@ public final class AddOnInstaller {
                 }
                 callback.fileRemoved();
                 if (parent.isDirectory() && parent.list().length == 0) {
-                    logger.debug("Deleting: {}", parent.getAbsolutePath());
+                    LOGGER.debug("Deleting: {}", parent.getAbsolutePath());
                     if (!parent.delete()) {
                         // Ignore - check for <= 2 as on *nix '.' and '..' are returned
-                        logger.debug("Failed to delete: {}", parent.getAbsolutePath());
+                        LOGGER.debug("Failed to delete: {}", parent.getAbsolutePath());
                     }
                 }
                 deleteEmptyDirsCreatedForAddOnFiles(file);
             } catch (Exception e) {
-                logger.error("Failed to uninstall file {}", file.getAbsolutePath(), e);
+                LOGGER.error("Failed to uninstall file {}", file.getAbsolutePath(), e);
             }
         }
 
@@ -934,14 +934,14 @@ public final class AddOnInstaller {
     }
 
     private static void deleteEmptyDirs(File dir) {
-        logger.debug("Deleting dir {}", dir.getAbsolutePath());
+        LOGGER.debug("Deleting dir {}", dir.getAbsolutePath());
         for (File d : dir.listFiles()) {
             if (d.isDirectory()) {
                 deleteEmptyDirs(d);
             }
         }
         if (!dir.delete()) {
-            logger.debug("Failed to delete: {}", dir.getAbsolutePath());
+            LOGGER.debug("Failed to delete: {}", dir.getAbsolutePath());
         }
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnLoader.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnLoader.java
@@ -92,7 +92,7 @@ public class AddOnLoader extends URLClassLoader {
     private static final AddOnUninstallationProgressCallback NULL_CALLBACK =
             NullUninstallationProgressCallBack.getSingleton();
 
-    private static final Logger logger = LogManager.getLogger(AddOnLoader.class);
+    private static final Logger LOGGER = LogManager.getLogger(AddOnLoader.class);
 
     static {
         ClassLoader.registerAsParallelCapable();
@@ -142,7 +142,7 @@ public class AddOnLoader extends URLClassLoader {
             try {
                 addOnsStateConfig.load();
             } catch (ConfigurationException e) {
-                logger.warn("Failed to read add-ons' state file:", e);
+                LOGGER.warn("Failed to read add-ons' state file:", e);
             }
         }
 
@@ -158,7 +158,7 @@ public class AddOnLoader extends URLClassLoader {
                 try {
                     this.addDirectory(dir);
                 } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
         }
@@ -167,7 +167,7 @@ public class AddOnLoader extends URLClassLoader {
             try {
                 this.addURL(jar.toURI().toURL());
             } catch (MalformedURLException e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
 
@@ -268,14 +268,14 @@ public class AddOnLoader extends URLClassLoader {
 
     private boolean canLoadAddOn(AddOn ao) {
         if (blockList.contains(ao.getId())) {
-            logger.debug(
+            LOGGER.debug(
                     "Can't load add-on {} it is on the block list (add-on uninstalled but the file couldn't be removed).",
                     ao.getName());
             return false;
         }
 
         if (!ao.canLoadInCurrentVersion()) {
-            logger.debug(
+            LOGGER.debug(
                     "Can't load add-on {} because of ZAP version constraints; Not before={} Not from={} Current Version={}",
                     ao.getName(),
                     ao.getNotBeforeVersion(),
@@ -291,8 +291,8 @@ public class AddOnLoader extends URLClassLoader {
             AddOn ao, Collection<AddOn> availableAddOns) {
         AddOnRunRequirements reqs = ao.calculateRunRequirements(availableAddOns);
         if (!reqs.isRunnable()) {
-            if (logger.isDebugEnabled()) {
-                logger.debug(
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
                         "Can't run add-on {} because of missing requirements: {}",
                         ao.getName(),
                         AddOnRunIssuesUtils.getRunningIssues(reqs));
@@ -335,7 +335,7 @@ public class AddOnLoader extends URLClassLoader {
             putAddOnClassLoader(ao, addOnClassLoader);
             return addOnClassLoader;
         } catch (MalformedURLException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             throw new RuntimeException(
                     "Failed to convert URL for AddOnClassLoader " + ao.getFile().toURI(), e);
         }
@@ -414,15 +414,15 @@ public class AddOnLoader extends URLClassLoader {
 
     private void addDirectory(File dir) {
         if (dir == null) {
-            logger.error("Null directory supplied");
+            LOGGER.error("Null directory supplied");
             return;
         }
         if (!dir.exists()) {
-            logger.debug("No such directory: {}", dir.getAbsolutePath());
+            LOGGER.debug("No such directory: {}", dir.getAbsolutePath());
             return;
         }
         if (!dir.isDirectory()) {
-            logger.warn("Not a directory: {}", dir.getAbsolutePath());
+            LOGGER.warn("Not a directory: {}", dir.getAbsolutePath());
             return;
         }
 
@@ -641,7 +641,7 @@ public class AddOnLoader extends URLClassLoader {
         }
 
         if (!this.aoc.includesAddOn(ao.getId())) {
-            logger.warn("Trying to uninstall an add-on that is not installed: {}", ao.getId());
+            LOGGER.warn("Trying to uninstall an add-on that is not installed: {}", ao.getId());
             return false;
         }
 
@@ -656,7 +656,7 @@ public class AddOnLoader extends URLClassLoader {
         }
 
         if (!canUnloadAllExtensions(ao)) {
-            logger.debug("Can't dynamically unload all the extensions of: {}", ao);
+            LOGGER.debug("Can't dynamically unload all the extensions of: {}", ao);
             ao.setInstallationStatus(AddOn.InstallationStatus.UNINSTALLATION_FAILED);
             postponedTasks.addUninstallAddOnTask(ao);
             return false;
@@ -715,7 +715,7 @@ public class AddOnLoader extends URLClassLoader {
 
         if (addOn.getFile() != null && addOn.getFile().exists()) {
             if (!addOn.getFile().delete() && !upgrading) {
-                logger.debug("Can't delete {}", addOn.getFile().getAbsolutePath());
+                LOGGER.debug("Can't delete {}", addOn.getFile().getAbsolutePath());
                 this.blockList.add(addOn.getId());
                 this.saveBlockList();
             }
@@ -730,7 +730,7 @@ public class AddOnLoader extends URLClassLoader {
                 }
                 ResourceBundle.clearCache(addOnClassLoader);
             } catch (Exception e) {
-                logger.error("Failure while closing class loader of {} add-on:", addOn.getId(), e);
+                LOGGER.error("Failure while closing class loader of {} add-on:", addOn.getId(), e);
             }
             addOn.setClassLoader(null);
         }
@@ -751,7 +751,7 @@ public class AddOnLoader extends URLClassLoader {
                         extensionClassLoader.clearDependencies();
                         ResourceBundle.clearCache(extensionClassLoader);
                     } catch (Exception e) {
-                        logger.error(
+                        LOGGER.error(
                                 "Failure while closing class loader of extension '{}':",
                                 classname,
                                 e);
@@ -886,8 +886,8 @@ public class AddOnLoader extends URLClassLoader {
                     if (ext != null) {
                         extensions.add(ext);
                     }
-                } else if (logger.isDebugEnabled()) {
-                    logger.debug(
+                } else if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(
                             "Can't run extension '{}' of add-on '{}' because of missing requirements: {}",
                             extReqs.getClassname(),
                             addOn.getName(),
@@ -956,7 +956,7 @@ public class AddOnLoader extends URLClassLoader {
                                     ? ((AbstractPlugin) rule).getName()
                                     : ((PluginPassiveScanner) rule).getName();
                     if (StringUtils.isBlank(name)) {
-                        logger.log(
+                        LOGGER.log(
                                 Constant.isDevBuild() ? Level.ERROR : Level.WARN,
                                 "Scan rule {} does not have a name.",
                                 rule.getClass().getCanonicalName());
@@ -1044,7 +1044,7 @@ public class AddOnLoader extends URLClassLoader {
                 }
             } catch (Throwable e) {
                 // Often not an error
-                logger.debug(e.getMessage(), e);
+                LOGGER.debug(e.getMessage(), e);
             }
         }
         return listClass;
@@ -1078,7 +1078,7 @@ public class AddOnLoader extends URLClassLoader {
                 return getJarClassNames(
                         this.getClass().getClassLoader(), new File(new URI(jarFile)), packageName);
             } catch (URISyntaxException e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         } else {
             try {
@@ -1090,7 +1090,7 @@ public class AddOnLoader extends URLClassLoader {
                         packageName.replace('.', File.separatorChar),
                         new ClassRecurseDirFileFilter(true));
             } catch (URISyntaxException e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
         return Collections.emptyList();
@@ -1139,7 +1139,7 @@ public class AddOnLoader extends URLClassLoader {
                 }
             }
         } catch (Exception e) {
-            logger.error("Failed to open file: {}", file.getAbsolutePath(), e);
+            LOGGER.error("Failed to open file: {}", file.getAbsolutePath(), e);
         }
         return classNames;
     }
@@ -1162,7 +1162,7 @@ public class AddOnLoader extends URLClassLoader {
                 }
             }
         } catch (Exception e) {
-            logger.error("Failed to open file: {}", ao.getFile().getAbsolutePath(), e);
+            LOGGER.error("Failed to open file: {}", ao.getFile().getAbsolutePath(), e);
         }
         return classNames;
     }
@@ -1242,7 +1242,7 @@ public class AddOnLoader extends URLClassLoader {
         try {
             config.save();
         } catch (ConfigurationException e) {
-            logger.error("Failed to save list [{}]: {}", key, sb, e);
+            LOGGER.error("Failed to save list [{}]: {}", key, sb, e);
         }
     }
 
@@ -1295,7 +1295,7 @@ public class AddOnLoader extends URLClassLoader {
         try {
             return new Version(version);
         } catch (IllegalArgumentException e) {
-            logger.debug(
+            LOGGER.debug(
                     "Failed to create (legacy?) version with [{}] for runnable add-on [{}]",
                     version,
                     addOnName,
@@ -1305,7 +1305,7 @@ public class AddOnLoader extends URLClassLoader {
         try {
             return new Version(version + ".0.0");
         } catch (IllegalArgumentException e) {
-            logger.debug(
+            LOGGER.debug(
                     "Failed to create legacy version with [{}.0.0] for runnable add-on [{}]",
                     version,
                     addOnName,
@@ -1342,7 +1342,7 @@ public class AddOnLoader extends URLClassLoader {
         try {
             addOnsStateConfig.save();
         } catch (ConfigurationException e) {
-            logger.error("Failed to save state of runnable add-ons:", e);
+            LOGGER.error("Failed to save state of runnable add-ons:", e);
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/control/ExtensionFactory.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/ExtensionFactory.java
@@ -44,7 +44,7 @@ import org.zaproxy.zap.utils.ZapResourceBundleControl;
 
 public class ExtensionFactory {
 
-    private static Logger log = LogManager.getLogger(ExtensionFactory.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionFactory.class);
 
     private static Vector<Extension> listAllExtension = new Vector<>();
     private static TreeMap<String, Extension> mapAllExtension = new TreeMap<>();
@@ -79,9 +79,9 @@ public class ExtensionFactory {
                             return addOn.getId().compareTo(otherAddOn.getId());
                         }
                     });
-            log.info("Installed add-ons: {}", sortedAddOns);
+            LOGGER.info("Installed add-ons: {}", sortedAddOns);
         } else {
-            log.error("AddOnLoader initialised without additional directories");
+            LOGGER.error("AddOnLoader initialised without additional directories");
         }
         return addOnLoader;
     }
@@ -94,7 +94,7 @@ public class ExtensionFactory {
                                 new File(Constant.getZapInstall(), Constant.FOLDER_PLUGIN),
                                 new File(Constant.getZapHome(), Constant.FOLDER_PLUGIN)
                             });
-            log.info(
+            LOGGER.info(
                     "Installed add-ons: {}", addOnLoader.getAddOnCollection().getInstalledAddOns());
         }
         return addOnLoader;
@@ -102,7 +102,7 @@ public class ExtensionFactory {
 
     public static synchronized void loadAllExtension(
             ExtensionLoader extensionLoader, OptionsParam optionsParam) {
-        log.info("Loading extensions");
+        LOGGER.info("Loading extensions");
         List<Extension> listExts = new ArrayList<>(CoreFunctionality.getBuiltInExtensions());
 
         listExts.addAll(getAddOnLoader().getExtensions());
@@ -121,7 +121,7 @@ public class ExtensionFactory {
                 Integer order = iter.next();
                 Extension ext = mapOrderToExtension.get(order);
                 if (ext.isEnabled()) {
-                    log.debug("Ordered extension {} {}", order, ext.getName());
+                    LOGGER.debug("Ordered extension {} {}", order, ext.getName());
                 }
                 loadMessagesAndAddExtension(extensionLoader, ext);
             }
@@ -129,13 +129,13 @@ public class ExtensionFactory {
             // And then the unordered ones
             for (Extension ext : unorderedExtensions) {
                 if (ext.isEnabled()) {
-                    log.debug("Unordered extension {}", ext.getName());
+                    LOGGER.debug("Unordered extension {}", ext.getName());
                 }
                 loadMessagesAndAddExtension(extensionLoader, ext);
             }
         }
 
-        log.info("Extensions loaded");
+        LOGGER.info("Extensions loaded");
     }
 
     /**
@@ -162,13 +162,13 @@ public class ExtensionFactory {
                 && (extension.supportsLowMemory() || !Constant.isLowMemoryOptionSet())) {
             extensionLoader.addExtension(extension);
         } else if (!extension.supportsDb(Model.getSingleton().getDb().getType())) {
-            log.debug(
+            LOGGER.debug(
                     "Not loading extension {}: doesn't support {}",
                     extension.getName(),
                     Model.getSingleton().getDb().getType());
             extension.setEnabled(false);
         } else if (extension.supportsLowMemory() || !Constant.isLowMemoryOptionSet()) {
-            log.debug(
+            LOGGER.debug(
                     "Not loading extension {}: doesn't support low memory option",
                     extension.getName());
             extension.setEnabled(false);
@@ -186,7 +186,7 @@ public class ExtensionFactory {
             Extension extension,
             List<Extension> extsBeingProcessed) {
         if (extsBeingProcessed.contains(extension)) {
-            log.error("Dependency loop with \"{}\" and {}", extension, extsBeingProcessed);
+            LOGGER.error("Dependency loop with \"{}\" and {}", extension, extsBeingProcessed);
             return false;
         }
 
@@ -221,7 +221,8 @@ public class ExtensionFactory {
 
     private static void logUnableToLoadExt(
             Extension extension, String reason, Class<? extends Extension> dependency) {
-        log.warn("Unable to load \"{}\", {}: {}", extension, reason, dependency.getCanonicalName());
+        LOGGER.warn(
+                "Unable to load \"{}\", {}: {}", extension, reason, dependency.getCanonicalName());
     }
 
     public static synchronized void addAddOnExtension(
@@ -230,7 +231,7 @@ public class ExtensionFactory {
             addExtensionImpl(extension, Model.getSingleton().getOptionsParam().getExtensionParam());
 
             if (extension.isEnabled()) {
-                log.debug("Adding new extension {}", extension.getName());
+                LOGGER.debug("Adding new extension {}", extension.getName());
             }
             loadMessagesAndAddExtension(extensionLoader, extension);
         }
@@ -240,7 +241,7 @@ public class ExtensionFactory {
         if (mapAllExtension.containsKey(extension.getName())) {
             if (mapAllExtension.get(extension.getName()).getClass().equals(extension.getClass())) {
                 // Same name, same class so ignore
-                log.error(
+                LOGGER.error(
                         "Duplicate extension: {} {}",
                         extension.getName(),
                         extension.getClass().getCanonicalName());
@@ -248,14 +249,14 @@ public class ExtensionFactory {
                 return;
             }
             // Same name but different class, log but still load it
-            log.error(
+            LOGGER.error(
                     "Duplicate extension name: {} {} {}",
                     extension.getName(),
                     extension.getClass().getCanonicalName(),
                     mapAllExtension.get(extension.getName()).getClass().getCanonicalName());
         }
         if (extension.isDepreciated()) {
-            log.debug("Depreciated extension {}", extension.getName());
+            LOGGER.debug("Depreciated extension {}", extension.getName());
             extension.setEnabled(false);
             return;
         }
@@ -272,7 +273,7 @@ public class ExtensionFactory {
         if (order == 0) {
             unorderedExtensions.add(extension);
         } else if (mapOrderToExtension.containsKey(order)) {
-            log.error(
+            LOGGER.error(
                     "Duplicate order {} {}/{} already registered, {}/{} will be added as an unordered extension",
                     order,
                     mapOrderToExtension.get(order).getName(),
@@ -296,7 +297,7 @@ public class ExtensionFactory {
             }
             for (Extension ext : listExts) {
                 if (ext.isEnabled()) {
-                    log.debug("Adding new extension {}", ext.getName());
+                    LOGGER.debug("Adding new extension {}", ext.getName());
                 }
                 loadMessagesAndAddExtension(extensionLoader, ext);
             }

--- a/zap/src/main/java/org/zaproxy/zap/db/sql/DbSQL.java
+++ b/zap/src/main/java/org/zaproxy/zap/db/sql/DbSQL.java
@@ -56,7 +56,7 @@ public class DbSQL implements DatabaseListener {
     private static DbSQL singleton = null;
     private static SqlDatabaseServer dbServer = null;
 
-    private static final Logger logger = LogManager.getLogger(DbSQL.class);
+    private static final Logger LOGGER = LogManager.getLogger(DbSQL.class);
 
     private Map<String, StatementPool> stmtPool = new HashMap<>();
 
@@ -119,7 +119,7 @@ public class DbSQL implements DatabaseListener {
         try (Reader sqlReader = new FileReader(sqlFile)) {
             sqlProperties.load(sqlReader);
         } catch (Exception e) {
-            logger.error("No SQL properties file for db type {}", sqlFile.getAbsolutePath());
+            LOGGER.error("No SQL properties file for db type {}", sqlFile.getAbsolutePath());
             throw new DatabaseException(
                     "Missing SQL properties file: " + sqlFile.getAbsolutePath());
         }
@@ -260,11 +260,11 @@ public class DbSQL implements DatabaseListener {
                         ps.close();
                         Stats.incCounter("sqldb.conn.closed");
                     } catch (SQLException e) {
-                        logger.error("Error closing prepared statement", e);
+                        LOGGER.error("Error closing prepared statement", e);
                     }
                 }
             } else {
-                logger.error(
+                LOGGER.error(
                         "Releasing prepared statement not in a pool",
                         new InvalidParameterException());
             }

--- a/zap/src/main/java/org/zaproxy/zap/db/sql/HsqldbDatabaseServer.java
+++ b/zap/src/main/java/org/zaproxy/zap/db/sql/HsqldbDatabaseServer.java
@@ -34,7 +34,7 @@ public class HsqldbDatabaseServer extends SqlDatabaseServer {
 
     public static final int DEFAULT_SERVER_PORT = 9001;
 
-    private static final Logger logger = LogManager.getLogger(HsqldbDatabaseServer.class);
+    private static final Logger LOGGER = LogManager.getLogger(HsqldbDatabaseServer.class);
 
     public HsqldbDatabaseServer(String dbname) throws ClassNotFoundException, Exception {
         super(dbname);
@@ -57,7 +57,7 @@ public class HsqldbDatabaseServer extends SqlDatabaseServer {
                         propsStream.close();
                     }
                 } catch (IOException e) {
-                    logger.debug(e.getMessage(), e);
+                    LOGGER.debug(e.getMessage(), e);
                 }
             }
             String version = (String) dbProps.get("version");

--- a/zap/src/main/java/org/zaproxy/zap/db/sql/SqlDatabaseServer.java
+++ b/zap/src/main/java/org/zaproxy/zap/db/sql/SqlDatabaseServer.java
@@ -31,7 +31,7 @@ public class SqlDatabaseServer implements DatabaseServer {
 
     public static final int DEFAULT_SERVER_PORT = 9001;
 
-    private static final Logger logger = LogManager.getLogger(SqlDatabaseServer.class);
+    private static final Logger LOGGER = LogManager.getLogger(SqlDatabaseServer.class);
 
     private String dbUrl = null;
     private String dbUser = null;
@@ -63,17 +63,17 @@ public class SqlDatabaseServer implements DatabaseServer {
                 conn = DriverManager.getConnection(dbUrl, dbUser, dbPassword);
                 return conn;
             } catch (SQLException e) {
-                logger.warn(e.getMessage(), e);
+                LOGGER.warn(e.getMessage(), e);
                 if (i == 4) {
                     throw e;
                 }
-                logger.warn("Recovering {} times", i);
+                LOGGER.warn("Recovering {} times", i);
             }
 
             try {
                 Thread.sleep(500);
             } catch (InterruptedException e) {
-                logger.debug(e.getMessage(), e);
+                LOGGER.debug(e.getMessage(), e);
             }
         }
         return conn;

--- a/zap/src/main/java/org/zaproxy/zap/db/sql/SqlTableHistory.java
+++ b/zap/src/main/java/org/zaproxy/zap/db/sql/SqlTableHistory.java
@@ -66,7 +66,7 @@ public class SqlTableHistory extends SqlAbstractTable implements TableHistory {
     private static boolean isExistStatusCode = false;
 
     // ZAP: Added logger
-    private static final Logger log = LogManager.getLogger(SqlTableHistory.class);
+    private static final Logger LOGGER = LogManager.getLogger(SqlTableHistory.class);
 
     private boolean bodiesAsBytes;
 
@@ -111,7 +111,7 @@ public class SqlTableHistory extends SqlAbstractTable implements TableHistory {
                     try {
                         stmt.close();
                     } catch (SQLException e) {
-                        log.debug(e.getMessage(), e);
+                        LOGGER.debug(e.getMessage(), e);
                     }
                 }
             }
@@ -172,14 +172,14 @@ public class SqlTableHistory extends SqlAbstractTable implements TableHistory {
                     }
                 }
             } catch (SQLException e) {
-                log.error("An error occurred while modifying a column length on {}", TABLE_NAME);
-                log.error(
+                LOGGER.error("An error occurred while modifying a column length on {}", TABLE_NAME);
+                LOGGER.error(
                         "The 'Maximum Request Body Size' value in the Database Options needs to be set to at least {} to avoid this error",
                         requestbodysizeindb);
-                log.error(
+                LOGGER.error(
                         "The 'Maximum Response Body Size' value in the Database Options needs to be set to at least {}  to avoid this error",
                         responsebodysizeindb);
-                log.error("The SQL Exception was:", e);
+                LOGGER.error("The SQL Exception was:", e);
                 throw e;
             }
         } catch (SQLException e) {
@@ -771,7 +771,7 @@ public class SqlTableHistory extends SqlAbstractTable implements TableHistory {
                     psReadCache.close();
                 } catch (Exception e) {
                     // ZAP: Log exceptions
-                    log.warn(e.getMessage(), e);
+                    LOGGER.warn(e.getMessage(), e);
                 }
             }
 
@@ -822,7 +822,7 @@ public class SqlTableHistory extends SqlAbstractTable implements TableHistory {
                     psReadCache.close();
                 } catch (Exception e) {
                     // ZAP: Log exceptions
-                    log.warn(e.getMessage(), e);
+                    LOGGER.warn(e.getMessage(), e);
                 }
             }
 

--- a/zap/src/main/java/org/zaproxy/zap/eventBus/SimpleEventBus.java
+++ b/zap/src/main/java/org/zaproxy/zap/eventBus/SimpleEventBus.java
@@ -56,7 +56,7 @@ public class SimpleEventBus implements EventBus {
      */
     private final Lock regMgmtLock = new ReentrantLock(true);
 
-    private static Logger log = LogManager.getLogger(SimpleEventBus.class);
+    private static final Logger LOGGER = LogManager.getLogger(SimpleEventBus.class);
 
     @Override
     public void registerPublisher(EventPublisher publisher, String... eventTypes) {
@@ -80,7 +80,7 @@ public class SimpleEventBus implements EventBus {
                                         .getClass()
                                         .getCanonicalName());
             }
-            log.debug("registerPublisher {}", publisherName);
+            LOGGER.debug("registerPublisher {}", publisherName);
 
             RegisteredPublisher regProd =
                     new RegisteredPublisher(publisher, new HashSet<>(asList(eventTypes)));
@@ -122,7 +122,7 @@ public class SimpleEventBus implements EventBus {
         regMgmtLock.lock();
         try {
             String publisherName = publisher.getPublisherName();
-            log.debug("unregisterPublisher {}", publisherName);
+            LOGGER.debug("unregisterPublisher {}", publisherName);
             if (nameToPublisher.remove(publisherName) == null) {
                 throw new InvalidParameterException(
                         "Publisher with name " + publisherName + " not registered");
@@ -149,7 +149,7 @@ public class SimpleEventBus implements EventBus {
 
         regMgmtLock.lock();
         try {
-            log.debug(
+            LOGGER.debug(
                     "registerConsumer {} for {}",
                     consumer.getClass().getCanonicalName(),
                     publisherName);
@@ -174,7 +174,7 @@ public class SimpleEventBus implements EventBus {
 
         regMgmtLock.lock();
         try {
-            log.debug("unregisterConsumer {}", consumer.getClass().getCanonicalName());
+            LOGGER.debug("unregisterConsumer {}", consumer.getClass().getCanonicalName());
             nameToPublisher.values().forEach(publisher -> publisher.removeConsumer(consumer));
             // Check to see if its cached waiting for a publisher
             removeDanglingConsumer(consumer);
@@ -196,7 +196,7 @@ public class SimpleEventBus implements EventBus {
 
         regMgmtLock.lock();
         try {
-            log.debug(
+            LOGGER.debug(
                     "unregisterConsumer {} for {}",
                     consumer.getClass().getCanonicalName(),
                     publisherName);
@@ -226,7 +226,7 @@ public class SimpleEventBus implements EventBus {
             throw new InvalidParameterException("Publisher not registered: " + publisherName);
         }
 
-        log.debug("publishSyncEvent {} from {}", eventType, publisherName);
+        LOGGER.debug("publishSyncEvent {} from {}", eventType, publisherName);
         if (!regPublisher.isEventRegistered(eventType)) {
             throw new InvalidParameterException(
                     "Event type: " + eventType + " not registered for publisher: " + publisherName);
@@ -240,7 +240,7 @@ public class SimpleEventBus implements EventBus {
                             try {
                                 regCon.getConsumer().eventReceived(event);
                             } catch (Exception e) {
-                                log.error(e.getMessage(), e);
+                                LOGGER.error(e.getMessage(), e);
                             }
                         });
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertAPI.java
@@ -112,7 +112,7 @@ public class AlertAPI extends ApiImplementor {
     private static final int NO_CONFIDENCE_ID = -1;
 
     private ExtensionAlert extension = null;
-    private static final Logger logger = LogManager.getLogger(AlertAPI.class);
+    private static final Logger LOGGER = LogManager.getLogger(AlertAPI.class);
 
     public AlertAPI(ExtensionAlert ext) {
         this.extension = ext;
@@ -201,7 +201,7 @@ public class AlertAPI extends ApiImplementor {
                 recordAlert = tableAlert.read(this.getParam(params, PARAM_ID, -1));
                 alertTags = tableAlertTag.getTagsByAlertId(this.getParam(params, PARAM_ID, -1));
             } catch (DatabaseException e) {
-                logger.error("Failed to read the alert from the session:", e);
+                LOGGER.error("Failed to read the alert from the session:", e);
                 throw new ApiException(ApiException.Type.INTERNAL_ERROR);
             }
             if (recordAlert == null) {
@@ -484,7 +484,7 @@ public class AlertAPI extends ApiImplementor {
                 }
             }
         } catch (DatabaseException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             throw new ApiException(ApiException.Type.INTERNAL_ERROR);
         }
     }
@@ -626,7 +626,7 @@ public class AlertAPI extends ApiImplementor {
         try {
             recAlert = Model.getSingleton().getDb().getTableAlert().read(alertId);
         } catch (DatabaseException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             throw new ApiException(ApiException.Type.INTERNAL_ERROR, e);
         }
 
@@ -640,7 +640,7 @@ public class AlertAPI extends ApiImplementor {
         try {
             extension.updateAlert(updatedAlert);
         } catch (HttpMalformedHeaderException | DatabaseException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             throw new ApiException(ApiException.Type.INTERNAL_ERROR, e);
         }
     }
@@ -662,7 +662,7 @@ public class AlertAPI extends ApiImplementor {
             if (e.getMessage() == null) {
                 throw new ApiException(ApiException.Type.DOES_NOT_EXIST, PARAM_MESSAGE_ID);
             }
-            logger.error("Failed to read the history record:", e);
+            LOGGER.error("Failed to read the history record:", e);
             throw new ApiException(ApiException.Type.INTERNAL_ERROR, e);
         }
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertAddDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertAddDialog.java
@@ -39,7 +39,7 @@ import org.parosproxy.paros.network.HttpMessage;
 @SuppressWarnings("serial")
 public class AlertAddDialog extends AbstractDialog {
 
-    private static final Logger logger = LogManager.getLogger(AlertAddDialog.class);
+    private static final Logger LOGGER = LogManager.getLogger(AlertAddDialog.class);
 
     private static final long serialVersionUID = 1L;
 
@@ -203,7 +203,7 @@ public class AlertAddDialog extends AbstractDialog {
                                     extAlert.alertFound(alert, historyRef);
                                 }
                             } catch (Exception ex) {
-                                logger.error(ex.getMessage(), ex);
+                                LOGGER.error(ex.getMessage(), ex);
                             }
                             clearAndCloseDialog();
                         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertPanel.java
@@ -79,7 +79,7 @@ public class AlertPanel extends AbstractPanel {
     public static final String ALERT_TREE_PANEL_NAME = "treeAlert";
 
     private static final long serialVersionUID = 1L;
-    private static final Logger logger = LogManager.getLogger(AlertPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(AlertPanel.class);
 
     private ViewDelegate view = null;
     private JTree treeAlert = null;
@@ -659,7 +659,7 @@ public class AlertPanel extends AbstractPanel {
                         }
                     });
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertTreeModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertTreeModel.java
@@ -37,7 +37,7 @@ class AlertTreeModel extends DefaultTreeModel {
     private static final Comparator<AlertNode> ALERT_CHILD_COMPARATOR =
             new AlertChildNodeComparator();
 
-    private static Logger logger = LogManager.getLogger(AlertTreeModel.class);
+    private static final Logger LOGGER = LogManager.getLogger(AlertTreeModel.class);
 
     AlertTreeModel() {
         super(
@@ -60,7 +60,7 @@ class AlertTreeModel extends DefaultTreeModel {
                             }
                         });
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -131,7 +131,7 @@ class AlertTreeModel extends DefaultTreeModel {
                             }
                         });
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertViewPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertViewPanel.java
@@ -80,7 +80,7 @@ import org.zaproxy.zap.view.ZapTable;
 public class AlertViewPanel extends AbstractPanel {
 
     private static final long serialVersionUID = 1L;
-    private static final Logger logger = LogManager.getLogger(AlertViewPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(AlertViewPanel.class);
 
     private static final int UNDEFINED_ID = -1;
 
@@ -717,7 +717,7 @@ public class AlertViewPanel extends AbstractPanel {
                         }
                     });
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -776,7 +776,7 @@ public class AlertViewPanel extends AbstractPanel {
                 uri = historyRef.getURI().toString();
                 msg = historyRef.getHttpMessage();
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         } else if (originalAlert != null) {
             uri = originalAlert.getUri();
@@ -812,7 +812,7 @@ public class AlertViewPanel extends AbstractPanel {
                 this.alertUrl.setText(msg.getRequestHeader().getURI().toString());
             }
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -73,7 +73,7 @@ public class ExtensionAlert extends ExtensionAdaptor
         implements SessionChangedListener, XmlReporterExtension, OptionsChangedListener {
 
     public static final String NAME = "ExtensionAlert";
-    private static final Logger logger = LogManager.getLogger(ExtensionAlert.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionAlert.class);
     private Map<Integer, HistoryReference> hrefs = new HashMap<>();
     private AlertTreeModel treeModel = null;
     private AlertTreeModel filteredTreeModel = null;
@@ -139,20 +139,20 @@ public class ExtensionAlert extends ExtensionAdaptor
         if (filename != null && filename.length() > 0) {
             File file = new File(filename);
             if (!file.isFile() || !file.canRead()) {
-                logger.error("Cannot read alert overrides file {}", file.getAbsolutePath());
+                LOGGER.error("Cannot read alert overrides file {}", file.getAbsolutePath());
                 return false;
             }
 
             try (BufferedReader br =
                     Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
                 this.alertOverrides.load(br);
-                logger.info(
+                LOGGER.info(
                         "Read {} overrides from {}",
                         this.alertOverrides.size(),
                         file.getAbsolutePath());
                 return true;
             } catch (IOException e) {
-                logger.error("Failed to read alert overrides file {}", file.getAbsolutePath(), e);
+                LOGGER.error("Failed to read alert overrides file {}", file.getAbsolutePath(), e);
                 return false;
             }
         }
@@ -179,7 +179,7 @@ public class ExtensionAlert extends ExtensionAdaptor
         }
 
         try {
-            logger.debug("alertFound {} {}", alert.getName(), alert.getUri());
+            LOGGER.debug("alertFound {} {}", alert.getName(), alert.getUri());
             if (ref == null) {
                 ref = alert.getHistoryRef();
             }
@@ -222,7 +222,7 @@ public class ExtensionAlert extends ExtensionAdaptor
 
                 ref.addAlert(alert);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
 
             addAlertToTree(alert);
@@ -233,13 +233,13 @@ public class ExtensionAlert extends ExtensionAdaptor
             publishAlertEvent(alert, AlertEventPublisher.ALERT_ADDED_EVENT);
 
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
     private static boolean isInvalid(Alert alert) {
         if (alert.getUri().isEmpty() || alert.getMessage() == null) {
-            logger.error(
+            LOGGER.error(
                     "Attempting to raise an alert without URI or HTTP message, Plugin ID: {} Alert Name:{}\n\t{}",
                     alert.getPluginId(),
                     alert.getName(),
@@ -367,7 +367,7 @@ public class ExtensionAlert extends ExtensionAdaptor
                             }
                         });
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -461,7 +461,7 @@ public class ExtensionAlert extends ExtensionAdaptor
     }
 
     public void updateAlert(Alert alert) throws HttpMalformedHeaderException, DatabaseException {
-        logger.debug("updateAlert {} {}", alert.getName(), alert.getUri());
+        LOGGER.debug("updateAlert {} {}", alert.getName(), alert.getUri());
         HistoryReference hRef = hrefs.get(alert.getSourceHistoryId());
         if (hRef != null) {
             updateAlertInDB(alert);
@@ -508,7 +508,7 @@ public class ExtensionAlert extends ExtensionAdaptor
     }
 
     public void displayAlert(Alert alert) {
-        logger.debug("displayAlert {} {}", alert.getName(), alert.getUri());
+        LOGGER.debug("displayAlert {} {}", alert.getName(), alert.getUri());
         this.alertPanel.getAlertViewPanel().displayAlert(alert);
     }
 
@@ -529,7 +529,7 @@ public class ExtensionAlert extends ExtensionAdaptor
                             }
                         });
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -564,7 +564,7 @@ public class ExtensionAlert extends ExtensionAdaptor
                             }
                         });
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -584,7 +584,7 @@ public class ExtensionAlert extends ExtensionAdaptor
         try {
             refreshAlert(session);
         } catch (DatabaseException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
         setTreeModel(getTreeModel());
     }
@@ -683,13 +683,13 @@ public class ExtensionAlert extends ExtensionAdaptor
     }
 
     public void deleteAlert(Alert alert) {
-        logger.debug("deleteAlert {} {}", alert.getName(), alert.getUri());
+        LOGGER.debug("deleteAlert {} {}", alert.getName(), alert.getUri());
 
         try {
             getModel().getDb().getTableAlert().deleteAlert(alert.getAlertId());
             getModel().getDb().getTableAlertTag().deleteAllTagsForAlert(alert.getAlertId());
         } catch (DatabaseException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         deleteAlertFromDisplay(alert);
@@ -701,7 +701,7 @@ public class ExtensionAlert extends ExtensionAdaptor
             getModel().getDb().getTableAlert().deleteAllAlerts();
             getModel().getDb().getTableAlertTag().deleteAllTags();
         } catch (DatabaseException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         if (!Constant.isLowMemoryOptionSet()) {
@@ -748,7 +748,7 @@ public class ExtensionAlert extends ExtensionAdaptor
                             }
                         });
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -789,7 +789,7 @@ public class ExtensionAlert extends ExtensionAdaptor
                     getModel().getDb().getTableAlert().deleteAlert(alert.getAlertId());
                     getModel().getDb().getTableAlertTag().deleteAllTagsForAlert(alert.getAlertId());
                 } catch (DatabaseException e) {
-                    logger.error("Failed to delete alert with ID: {}", alert.getAlertId(), e);
+                    LOGGER.error("Failed to delete alert with ID: {}", alert.getAlertId(), e);
                 }
             }
 
@@ -883,7 +883,7 @@ public class ExtensionAlert extends ExtensionAdaptor
                 }
             }
         } catch (DatabaseException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
         return allAlerts;
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/PopupMenuAlert.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/PopupMenuAlert.java
@@ -32,7 +32,7 @@ public class PopupMenuAlert extends PopupMenuItemHistoryReferenceContainer {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Logger logger = LogManager.getLogger(PopupMenuAlert.class);
+    private static final Logger LOGGER = LogManager.getLogger(PopupMenuAlert.class);
 
     private final ExtensionAlert extension;
 
@@ -55,13 +55,13 @@ public class PopupMenuAlert extends PopupMenuItemHistoryReferenceContainer {
             try {
                 extension.showAlertAddDialog(href.getHttpMessage(), HistoryReference.TYPE_SCANNER);
             } catch (HttpMalformedHeaderException | DatabaseException e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         } else if (invoker == Invoker.FUZZER_PANEL) {
             try {
                 extension.showAlertAddDialog(href.getHttpMessage(), HistoryReference.TYPE_FUZZER);
             } catch (HttpMalformedHeaderException | DatabaseException e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         } else {
             extension.showAlertAddDialog(href);

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/PopupMenuItemAlert.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/PopupMenuItemAlert.java
@@ -46,7 +46,7 @@ public abstract class PopupMenuItemAlert extends ExtensionPopupMenuItem {
     private final boolean multiSelect;
     private final ExtensionAlert extAlert;
 
-    private static final Logger log = LogManager.getLogger(PopupMenuItemAlert.class);
+    private static final Logger LOGGER = LogManager.getLogger(PopupMenuItemAlert.class);
 
     /**
      * Constructs a {@code PopupMenuItemAlert} with the given label and with no support for multiple
@@ -219,7 +219,7 @@ public abstract class PopupMenuItemAlert extends ExtensionPopupMenuItem {
                 Set<Alert> alerts = getAlertNodes();
                 performActions(alerts);
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/PopupMenuShowAlert.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/PopupMenuShowAlert.java
@@ -33,7 +33,7 @@ public class PopupMenuShowAlert extends JMenuItem implements Comparable<PopupMen
     private final ExtensionAlert extension;
     private final Alert alert;
 
-    private static final Logger log = LogManager.getLogger(ExtensionPopupMenuItem.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionPopupMenuItem.class);
 
     public PopupMenuShowAlert(String name, ExtensionAlert extension, Alert alert) {
         super(name);
@@ -49,7 +49,7 @@ public class PopupMenuShowAlert extends JMenuItem implements Comparable<PopupMen
                             PopupMenuShowAlert.this.extension.showAlertEditDialog(
                                     PopupMenuShowAlert.this.alert);
                         } catch (Exception e2) {
-                            log.error(e2.getMessage(), e2);
+                            LOGGER.error(e2.getMessage(), e2);
                         }
                     }
                 });

--- a/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/AntiCsrfParam.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/AntiCsrfParam.java
@@ -32,7 +32,7 @@ import org.zaproxy.zap.extension.api.ZapApiIgnore;
 
 public class AntiCsrfParam extends AbstractParam {
 
-    private static final Logger logger = LogManager.getLogger(AntiCsrfParam.class);
+    private static final Logger LOGGER = LogManager.getLogger(AntiCsrfParam.class);
 
     private static final String ANTI_CSRF_BASE_KEY = "anticsrf";
 
@@ -93,7 +93,7 @@ public class AntiCsrfParam extends AbstractParam {
                 }
             }
         } catch (ConversionException e) {
-            logger.error("Error while loading anti CSRF tokens: {}", e.getMessage(), e);
+            LOGGER.error("Error while loading anti CSRF tokens: {}", e.getMessage(), e);
             this.tokens = new ArrayList<>(DEFAULT_TOKENS_NAMES.length);
             this.enabledTokensNames = new ArrayList<>(DEFAULT_TOKENS_NAMES.length);
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRF.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRF.java
@@ -72,7 +72,7 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
     private OptionsAntiCsrfPanel optionsAntiCsrfPanel = null;
     private PopupMenuGenerateForm popupMenuGenerateForm = null;
 
-    private static Logger log = LogManager.getLogger(ExtensionAntiCSRF.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionAntiCSRF.class);
 
     private AntiCsrfParam antiCsrfParam;
     private AntiCsrfDetectScanner antiCsrfDetectScanner;
@@ -233,7 +233,7 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
     }
 
     public void registerAntiCsrfToken(AntiCsrfToken token) {
-        log.debug(
+        LOGGER.debug(
                 "registerAntiCsrfToken {} {}",
                 token.getMsg().getRequestHeader().getURI(),
                 token.getValue());
@@ -252,7 +252,7 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
                 token.setHistoryReferenceId(hRef.getHistoryId());
                 valueToToken.put(getURLEncode(token.getValue()), token);
             } catch (HttpMalformedHeaderException | DatabaseException e) {
-                log.error("Failed to persist the message: ", e);
+                LOGGER.error("Failed to persist the message: ", e);
             }
         }
     }
@@ -351,7 +351,7 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
 
         if (formElements != null && formElements.size() > 0) {
             // Loop through all of the FORM tags
-            log.debug("Found {} forms", formElements.size());
+            LOGGER.debug("Found {} forms", formElements.size());
             int formIndex = 0;
 
             for (Element formElement : formElements) {
@@ -359,7 +359,7 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
 
                 if (inputElements != null && inputElements.size() > 0) {
                     // Loop through all of the INPUT elements
-                    log.debug("Found {} inputs", inputElements.size());
+                    LOGGER.debug("Found {} inputs", inputElements.size());
                     for (Element inputElement : inputElements) {
                         String value = inputElement.getAttributeValue("VALUE");
                         if (value == null) {
@@ -437,7 +437,7 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
                 }
             }
         } catch (DatabaseException | HttpMalformedHeaderException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -588,13 +588,13 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
             tokenValue = getTokenValue(tokenMsg, antiCsrfToken.getName());
 
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         if (tokenValue != null) {
             // Replace token value - only supported in the body right now
-            if (log.isDebugEnabled()) {
-                log.debug(
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(
                         "regenerateAntiCsrfToken replacing {} with {}",
                         antiCsrfToken.getValue(),
                         getURLEncode(tokenValue));
@@ -618,7 +618,7 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
         try {
             result = URLEncoder.encode(msg, "UTF8");
         } catch (UnsupportedEncodingException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
         return result;
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/API.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/API.java
@@ -133,7 +133,7 @@ public class API {
     private org.parosproxy.paros.core.proxy.ProxyParam proxyParam;
 
     private Random random = new SecureRandom();
-    private static final Logger logger = LogManager.getLogger(API.class);
+    private static final Logger LOGGER = LogManager.getLogger(API.class);
 
     private static synchronized API newInstance() {
         if (api == null) {
@@ -167,16 +167,16 @@ public class API {
      */
     public void registerApiImplementor(ApiImplementor impl) {
         if (implementors.get(impl.getPrefix()) != null) {
-            logger.error(
+            LOGGER.error(
                     "Second attempt to register API implementor with prefix of {}",
                     impl.getPrefix());
             return;
         }
         implementors.put(impl.getPrefix(), impl);
         for (String shortcut : impl.getApiShortcuts()) {
-            logger.debug("Registering API shortcut: {}", shortcut);
+            LOGGER.debug("Registering API shortcut: {}", shortcut);
             if (this.shortcuts.containsKey(shortcut)) {
-                logger.error("Duplicate API shortcut: {}", shortcut);
+                LOGGER.error("Duplicate API shortcut: {}", shortcut);
             }
             this.shortcuts.put("/" + shortcut, impl);
         }
@@ -194,7 +194,7 @@ public class API {
      */
     public void removeApiImplementor(ApiImplementor impl) {
         if (!implementors.containsKey(impl.getPrefix())) {
-            logger.warn(
+            LOGGER.warn(
                     "Attempting to remove an API implementor not registered, with prefix: {}",
                     impl.getPrefix());
             return;
@@ -203,7 +203,7 @@ public class API {
         for (String shortcut : impl.getApiShortcuts()) {
             String key = "/" + shortcut;
             if (this.shortcuts.containsKey(key)) {
-                logger.debug("Removing registered API shortcut: {}", shortcut);
+                LOGGER.debug("Removing registered API shortcut: {}", shortcut);
                 this.shortcuts.remove(key);
             }
         }
@@ -264,13 +264,13 @@ public class API {
             if (getOptionsParamApi().isPermittedAddress(requestHeader.getHostName())) {
                 return true;
             }
-            logger.warn(
+            LOGGER.warn(
                     "Request to API URL {} with host header {} not permitted",
                     requestHeader.getURI(),
                     requestHeader.getHostName());
             return false;
         }
-        logger.warn(
+        LOGGER.warn(
                 "Request to API URL {} from {} not permitted",
                 requestHeader.getURI(),
                 requestHeader.getSenderAddress().getHostAddress());
@@ -302,7 +302,7 @@ public class API {
 
         // Check for callbacks
         if (url.contains(CALL_BACK_URL)) {
-            logger.debug("handleApiRequest Callback: {}", url);
+            LOGGER.debug("handleApiRequest Callback: {}", url);
             for (Entry<String, ApiImplementor> callback : callBacks.entrySet()) {
                 if (url.startsWith(callback.getKey())) {
                     callbackImpl = callback.getValue();
@@ -321,7 +321,7 @@ public class API {
                 }
             }
             if (callbackImpl == null) {
-                logger.warn(
+                LOGGER.warn(
                         "Request to callback URL {} from {} not found - this could be a callback url from a previous session or possibly an attempt to attack ZAP",
                         requestHeader.getURI(),
                         requestHeader.getSenderAddress().getHostAddress());
@@ -350,11 +350,11 @@ public class API {
         }
         if (getOptionsParamApi().isSecureOnly() && !requestHeader.isSecure()) {
             // Insecure request with secure only set, always ignore
-            logger.debug("handleApiRequest rejecting insecure request");
+            LOGGER.debug("handleApiRequest rejecting insecure request");
             return new HttpMessage();
         }
 
-        logger.debug("handleApiRequest {}", url);
+        LOGGER.debug("handleApiRequest {}", url);
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader(requestHeader);
@@ -692,7 +692,7 @@ public class API {
                 return responseToHtml(res);
             default:
                 // Should not happen, format validation should prevent this case...
-                logger.error("Unhandled format: {}", format);
+                LOGGER.error("Unhandled format: {}", format);
                 throw new ApiException(ApiException.Type.INTERNAL_ERROR);
         }
     }
@@ -834,7 +834,7 @@ public class API {
             return sw.toString();
 
         } catch (Exception e) {
-            logger.error("Failed to convert API response to XML: {}", e.getMessage(), e);
+            LOGGER.error("Failed to convert API response to XML: {}", e.getMessage(), e);
             throw new ApiException(ApiException.Type.INTERNAL_ERROR, e);
         }
     }
@@ -865,12 +865,12 @@ public class API {
                     // Carry on anyway
                     Exception apiException =
                             new ApiException(ApiException.Type.ILLEGAL_PARAMETER, params, e);
-                    logger.error(apiException.getMessage(), apiException);
+                    LOGGER.error(apiException.getMessage(), apiException);
                 }
             } else {
                 // Carry on anyway
                 Exception e = new ApiException(ApiException.Type.ILLEGAL_PARAMETER, params);
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
         return jp;
@@ -898,7 +898,7 @@ public class API {
     public String getCallBackUrl(ApiImplementor impl, String site) {
         String url = site + CALL_BACK_URL + random.nextLong();
         this.callBacks.put(url, impl);
-        logger.debug("Callback {} registered for {}", url, impl.getClass().getCanonicalName());
+        LOGGER.debug("Callback {} registered for {}", url, impl.getClass().getCanonicalName());
         return url;
     }
 
@@ -912,7 +912,7 @@ public class API {
      * @see #removeApiImplementor(ApiImplementor)
      */
     public void removeCallBackUrl(String url) {
-        logger.debug("Callback {} removed", url);
+        LOGGER.debug("Callback {} removed", url);
         this.callBacks.remove(url);
     }
 
@@ -930,7 +930,7 @@ public class API {
         if (impl == null) {
             throw new IllegalArgumentException("Parameter impl must not be null.");
         }
-        logger.debug("All callbacks removed for {}", impl.getClass().getCanonicalName());
+        LOGGER.debug("All callbacks removed for {}", impl.getClass().getCanonicalName());
         this.callBacks.values().removeIf(impl::equals);
     }
 
@@ -1005,7 +1005,7 @@ public class API {
             HttpRequestHeader requestHeader = msg.getRequestHeader();
             return this.hasValidKey(requestHeader, getParams(requestHeader));
         } catch (ApiException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             return false;
         }
     }
@@ -1024,7 +1024,7 @@ public class API {
             try {
                 apiPath = reqHeader.getURI().getPath();
             } catch (URIException e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
                 return false;
             }
             String nonceParam = reqHeader.getHeader(HttpHeader.X_ZAP_API_NONCE);
@@ -1035,7 +1035,7 @@ public class API {
             if (nonceParam != null) {
                 Nonce nonce = nonces.get(nonceParam);
                 if (nonce == null) {
-                    logger.warn(
+                    LOGGER.warn(
                             "API nonce {} not found in request from {}",
                             nonceParam,
                             reqHeader.getSenderAddress().getHostAddress());
@@ -1044,7 +1044,7 @@ public class API {
                     nonces.remove(nonceParam);
                 }
                 if (!nonce.isValid()) {
-                    logger.warn(
+                    LOGGER.warn(
                             "API nonce {} expired at {} in request from {}",
                             nonce.getNonceKey(),
                             nonce.getExpires(),
@@ -1053,7 +1053,7 @@ public class API {
                 }
 
                 if (!apiPath.equals(nonce.getApiPath())) {
-                    logger.warn(
+                    LOGGER.warn(
                             "API nonce path was {} but call was for {} in request from {}",
                             nonce.getApiPath(),
                             apiPath,
@@ -1066,7 +1066,7 @@ public class API {
                     keyParam = params.getString(API_KEY_PARAM);
                 }
                 if (!getOptionsParamApi().getKey().equals(keyParam)) {
-                    logger.warn(
+                    LOGGER.warn(
                             "API key incorrect or not supplied: {} in request from {}",
                             keyParam,
                             reqHeader.getSenderAddress().getHostAddress());
@@ -1156,7 +1156,7 @@ public class API {
             }
 
             if (logError) {
-                logger.error("API 'other' endpoint didn't handle exception:", cause);
+                LOGGER.error("API 'other' endpoint didn't handle exception:", cause);
             }
         } else {
             ApiException exception;
@@ -1168,7 +1168,7 @@ public class API {
                 }
             } else {
                 exception = new ApiException(ApiException.Type.INTERNAL_ERROR, cause);
-                logger.error("Exception while handling API request:", cause);
+                LOGGER.error("Exception while handling API request:", cause);
             }
             String response =
                     exception.toString(
@@ -1184,12 +1184,12 @@ public class API {
                     getDefaultResponseHeader(
                             responseStatus, contentType, msg.getResponseBody().length()));
         } catch (HttpMalformedHeaderException e) {
-            logger.warn("Failed to build API error response:", e);
+            LOGGER.warn("Failed to build API error response:", e);
         }
     }
 
     private static void logBadRequest(HttpMessage msg, Exception cause) {
-        logger.warn(
+        LOGGER.warn(
                 "Bad request to API endpoint [{}] from [{}]:",
                 msg.getRequestHeader().getURI().getEscapedPath(),
                 msg.getRequestHeader().getSenderAddress().getHostAddress(),

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ApiException.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ApiException.java
@@ -109,7 +109,7 @@ public class ApiException extends Exception {
     private final String code;
     private final String detail;
 
-    private static final Logger logger = LogManager.getLogger(ApiException.class);
+    private static final Logger LOGGER = LogManager.getLogger(ApiException.class);
 
     public ApiException(Type type) {
         this(type, null, null);
@@ -186,7 +186,7 @@ public class ApiException extends Exception {
                     return sw.toString();
 
                 } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
                 break;
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ContextAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ContextAPI.java
@@ -57,7 +57,7 @@ import org.zaproxy.zap.utils.XMLStringUtil;
 
 public class ContextAPI extends ApiImplementor {
 
-    private static final Logger log = LogManager.getLogger(ContextAPI.class);
+    private static final Logger LOGGER = LogManager.getLogger(ContextAPI.class);
 
     private static final String PREFIX = "context";
     private static final String TECH_NAME = "technologyName";
@@ -159,7 +159,7 @@ public class ContextAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiAction {} {}", name, params);
+        LOGGER.debug("handleApiAction {} {}", name, params);
 
         Context context;
         TechSet techSet;
@@ -285,7 +285,7 @@ public class ContextAPI extends ApiImplementor {
                     } catch (IllegalContextNameException e) {
                         throw new ApiException(ApiException.Type.BAD_EXTERNAL_DATA, e);
                     } catch (Exception e) {
-                        log.error(e.getMessage(), e);
+                        LOGGER.error(e.getMessage(), e);
                         throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
                     }
                 }
@@ -368,7 +368,7 @@ public class ContextAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiView(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiView {} {}", name, params);
+        LOGGER.debug("handleApiView {} {}", name, params);
 
         ApiResponse result;
         ApiResponseList resultList;

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -83,7 +83,7 @@ import org.zaproxy.zap.utils.HarUtils;
 
 public class CoreAPI extends ApiImplementor implements SessionListener {
 
-    private static final Logger logger = LogManager.getLogger(CoreAPI.class);
+    private static final Logger LOGGER = LogManager.getLogger(CoreAPI.class);
 
     private enum ScanReportType {
         HTML,
@@ -533,9 +533,9 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                                                         .getOptionsParam()
                                                         .getDatabaseParam()
                                                         .isCompactDatabase());
-                                logger.info("{} terminated.", Constant.PROGRAM_TITLE);
+                                LOGGER.info("{} terminated.", Constant.PROGRAM_TITLE);
                             } catch (Throwable e) {
-                                logger.error("An error occurred while shutting down:", e);
+                                LOGGER.error("An error occurred while shutting down:", e);
                             } finally {
                                 System.exit(Control.getSingleton().getExitStatus());
                             }
@@ -557,7 +557,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                         sameSession =
                                 Files.isSameFile(Paths.get(session.getFileName()), sessionPath);
                     } catch (IOException e) {
-                        logger.error("Failed to check if same session path:", e);
+                        LOGGER.error("Failed to check if same session path:", e);
                         throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
                     }
                 }
@@ -570,7 +570,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
             try {
                 Control.getSingleton().saveSession(filename, this);
             } catch (Exception e) {
-                logger.error("Failed to save the session:", e);
+                LOGGER.error("Failed to save the session:", e);
                 this.savingSession = false;
                 throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
             }
@@ -581,9 +581,9 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                 }
             } catch (InterruptedException e) {
                 // Probably not an error
-                logger.debug(e.getMessage(), e);
+                LOGGER.debug(e.getMessage(), e);
             }
-            logger.debug("Can now return after saving session");
+            LOGGER.debug("Can now return after saving session");
 
         } else if (ACTION_SNAPSHOT_SESSION.equalsIgnoreCase(
                 name)) { // Ignore case for backwards compatibility
@@ -618,7 +618,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                         sameSession =
                                 Files.isSameFile(Paths.get(session.getFileName()), sessionPath);
                     } catch (IOException e) {
-                        logger.error("Failed to check if same session path:", e);
+                        LOGGER.error("Failed to check if same session path:", e);
                         throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
                     }
 
@@ -632,7 +632,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
             try {
                 Control.getSingleton().snapshotSession(fileName, this);
             } catch (Exception e) {
-                logger.error("Failed to snapshot the session:", e);
+                LOGGER.error("Failed to snapshot the session:", e);
                 this.savingSession = false;
                 throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
             }
@@ -643,9 +643,9 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                 }
             } catch (InterruptedException e) {
                 // Probably not an error
-                logger.debug(e.getMessage(), e);
+                LOGGER.debug(e.getMessage(), e);
             }
-            logger.debug("Can now return after saving session");
+            LOGGER.debug("Can now return after saving session");
 
         } else if (ACTION_LOAD_SESSION.equalsIgnoreCase(
                 name)) { // Ignore case for backwards compatibility
@@ -658,7 +658,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
             try {
                 Control.getSingleton().runCommandLineOpenSession(filename);
             } catch (Exception e) {
-                logger.error("Failed to load the session:", e);
+                LOGGER.error("Failed to load the session:", e);
                 throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
             }
 
@@ -676,7 +676,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                 try {
                     Control.getSingleton().newSession();
                 } catch (Exception e) {
-                    logger.error("Failed to create a new session:", e);
+                    LOGGER.error("Failed to create a new session:", e);
                     throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
                 }
             } else {
@@ -691,7 +691,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                 try {
                     Control.getSingleton().runCommandLineNewSession(filename);
                 } catch (Exception e) {
-                    logger.error("Failed to create a new session:", e);
+                    LOGGER.error("Failed to create a new session:", e);
                     throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
                 }
             }
@@ -706,7 +706,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
             try {
                 session.addExcludeFromProxyRegex(regex);
             } catch (DatabaseException e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
                 throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
             } catch (PatternSyntaxException e) {
                 throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_REGEX);
@@ -986,7 +986,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
         } catch (ApiException e) {
             throw e;
         } catch (Exception e) {
-            logger.warn("Failed to send the HTTP request:", e);
+            LOGGER.warn("Failed to send the HTTP request:", e);
             throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
         }
     }
@@ -1046,7 +1046,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                             HistoryReference.TYPE_ZAP_USER,
                             message);
         } catch (Exception e) {
-            logger.warn(e.getMessage(), e);
+            LOGGER.warn(e.getMessage(), e);
             return;
         }
 
@@ -1259,7 +1259,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
         try {
             recordHistory = tableHistory.read(id);
         } catch (HttpMalformedHeaderException | DatabaseException e) {
-            logger.error("Failed to read the history record:", e);
+            LOGGER.error("Failed to read the history record:", e);
             throw new ApiException(ApiException.Type.INTERNAL_ERROR, e);
         }
         if (recordHistory == null) {
@@ -1337,7 +1337,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                         e.toString(API.Format.JSON, incErrorDetails())
                                 .getBytes(StandardCharsets.UTF_8);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
 
                 ApiException apiException =
                         new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
@@ -1352,7 +1352,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                         API.getDefaultResponseHeader(
                                 "application/json; charset=UTF-8", responseBody.length));
             } catch (HttpMalformedHeaderException e) {
-                logger.error("Failed to create response header: {}", e.getMessage(), e);
+                LOGGER.error("Failed to create response header: {}", e.getMessage(), e);
             }
             msg.setResponseBody(responseBody);
 
@@ -1384,7 +1384,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                         e.toString(API.Format.JSON, incErrorDetails())
                                 .getBytes(StandardCharsets.UTF_8);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
 
                 ApiException apiException =
                         new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
@@ -1399,7 +1399,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                         API.getDefaultResponseHeader(
                                 "application/json; charset=UTF-8", responseBody.length));
             } catch (HttpMalformedHeaderException e) {
-                logger.error("Failed to create response header: {}", e.getMessage(), e);
+                LOGGER.error("Failed to create response header: {}", e.getMessage(), e);
             }
             msg.setResponseBody(responseBody);
 
@@ -1450,7 +1450,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                                 e.toString(API.Format.JSON, incErrorDetails())
                                         .getBytes(StandardCharsets.UTF_8);
                     } catch (Exception e) {
-                        logger.error(e.getMessage(), e);
+                        LOGGER.error(e.getMessage(), e);
 
                         ApiException apiException =
                                 new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
@@ -1467,7 +1467,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                         API.getDefaultResponseHeader(
                                 "application/json; charset=UTF-8", responseBody.length));
             } catch (HttpMalformedHeaderException e) {
-                logger.error("Failed to create response header: {}", e.getMessage(), e);
+                LOGGER.error("Failed to create response header: {}", e.getMessage(), e);
             }
             msg.setResponseBody(responseBody);
 
@@ -1481,7 +1481,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                 msg.getResponseHeader()
                         .addHeader(HttpResponseHeader.CACHE_CONTROL, API_SCRIPT_CACHE_CONTROL);
             } catch (HttpMalformedHeaderException e) {
-                logger.error("Failed to create response header: {}", e.getMessage(), e);
+                LOGGER.error("Failed to create response header: {}", e.getMessage(), e);
             }
 
             return msg;
@@ -1582,11 +1582,11 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
             msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
 
             if (!xmlFile.delete()) {
-                logger.debug(
+                LOGGER.debug(
                         "Failed to delete temporary report file {}", xmlFile.getAbsolutePath());
             }
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
         }
     }
@@ -1598,7 +1598,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                 return this.handleApiOther(msg, OTHER_SCRIPT_JS, new JSONObject());
             }
         } catch (URIException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             throw new ApiException(ApiException.Type.INTERNAL_ERROR);
         }
         throw new ApiException(
@@ -1656,7 +1656,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                 }
             }
         } catch (HttpMalformedHeaderException | DatabaseException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             throw new ApiException(ApiException.Type.INTERNAL_ERROR);
         }
     }
@@ -1691,13 +1691,13 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
 
     @Override
     public void sessionSaved(Exception e) {
-        logger.debug("Saved session notification");
+        LOGGER.debug("Saved session notification");
         this.savingSession = false;
     }
 
     @Override
     public void sessionSnapshot(Exception e) {
-        logger.debug("Snapshot session notification");
+        LOGGER.debug("Snapshot session notification");
         this.savingSession = false;
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScan.java
@@ -79,7 +79,7 @@ public class ActiveScan extends org.parosproxy.paros.core.scanner.Scanner
     private ScheduledExecutorService scheduler;
     private ScheduledFuture<?> schedHandle;
 
-    private static final Logger log = LogManager.getLogger(ActiveScan.class);
+    private static final Logger LOGGER = LogManager.getLogger(ActiveScan.class);
 
     @Deprecated
     public ActiveScan(
@@ -288,7 +288,7 @@ public class ActiveScan extends org.parosproxy.paros.core.scanner.Scanner
                 msg.setHistoryRef(null);
                 hRefs.add(hRef.getHistoryId());
             } catch (HttpMalformedHeaderException | DatabaseException e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         } else {
             hRefs.add(hRef.getHistoryId());

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanAPI.java
@@ -74,7 +74,7 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 public class ActiveScanAPI extends ApiImplementor {
 
-    private static Logger log = LogManager.getLogger(ActiveScanAPI.class);
+    private static final Logger LOGGER = LogManager.getLogger(ActiveScanAPI.class);
 
     private static final String PREFIX = "ascan";
     private static final String ACTION_SCAN = "scan";
@@ -293,7 +293,7 @@ public class ActiveScanAPI extends ApiImplementor {
     @SuppressWarnings({"fallthrough"})
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiAction {} {}", name, params);
+        LOGGER.debug("handleApiAction {} {}", name, params);
         ScanPolicy policy;
         int categoryId;
 
@@ -351,7 +351,7 @@ public class ActiveScanAPI extends ApiImplementor {
                     try {
                         if (policyName != null && policyName.length() > 0) {
                             // Not specified, use the default one
-                            log.debug("handleApiAction scan policy ={}", policyName);
+                            LOGGER.debug("handleApiAction scan policy ={}", policyName);
                             policy = controller.getPolicyManager().getPolicy(policyName);
                         }
                     } catch (ConfigurationException e) {
@@ -411,7 +411,7 @@ public class ActiveScanAPI extends ApiImplementor {
                         Session session = Model.getSingleton().getSession();
                         session.setExcludeFromScanRegexs(new ArrayList<>());
                     } catch (DatabaseException e) {
-                        log.error(e.getMessage(), e);
+                        LOGGER.error(e.getMessage(), e);
                         throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
                     }
                     break;
@@ -421,7 +421,7 @@ public class ActiveScanAPI extends ApiImplementor {
                         Session session = Model.getSingleton().getSession();
                         session.addExcludeFromScanRegexs(regex);
                     } catch (DatabaseException e) {
-                        log.error(e.getMessage(), e);
+                        LOGGER.error(e.getMessage(), e);
                         throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
                     } catch (PatternSyntaxException e) {
                         throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_REGEX);
@@ -791,7 +791,7 @@ public class ActiveScanAPI extends ApiImplementor {
                 }
             }
         } catch (NumberFormatException e) {
-            log.warn("Failed to parse scanner ID: ", e);
+            LOGGER.warn("Failed to parse scanner ID: ", e);
             throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, e.getMessage(), e);
         }
 
@@ -810,7 +810,7 @@ public class ActiveScanAPI extends ApiImplementor {
                 updateRulesOfCategoryInPolicy(categoryId, policy, s -> s.setEnabled(true));
             }
         } catch (NumberFormatException e) {
-            log.warn("Failed to parse category ID: ", e);
+            LOGGER.warn("Failed to parse category ID: ", e);
             throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, e.getMessage(), e);
         }
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanController.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ActiveScanController.java
@@ -45,7 +45,7 @@ import org.zaproxy.zap.users.User;
 public class ActiveScanController implements ScanController<ActiveScan> {
 
     private ExtensionActiveScan extension;
-    private static final Logger logger = LogManager.getLogger(ActiveScanController.class);
+    private static final Logger LOGGER = LogManager.getLogger(ActiveScanController.class);
 
     private ExtensionAlert extAlert = null;
 
@@ -142,11 +142,11 @@ public class ActiveScanController implements ScanController<ActiveScan> {
             if (contextSpecificObjects != null) {
                 for (Object obj : contextSpecificObjects) {
                     if (obj instanceof ScannerParam) {
-                        logger.debug("Setting custom scanner params");
+                        LOGGER.debug("Setting custom scanner params");
                         ascan.setScannerParam((ScannerParam) obj);
                     } else if (obj instanceof ScanPolicy) {
                         policy = (ScanPolicy) obj;
-                        logger.debug("Setting custom policy {}", policy.getName());
+                        LOGGER.debug("Setting custom policy {}", policy.getName());
                         ascan.setScanPolicy(policy);
                     } else if (obj instanceof TechSet) {
                         ascan.setTechSet((TechSet) obj);
@@ -156,7 +156,7 @@ public class ActiveScanController implements ScanController<ActiveScan> {
                     } else if (obj instanceof ScanFilter) {
                         ascan.addScanFilter((ScanFilter) obj);
                     } else {
-                        logger.error(
+                        LOGGER.error(
                                 "Unexpected contextSpecificObject: {}",
                                 obj.getClass().getCanonicalName());
                     }
@@ -165,7 +165,7 @@ public class ActiveScanController implements ScanController<ActiveScan> {
             if (policy == null) {
                 // use the default
                 policy = extension.getPolicyManager().getDefaultScanPolicy();
-                logger.debug("Setting default policy {}", policy.getName());
+                LOGGER.debug("Setting default policy {}", policy.getName());
                 ascan.setScanPolicy(policy);
             }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/AttackModeScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/AttackModeScanner.java
@@ -61,7 +61,7 @@ public class AttackModeScanner implements EventConsumer {
     private AttackModeThread attackModeThread = null;
     private boolean rescanOnChange = false;
 
-    private Logger log = LogManager.getLogger(AttackModeScanner.class);
+    private static final Logger LOGGER = LogManager.getLogger(AttackModeScanner.class);
 
     private List<SiteNode> nodeStack = new ArrayList<>();
 
@@ -81,7 +81,7 @@ public class AttackModeScanner implements EventConsumer {
     }
 
     public void start() {
-        log.debug("Starting");
+        LOGGER.debug("Starting");
         nodeStack.clear();
 
         this.addAllInScope();
@@ -98,14 +98,14 @@ public class AttackModeScanner implements EventConsumer {
     private void addAllInScope() {
         if (this.rescanOnChange) {
             this.nodeStack.addAll(Model.getSingleton().getSession().getNodesInScopeFromSiteTree());
-            log.debug(
+            LOGGER.debug(
                     "Added existing in scope nodes to attack mode stack {}", this.nodeStack.size());
             updateCount();
         }
     }
 
     public void stop() {
-        log.debug("Stopping");
+        LOGGER.debug("Stopping");
         if (this.attackModeThread != null) {
             this.attackModeThread.shutdown();
         }
@@ -121,7 +121,7 @@ public class AttackModeScanner implements EventConsumer {
                 if (event.getTarget().getStartNode().getHistoryReference().getHistoryType()
                         != HistoryReference.TYPE_TEMPORARY) {
                     // Add to the stack awaiting attack
-                    log.debug(
+                    LOGGER.debug(
                             "Adding node to attack mode stack {}",
                             event.getTarget().getStartNode());
                     nodeStack.add(event.getTarget().getStartNode());
@@ -264,7 +264,7 @@ public class AttackModeScanner implements EventConsumer {
 
         @Override
         public void run() {
-            log.debug("Starting attack thread");
+            LOGGER.debug("Starting attack thread");
             this.running = true;
 
             RuleConfigParam ruleConfigParam = null;
@@ -303,7 +303,7 @@ public class AttackModeScanner implements EventConsumer {
                 }
                 while (nodeStack.size() > 0 && scanners.size() < scannerCount) {
                     SiteNode node = nodeStack.remove(0);
-                    log.debug("Attacking node {}", node.getNodeName());
+                    LOGGER.debug("Attacking node {}", node.getNodeName());
 
                     Scanner scanner =
                             new Scanner(
@@ -329,7 +329,7 @@ public class AttackModeScanner implements EventConsumer {
                     scanner.stop();
                 }
             }
-            log.debug("Attack thread finished");
+            LOGGER.debug("Attack thread finished");
         }
 
         @Override
@@ -341,7 +341,7 @@ public class AttackModeScanner implements EventConsumer {
                     if (scanner.isStop()) {
                         SiteNode node = scanner.getStartNode();
                         if (node != null) {
-                            log.debug("Finished attacking node {}", node.getNodeName());
+                            LOGGER.debug("Finished attacking node {}", node.getNodeName());
                             if (View.isInitialised()) {
                                 // Remove the icon
                                 node.removeCustomIcon(ATTACK_ICON_RESOURCE);

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/CustomScanDialog.java
@@ -99,7 +99,7 @@ public class CustomScanDialog extends StandardFieldsDialog {
     private static final String FIELD_RECURSE = "ascan.custom.label.recurse";
     private static final String FIELD_ADVANCED = "ascan.custom.label.adv";
 
-    private static final Logger logger = LogManager.getLogger(CustomScanDialog.class);
+    private static final Logger LOGGER = LogManager.getLogger(CustomScanDialog.class);
     private static final long serialVersionUID = 1L;
 
     private JButton[] extraButtons = null;
@@ -167,7 +167,7 @@ public class CustomScanDialog extends StandardFieldsDialog {
             this.target = target;
         }
 
-        logger.debug("init {}", this.target);
+        LOGGER.debug("init {}", this.target);
 
         this.removeAllFields();
         this.injectionPointModel.clear();
@@ -179,7 +179,7 @@ public class CustomScanDialog extends StandardFieldsDialog {
             try {
                 scanPolicy = extension.getPolicyManager().getPolicy(scanPolicyName);
             } catch (ConfigurationException e) {
-                logger.warn("Failed to load scan policy ({}):", scanPolicyName, e);
+                LOGGER.warn("Failed to load scan policy ({}):", scanPolicyName, e);
             }
         }
 
@@ -299,7 +299,7 @@ public class CustomScanDialog extends StandardFieldsDialog {
 
             scanPolicyName = policyName;
         } catch (ConfigurationException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -572,7 +572,7 @@ public class CustomScanDialog extends StandardFieldsDialog {
                                     getRequestField().getCaret().setVisible(true);
 
                                 } catch (BadLocationException e1) {
-                                    logger.error(e1.getMessage(), e1);
+                                    LOGGER.error(e1.getMessage(), e1);
                                 }
                             }
                         }
@@ -859,7 +859,7 @@ public class CustomScanDialog extends StandardFieldsDialog {
                     }
 
                 } catch (Exception e) {
-                    logger.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -64,7 +64,7 @@ import org.zaproxy.zap.view.ZapMenuItem;
 public class ExtensionActiveScan extends ExtensionAdaptor
         implements SessionChangedListener, CommandLineListener, ScanController<ActiveScan> {
 
-    private static final Logger logger = LogManager.getLogger(ExtensionActiveScan.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionActiveScan.class);
     private static final int ARG_SCAN_IDX = 0;
 
     public static final String NAME = "ExtensionActiveScan";
@@ -386,7 +386,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor
                 getModel().getOptionsParam().getConfig().save();
 
             } catch (ConfigurationException ce) {
-                logger.error(ce.getMessage(), ce);
+                LOGGER.error(ce.getMessage(), ce);
                 getView().showWarningDialog(Constant.messages.getString("scanner.save.warning"));
             }
         }
@@ -431,7 +431,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor
                         });
 
             } catch (InterruptedException | InvocationTargetException e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyAllCategoryPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyAllCategoryPanel.java
@@ -72,7 +72,7 @@ public class PolicyAllCategoryPanel extends AbstractParamPanel {
     // private static final String ILLEGAL_CHRS = "/`?*\\<>|\":\t\n\r";
 
     private static final long serialVersionUID = 1L;
-    private static final Logger logger = LogManager.getLogger(PolicyAllCategoryPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(PolicyAllCategoryPanel.class);
 
     private ZapTextField policyName = null;
     private JTable tableTest = null;
@@ -282,7 +282,7 @@ public class PolicyAllCategoryPanel extends AbstractParamPanel {
                                     fireScanPolicyChanged(policy);
                                 }
                             } catch (ConfigurationException e1) {
-                                logger.error(e1.getMessage(), e1);
+                                LOGGER.error(e1.getMessage(), e1);
                             }
                         }
                     });

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyManager.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyManager.java
@@ -41,7 +41,7 @@ public class PolicyManager {
     private List<String> allPolicyNames = null;
     private ExtensionActiveScan extension;
 
-    private static final Logger logger = LogManager.getLogger(PolicyManager.class);
+    private static final Logger LOGGER = LogManager.getLogger(PolicyManager.class);
 
     public PolicyManager(ExtensionActiveScan extension) {
         this.extension = extension;
@@ -59,7 +59,7 @@ public class PolicyManager {
             if (files != null) {
                 for (String file : files) {
                     if (file.endsWith(POLICY_EXTENSION)) {
-                        logger.debug("Found policy file {}", file);
+                        LOGGER.debug("Found policy file {}", file);
                         allPolicyNames.add(file.substring(0, file.lastIndexOf(POLICY_EXTENSION)));
                     }
                 }
@@ -76,7 +76,7 @@ public class PolicyManager {
                     // Note this will add the name to allPolicyNames
                     this.savePolicy(defaultPolicy);
                 } catch (ConfigurationException e) {
-                    logger.debug(
+                    LOGGER.debug(
                             "Failed to create default scan policy in {}",
                             Constant.getPoliciesDir().getAbsolutePath(),
                             e);
@@ -93,7 +93,7 @@ public class PolicyManager {
     }
 
     public void savePolicy(ScanPolicy policy, String previousName) throws ConfigurationException {
-        logger.debug("Save policy {}", policy.getName());
+        LOGGER.debug("Save policy {}", policy.getName());
 
         File file = new File(Constant.getPoliciesDir(), policy.getName() + POLICY_EXTENSION);
 
@@ -167,7 +167,7 @@ public class PolicyManager {
     }
 
     public void importPolicy(File file) throws ConfigurationException, IOException {
-        logger.debug("Import policy from {}", file.getAbsolutePath());
+        LOGGER.debug("Import policy from {}", file.getAbsolutePath());
         ScanPolicy policy = new ScanPolicy(new ZapXmlConfiguration(file));
         String baseName = file.getName();
         if (baseName.endsWith(POLICY_EXTENSION)) {
@@ -188,7 +188,7 @@ public class PolicyManager {
     }
 
     public void exportPolicy(ScanPolicy policy, File file) throws ConfigurationException {
-        logger.debug("Export policy to {}", file.getAbsolutePath());
+        LOGGER.debug("Export policy to {}", file.getAbsolutePath());
         ZapXmlConfiguration conf = new ZapXmlConfiguration();
         conf.setProperty("policy", policy.getName());
         conf.setProperty("scanner.level", policy.getDefaultThreshold().name());
@@ -202,7 +202,7 @@ public class PolicyManager {
     }
 
     public void deletePolicy(String name) {
-        logger.debug("Delete policy {}", name);
+        LOGGER.debug("Delete policy {}", name);
         File file = new File(Constant.getPoliciesDir(), name + POLICY_EXTENSION);
         if (file.exists()) {
             file.delete();
@@ -214,26 +214,26 @@ public class PolicyManager {
         try {
             String policyName = extension.getScannerParam().getDefaultPolicy();
             if (policyExists(policyName)) {
-                logger.debug("getDefaultScanPolicy: {}", policyName);
+                LOGGER.debug("getDefaultScanPolicy: {}", policyName);
                 return this.loadPolicy(policyName);
             }
             // No good, try the default name
             policyName = DEFAULT_POLICY_NAME;
             if (policyExists(policyName)) {
-                logger.debug("getDefaultScanPolicy (default name): {}", policyName);
+                LOGGER.debug("getDefaultScanPolicy (default name): {}", policyName);
                 return this.loadPolicy(policyName);
             }
             if (this.allPolicyNames.size() > 0) {
                 // Still no joy, try the first
-                logger.debug("getDefaultScanPolicy (first one): {}", policyName);
+                LOGGER.debug("getDefaultScanPolicy (first one): {}", policyName);
                 return this.loadPolicy(this.allPolicyNames.get(0));
             }
 
         } catch (ConfigurationException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
         // Return a new 'blank' one
-        logger.debug("getDefaultScanPolicy (new blank)");
+        LOGGER.debug("getDefaultScanPolicy (new blank)");
         return new ScanPolicy();
     }
 
@@ -253,7 +253,7 @@ public class PolicyManager {
                 return this.loadPolicy(this.allPolicyNames.get(0));
             }
         } catch (ConfigurationException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
         // Return a new 'blank' one
         return new ScanPolicy();

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyManagerDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyManagerDialog.java
@@ -61,7 +61,7 @@ public class PolicyManagerDialog extends StandardFieldsDialog {
 
     private ExtensionActiveScan extension;
 
-    private static final Logger logger = LogManager.getLogger(PolicyManagerDialog.class);
+    private static final Logger LOGGER = LogManager.getLogger(PolicyManagerDialog.class);
 
     public PolicyManagerDialog(Frame owner) {
         super(owner, "ascan.policymgr.title", DisplayUtils.getScaledDimension(512, 400));
@@ -105,7 +105,7 @@ public class PolicyManagerDialog extends StandardFieldsDialog {
                             try {
                                 extension.showPolicyDialog(PolicyManagerDialog.this);
                             } catch (ConfigurationException e1) {
-                                logger.error(e1.getMessage(), e1);
+                                LOGGER.error(e1.getMessage(), e1);
                             }
                         }
                     });
@@ -131,7 +131,7 @@ public class PolicyManagerDialog extends StandardFieldsDialog {
                                 try {
                                     extension.showPolicyDialog(PolicyManagerDialog.this, name);
                                 } catch (ConfigurationException e1) {
-                                    logger.error(e1.getMessage(), e1);
+                                    LOGGER.error(e1.getMessage(), e1);
                                 }
                             }
                         }
@@ -197,7 +197,7 @@ public class PolicyManagerDialog extends StandardFieldsDialog {
                                     extension.getPolicyManager().importPolicy(file);
                                     policyNamesChanged();
                                 } catch (ConfigurationException | IOException e1) {
-                                    logger.error(e1.getMessage(), e1);
+                                    LOGGER.error(e1.getMessage(), e1);
                                     View.getSingleton()
                                             .showWarningDialog(
                                                     Constant.messages.getString(
@@ -251,7 +251,7 @@ public class PolicyManagerDialog extends StandardFieldsDialog {
                                             extension.getPolicyManager().exportPolicy(policy, file);
                                         }
                                     } catch (ConfigurationException e1) {
-                                        logger.error(e1.getMessage(), e1);
+                                        LOGGER.error(e1.getMessage(), e1);
                                         View.getSingleton()
                                                 .showWarningDialog(
                                                         Constant.messages.getString(
@@ -301,7 +301,7 @@ public class PolicyManagerDialog extends StandardFieldsDialog {
                                             extension.showPolicyDialog(
                                                     PolicyManagerDialog.this, name);
                                         } catch (ConfigurationException e1) {
-                                            logger.error(e1.getMessage(), e1);
+                                            LOGGER.error(e1.getMessage(), e1);
                                         }
                                     }
                                 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanPolicy.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanPolicy.java
@@ -32,7 +32,7 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 public class ScanPolicy {
 
-    private static final Logger logger = LogManager.getLogger(ScanPolicy.class);
+    private static final Logger LOGGER = LogManager.getLogger(ScanPolicy.class);
 
     private String name;
     private PluginFactory pluginFactory = new PluginFactory();
@@ -126,7 +126,7 @@ public class ScanPolicy {
         if (alertThreshold.isEmpty()
                 || !EnumUtils.isValidEnum(AlertThreshold.class, alertThreshold)
                 || AlertThreshold.DEFAULT.name().equals(alertThreshold)) {
-            logger.warn(
+            LOGGER.warn(
                     "Found illegal value {} for alert threshold, using MEDIUM instead.",
                     alertThreshold);
             return AlertThreshold.MEDIUM;
@@ -139,7 +139,7 @@ public class ScanPolicy {
         if (attackStrength.isEmpty()
                 || !EnumUtils.isValidEnum(AttackStrength.class, attackStrength)
                 || AttackStrength.DEFAULT.name().equals(attackStrength)) {
-            logger.warn(
+            LOGGER.warn(
                     "Found illegal value {} for attack strength, using MEDIUM instead.",
                     attackStrength);
             return AttackStrength.MEDIUM;

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanProgressDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanProgressDialog.java
@@ -80,7 +80,7 @@ import org.zaproxy.zap.view.LayoutHelper;
 public class ScanProgressDialog extends AbstractDialog {
 
     private static final long serialVersionUID = 1L;
-    private static Logger log = LogManager.getLogger(ScanProgressDialog.class);
+    private static final Logger LOGGER = LogManager.getLogger(ScanProgressDialog.class);
 
     private ExtensionActiveScan extension;
     private JScrollPane jScrollPane;
@@ -321,7 +321,7 @@ public class ScanProgressDialog extends AbstractDialog {
                                                 ScanProgressDialog.this,
                                                 Constant.messages.getString(
                                                         "ascan.progress.copyclipboard.error"));
-                                log.warn("Failed to copy the contents to clipboard:", e);
+                                LOGGER.warn("Failed to copy the contents to clipboard:", e);
                             }
                         }
                     });
@@ -447,7 +447,7 @@ public class ScanProgressDialog extends AbstractDialog {
                             }
                         }
                     } catch (Exception e) {
-                        log.error(e.getMessage(), e);
+                        LOGGER.error(e.getMessage(), e);
                         snapshot = null;
                     }
                 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScriptsActiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScriptsActiveScanner.java
@@ -45,7 +45,7 @@ public class ScriptsActiveScanner extends AbstractAppParamPlugin {
     private ExtensionScript extension = null;
     private ScriptsCache<ActiveScript> cachedScripts;
 
-    private static Logger logger = LogManager.getLogger(ScriptsActiveScanner.class);
+    private static final Logger LOGGER = LogManager.getLogger(ScriptsActiveScanner.class);
     /**
      * A {@code Set} containing the scripts that do not implement {@code ActiveScript2}, to show an
      * error if those scripts do not implement {@code ActiveScript} (thus not implementing any of
@@ -159,7 +159,7 @@ public class ScriptsActiveScanner extends AbstractAppParamPlugin {
 
                     if (s != null) {
                         HttpMessage msg = this.getNewMsg();
-                        logger.debug(
+                        LOGGER.debug(
                                 "Calling script {} scanNode for {}",
                                 script.getName(),
                                 msg.getRequestHeader().getURI());
@@ -214,7 +214,7 @@ public class ScriptsActiveScanner extends AbstractAppParamPlugin {
 
             ScriptWrapper script = cachedScript.getScriptWrapper();
             try {
-                logger.debug(
+                LOGGER.debug(
                         "Calling script {} scan for {} param={} value={}",
                         script.getName(),
                         msg.getRequestHeader().getURI(),

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/VariantFactory.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/VariantFactory.java
@@ -50,7 +50,7 @@ import org.zaproxy.zap.extension.script.ScriptsCache;
 import org.zaproxy.zap.extension.script.ScriptsCache.Configuration;
 
 public class VariantFactory {
-    private static final Logger LOG = LogManager.getLogger(VariantFactory.class);
+    private static final Logger LOGGER = LogManager.getLogger(VariantFactory.class);
 
     private ExtensionScript extension;
     private final List<Class<? extends Variant>> customVariants = new ArrayList<>();
@@ -184,7 +184,7 @@ public class VariantFactory {
             try {
                 list.add(variant.getDeclaredConstructor().newInstance());
             } catch (Exception e) {
-                LOG.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/authentication/AuthenticationAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authentication/AuthenticationAPI.java
@@ -49,7 +49,7 @@ import org.zaproxy.zap.utils.ApiUtils;
  */
 public class AuthenticationAPI extends ApiImplementor {
 
-    private static final Logger log = LogManager.getLogger(AuthenticationAPI.class);
+    private static final Logger LOGGER = LogManager.getLogger(AuthenticationAPI.class);
 
     private static final String PREFIX = "authentication";
 
@@ -116,7 +116,7 @@ public class AuthenticationAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiView(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiView {} {}", name, params);
+        LOGGER.debug("handleApiView {} {}", name, params);
 
         switch (name) {
             case VIEW_GET_AUTHENTICATION:
@@ -149,7 +149,7 @@ public class AuthenticationAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiAction {} {}", name, params);
+        LOGGER.debug("handleApiAction {} {}", name, params);
 
         Context context;
         switch (name) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/authentication/ContextAuthenticationPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authentication/ContextAuthenticationPanel.java
@@ -74,7 +74,7 @@ import org.zaproxy.zap.view.NodeSelectDialog;
 @SuppressWarnings("serial")
 public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
 
-    private static final Logger log = LogManager.getLogger(ContextAuthenticationPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(ContextAuthenticationPanel.class);
     private static final long serialVersionUID = -898084998156067286L;
 
     /** The Constant PANEL NAME. */
@@ -274,7 +274,7 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
             return;
         }
 
-        log.debug("Creating new panel for configuring: {}", newMethodType.getName());
+        LOGGER.debug("Creating new panel for configuring: {}", newMethodType.getName());
 
         this.getConfigContainerPanel().removeAll();
 
@@ -313,7 +313,7 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
                         public void itemStateChanged(ItemEvent e) {
                             if (e.getStateChange() == ItemEvent.SELECTED
                                     && !e.getItem().equals(shownMethodType)) {
-                                log.debug("Selected new Authentication type: {}", e.getItem());
+                                LOGGER.debug("Selected new Authentication type: {}", e.getItem());
 
                                 AuthenticationMethodType type =
                                         ((AuthenticationMethodType) e.getItem());
@@ -323,7 +323,7 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
                                                         .getAuthenticationCredentialsType()) {
 
                                     if (needsConfirm && !confirmAndResetUsersCredentials(type)) {
-                                        log.debug("Cancelled change of authentication type.");
+                                        LOGGER.debug("Cancelled change of authentication type.");
 
                                         authenticationMethodsComboBox.setSelectedItem(
                                                 shownMethodType);
@@ -550,7 +550,7 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
                                                             .getRequestBody()
                                                             .toString());
                                 } catch (Exception e1) {
-                                    log.error(e1.getMessage(), e1);
+                                    LOGGER.error(e1.getMessage(), e1);
                                 }
                             }
                         }
@@ -598,7 +598,7 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
     @Override
     public void initContextData(Session session, Context uiSharedContext) {
         selectedAuthenticationMethod = uiSharedContext.getAuthenticationMethod();
-        log.debug(
+        LOGGER.debug(
                 "Initializing configuration panel for authentication method: {} for context {}",
                 selectedAuthenticationMethod,
                 uiSharedContext.getName());
@@ -646,7 +646,7 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
             if (shownMethodType != null
                     && shownMethodType.isTypeForMethod(selectedAuthenticationMethod)) {
                 if (shownMethodType.hasOptionsPanel()) {
-                    log.debug(
+                    LOGGER.debug(
                             "Binding authentication method to existing panel of proper type for context {}",
                             uiSharedContext.getName());
                     shownConfigPanel.bindMethod(
@@ -660,7 +660,7 @@ public class ContextAuthenticationPanel extends AbstractContextPropertiesPanel {
                 if (type.isTypeForMethod(selectedAuthenticationMethod)) {
                     // Selecting the type here will also force the selection listener to run and
                     // change the config panel accordingly
-                    log.debug(
+                    LOGGER.debug(
                             "Binding authentication method to new panel of proper type for context {}",
                             uiSharedContext.getName());
                     // Add hack to make sure no confirmation is needed if a change has been done

--- a/zap/src/main/java/org/zaproxy/zap/extension/authentication/ExtensionAuthentication.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authentication/ExtensionAuthentication.java
@@ -66,7 +66,7 @@ public class ExtensionAuthentication extends ExtensionAdaptor
     private static final int NO_AUTH_METHOD = -1;
 
     /** The Constant log. */
-    private static final Logger log = LogManager.getLogger(ExtensionAuthentication.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionAuthentication.class);
 
     /** The automatically loaded authentication method types. */
     List<AuthenticationMethodType> authenticationMethodTypes = new ArrayList<>();
@@ -204,7 +204,7 @@ public class ExtensionAuthentication extends ExtensionAdaptor
             a.hook(hook);
         }
 
-        log.info("Loaded authentication method types: {}", authenticationMethodTypes);
+        LOGGER.info("Loaded authentication method types: {}", authenticationMethodTypes);
     }
 
     /**
@@ -269,7 +269,7 @@ public class ExtensionAuthentication extends ExtensionAdaptor
                                     .setAuthCheckingStrategy(
                                             AuthCheckingStrategy.valueOf(strategy));
                         } catch (Exception e) {
-                            log.error("Failed to parse auth checking strategy {}", strategy, e);
+                            LOGGER.error("Failed to parse auth checking strategy {}", strategy, e);
                         }
                     }
 
@@ -308,7 +308,7 @@ public class ExtensionAuthentication extends ExtensionAdaptor
                                     .setPollFrequencyUnits(
                                             AuthPollFrequencyUnits.valueOf(freqUnits));
                         } catch (Exception e) {
-                            log.error("Failed to parse auth frequency units {}", freqUnits, e);
+                            LOGGER.error("Failed to parse auth frequency units {}", freqUnits, e);
                         }
                     }
 
@@ -329,7 +329,7 @@ public class ExtensionAuthentication extends ExtensionAdaptor
             }
 
         } catch (DatabaseException e) {
-            log.error("Unable to load Authentication method.", e);
+            LOGGER.error("Unable to load Authentication method.", e);
         }
     }
 
@@ -404,7 +404,7 @@ public class ExtensionAuthentication extends ExtensionAdaptor
 
             t.persistMethodToSession(session, contextIdx, context.getAuthenticationMethod());
         } catch (DatabaseException e) {
-            log.error("Unable to persist Authentication method.", e);
+            LOGGER.error("Unable to persist Authentication method.", e);
         }
     }
 
@@ -477,7 +477,7 @@ public class ExtensionAuthentication extends ExtensionAdaptor
 
         AuthenticationMethodType authMethodType = getAuthenticationMethodTypeForIdentifier(typeId);
         if (authMethodType == null) {
-            log.warn("No authentication method type found for ID: {}", typeId);
+            LOGGER.warn("No authentication method type found for ID: {}", typeId);
             return;
         }
         ctx.setAuthenticationMethod(authMethodType.createAuthenticationMethod(ctx.getId()));

--- a/zap/src/main/java/org/zaproxy/zap/extension/authorization/AuthorizationAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authorization/AuthorizationAPI.java
@@ -36,7 +36,7 @@ import org.zaproxy.zap.utils.ApiUtils;
 /** The API for managing the Authorization for a Context. */
 public class AuthorizationAPI extends ApiImplementor {
 
-    private static final Logger log = LogManager.getLogger(AuthorizationAPI.class);
+    private static final Logger LOGGER = LogManager.getLogger(AuthorizationAPI.class);
 
     private static final String PREFIX = "authorization";
 
@@ -73,7 +73,7 @@ public class AuthorizationAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiView(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiView {} {}", name, params);
+        LOGGER.debug("handleApiView {} {}", name, params);
 
         switch (name) {
             case VIEW_GET_AUTHORIZATION_METHOD:
@@ -87,7 +87,7 @@ public class AuthorizationAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiAction {} {}", name, params);
+        LOGGER.debug("handleApiAction {} {}", name, params);
         Context context;
         switch (name) {
             case ACTION_SET_AUTHORIZATION_METHOD:
@@ -108,7 +108,7 @@ public class AuthorizationAPI extends ApiImplementor {
                                 PARAM_STATUS_CODE,
                                 BasicAuthorizationDetectionMethod.NO_STATUS_CODE);
 
-                log.debug(
+                LOGGER.debug(
                         "Setting basic authorization detection to: {} / {} / {} / {}",
                         headerRegex,
                         bodyRegex,

--- a/zap/src/main/java/org/zaproxy/zap/extension/authorization/ContextAuthorizationPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authorization/ContextAuthorizationPanel.java
@@ -45,7 +45,7 @@ import org.zaproxy.zap.view.LayoutHelper;
 public class ContextAuthorizationPanel extends AbstractContextPropertiesPanel {
 
     private static final long serialVersionUID = 2416553589170267959L;
-    private static final Logger log = LogManager.getLogger(ContextAuthorizationPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(ContextAuthorizationPanel.class);
 
     private static final String PANEL_NAME =
             Constant.messages.getString("authorization.panel.title");
@@ -160,7 +160,7 @@ public class ContextAuthorizationPanel extends AbstractContextPropertiesPanel {
         this.authorizationMethod = uiSharedContext.getAuthorizationDetectionMethod();
         if (this.authorizationMethod != null) {
             if (authorizationMethod instanceof BasicAuthorizationDetectionMethod) {
-                log.debug(
+                LOGGER.debug(
                         "Initializing panel with {}: {}",
                         BasicAuthorizationDetectionMethod.class.getSimpleName(),
                         authorizationMethod);
@@ -178,7 +178,7 @@ public class ContextAuthorizationPanel extends AbstractContextPropertiesPanel {
                 else this.logicalOperatorComboBox.setSelectedItem(FIELD_VALUE_OR_COMPOSITION);
                 return;
             }
-            log.warn(
+            LOGGER.warn(
                     "Unsupported authorization method on panel: {}",
                     authorizationMethod.getClass().getSimpleName());
         }
@@ -227,7 +227,7 @@ public class ContextAuthorizationPanel extends AbstractContextPropertiesPanel {
     public void saveContextData(Session session) throws Exception {
         saveMethod();
         session.getContext(getContextId()).setAuthorizationDetectionMethod(authorizationMethod);
-        log.debug("Saving authorization method: {}", authorizationMethod);
+        LOGGER.debug("Saving authorization method: {}", authorizationMethod);
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/authorization/ExtensionAuthorization.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/authorization/ExtensionAuthorization.java
@@ -45,7 +45,7 @@ public class ExtensionAuthorization extends ExtensionAdaptor
         implements ContextPanelFactory, ContextDataFactory {
 
     /** The Constant log. */
-    private static final Logger log = LogManager.getLogger(ExtensionAuthorization.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionAuthorization.class);
 
     /** The NAME of the extension. */
     public static final String NAME = "ExtensionAuthorization";
@@ -131,7 +131,7 @@ public class ExtensionAuthorization extends ExtensionAdaptor
                 }
             }
         } catch (DatabaseException e) {
-            log.error("Unable to load Authorization Detection method.", e);
+            LOGGER.error("Unable to load Authorization Detection method.", e);
         }
     }
 
@@ -147,7 +147,7 @@ public class ExtensionAuthorization extends ExtensionAdaptor
             context.getAuthorizationDetectionMethod()
                     .persistMethodToSession(session, context.getId());
         } catch (DatabaseException e) {
-            log.error("Unable to persist Authorization Detection method.", e);
+            LOGGER.error("Unable to persist Authorization Detection method.", e);
         }
     }
 
@@ -174,7 +174,7 @@ public class ExtensionAuthorization extends ExtensionAdaptor
                 ctx.setAuthorizationDetectionMethod(new BasicAuthorizationDetectionMethod(config));
                 break;
             default:
-                log.warn("No authorization detection method found for ID: {}", type);
+                LOGGER.warn("No authorization detection method found for ID: {}", type);
         }
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/AutoUpdateAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/AutoUpdateAPI.java
@@ -44,7 +44,7 @@ import org.zaproxy.zap.extension.api.ApiView;
 
 public class AutoUpdateAPI extends ApiImplementor {
 
-    private static Logger log = LogManager.getLogger(AutoUpdateAPI.class);
+    private static final Logger LOGGER = LogManager.getLogger(AutoUpdateAPI.class);
 
     private static final String PREFIX = "autoupdate";
     private static final String ACTION_DOWNLOAD_LATEST_RELEASE = "downloadLatestRelease";
@@ -87,7 +87,7 @@ public class AutoUpdateAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiAction {} {}", name, params);
+        LOGGER.debug("handleApiAction {} {}", name, params);
         if (ACTION_DOWNLOAD_LATEST_RELEASE.equals(name)) {
             if (this.downloadLatestRelease()) {
                 return ApiResponseElement.OK;

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/DownloadManager.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/DownloadManager.java
@@ -32,7 +32,7 @@ import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.view.View;
 
 public class DownloadManager extends Thread {
-    private static final Logger logger = LogManager.getLogger(DownloadManager.class);
+    private static final Logger LOGGER = LogManager.getLogger(DownloadManager.class);
     private final int initiator;
     private Collection<Downloader> currentDownloads = new ConcurrentLinkedQueue<>();
     private Collection<Downloader> completedDownloads = new ConcurrentLinkedQueue<>();
@@ -52,7 +52,7 @@ public class DownloadManager extends Thread {
     }
 
     public Downloader downloadFile(URL url, File targetFile, long size, String hash) {
-        logger.debug("Download file {} to {}", url, targetFile.getAbsolutePath());
+        LOGGER.debug("Download file {} to {}", url, targetFile.getAbsolutePath());
 
         Downloader dl = new Downloader(url, targetFile, size, hash, initiator);
         dl.start();
@@ -69,14 +69,14 @@ public class DownloadManager extends Thread {
             for (Downloader dl : this.currentDownloads) {
                 if (!dl.isAlive()) {
                     if (dl.getException() != null) {
-                        logger.debug("Download failed {}", dl.getTargetFile().getAbsolutePath());
+                        LOGGER.debug("Download failed {}", dl.getTargetFile().getAbsolutePath());
                     } else if (dl.isValidated()) {
-                        logger.debug("Download finished {}", dl.getTargetFile().getAbsolutePath());
+                        LOGGER.debug("Download finished {}", dl.getTargetFile().getAbsolutePath());
                     } else if (dl.isCancelled()) {
-                        logger.debug("Download cancelled {}", dl.getTargetFile().getAbsolutePath());
+                        LOGGER.debug("Download cancelled {}", dl.getTargetFile().getAbsolutePath());
                     } else {
                         // Corrupt or corrupted file? Pretty bad anyway
-                        logger.error("Validation failed {}", dl.getTargetFile().getAbsolutePath());
+                        LOGGER.error("Validation failed {}", dl.getTargetFile().getAbsolutePath());
                         dl.cancelDownload();
                         if (View.isInitialised()) {
                             View.getSingleton()
@@ -88,10 +88,10 @@ public class DownloadManager extends Thread {
                     }
                     finishedDownloads.add(dl);
                 } else if (this.cancelDownloads) {
-                    logger.debug("Cancelling download {}", dl.getTargetFile().getAbsolutePath());
+                    LOGGER.debug("Cancelling download {}", dl.getTargetFile().getAbsolutePath());
                     dl.cancelDownload();
                 } else {
-                    logger.debug(
+                    LOGGER.debug(
                             "Still downloading {} progress % {}",
                             dl.getTargetFile().getAbsolutePath(), dl.getProgressPercent());
                 }
@@ -110,7 +110,7 @@ public class DownloadManager extends Thread {
                 // Ignore
             }
         }
-        logger.debug("Shutdown");
+        LOGGER.debug("Shutdown");
     }
 
     public int getCurrentDownloadCount() {

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/Downloader.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/Downloader.java
@@ -43,7 +43,7 @@ public class Downloader extends Thread {
     private boolean validated = false;
     private final int initiator;
 
-    private static final Logger logger = LogManager.getLogger(Downloader.class);
+    private static final Logger LOGGER = LogManager.getLogger(Downloader.class);
 
     /** @deprecated (2.12.0) */
     @Deprecated
@@ -77,12 +77,12 @@ public class Downloader extends Thread {
                     validateHashDownload();
                 }
             } else {
-                logger.debug(
+                LOGGER.debug(
                         "Not downloading file, hash field does not have valid content (\"<ALGORITHM>:<HASH>\"): {}",
                         hash);
             }
         } else {
-            logger.debug("Not downloading file, does not have a hash: {}", url);
+            LOGGER.debug("Not downloading file, does not have a hash: {}", url);
         }
 
         this.complete = true;
@@ -111,11 +111,11 @@ public class Downloader extends Thread {
             if (realHash.equalsIgnoreCase(hashValue)) {
                 validated = true;
             } else {
-                logger.debug("Wrong hash - expected {} got {}", hashValue, realHash);
+                LOGGER.debug("Wrong hash - expected {} got {}", hashValue, realHash);
             }
         } catch (Exception e) {
             // Ignore - we default to unvalidated
-            logger.debug("Error checking hash", e);
+            LOGGER.debug("Error checking hash", e);
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -99,7 +99,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
     private ZapMenuItem menuItemCheckUpdate = null;
     private ZapMenuItem menuItemLoadAddOn = null;
 
-    private static final Logger logger = LogManager.getLogger(ExtensionAutoUpdate.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionAutoUpdate.class);
 
     private DownloadManager downloadManager = null;
     private ManageAddOnsDialog addonsDialog = null;
@@ -238,7 +238,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                                     installLocalAddOn(file.toPath());
                                 }
                             } catch (Exception e1) {
-                                logger.error(e1.getMessage(), e1);
+                                LOGGER.error(e1.getMessage(), e1);
                             }
                         }
                     });
@@ -251,12 +251,12 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
         try {
             ao = new AddOn(file);
         } catch (IOException e) {
-            logger.warn("Failed to create the add-on: {}", e.getMessage(), e);
+            LOGGER.warn("Failed to create the add-on: {}", e.getMessage(), e);
             return false;
         }
 
         if (!ao.canLoadInCurrentVersion()) {
-            logger.warn("Can not install the add-on, incompatible ZAP version.");
+            LOGGER.warn("Can not install the add-on, incompatible ZAP version.");
             return false;
         }
 
@@ -273,11 +273,11 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
         if (installedAddOn != null) {
             try {
                 if (Files.isSameFile(installedAddOn.getFile().toPath(), ao.getFile().toPath())) {
-                    logger.warn("Can not install the add-on, same file already installed.");
+                    LOGGER.warn("Can not install the add-on, same file already installed.");
                     return false;
                 }
             } catch (IOException e) {
-                logger.warn(
+                LOGGER.warn(
                         "An error occurred while checking the add-ons' files: {}",
                         e.getMessage(),
                         e);
@@ -293,10 +293,10 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
         try {
             addOnFile = copyAddOnFileToLocalPluginFolder(ao);
         } catch (FileAlreadyExistsException e) {
-            logger.warn("Unable to copy add-on, a file with the same name already exists.", e);
+            LOGGER.warn("Unable to copy add-on, a file with the same name already exists.", e);
             return false;
         } catch (IOException e) {
-            logger.warn("Unable to copy add-on to local plugin folder.", e);
+            LOGGER.warn("Unable to copy add-on to local plugin folder.", e);
             return false;
         }
 
@@ -349,7 +349,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                     break;
                 default:
                     showWarningMessageInvalidAddOnFile(e.getMessage());
-                    logger.warn(e);
+                    LOGGER.warn(e);
                     break;
             }
             return;
@@ -459,11 +459,11 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
             addOnFile = copyAddOnFileToLocalPluginFolder(ao);
         } catch (FileAlreadyExistsException e) {
             showWarningMessageAddOnFileAlreadyExists(e.getFile(), e.getOtherFile());
-            logger.warn("Unable to copy add-on, a file with the same name already exists.", e);
+            LOGGER.warn("Unable to copy add-on, a file with the same name already exists.", e);
             return;
         } catch (IOException e) {
             showWarningMessageUnableToCopyAddOnFile();
-            logger.warn("Unable to copy add-on to local plugin folder.", e);
+            LOGGER.warn("Unable to copy add-on to local plugin folder.", e);
             return;
         }
 
@@ -596,7 +596,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
             handledFiles.add(dl);
             try {
                 if (!dl.isValidated()) {
-                    logger.debug("Ignoring unvalidated download: {}", dl.getUrl());
+                    LOGGER.debug("Ignoring unvalidated download: {}", dl.getUrl());
                     allInstalled.setFalse();
                     if (addonsDialog != null) {
                         addonsDialog.notifyAddOnDownloadFailed(dl.getUrl().toString());
@@ -623,21 +623,21 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                                     new File(
                                             options.getDownloadDirectory(),
                                             dl.getTargetFile().getName());
-                            logger.info(
+                            LOGGER.info(
                                     "Moving downloaded add-on from {} to {}",
                                     dl.getTargetFile().getAbsolutePath(),
                                     f.getAbsolutePath());
                             FileUtils.moveFile(dl.getTargetFile(), f);
                         } catch (Exception e) {
                             if (!f.exists() && dl.getTargetFile().exists()) {
-                                logger.error(
+                                LOGGER.error(
                                         "Failed to move downloaded add-on from {} to {} - left at original location",
                                         dl.getTargetFile().getAbsolutePath(),
                                         f.getAbsolutePath(),
                                         e);
                                 f = dl.getTargetFile();
                             } else {
-                                logger.error(
+                                LOGGER.error(
                                         "Failed to move downloaded add-on from {} to {} - skipping",
                                         dl.getTargetFile().getAbsolutePath(),
                                         f.getAbsolutePath(),
@@ -655,7 +655,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                                             allInstalled.setValue(
                                                     allInstalled.booleanValue() & install(ao));
                                         } else {
-                                            logger.info(
+                                            LOGGER.info(
                                                     "Can't load add-on: {} Not before={} Not from={} Version={}",
                                                     ao.getName(),
                                                     ao.getNotBeforeVersion(),
@@ -665,7 +665,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                                     });
                 }
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
 
@@ -782,7 +782,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
 
         if (Constant.isSilent()) {
             // Never make unsolicited requests in silent mode
-            logger.info("Shh! No check-for-update - silent mode enabled");
+            LOGGER.info("Shh! No check-for-update - silent mode enabled");
             return;
         }
 
@@ -842,7 +842,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                     CommandLine.error(
                             "This ZAP installation is over a year old - its probably very out of date");
                 } else {
-                    logger.warn(
+                    LOGGER.warn(
                             "This ZAP installation is over a year old - its probably very out of date");
                 }
                 return;
@@ -859,7 +859,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                 CommandLine.error(
                         "No check for updates for over 3 month - add-ons may well be out of date");
             } else {
-                logger.warn(
+                LOGGER.warn(
                         "No check for updates for over 3 month - add-ons may well be out of date");
             }
         }
@@ -872,11 +872,11 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
         Date releaseCreated = Constant.getReleaseCreateDate();
         Date lastInstallWarning = options.getDayLastInstallWarned();
         int result = -1;
-        logger.debug("Install created {}", releaseCreated);
+        LOGGER.debug("Install created {}", releaseCreated);
         if (releaseCreated != null) {
             // Should only be null for dev builds
             int daysOld = dayDiff(today, releaseCreated);
-            logger.debug("Install is {} days old", daysOld);
+            LOGGER.debug("Install is {} days old", daysOld);
             if (daysOld > 365) {
                 // Oh no, its more than a year old!
                 boolean setCfuOnStart = false;
@@ -1004,7 +1004,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                 try {
                     config.save(f);
                 } catch (Exception ex) {
-                    logger.error(ex.getMessage(), ex);
+                    LOGGER.error(ex.getMessage(), ex);
                 }
                 return config;
             }
@@ -1061,7 +1061,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                     this.previousVersionInfo =
                             new AddOnCollection(new ZapXmlConfiguration(f), this.getPlatform());
                 } catch (ConfigurationException e) {
-                    logger.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
         }
@@ -1131,7 +1131,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                                                 new AddOnCollection(conf, getPlatform(), false);
                                     }
                                 } catch (Exception e1) {
-                                    logger.warn(
+                                    LOGGER.warn(
                                             "Failed to check for updates - see log for details",
                                             e1);
                                 }
@@ -1146,10 +1146,10 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                                     }
                                 }
                                 if (callback != null) {
-                                    logger.debug("Calling callback with {}", latestVersionInfo);
+                                    LOGGER.debug("Calling callback with {}", latestVersionInfo);
                                     callback.gotLatestData(latestVersionInfo);
                                 }
-                                logger.debug("Done");
+                                LOGGER.debug("Done");
                             }
                         };
                 this.remoteCallThread.start();
@@ -1219,7 +1219,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
             // Can't uninstall the old version, so dont try to install the new one
             return false;
         }
-        logger.info("Installing new addon {} v{}", ao.getId(), ao.getVersion());
+        LOGGER.info("Installing new addon {} v{}", ao.getId(), ao.getVersion());
         if (hasView()) {
             // Report info to the Output tab
             getView()
@@ -1232,7 +1232,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
 
         ExtensionFactory.getAddOnLoader().addAddon(ao);
 
-        logger.info("Finished installing new addon {} v{}", ao.getId(), ao.getVersion());
+        LOGGER.info("Finished installing new addon {} v{}", ao.getId(), ao.getVersion());
         if (hasView()) {
             // Report info to the Output tab
             getView()
@@ -1261,12 +1261,12 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
 
     private boolean uninstall(
             AddOn addOn, boolean upgrading, AddOnUninstallationProgressCallback callback) {
-        logger.debug("Trying to uninstall addon {} v{}", addOn.getId(), addOn.getVersion());
+        LOGGER.debug("Trying to uninstall addon {} v{}", addOn.getId(), addOn.getVersion());
 
         boolean removedDynamically =
                 ExtensionFactory.getAddOnLoader().removeAddOn(addOn, upgrading, callback);
         if (removedDynamically) {
-            logger.debug("Uninstalled add-on {}", addOn.getName());
+            LOGGER.debug("Uninstalled add-on {}", addOn.getName());
 
             if (latestVersionInfo != null) {
                 AddOn availableAddOn = latestVersionInfo.getAddOn(addOn.getId());
@@ -1277,14 +1277,14 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                 }
             }
         } else {
-            logger.debug("Failed to uninstall add-on {} v{}", addOn.getId(), addOn.getVersion());
+            LOGGER.debug("Failed to uninstall add-on {} v{}", addOn.getId(), addOn.getVersion());
         }
         return removedDynamically;
     }
 
     @Override
     public void insecureUrl(String url, Exception cause) {
-        logger.error("Failed to get check for updates on {}", url, cause);
+        LOGGER.error("Failed to get check for updates on {}", url, cause);
         if (hasView()) {
             getView().showWarningDialog(Constant.messages.getString("cfu.warn.badurl"));
         }
@@ -1301,7 +1301,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
             try {
                 EventQueue.invokeAndWait(() -> getAddOnsDialog());
             } catch (InvocationTargetException | InterruptedException e) {
-                logger.error("Failed to initialise the Manage Add-ons dialogue:", e);
+                LOGGER.error("Failed to initialise the Manage Add-ons dialogue:", e);
             }
         }
         try {
@@ -1311,7 +1311,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                     getModel().getOptionsParam().getCheckForUpdatesParam();
 
             if (rel.isNewerThan(getCurrentVersion())) {
-                logger.debug("There is a newer release: {}", rel.getVersion());
+                LOGGER.debug("There is a newer release: {}", rel.getVersion());
                 // New ZAP release
                 if (Constant.isKali()) {
                     // Kali has its own package management system
@@ -1326,7 +1326,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                     // Already downloaded, prompt to install and exit
                     promptToLaunchReleaseAndClose(rel.getVersion(), f);
                 } else if (options.isDownloadNewRelease()) {
-                    logger.debug("Auto-downloading release");
+                    LOGGER.debug("Auto-downloading release");
                     if (downloadLatestRelease() && addonsDialog != null) {
                         addonsDialog.setDownloadingZap();
                     }
@@ -1372,7 +1372,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
             }
         } catch (Exception e) {
             // Ignore (well, debug;), will be already logged
-            logger.debug(e.getMessage(), e);
+            LOGGER.debug(e.getMessage(), e);
         }
     }
 
@@ -1383,7 +1383,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
         }
 
         // Log at info for daemon mode as its the only indication if not auto-installing
-        logger.info("There is/are {} newer addons", updates.size());
+        LOGGER.info("There is/are {} newer addons", updates.size());
         AddOnDependencyChecker addOnDependencyChecker =
                 new AddOnDependencyChecker(localVersionInfo, aoc);
         Set<AddOn> addOns = new HashSet<>(updates);
@@ -1397,7 +1397,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                     getAddOnsDialog().setVisible(true);
                     return false;
                 }
-                logger.info(
+                LOGGER.info(
                         "Updates not installed some add-ons would be uninstalled or require newer java version: {}",
                         result.getUninstalls());
             }
@@ -1405,7 +1405,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
         }
 
         if (options.isInstallAddonUpdates()) {
-            logger.debug("Auto-downloading addons");
+            LOGGER.debug("Auto-downloading addons");
             processAddOnChanges(null, result);
 
             return false;
@@ -1418,7 +1418,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                 }
             }
 
-            logger.debug("Auto-downloading scanner rules");
+            LOGGER.debug("Auto-downloading scanner rules");
             processAddOnChanges(null, addOnDependencyChecker.calculateUpdateChanges(addOns));
             return false;
         }
@@ -1573,7 +1573,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                                     return messages;
                                 }
                             } catch (Throwable ex) {
-                                logger.error(
+                                LOGGER.error(
                                         "Error while getting messages from {}",
                                         e.getClass().getCanonicalName(),
                                         ex);
@@ -1644,7 +1644,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
         }
 
         if (!failedUninstallations.isEmpty()) {
-            logger.warn(
+            LOGGER.warn(
                     "It's recommended to restart ZAP. Not all add-ons were successfully uninstalled: {}",
                     failedUninstallations);
             return false;
@@ -1669,7 +1669,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                                 uninstallAddOnsWithView(
                                         caller, addOns, updates, failedUninstallations));
             } catch (InvocationTargetException | InterruptedException e) {
-                logger.error("Failed to uninstall add-ons:", e);
+                LOGGER.error("Failed to uninstall add-ons:", e);
                 return false;
             }
             return failedUninstallations.isEmpty();
@@ -1761,7 +1761,7 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                         }
 
                         if (!failedUninstallations.isEmpty()) {
-                            logger.warn(
+                            LOGGER.warn(
                                     "Not all add-ons were successfully uninstalled: {}",
                                     failedUninstallations);
                         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ManageAddOnsDialog.java
@@ -119,7 +119,7 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
     private static final String ADD_ON_NOT_MANDATORY =
             Constant.messages.getString("cfu.table.mandatory.value.no");
 
-    private static final Logger logger = LogManager.getLogger(ManageAddOnsDialog.class);
+    private static final Logger LOGGER = LogManager.getLogger(ManageAddOnsDialog.class);
     private static final long serialVersionUID = 1L;
     private JTabbedPane jTabbed = null;
     private JPanel topPanel = null;
@@ -1150,7 +1150,7 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
                     }
                 }
             } catch (Exception e) {
-                logger.debug("Error on {}", this.latestInfo.getZapRelease().getUrl(), e);
+                LOGGER.debug("Error on {}", this.latestInfo.getZapRelease().getUrl(), e);
                 this.getDownloadProgress()
                         .setText(Constant.messages.getString("cfu.table.label.failed"));
             }
@@ -1189,7 +1189,7 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
     @Override
     public void gotLatestData(AddOnCollection aoc) {
         // Callback
-        logger.debug("gotLatestData(AddOnCollection {}", aoc);
+        LOGGER.debug("gotLatestData(AddOnCollection {}", aoc);
 
         if (aoc != null) {
             EventQueue.invokeLater(() -> setLatestVersionInfo(aoc));
@@ -1201,7 +1201,7 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
 
     @Override
     public void insecureUrl(String url, Exception cause) {
-        logger.error("Failed to get check for updates on {}", url, cause);
+        LOGGER.error("Failed to get check for updates on {}", url, cause);
         View.getSingleton().showWarningDialog(this, Constant.messages.getString("cfu.warn.badurl"));
     }
 
@@ -1279,7 +1279,7 @@ public class ManageAddOnsDialog extends AbstractFrame implements CheckForUpdateC
                             try {
                                 Desktop.getDesktop().browse(evt.getURL().toURI());
                             } catch (IOException | URISyntaxException e) {
-                                logger.warn("Failed to open the URL: {}", evt.getURL(), e);
+                                LOGGER.warn("Failed to open the URL: {}", evt.getURL(), e);
                             }
                         }
                     });

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/OptionsParamCheckForUpdates.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/OptionsParamCheckForUpdates.java
@@ -67,7 +67,7 @@ public class OptionsParamCheckForUpdates extends AbstractParam {
     private String dayLastChecked = null;
     private String dayLastInstallWarned = null;
     private String dayLastUpdateWarned = null;
-    private static Logger log = LogManager.getLogger(OptionsParamCheckForUpdates.class);
+    private static final Logger LOGGER = LogManager.getLogger(OptionsParamCheckForUpdates.class);
 
     public OptionsParamCheckForUpdates() {}
 
@@ -88,11 +88,11 @@ public class OptionsParamCheckForUpdates extends AbstractParam {
         for (Object dir : getConfig().getList(ADDON_DIRS)) {
             File f = new File(dir.toString());
             if (!f.exists()) {
-                log.error("Add-on directory does not exist: {}", f.getAbsolutePath());
+                LOGGER.error("Add-on directory does not exist: {}", f.getAbsolutePath());
             } else if (!f.isDirectory()) {
-                log.error("Add-on directory is not a directory: {}", f.getAbsolutePath());
+                LOGGER.error("Add-on directory is not a directory: {}", f.getAbsolutePath());
             } else if (!f.canRead()) {
-                log.error("Add-on directory not readable: {}", f.getAbsolutePath());
+                LOGGER.error("Add-on directory not readable: {}", f.getAbsolutePath());
             } else {
                 this.addonDirectories.add(f);
             }
@@ -148,19 +148,19 @@ public class OptionsParamCheckForUpdates extends AbstractParam {
     @ZapApiIgnore
     public boolean checkOnStart() {
         if (!checkOnStart) {
-            log.debug("isCheckForStart - false");
+            LOGGER.debug("isCheckForStart - false");
             return false;
         }
         String today = getSdf().format(new Date());
         if (today.equals(dayLastChecked)) {
-            log.debug("isCheckForStart - already checked today");
+            LOGGER.debug("isCheckForStart - already checked today");
             return false;
         }
         getConfig().setProperty(DAY_LAST_CHECKED, today);
         try {
             getConfig().save();
         } catch (ConfigurationException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         return true;
@@ -215,7 +215,7 @@ public class OptionsParamCheckForUpdates extends AbstractParam {
         try {
             getConfig().save();
         } catch (ConfigurationException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -224,7 +224,7 @@ public class OptionsParamCheckForUpdates extends AbstractParam {
         try {
             getConfig().save();
         } catch (ConfigurationException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakpointsPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakpointsPanel.java
@@ -57,7 +57,7 @@ public class BreakpointsPanel extends AbstractPanel {
     private final Preferences preferences;
     private final String prefnzPrefix = this.getClass().getSimpleName() + ".";
 
-    private static Logger log = LogManager.getLogger(BreakpointsPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(BreakpointsPanel.class);
 
     public BreakpointsPanel(ExtensionBreak extension) {
         super();
@@ -241,7 +241,7 @@ public class BreakpointsPanel extends AbstractPanel {
                         }
                     });
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -267,7 +267,7 @@ public class BreakpointsPanel extends AbstractPanel {
                         }
                     });
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -289,13 +289,13 @@ public class BreakpointsPanel extends AbstractPanel {
                         }
                     });
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
     private void saveColumnWidth(String prefix, int width) {
         if (width > 0) {
-            log.debug(
+            LOGGER.debug(
                     "Saving preference {}{}.{}={}", prefnzPrefix, prefix, PREF_COLUMN_WIDTH, width);
             this.preferences.put(
                     prefnzPrefix + prefix + "." + PREF_COLUMN_WIDTH, Integer.toString(width));
@@ -303,7 +303,7 @@ public class BreakpointsPanel extends AbstractPanel {
             try {
                 this.preferences.flush();
             } catch (final BackingStoreException e) {
-                log.error("Error while saving the preferences", e);
+                LOGGER.error("Error while saving the preferences", e);
             }
         }
     }
@@ -321,7 +321,7 @@ public class BreakpointsPanel extends AbstractPanel {
             }
             if (width > 0) {
                 result = width;
-                log.debug(
+                LOGGER.debug(
                         "Restoring preference {}{}.{}={}",
                         prefnzPrefix,
                         prefix,
@@ -346,7 +346,8 @@ public class BreakpointsPanel extends AbstractPanel {
         public void propertyChange(PropertyChangeEvent evt) {
             TableColumn column = (TableColumn) evt.getSource();
             if (column != null) {
-                log.debug("{}{}.{}={}", prefnzPrefix, prefix, PREF_COLUMN_WIDTH, column.getWidth());
+                LOGGER.debug(
+                        "{}{}.{}={}", prefnzPrefix, prefix, PREF_COLUMN_WIDTH, column.getWidth());
                 saveColumnWidth(prefix, column.getWidth());
             }
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/ExtensionBreak.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/ExtensionBreak.java
@@ -62,7 +62,7 @@ public class ExtensionBreak extends ExtensionAdaptor
 
     public static final String NAME = "ExtensionBreak";
 
-    private static final Logger logger = LogManager.getLogger(ExtensionBreak.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionBreak.class);
 
     public static final String BREAK_POINT_HIT_STATS = "stats.break.hit";
     public static final String BREAK_POINT_STEP_STATS = "stats.break.step";
@@ -560,7 +560,7 @@ public class ExtensionBreak extends ExtensionAdaptor
                             }
                         });
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -628,7 +628,7 @@ public class ExtensionBreak extends ExtensionAdaptor
     }
 
     public void setBreakOnId(String id, boolean enable) {
-        logger.debug("setBreakOnId {} {}", id, enable);
+        LOGGER.debug("setBreakOnId {} {}", id, enable);
         if (enable) {
             breakpointMessageHandler.getEnabledKeyBreakpoints().add(id);
         } else {

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/impl/http/HttpBreakpointMessage.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/impl/http/HttpBreakpointMessage.java
@@ -44,7 +44,7 @@ public class HttpBreakpointMessage extends AbstractBreakPointMessage {
         regex
     }
 
-    private static final Logger logger = LogManager.getLogger(HttpBreakpointMessage.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpBreakpointMessage.class);
 
     private static final String TYPE = "HTTP";
 
@@ -188,7 +188,7 @@ public class HttpBreakpointMessage extends AbstractBreakPointMessage {
                 }
 
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
 
@@ -204,7 +204,7 @@ public class HttpBreakpointMessage extends AbstractBreakPointMessage {
             }
         } catch (Exception e) {
             // This wont be a problem if its a 'contains' match
-            logger.debug("Potentially invalid regex", e);
+            LOGGER.debug("Potentially invalid regex", e);
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/impl/http/PopupMenuAddBreakHistory.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/impl/http/PopupMenuAddBreakHistory.java
@@ -34,7 +34,7 @@ public class PopupMenuAddBreakHistory extends PopupMenuItemHistoryReferenceConta
 
     private static final long serialVersionUID = -1984801437717248474L;
 
-    private static final Logger logger = LogManager.getLogger(PopupMenuAddBreakHistory.class);
+    private static final Logger LOGGER = LogManager.getLogger(PopupMenuAddBreakHistory.class);
 
     private final ExtensionBreak extension;
 
@@ -54,7 +54,7 @@ public class PopupMenuAddBreakHistory extends PopupMenuItemHistoryReferenceConta
         try {
             extension.addUiBreakpoint(href.getHttpMessage());
         } catch (HttpMalformedHeaderException | DatabaseException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             extension
                     .getView()
                     .showWarningDialog(Constant.messages.getString("brk.add.error.history"));

--- a/zap/src/main/java/org/zaproxy/zap/extension/compare/ExtensionCompare.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/compare/ExtensionCompare.java
@@ -85,7 +85,7 @@ public class ExtensionCompare extends ExtensionAdaptor
     private static final String CRLF = "\r\n";
     private JMenuItem menuCompare = null;
 
-    private static Logger log = LogManager.getLogger(ExtensionCompare.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionCompare.class);
 
     public ExtensionCompare() {
         super(NAME);
@@ -122,7 +122,7 @@ public class ExtensionCompare extends ExtensionAdaptor
                             }
                         });
             } catch (Exception e) {
-                log.warn(e.getMessage(), e);
+                LOGGER.warn(e.getMessage(), e);
             }
         }
     }
@@ -324,7 +324,7 @@ public class ExtensionCompare extends ExtensionAdaptor
                             try (InputStream is =
                                     ExtensionCompare.class.getResourceAsStream(path)) {
                                 if (is == null) {
-                                    log.error("Bundled file not found: {}", path);
+                                    LOGGER.error("Bundled file not found: {}", path);
                                     return;
                                 }
                                 stringToHtml(
@@ -335,14 +335,14 @@ public class ExtensionCompare extends ExtensionAdaptor
                         }
 
                         if (Files.notExists(outputFile.toPath())) {
-                            log.info("Not opening report, does not exist: {}", outputFile);
+                            LOGGER.info("Not opening report, does not exist: {}", outputFile);
                             return;
                         }
 
                         try {
                             DesktopUtils.openUrlInBrowser(outputFile.toURI());
                         } catch (Exception e) {
-                            log.error(e.getMessage(), e);
+                            LOGGER.error(e.getMessage(), e);
                             getView()
                                     .showMessageDialog(
                                             Constant.messages.getString(
@@ -351,12 +351,12 @@ public class ExtensionCompare extends ExtensionAdaptor
                         }
 
                     } catch (Exception e1) {
-                        log.warn(e1.getMessage(), e1);
+                        LOGGER.warn(e1.getMessage(), e1);
                     }
                 }
 
             } catch (Exception e) {
-                log.warn(e.getMessage(), e);
+                LOGGER.warn(e.getMessage(), e);
             }
         }
     }
@@ -395,7 +395,7 @@ public class ExtensionCompare extends ExtensionAdaptor
                     | SAXException
                     | ParserConfigurationException
                     | IOException e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
                 // Save the xml for diagnosing the problem
                 BufferedWriter bw = null;
                 try {
@@ -405,7 +405,7 @@ public class ExtensionCompare extends ExtensionAdaptor
                                     StandardCharsets.UTF_8);
                     bw.write(inxml);
                 } catch (IOException e2) {
-                    log.error("Failed to write debug XML file", e);
+                    LOGGER.error("Failed to write debug XML file", e);
                     return new File(outfilename);
                 } finally {
                     try {
@@ -437,7 +437,7 @@ public class ExtensionCompare extends ExtensionAdaptor
                 }
 
             } catch (IOException e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
             // Remove the temporary file
             outfile.delete();
@@ -451,7 +451,7 @@ public class ExtensionCompare extends ExtensionAdaptor
                                 new File(outfilename).toPath(), StandardCharsets.UTF_8);
                 bw.write(inxml);
             } catch (IOException e2) {
-                log.error(e2.getMessage(), e2);
+                LOGGER.error(e2.getMessage(), e2);
             } finally {
                 try {
                     if (bw != null) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/ext/ExtensionExtension.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ext/ExtensionExtension.java
@@ -23,8 +23,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.CommandLineArgument;
@@ -37,8 +35,6 @@ public class ExtensionExtension extends ExtensionAdaptor implements CommandLineL
     public static final String NAME = "ExtensionExtension";
 
     private OptionsExtensionPanel optionsExceptionsPanel = null;
-
-    private Logger logger = LogManager.getLogger(ExtensionExtension.class);
 
     public ExtensionExtension() {
         super();

--- a/zap/src/main/java/org/zaproxy/zap/extension/ext/OptionsExtensionPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ext/OptionsExtensionPanel.java
@@ -62,7 +62,7 @@ public class OptionsExtensionPanel extends AbstractParamPanel {
     private JScrollPane extDescScrollPane = null;
     private JButton urlLaunchButton = null;
 
-    private static Logger log = LogManager.getLogger(OptionsExtensionPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(OptionsExtensionPanel.class);
 
     public OptionsExtensionPanel(ExtensionExtension ext) {
         super();
@@ -171,7 +171,7 @@ public class OptionsExtensionPanel extends AbstractParamPanel {
                                         }
                                     } catch (Exception e) {
                                         // Just to be safe
-                                        log.error(e.getMessage(), e);
+                                        LOGGER.error(e.getMessage(), e);
                                     }
                                 }
                             }

--- a/zap/src/main/java/org/zaproxy/zap/extension/ext/OptionsExtensionTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ext/OptionsExtensionTableModel.java
@@ -44,7 +44,7 @@ public class OptionsExtensionTableModel extends AbstractTableModel {
 
     private List<Extension> extensions = ExtensionFactory.getAllExtensions();
 
-    private static Logger log = LogManager.getLogger(OptionsExtensionTableModel.class);
+    private static final Logger LOGGER = LogManager.getLogger(OptionsExtensionTableModel.class);
 
     private Map<String, Boolean> extensionsState = new HashMap<>();
 
@@ -81,7 +81,7 @@ public class OptionsExtensionTableModel extends AbstractTableModel {
                         return ext.getUIName();
                 }
             } catch (Exception e) {
-                log.error("Failed on extension {}", ext.getName(), e);
+                LOGGER.error("Failed on extension {}", ext.getName(), e);
             }
         }
         return null;

--- a/zap/src/main/java/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/forceduser/ExtensionForcedUser.java
@@ -87,7 +87,7 @@ public class ExtensionForcedUser extends ExtensionAdaptor
     private static final int NO_FORCED_USER = -1;
 
     /** The Constant log. */
-    private static final Logger log = LogManager.getLogger(ExtensionForcedUser.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionForcedUser.class);
 
     /** The map of context panels. */
     private Map<Integer, ContextForcedUserPanel> contextPanelsMap = new HashMap<>();
@@ -357,7 +357,7 @@ public class ExtensionForcedUser extends ExtensionAdaptor
 
         if (requestingUser == null || !requestingUser.isEnabled()) return;
 
-        log.debug(
+        LOGGER.debug(
                 "Modifying request message ({}) to match user: {}",
                 msg.getRequestHeader().getURI(),
                 requestingUser);
@@ -381,7 +381,7 @@ public class ExtensionForcedUser extends ExtensionAdaptor
                 setForcedUser(context.getId(), forcedUserId);
             }
         } catch (Exception e) {
-            log.error("Unable to load forced user.", e);
+            LOGGER.error("Unable to load forced user.", e);
         }
     }
 
@@ -401,7 +401,7 @@ public class ExtensionForcedUser extends ExtensionAdaptor
                 session.clearContextDataForType(context.getId(), RecordContext.TYPE_FORCED_USER_ID);
             }
         } catch (Exception e) {
-            log.error("Unable to persist forced user.", e);
+            LOGGER.error("Unable to persist forced user.", e);
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/forceduser/ForcedUserAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/forceduser/ForcedUserAPI.java
@@ -30,7 +30,6 @@ import org.zaproxy.zap.extension.api.ApiImplementor;
 import org.zaproxy.zap.extension.api.ApiResponse;
 import org.zaproxy.zap.extension.api.ApiResponseElement;
 import org.zaproxy.zap.extension.api.ApiView;
-import org.zaproxy.zap.extension.authentication.AuthenticationAPI;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.users.User;
 import org.zaproxy.zap.utils.ApiUtils;
@@ -38,7 +37,7 @@ import org.zaproxy.zap.utils.ApiUtils;
 /** The API for managing the Forced User for a Context. */
 public class ForcedUserAPI extends ApiImplementor {
 
-    private static final Logger log = LogManager.getLogger(AuthenticationAPI.class);
+    private static final Logger LOGGER = LogManager.getLogger(ForcedUserAPI.class);
 
     private static final String PREFIX = "forcedUser";
 
@@ -71,7 +70,7 @@ public class ForcedUserAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiView(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiView {} {}", name, params);
+        LOGGER.debug("handleApiView {} {}", name, params);
 
         switch (name) {
             case VIEW_GET_FORCED_USER:
@@ -91,7 +90,7 @@ public class ForcedUserAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiAction {} {}", name, params);
+        LOGGER.debug("handleApiAction {} {}", name, params);
         Context context;
         switch (name) {
             case ACTION_SET_FORCED_USER:

--- a/zap/src/main/java/org/zaproxy/zap/extension/globalexcludeurl/ExtensionGlobalExcludeURL.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/globalexcludeurl/ExtensionGlobalExcludeURL.java
@@ -20,8 +20,6 @@
  */
 package org.zaproxy.zap.extension.globalexcludeurl;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
@@ -34,8 +32,6 @@ public class ExtensionGlobalExcludeURL extends ExtensionAdaptor {
 
     private OptionsGlobalExcludeURLPanel optionsGlobalExcludeURLPanel = null;
     // TODO Implement later ... private PopupMenuGenerateForm popupMenuGenerateForm = null;
-
-    private static Logger log = LogManager.getLogger(ExtensionGlobalExcludeURL.class);
 
     public ExtensionGlobalExcludeURL() {
         super();

--- a/zap/src/main/java/org/zaproxy/zap/extension/globalexcludeurl/GlobalExcludeURLParam.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/globalexcludeurl/GlobalExcludeURLParam.java
@@ -31,7 +31,7 @@ import org.zaproxy.zap.extension.api.ZapApiIgnore;
 
 public class GlobalExcludeURLParam extends AbstractParam {
 
-    private static final Logger logger = LogManager.getLogger(GlobalExcludeURLParam.class);
+    private static final Logger LOGGER = LogManager.getLogger(GlobalExcludeURLParam.class);
 
     private static final String GLOBAL_EXCLUDE_URL_BASE_KEY = "globalexcludeurl";
 
@@ -219,7 +219,7 @@ public class GlobalExcludeURLParam extends AbstractParam {
                 }
             }
         } catch (ConversionException e) {
-            logger.error("Error while loading Global Exclude URL tokens: {}", e.getMessage(), e);
+            LOGGER.error("Error while loading Global Exclude URL tokens: {}", e.getMessage(), e);
             this.tokens = new ArrayList<>(defaultList.size());
             this.enabledTokensNames = new ArrayList<>(defaultList.size());
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/help/BasicOnlineContentViewerUI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/help/BasicOnlineContentViewerUI.java
@@ -32,7 +32,7 @@ import org.apache.logging.log4j.Logger;
 
 public class BasicOnlineContentViewerUI extends BasicContentViewerUI {
 
-    private static final Logger logger = LogManager.getLogger(BasicOnlineContentViewerUI.class);
+    private static final Logger LOGGER = LogManager.getLogger(BasicOnlineContentViewerUI.class);
 
     private static final long serialVersionUID = -1640590425627589113L;
 
@@ -48,7 +48,7 @@ public class BasicOnlineContentViewerUI extends BasicContentViewerUI {
             try {
                 Desktop.getDesktop().browse(u.toURI());
             } catch (IOException | URISyntaxException e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         } else {
             super.linkActivated(u);

--- a/zap/src/main/java/org/zaproxy/zap/extension/help/ExtensionHelp.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/help/ExtensionHelp.java
@@ -128,7 +128,7 @@ public class ExtensionHelp extends ExtensionAdaptor {
 
     private static Map<AddOn, List<HelpSet>> addOnHelpSets = new HashMap<>();
 
-    private static final Logger logger = LogManager.getLogger(ExtensionHelp.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionHelp.class);
 
     public ExtensionHelp() {
         super(NAME);
@@ -265,7 +265,7 @@ public class ExtensionHelp extends ExtensionAdaptor {
                         Constant.getLocale(),
                         classLoader::getResource);
         if (helpSetUrl == null) {
-            logger.error(
+            LOGGER.error(
                     "Declared helpset not found for '{}' add-on, with base name: {} {}",
                     addOn.getId(),
                     helpSetData.getBaseName(),
@@ -276,10 +276,10 @@ public class ExtensionHelp extends ExtensionAdaptor {
         }
 
         try {
-            logger.debug("Loading help for '{}' add-on and merging with core help.", addOn.getId());
+            LOGGER.debug("Loading help for '{}' add-on and merging with core help.", addOn.getId());
             addHelpSet(addOn, new HelpSet(classLoader, helpSetUrl));
         } catch (HelpSetException e) {
-            logger.error("An error occured while adding help for '{}' add-on:", addOn.getId(), e);
+            LOGGER.error("An error occured while adding help for '{}' add-on:", addOn.getId(), e);
         }
     }
 
@@ -292,13 +292,13 @@ public class ExtensionHelp extends ExtensionAdaptor {
         URL helpSetUrl = getExtensionHelpSetUrl(ext);
         if (helpSetUrl != null) {
             try {
-                logger.debug(
+                LOGGER.debug(
                         "Load help files for extension '{}' and merge with core help.",
                         ext.getName());
                 addHelpSet(
                         ext.getAddOn(), new HelpSet(ext.getClass().getClassLoader(), helpSetUrl));
             } catch (HelpSetException e) {
-                logger.error(
+                LOGGER.error(
                         "An error occured while adding help file of extension '{}': {}",
                         ext.getName(),
                         e.getMessage(),
@@ -370,7 +370,7 @@ public class ExtensionHelp extends ExtensionAdaptor {
                     showHelpActionListener = new CSH.DisplayHelpFromFocus(hb);
                 }
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -445,7 +445,7 @@ public class ExtensionHelp extends ExtensionAdaptor {
         try {
             getHelpBroker().showID(helpindex, "javax.help.SecondaryWindow", null);
         } catch (Exception e) {
-            logger.error("error loading help with index: {}", helpindex, e);
+            LOGGER.error("error loading help with index: {}", helpindex, e);
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuNote.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuNote.java
@@ -34,7 +34,7 @@ public class PopupMenuNote extends PopupMenuItemHistoryReferenceContainer {
 
     private static final long serialVersionUID = -5692544221103745600L;
 
-    private static final Logger logger = LogManager.getLogger(PopupMenuNote.class);
+    private static final Logger LOGGER = LogManager.getLogger(PopupMenuNote.class);
 
     private final ExtensionHistory extension;
 
@@ -55,7 +55,7 @@ public class PopupMenuNote extends PopupMenuItemHistoryReferenceContainer {
             extension.showNotesAddDialog(href, href.getHttpMessage().getNote());
 
         } catch (HttpMalformedHeaderException | DatabaseException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/HttpPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/HttpPanel.java
@@ -70,7 +70,7 @@ public abstract class HttpPanel extends AbstractPanel {
 
     private static final long serialVersionUID = 5221591643257366570L;
 
-    private static final Logger logger = LogManager.getLogger(HttpPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpPanel.class);
 
     private static final String NO_SUITABLE_COMPONENT_FOUND_LABEL =
             Constant.messages.getString("http.panel.noSuitableComponentFound");
@@ -370,7 +370,7 @@ public abstract class HttpPanel extends AbstractPanel {
         HttpPanelComponentInterface newComponent = components.get(name);
 
         if (newComponent == null) {
-            logger.info("No component found with name: {}", name);
+            LOGGER.info("No component found with name: {}", name);
             return;
         }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/component/HttpPanelComponentViewsManager.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/component/HttpPanelComponentViewsManager.java
@@ -60,7 +60,7 @@ import org.zaproxy.zap.view.messagelocation.MessageLocationHighlighter;
 
 public class HttpPanelComponentViewsManager implements ItemListener, MessageLocationHighlighter {
 
-    private static final Logger logger = LogManager.getLogger(HttpPanelComponentViewsManager.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpPanelComponentViewsManager.class);
 
     private static final String VIEWS_KEY = "views";
     private static final String DEFAULT_VIEW_KEY = "defaultview";
@@ -164,7 +164,7 @@ public class HttpPanelComponentViewsManager implements ItemListener, MessageLoca
         HttpPanelView view = views.get(name);
 
         if (view == null) {
-            logger.info("No view found with name: {}", name);
+            LOGGER.info("No view found with name: {}", name);
             return;
         }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/component/all/request/HttpRequestAllPanelTextView.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/component/all/request/HttpRequestAllPanelTextView.java
@@ -22,8 +22,6 @@ package org.zaproxy.zap.extension.httppanel.component.all.request;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.request.RequestStringHttpPanelViewModel;
 import org.zaproxy.zap.extension.httppanel.view.text.HttpPanelTextArea;
@@ -32,8 +30,6 @@ import org.zaproxy.zap.extension.httppanel.view.util.HttpTextViewUtils;
 import org.zaproxy.zap.extension.search.SearchMatch;
 
 public class HttpRequestAllPanelTextView extends HttpPanelTextView {
-
-    private static final Logger log = LogManager.getLogger(HttpRequestAllPanelTextView.class);
 
     public HttpRequestAllPanelTextView(RequestStringHttpPanelViewModel model) {
         super(model);

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/component/all/response/HttpResponseAllPanelTextView.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/component/all/response/HttpResponseAllPanelTextView.java
@@ -22,8 +22,6 @@ package org.zaproxy.zap.extension.httppanel.component.all.response;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.response.ResponseStringHttpPanelViewModel;
 import org.zaproxy.zap.extension.httppanel.view.text.HttpPanelTextArea;
@@ -32,8 +30,6 @@ import org.zaproxy.zap.extension.httppanel.view.util.HttpTextViewUtils;
 import org.zaproxy.zap.extension.search.SearchMatch;
 
 public class HttpResponseAllPanelTextView extends HttpPanelTextView {
-
-    private static final Logger log = LogManager.getLogger(HttpResponseAllPanelTextView.class);
 
     public HttpResponseAllPanelTextView(ResponseStringHttpPanelViewModel model) {
         super(model);

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestByteHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestByteHttpPanelViewModel.java
@@ -30,7 +30,7 @@ import org.zaproxy.zap.extension.httppanel.view.impl.models.http.HttpPanelViewMo
 
 public class RequestByteHttpPanelViewModel extends AbstractHttpByteHttpPanelViewModel {
 
-    private static final Logger logger = LogManager.getLogger(RequestByteHttpPanelViewModel.class);
+    private static final Logger LOGGER = LogManager.getLogger(RequestByteHttpPanelViewModel.class);
 
     @Override
     public byte[] getData() {
@@ -58,8 +58,8 @@ public class RequestByteHttpPanelViewModel extends AbstractHttpByteHttpPanelView
         int pos = HttpPanelViewModelUtils.findHeaderLimit(data);
 
         if (pos == -1) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("Could not Save Header, limit not found. Header: {}", new String(data));
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn("Could not Save Header, limit not found. Header: {}", new String(data));
             }
             throw new InvalidMessageDataException(
                     Constant.messages.getString("http.panel.model.header.warn.notfound"));
@@ -68,8 +68,8 @@ public class RequestByteHttpPanelViewModel extends AbstractHttpByteHttpPanelView
         try {
             httpMessage.setRequestHeader(new String(data, 0, pos));
         } catch (HttpMalformedHeaderException e) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("Could not Save Header: {}", new String(data, 0, pos), e);
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn("Could not Save Header: {}", new String(data, 0, pos), e);
             }
             throw new InvalidMessageDataException(
                     Constant.messages.getString("http.panel.model.header.warn.malformed"), e);

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestHeaderByteHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestHeaderByteHttpPanelViewModel.java
@@ -29,7 +29,7 @@ import org.zaproxy.zap.extension.httppanel.view.impl.models.http.AbstractHttpByt
 
 public class RequestHeaderByteHttpPanelViewModel extends AbstractHttpByteHttpPanelViewModel {
 
-    private static final Logger logger =
+    private static final Logger LOGGER =
             LogManager.getLogger(RequestHeaderByteHttpPanelViewModel.class);
 
     @Override
@@ -50,8 +50,8 @@ public class RequestHeaderByteHttpPanelViewModel extends AbstractHttpByteHttpPan
         try {
             httpMessage.setRequestHeader(new String(data));
         } catch (HttpMalformedHeaderException e) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("Could not Save Header: {}", Arrays.toString(data), e);
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn("Could not Save Header: {}", Arrays.toString(data), e);
             }
             throw new InvalidMessageDataException(
                     Constant.messages.getString("http.panel.model.header.warn.malformed"), e);

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestHeaderStringHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestHeaderStringHttpPanelViewModel.java
@@ -29,7 +29,7 @@ import org.zaproxy.zap.extension.httppanel.view.impl.models.http.AbstractHttpStr
 
 public class RequestHeaderStringHttpPanelViewModel extends AbstractHttpStringHttpPanelViewModel {
 
-    private static final Logger logger =
+    private static final Logger LOGGER =
             LogManager.getLogger(RequestHeaderStringHttpPanelViewModel.class);
 
     @Override
@@ -51,7 +51,7 @@ public class RequestHeaderStringHttpPanelViewModel extends AbstractHttpStringHtt
         try {
             httpMessage.setRequestHeader(header);
         } catch (HttpMalformedHeaderException e) {
-            logger.warn("Could not Save Header: {}", header, e);
+            LOGGER.warn("Could not Save Header: {}", header, e);
             throw new InvalidMessageDataException(
                     Constant.messages.getString("http.panel.model.header.warn.malformed"), e);
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModel.java
@@ -29,7 +29,7 @@ import org.zaproxy.zap.extension.httppanel.view.impl.models.http.AbstractHttpStr
 
 public class RequestStringHttpPanelViewModel extends AbstractHttpStringHttpPanelViewModel {
 
-    private static final Logger logger =
+    private static final Logger LOGGER =
             LogManager.getLogger(RequestStringHttpPanelViewModel.class);
 
     @Override
@@ -55,7 +55,7 @@ public class RequestStringHttpPanelViewModel extends AbstractHttpStringHttpPanel
         try {
             httpMessage.setRequestHeader(header);
         } catch (HttpMalformedHeaderException e) {
-            logger.warn("Could not Save Header: {}", header, e);
+            LOGGER.warn("Could not Save Header: {}", header, e);
             throw new InvalidMessageDataException(
                     Constant.messages.getString("http.panel.model.header.warn.malformed"), e);
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseByteHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseByteHttpPanelViewModel.java
@@ -31,7 +31,7 @@ import org.zaproxy.zap.extension.httppanel.view.impl.models.http.HttpPanelViewMo
 
 public class ResponseByteHttpPanelViewModel extends AbstractHttpByteHttpPanelViewModel {
 
-    private static final Logger logger = LogManager.getLogger(ResponseByteHttpPanelViewModel.class);
+    private static final Logger LOGGER = LogManager.getLogger(ResponseByteHttpPanelViewModel.class);
 
     @Override
     public byte[] getData() {
@@ -59,8 +59,8 @@ public class ResponseByteHttpPanelViewModel extends AbstractHttpByteHttpPanelVie
         int pos = HttpPanelViewModelUtils.findHeaderLimit(data);
 
         if (pos == -1) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("Could not Save Header, limit not found. Header: {}", new String(data));
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn("Could not Save Header, limit not found. Header: {}", new String(data));
             }
             throw new InvalidMessageDataException(
                     Constant.messages.getString("http.panel.model.header.warn.notfound"));
@@ -69,8 +69,8 @@ public class ResponseByteHttpPanelViewModel extends AbstractHttpByteHttpPanelVie
         try {
             httpMessage.setResponseHeader(new String(data, 0, pos));
         } catch (HttpMalformedHeaderException e) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("Could not Save Header: {}", Arrays.toString(data), e);
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn("Could not Save Header: {}", Arrays.toString(data), e);
             }
             throw new InvalidMessageDataException(
                     Constant.messages.getString("http.panel.model.header.warn.malformed"), e);

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseHeaderByteHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseHeaderByteHttpPanelViewModel.java
@@ -29,7 +29,7 @@ import org.zaproxy.zap.extension.httppanel.view.impl.models.http.AbstractHttpByt
 
 public class ResponseHeaderByteHttpPanelViewModel extends AbstractHttpByteHttpPanelViewModel {
 
-    private static final Logger logger =
+    private static final Logger LOGGER =
             LogManager.getLogger(ResponseHeaderByteHttpPanelViewModel.class);
 
     @Override
@@ -50,8 +50,8 @@ public class ResponseHeaderByteHttpPanelViewModel extends AbstractHttpByteHttpPa
         try {
             httpMessage.setResponseHeader(new String(data));
         } catch (HttpMalformedHeaderException e) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("Could not Save Header: {}", Arrays.toString(data), e);
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn("Could not Save Header: {}", Arrays.toString(data), e);
             }
             throw new InvalidMessageDataException(
                     Constant.messages.getString("http.panel.model.header.warn.malformed"), e);

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseHeaderStringHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseHeaderStringHttpPanelViewModel.java
@@ -29,7 +29,7 @@ import org.zaproxy.zap.extension.httppanel.view.impl.models.http.AbstractHttpStr
 
 public class ResponseHeaderStringHttpPanelViewModel extends AbstractHttpStringHttpPanelViewModel {
 
-    private static final Logger logger =
+    private static final Logger LOGGER =
             LogManager.getLogger(ResponseHeaderStringHttpPanelViewModel.class);
 
     @Override
@@ -54,7 +54,7 @@ public class ResponseHeaderStringHttpPanelViewModel extends AbstractHttpStringHt
         try {
             httpMessage.setResponseHeader(header);
         } catch (HttpMalformedHeaderException e) {
-            logger.warn("Could not Save Header: {}", header, e);
+            LOGGER.warn("Could not Save Header: {}", header, e);
             throw new InvalidMessageDataException(
                     Constant.messages.getString("http.panel.model.header.warn.malformed"), e);
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseStringHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/response/ResponseStringHttpPanelViewModel.java
@@ -29,7 +29,7 @@ import org.zaproxy.zap.extension.httppanel.view.impl.models.http.AbstractHttpStr
 
 public class ResponseStringHttpPanelViewModel extends AbstractHttpStringHttpPanelViewModel {
 
-    private static final Logger logger =
+    private static final Logger LOGGER =
             LogManager.getLogger(ResponseStringHttpPanelViewModel.class);
 
     @Override
@@ -55,7 +55,7 @@ public class ResponseStringHttpPanelViewModel extends AbstractHttpStringHttpPane
         try {
             httpMessage.setResponseHeader(header);
         } catch (HttpMalformedHeaderException e) {
-            logger.warn("Could not Save Header: {}", header, e);
+            LOGGER.warn("Could not Save Header: {}", header, e);
             throw new InvalidMessageDataException(
                     Constant.messages.getString("http.panel.model.header.warn.malformed"), e);
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/paramtable/HttpPanelParamTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/paramtable/HttpPanelParamTableModel.java
@@ -34,7 +34,7 @@ public abstract class HttpPanelParamTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 8714941615215038148L;
 
-    private static final Logger log = LogManager.getLogger(HttpPanelParamTableModel.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpPanelParamTableModel.class);
 
     private static final String[] columnNames = {
         Constant.messages.getString("http.panel.view.tableparam.type"),
@@ -113,7 +113,7 @@ public abstract class HttpPanelParamTableModel extends AbstractTableModel {
                     changed = true;
                     col = 2;
                 } catch (UnsupportedEncodingException e) {
-                    log.warn(e.getMessage(), e);
+                    LOGGER.warn(e.getMessage(), e);
                 }
             }
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/posttable/RequestPostTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/posttable/RequestPostTableModel.java
@@ -23,6 +23,7 @@
 // ZAP: 2017/05/31 Added multi-catch in a specific handler.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2023/01/10 Tidy up logger.
 package org.zaproxy.zap.extension.httppanel.view.posttable;
 
 import java.io.UnsupportedEncodingException;
@@ -49,7 +50,7 @@ public class RequestPostTableModel extends AbstractTableModel {
     private boolean isChanged = false;
 
     // ZAP: Added logger
-    private static final Logger logger = LogManager.getLogger(RequestPostTableModel.class);
+    private static final Logger LOGGER = LogManager.getLogger(RequestPostTableModel.class);
 
     public boolean isEditable() {
         return editable;
@@ -104,7 +105,7 @@ public class RequestPostTableModel extends AbstractTableModel {
                 listPair.add(cell);
             } catch (UnsupportedEncodingException | IllegalArgumentException e) {
                 // ZAP: Log the exception
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
 
@@ -146,7 +147,7 @@ public class RequestPostTableModel extends AbstractTableModel {
                 }
             } catch (UnsupportedEncodingException | IllegalArgumentException e) {
                 // ZAP: Log the exception
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
         return sb.toString();

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/HttpPanelSyntaxHighlightTextArea.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/HttpPanelSyntaxHighlightTextArea.java
@@ -61,7 +61,8 @@ public abstract class HttpPanelSyntaxHighlightTextArea extends RSyntaxTextArea {
 
     private static final long serialVersionUID = -9082089105656842054L;
 
-    private static Logger log = LogManager.getLogger(HttpPanelSyntaxHighlightTextArea.class);
+    private static final Logger LOGGER =
+            LogManager.getLogger(HttpPanelSyntaxHighlightTextArea.class);
 
     public static final String PLAIN_SYNTAX_LABEL =
             Constant.messages.getString("http.panel.view.syntaxtext.syntax.plain");
@@ -253,7 +254,7 @@ public abstract class HttpPanelSyntaxHighlightTextArea extends RSyntaxTextArea {
                 hilite.addHighlight(lastPos, lastPos + entry.getToken().length(), painter);
                 lastPos += entry.getToken().length();
             } catch (BadLocationException e) {
-                log.warn("Could not highlight entry", e);
+                LOGGER.warn("Could not highlight entry", e);
             }
         }
     }
@@ -280,7 +281,7 @@ public abstract class HttpPanelSyntaxHighlightTextArea extends RSyntaxTextArea {
             hilite.addHighlight(start, end, painter);
             this.setCaretPosition(start);
         } catch (BadLocationException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -290,7 +291,7 @@ public abstract class HttpPanelSyntaxHighlightTextArea extends RSyntaxTextArea {
             this.setCaretPosition(start);
             return highlightReference;
         } catch (BadLocationException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
         return null;
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/all/request/HttpRequestAllPanelSyntaxHighlightTextView.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/all/request/HttpRequestAllPanelSyntaxHighlightTextView.java
@@ -23,8 +23,6 @@ import java.awt.Component;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.httppanel.Message;
@@ -113,9 +111,6 @@ public class HttpRequestAllPanelSyntaxHighlightTextView extends HttpPanelSyntaxH
             extends HttpPanelSyntaxHighlightTextArea {
 
         private static final long serialVersionUID = 923466158533211593L;
-
-        private static final Logger log =
-                LogManager.getLogger(HttpRequestAllPanelSyntaxHighlightTextArea.class);
 
         // private static final String HTTP_REQUEST_HEADER_AND_BODY = "HTTP Request Header and
         // Body";

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/all/response/HttpResponseAllPanelSyntaxHighlightTextView.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/syntaxhighlight/components/all/response/HttpResponseAllPanelSyntaxHighlightTextView.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpHeader;
@@ -83,9 +81,6 @@ public class HttpResponseAllPanelSyntaxHighlightTextView extends HttpPanelSyntax
             extends AutoDetectSyntaxHttpPanelTextArea {
 
         private static final long serialVersionUID = 3665478428546560762L;
-
-        private static final Logger log =
-                LogManager.getLogger(HttpResponseAllPanelSyntaxHighlightTextArea.class);
 
         // private static final String HTTP_RESPONSE_HEADER_AND_BODY = "HTTP Response Header and
         // Body";

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/text/HttpPanelTextArea.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/text/HttpPanelTextArea.java
@@ -43,7 +43,7 @@ public abstract class HttpPanelTextArea extends ZapTextArea {
 
     private static final long serialVersionUID = 1L;
 
-    private static Logger log = LogManager.getLogger(HttpPanelTextArea.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpPanelTextArea.class);
 
     private Message message;
 
@@ -102,7 +102,7 @@ public abstract class HttpPanelTextArea extends ZapTextArea {
                 hilite.addHighlight(lastPos, lastPos + entry.getToken().length(), painter);
                 lastPos += entry.getToken().length();
             } catch (BadLocationException e) {
-                log.warn("Could not highlight entry", e);
+                LOGGER.warn("Could not highlight entry", e);
             }
         }
     }
@@ -124,7 +124,7 @@ public abstract class HttpPanelTextArea extends ZapTextArea {
             hilite.addHighlight(start, end, painter);
             this.setCaretPosition(start);
         } catch (BadLocationException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/ExtensionHttpSessions.java
@@ -71,7 +71,7 @@ public class ExtensionHttpSessions extends ExtensionAdaptor
     public static final String NAME = "ExtensionHttpSessions";
 
     /** The Constant log. */
-    private static final Logger log = LogManager.getLogger(ExtensionHttpSessions.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionHttpSessions.class);
 
     /** The http sessions panel. */
     private HttpSessionsPanel httpSessionsPanel;
@@ -370,7 +370,7 @@ public class ExtensionHttpSessions extends ExtensionAdaptor
             sessionTokens.put(site, siteTokens);
         }
 
-        log.debug("Added new session token for site '{}': {}", site, token);
+        LOGGER.debug("Added new session token for site '{}': {}", site, token);
 
         siteTokens.addToken(token);
         // If the session token is a default token and was previously marked as remove, undo that
@@ -411,7 +411,7 @@ public class ExtensionHttpSessions extends ExtensionAdaptor
         // be detected again and added as a session token
         if (isDefaultSessionToken(token)) markRemovedDefaultSessionToken(site, token);
 
-        log.debug("Removed session token for site '{}': {}", site, token);
+        LOGGER.debug("Removed session token for site '{}': {}", site, token);
     }
 
     /**
@@ -612,7 +612,7 @@ public class ExtensionHttpSessions extends ExtensionAdaptor
         try {
             requestCookies = msg.getRequestHeader().getHttpCookies();
         } catch (IllegalArgumentException e) {
-            log.warn("Failed to obtain the cookies: {}", e.getMessage(), e);
+            LOGGER.warn("Failed to obtain the cookies: {}", e.getMessage(), e);
             return;
         }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/HttpSessionsAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/HttpSessionsAPI.java
@@ -48,7 +48,7 @@ import org.zaproxy.zap.utils.XMLStringUtil;
 public class HttpSessionsAPI extends ApiImplementor {
 
     /** The Constant log. */
-    private static final Logger log = LogManager.getLogger(HttpSessionsAPI.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpSessionsAPI.class);
 
     /** The Constant PREFIX defining the name/prefix of the api. */
     private static final String PREFIX = "httpSessions";
@@ -217,7 +217,7 @@ public class HttpSessionsAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
-        log.debug("Request for handleApiAction: {} (params: {}]", name, params);
+        LOGGER.debug("Request for handleApiAction: {} (params: {}]", name, params);
 
         HttpSessionsSite site;
         switch (name) {
@@ -357,7 +357,7 @@ public class HttpSessionsAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiView(String name, JSONObject params) throws ApiException {
-        log.debug("Request for handleApiView: {} (params: {})", name, params);
+        LOGGER.debug("Request for handleApiView: {} (params: {})", name, params);
 
         HttpSessionsSite site;
         switch (name) {
@@ -382,8 +382,8 @@ public class HttpSessionsAPI extends ApiImplementor {
                 // If a session name was not provided
                 if (vsName == null || vsName.isEmpty()) {
                     Set<HttpSession> sessions = site.getHttpSessions();
-                    if (log.isDebugEnabled()) {
-                        log.debug(
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug(
                                 "API View for sessions for {}:{}",
                                 ApiUtils.getAuthority(params.getString(VIEW_PARAM_SITE)),
                                 site);
@@ -412,8 +412,8 @@ public class HttpSessionsAPI extends ApiImplementor {
                 if (site == null) {
                     throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, ACTION_PARAM_SITE);
                 }
-                if (log.isDebugEnabled()) {
-                    log.debug(
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(
                             "API View for active session for {}:{}",
                             ApiUtils.getAuthority(params.getString(VIEW_PARAM_SITE)),
                             site);

--- a/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/HttpSessionsSite.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/HttpSessionsSite.java
@@ -46,7 +46,7 @@ import org.zaproxy.zap.utils.ThreadUtils;
 public class HttpSessionsSite {
 
     /** The Constant log. */
-    private static final Logger log = LogManager.getLogger(HttpSessionsSite.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpSessionsSite.class);
 
     /** The last session id. */
     private static int lastGeneratedSessionID = 0;
@@ -146,7 +146,7 @@ public class HttpSessionsSite {
      * @throws IllegalArgumentException If the session provided as parameter is null.
      */
     public void setActiveSession(HttpSession activeSession) {
-        log.info("Setting new active session for site '{}': {}", site, activeSession);
+        LOGGER.info("Setting new active session for site '{}': {}", site, activeSession);
         if (activeSession == null) {
             throw new IllegalArgumentException(
                     "When setting an active session, a non-null session has to be provided.");
@@ -179,7 +179,7 @@ public class HttpSessionsSite {
      * @see #setActiveSession(HttpSession)
      */
     public void unsetActiveSession() {
-        log.info("Setting no active session for site '{}'.", site);
+        LOGGER.info("Setting no active session for site '{}'.", site);
 
         if (this.activeSession != null) {
             this.activeSession.setActive(false);
@@ -338,14 +338,14 @@ public class HttpSessionsSite {
 
         // No tokens for this site, so no processing
         if (siteTokensSet == null) {
-            log.debug("No session tokens for: {}", this.getSite());
+            LOGGER.debug("No session tokens for: {}", this.getSite());
             return;
         }
 
         // Get the matching session, based on the request header
         List<HttpCookie> requestCookies = message.getRequestHeader().getHttpCookies();
         HttpSession session = getMatchingHttpSession(requestCookies, siteTokensSet);
-        log.debug("Matching session for request message (for site {}): {}", getSite(), session);
+        LOGGER.debug("Matching session for request message (for site {}): {}", getSite(), session);
 
         // If any session is active (forced), change the necessary cookies
         if (activeSession != null && activeSession != session) {
@@ -353,10 +353,10 @@ public class HttpSessionsSite {
                     message, requestCookies, activeSession);
         } else {
             if (activeSession == session) {
-                log.debug(
+                LOGGER.debug(
                         "Session of request message is the same as the active session, so no request changes needed.");
             } else {
-                log.debug("No active session is selected.");
+                LOGGER.debug("No active session is selected.");
             }
 
             // Store the session in the HttpMessage for caching purpose
@@ -376,7 +376,7 @@ public class HttpSessionsSite {
 
         // No tokens for this site, so no processing
         if (siteTokensSet == null) {
-            log.debug("No session tokens for: {}", this.getSite());
+            LOGGER.debug("No session tokens for: {}", this.getSite());
             return;
         }
         // Create an auxiliary map of token values and insert keys for every token
@@ -405,7 +405,7 @@ public class HttpSessionsSite {
                                     cookie.getSecure());
                     tokenValues.put(lcCookieName, ck);
                 } catch (IllegalArgumentException e) {
-                    log.warn(
+                    LOGGER.warn(
                             "Failed to create cookie [{}] for site [{}]: {}",
                             cookie,
                             getSite(),
@@ -425,10 +425,10 @@ public class HttpSessionsSite {
         HttpSession session = message.getHttpSession();
         if (session == null || !session.isValid()) {
             session = getMatchingHttpSession(requestCookies, siteTokensSet);
-            log.debug(
+            LOGGER.debug(
                     "Matching session for response message (from site {}): {}", getSite(), session);
         } else {
-            log.debug(
+            LOGGER.debug(
                     "Matching cached session for response message (from site {}): {}",
                     getSite(),
                     session);
@@ -487,7 +487,7 @@ public class HttpSessionsSite {
         }
 
         if (newSession) {
-            log.debug("Created a new session as no match was found: {}", session);
+            LOGGER.debug("Created a new session as no match was found: {}", session);
         }
 
         // Update the count of messages matched
@@ -539,7 +539,7 @@ public class HttpSessionsSite {
             return;
         }
 
-        log.debug(
+        LOGGER.debug(
                 "Removing duplicates and cleaning up sessions for site - token: {} - {}",
                 site,
                 token);
@@ -548,7 +548,7 @@ public class HttpSessionsSite {
             // If there are no more session tokens, delete all sessions
             HttpSessionTokensSet siteTokensSet = extension.getHttpSessionTokensSet(site);
             if (siteTokensSet == null) {
-                log.info("No more session tokens. Removing all sessions...");
+                LOGGER.info("No more session tokens. Removing all sessions...");
                 // Invalidate all sessions
                 for (HttpSession session : this.sessions) {
                     session.invalidate();
@@ -596,7 +596,7 @@ public class HttpSessionsSite {
             }
 
             // Delete the duplicate sessions
-            log.info("Removing duplicate or empty sessions: {}", toDelete);
+            LOGGER.info("Removing duplicate or empty sessions: {}", toDelete);
             Iterator<HttpSession> it = toDelete.iterator();
             while (it.hasNext()) {
                 HttpSession ses = it.next();
@@ -646,7 +646,7 @@ public class HttpSessionsSite {
     public boolean renameHttpSession(String oldName, String newName) {
         // Check new name validity
         if (newName == null || newName.isEmpty()) {
-            log.warn("Trying to rename session from {} illegal name: {}", oldName, newName);
+            LOGGER.warn("Trying to rename session from {} illegal name: {}", oldName, newName);
             return false;
         }
 
@@ -658,7 +658,8 @@ public class HttpSessionsSite {
 
         // Check new name uniqueness
         if (getHttpSession(newName) != null) {
-            log.warn("Trying to rename session from {} to already existing: {}", oldName, newName);
+            LOGGER.warn(
+                    "Trying to rename session from {} to already existing: {}", oldName, newName);
             return false;
         }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/PopupMenuFactoryAddUserFromSession.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httpsessions/PopupMenuFactoryAddUserFromSession.java
@@ -43,7 +43,7 @@ import org.zaproxy.zap.users.User;
 @SuppressWarnings("serial")
 public class PopupMenuFactoryAddUserFromSession extends PopupContextMenuItemFactory {
 
-    private static final Logger log =
+    private static final Logger LOGGER =
             LogManager.getLogger(PopupMenuFactoryAddUserFromSession.class);
 
     private static final long serialVersionUID = 2453839120088204122L;
@@ -253,7 +253,7 @@ public class PopupMenuFactoryAddUserFromSession extends PopupContextMenuItemFact
 
             HttpSessionsPanel panel = extension.getHttpSessionsPanel();
             HttpSession session = panel.getSelectedSession();
-            log.info(
+            LOGGER.info(
                     "Creating user from HttpSession {} for Context {}",
                     session.getName(),
                     uiSharedContext.getName());
@@ -264,7 +264,7 @@ public class PopupMenuFactoryAddUserFromSession extends PopupContextMenuItemFact
             // First make sure the authentication method is Manual Authentication
             if (!(uiSharedContext.getAuthenticationMethod()
                     instanceof ManualAuthenticationMethod)) {
-                log.info(
+                LOGGER.info(
                         "Creating new Manual Authentication instance for Context {}",
                         uiSharedContext.getName());
                 ManualAuthenticationMethod method =
@@ -272,7 +272,7 @@ public class PopupMenuFactoryAddUserFromSession extends PopupContextMenuItemFact
                                 .createAuthenticationMethod(context.getId());
 
                 if (!confirmUsersDeletion(uiSharedContext)) {
-                    log.debug("Cancelled change of authentication type.");
+                    LOGGER.debug("Cancelled change of authentication type.");
                     return;
                 }
 
@@ -283,10 +283,10 @@ public class PopupMenuFactoryAddUserFromSession extends PopupContextMenuItemFact
 
             newUser = showAddUserDialogue(uiSharedContext, session);
             if (newUser == null) {
-                log.debug("Cancelled creation of user from HttpSession.");
+                LOGGER.debug("Cancelled creation of user from HttpSession.");
                 return;
             }
-            log.info("Created user: {}", newUser);
+            LOGGER.info("Created user: {}", newUser);
 
             // Show the session dialog without recreating UI Shared contexts
             // NOTE: First init the panels of the dialog so old users data gets loaded and just then

--- a/zap/src/main/java/org/zaproxy/zap/extension/keyboard/ExtensionKeyboard.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/keyboard/ExtensionKeyboard.java
@@ -39,7 +39,7 @@ import org.zaproxy.zap.view.ZapMenuItem;
 
 public class ExtensionKeyboard extends ExtensionAdaptor {
 
-    private static final Logger logger = LogManager.getLogger(ExtensionKeyboard.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionKeyboard.class);
 
     public static final String NAME = "ExtensionKeyboard";
 
@@ -90,7 +90,7 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
     @Override
     public void postInit() {
         if (hasView()) {
-            logger.info("Initializing keyboard shortcuts");
+            LOGGER.info("Initializing keyboard shortcuts");
             processMainMenuBarMenus(this::initAllMenuItems);
         }
     }
@@ -112,7 +112,7 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
             setConfiguredAccelerator(zme);
             this.map.put(identifier, new KeyboardMapping(zme));
         } else {
-            logger.warn("ZapMenuItem \"{}\" has a null identifier.", zme.getName());
+            LOGGER.warn("ZapMenuItem \"{}\" has a null identifier.", zme.getName());
         }
     }
 
@@ -146,7 +146,7 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
                         String.format(
                                 "Menus %s and %s use the same default accelerator: %s",
                                 zme.getIdentifier(), km.getIdentifier(), ks);
-                logger.log(Constant.isDevMode() ? Level.ERROR : Level.WARN, msg);
+                LOGGER.log(Constant.isDevMode() ? Level.ERROR : Level.WARN, msg);
                 if (menusDupDefaultAccelerator == null) {
                     menusDupDefaultAccelerator = new ArrayList<>();
                 }
@@ -197,7 +197,7 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
 
             } else if (c instanceof JMenuItem) {
                 JMenuItem menuItem = (JMenuItem) c;
-                logger.debug("Unable to set accelerators on menu {}", menuItem.getText());
+                LOGGER.debug("Unable to set accelerators on menu {}", menuItem.getText());
             }
         }
     }
@@ -210,10 +210,10 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
 
         if (ks.getKeyCode() == 0) {
             // Used to indicate no accelerator should be used
-            logger.debug("Cleaning menu {} accelerator", menuItem.getIdentifier());
+            LOGGER.debug("Cleaning menu {} accelerator", menuItem.getIdentifier());
             ks = null;
         } else {
-            logger.debug("Setting menu {} accelerator to {}", menuItem.getIdentifier(), ks);
+            LOGGER.debug("Setting menu {} accelerator to {}", menuItem.getIdentifier(), ks);
         }
         menuItem.setAccelerator(ks);
     }
@@ -241,7 +241,7 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
 
             } else if (c instanceof JMenuItem) {
                 JMenuItem menuItem = (JMenuItem) c;
-                logger.debug("Unable to set accelerators on menu {}", menuItem.getText());
+                LOGGER.debug("Unable to set accelerators on menu {}", menuItem.getText());
             }
         }
     }
@@ -282,7 +282,7 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
     public void setShortcut(String identifier, KeyStroke ks) {
         KeyboardMapping mapping = (KeyboardMapping) this.map.get(identifier);
         if (mapping == null) {
-            logger.error("No mapping found for keyboard shortcut: {}", identifier);
+            LOGGER.error("No mapping found for keyboard shortcut: {}", identifier);
             return;
         }
         mapping.setKeyStroke(ks);
@@ -300,7 +300,7 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
         try {
             DesktopUtils.openUrlInBrowser(api.getCheatSheetActionURI());
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -308,7 +308,7 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
         try {
             DesktopUtils.openUrlInBrowser(api.getCheatSheetKeyURI());
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/keyboard/OptionsKeyboardShortcutPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/keyboard/OptionsKeyboardShortcutPanel.java
@@ -43,7 +43,7 @@ import org.zaproxy.zap.view.panels.TableFilterPanel;
 public class OptionsKeyboardShortcutPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;
-    private static final Logger logger = LogManager.getLogger(OptionsKeyboardShortcutPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(OptionsKeyboardShortcutPanel.class);
 
     private ExtensionKeyboard extension;
     private KeyboardOptionsPanel tkeyboardOptionsPanel;
@@ -195,7 +195,7 @@ public class OptionsKeyboardShortcutPanel extends AbstractParamPanel {
                 }
             }
             if (setShortcut) {
-                logger.debug(
+                LOGGER.debug(
                         "Setting keyboard shortcut for {} to {}",
                         ks.getIdentifier(),
                         ks.getKeyStroke());

--- a/zap/src/main/java/org/zaproxy/zap/extension/lang/LangImporter.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/lang/LangImporter.java
@@ -39,7 +39,7 @@ import org.zaproxy.zap.utils.LocaleUtils;
 
 public final class LangImporter {
 
-    private static final Logger logger = LogManager.getLogger(LangImporter.class);
+    private static final Logger LOGGER = LogManager.getLogger(LangImporter.class);
 
     private static final String MSG_SUCCESS = "options.lang.importer.dialog.message.success";
     private static final String MSG_ERROR = "options.lang.importer.dialog.message.error";
@@ -92,7 +92,7 @@ public final class LangImporter {
 
         } catch (IOException e) {
             message = MSG_FILE_NOT_FOUND;
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
 
         if (View.isInitialised()) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/params/ExtensionParams.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/params/ExtensionParams.java
@@ -74,7 +74,7 @@ public class ExtensionParams extends ExtensionAdaptor
     private PopupMenuRemoveSession popupMenuRemoveSession = null;
     private Map<String, SiteParameters> siteParamsMap = new HashMap<>();
 
-    private Logger logger = LogManager.getLogger(ExtensionParams.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionParams.class);
 
     private ExtensionHttpSessions extensionHttpSessions;
     private ParamScanner paramScanner;
@@ -209,7 +209,7 @@ public class ExtensionParams extends ExtensionAdaptor
                             }
                         });
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -259,7 +259,7 @@ public class ExtensionParams extends ExtensionAdaptor
                 sps.addParam(param.getSite(), param);
             }
         } catch (DatabaseException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -289,7 +289,7 @@ public class ExtensionParams extends ExtensionAdaptor
                 persist(sps.addParam(site, iter.next(), msg));
             }
         } catch (IllegalArgumentException e) {
-            logger.warn("Failed to obtain the cookies: {}", e.getMessage(), e);
+            LOGGER.warn("Failed to obtain the cookies: {}", e.getMessage(), e);
         }
 
         // URL Parameters
@@ -382,13 +382,13 @@ public class ExtensionParams extends ExtensionAdaptor
             }
         } catch (DatabaseException e) {
             if (e.getCause().getMessage().contains("truncation")) {
-                logger.warn("Could not add or update param: {}", param.getName());
-                logger.warn(
+                LOGGER.warn("Could not add or update param: {}", param.getName());
+                LOGGER.warn(
                         "It is likely that the length of one of the data elements exceeded the column size.");
-                logger.warn(e.getMessage());
-                logger.debug(e.getMessage(), e);
+                LOGGER.warn(e.getMessage());
+                LOGGER.debug(e.getMessage(), e);
             } else {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -413,7 +413,7 @@ public class ExtensionParams extends ExtensionAdaptor
                 persist(sps.addParam(site, iter.next(), msg));
             }
         } catch (IllegalArgumentException e) {
-            logger.warn("Failed to obtain the cookies: {}", e.getMessage(), e);
+            LOGGER.warn("Failed to obtain the cookies: {}", e.getMessage(), e);
         }
 
         // Header "Parameters"

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -60,7 +60,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
     // the HttpMessage.
     public static final int PROXY_LISTENER_ORDER = ProxyListenerLog.PROXY_LISTENER_ORDER + 1;
 
-    private static final Logger logger = LogManager.getLogger(ExtensionPassiveScan.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionPassiveScan.class);
     private PassiveScannerList scannerList;
     private OptionsPassiveScan optionsPassiveScan = null;
     private PolicyPassiveScanPanel policyPanel = null;
@@ -266,16 +266,16 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
                 getPolicyPanel().getPassiveScanTableModel().addScanner(scanner);
             }
 
-            logger.info("loaded passive scan rule: {}", scanner.getName());
+            LOGGER.info("loaded passive scan rule: {}", scanner.getName());
             if (scanner.getPluginId() == -1) {
-                logger.error(
+                LOGGER.error(
                         "The passive scan rule \"{}\" [{}] does not have a defined ID.",
                         scanner.getName(),
                         scanner.getClass().getCanonicalName());
             }
 
         } catch (Exception e) {
-            logger.error("Failed to load passive scan rule {}", scanner.getName(), e);
+            LOGGER.error("Failed to load passive scan rule {}", scanner.getName(), e);
         }
 
         return added;

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanAPI.java
@@ -39,7 +39,7 @@ import org.zaproxy.zap.utils.ApiUtils;
 
 public class PassiveScanAPI extends ApiImplementor {
 
-    private static final Logger logger = LogManager.getLogger(PassiveScanAPI.class);
+    private static final Logger LOGGER = LogManager.getLogger(PassiveScanAPI.class);
 
     private static final String PREFIX = "pscan";
 
@@ -188,7 +188,7 @@ public class PassiveScanAPI extends ApiImplementor {
                 extension.setPluginPassiveScannerEnabled(pluginId, enabled);
             }
         } catch (NumberFormatException e) {
-            logger.error("Failed to parse scanner ID: {}", e.getMessage(), e);
+            LOGGER.error("Failed to parse scanner ID: {}", e.getMessage(), e);
             throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, e.getMessage(), e);
         }
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanController.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanController.java
@@ -44,7 +44,7 @@ import org.zaproxy.zap.view.ScanStatus;
  */
 public class PassiveScanController extends Thread implements ProxyListener {
 
-    private static final Logger logger = LogManager.getLogger(PassiveScanController.class);
+    private static final Logger LOGGER = LogManager.getLogger(PassiveScanController.class);
 
     private ExtensionHistory extHist;
     private PassiveScanParam pscanOptions;
@@ -84,11 +84,11 @@ public class PassiveScanController extends Thread implements ProxyListener {
 
     @Override
     public void run() {
-        logger.debug("Starting passive scan monitoring");
+        LOGGER.debug("Starting passive scan monitoring");
         try {
             scan();
         } finally {
-            logger.debug("Stopping passive scan monitoring");
+            LOGGER.debug("Stopping passive scan monitoring");
         }
     }
 
@@ -127,7 +127,7 @@ public class PassiveScanController extends Thread implements ProxyListener {
 
                 if (href != null
                         && (!pscanOptions.isScanOnlyInScope() || session.isInScope(href))) {
-                    logger.debug(
+                    LOGGER.debug(
                             "Submitting request to executor: {} id {} type {}",
                             href.getURI(),
                             currentId,
@@ -146,9 +146,9 @@ public class PassiveScanController extends Thread implements ProxyListener {
                 }
                 if (href != null
                         && HistoryReference.getTemporaryTypes().contains(href.getHistoryType())) {
-                    logger.debug("Temporary record {} no longer available:", currentId, e);
+                    LOGGER.debug("Temporary record {} no longer available:", currentId, e);
                 } else {
-                    logger.error("Failed on record {} from History table", currentId, e);
+                    LOGGER.error("Failed on record {} from History table", currentId, e);
                 }
             }
         }
@@ -157,7 +157,7 @@ public class PassiveScanController extends Thread implements ProxyListener {
     private ThreadPoolExecutor getExecutor() {
         if (this.executor == null || this.executor.isShutdown()) {
             int threads = pscanOptions.getPassiveScanThreads();
-            logger.debug("Creating new executor with {} threads", threads);
+            LOGGER.debug("Creating new executor with {} threads", threads);
 
             this.executor =
                     (ThreadPoolExecutor)
@@ -195,7 +195,7 @@ public class PassiveScanController extends Thread implements ProxyListener {
     }
 
     protected void shutdown() {
-        logger.debug("Shutdown");
+        LOGGER.debug("Shutdown");
         this.shutDown = true;
         if (this.executor != null) {
             this.executor.shutdown();

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanParam.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanParam.java
@@ -33,7 +33,7 @@ import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
 
 public class PassiveScanParam extends AbstractParam {
 
-    private static final Logger logger = LogManager.getLogger(PassiveScanParam.class);
+    private static final Logger LOGGER = LogManager.getLogger(PassiveScanParam.class);
 
     static final String PASSIVE_SCANS_BASE_KEY = "pscans";
     private static final String ALL_AUTO_TAG_SCANNERS_KEY =
@@ -124,7 +124,7 @@ public class PassiveScanParam extends AbstractParam {
                 }
             }
         } catch (ConversionException e) {
-            logger.error("Error while loading the auto tag scanners: {}", e.getMessage(), e);
+            LOGGER.error("Error while loading the auto tag scanners: {}", e.getMessage(), e);
         }
 
         this.confirmRemoveAutoTagScanner = getBoolean(CONFIRM_REMOVE_AUTO_TAG_SCANNER_KEY, true);

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanTask.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanTask.java
@@ -54,7 +54,7 @@ public class PassiveScanTask implements Runnable {
     private long startTime;
     private long stopTime;
 
-    private static final Logger logger = LogManager.getLogger(PassiveScanTask.class);
+    private static final Logger LOGGER = LogManager.getLogger(PassiveScanTask.class);
 
     @SuppressWarnings("deprecation")
     public PassiveScanTask(HistoryReference hr, PassiveScanTaskHelper helper) {
@@ -126,7 +126,7 @@ public class PassiveScanTask implements Runnable {
                         scanner.setParent(psThread);
                         scanner.setTaskHelper(helper);
 
-                        logger.debug(
+                        LOGGER.debug(
                                 "Running scan rule, URL {} plugin {}",
                                 msg.getRequestHeader().getURI(),
                                 scanner.getName());
@@ -137,7 +137,7 @@ public class PassiveScanTask implements Runnable {
                             scanned = true;
                         } else {
                             Stats.incCounter("stats.pscan.reqBodyTooBig");
-                            logger.debug(
+                            LOGGER.debug(
                                     "Request to {} body size {} larger than max configured {}",
                                     msg.getRequestHeader().getURI(),
                                     msg.getRequestBody().length(),
@@ -149,7 +149,7 @@ public class PassiveScanTask implements Runnable {
                                 scanned = true;
                             } else {
                                 Stats.incCounter("stats.pscan.respBodyTooBig");
-                                logger.debug(
+                                LOGGER.debug(
                                         "Response from {} body size {} larger than max configured {}",
                                         msg.getRequestHeader().getURI(),
                                         msg.getResponseBody().length(),
@@ -175,7 +175,7 @@ public class PassiveScanTask implements Runnable {
                                                     + " "
                                                     + msg.getResponseBody().length();
                                 }
-                                logger.warn(
+                                LOGGER.warn(
                                         "Passive Scan rule {} took {} seconds to scan {} {}",
                                         scanner.getName(),
                                         timeTaken / 1000,
@@ -185,7 +185,7 @@ public class PassiveScanTask implements Runnable {
                         }
                     }
                 } catch (Exception e) {
-                    logger.error(
+                    LOGGER.error(
                             "Scan rule '{}' failed on record {} from History table: {} {}",
                             scanner.getName(),
                             href.getHistoryId(),
@@ -197,7 +197,7 @@ public class PassiveScanTask implements Runnable {
 
         } catch (Exception e) {
             if (HistoryReference.getTemporaryTypes().contains(href.getHistoryType())) {
-                logger.debug("Temporary record {} no longer available:", href.getHistoryId(), e);
+                LOGGER.debug("Temporary record {} no longer available:", href.getHistoryId(), e);
             } else {
                 RecordHistory rec = null;
                 try {
@@ -208,12 +208,12 @@ public class PassiveScanTask implements Runnable {
                 if (rec == null) {
                     return;
                 }
-                logger.error(
+                LOGGER.error(
                         "Parser failed on record {} from History table", href.getHistoryId(), e);
                 HttpMessage msg;
                 try {
                     msg = href.getHttpMessage();
-                    logger.error("Req Header {}", msg.getRequestHeader(), e);
+                    LOGGER.error("Req Header {}", msg.getRequestHeader(), e);
                 } catch (Exception e1) {
                     // Ignore
                 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanTaskHelper.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanTaskHelper.java
@@ -39,7 +39,7 @@ import org.zaproxy.zap.extension.alert.ExtensionAlert;
 /** @since 2.12.0 */
 public class PassiveScanTaskHelper {
 
-    private static final Logger logger = LogManager.getLogger(PassiveScanTaskHelper.class);
+    private static final Logger LOGGER = LogManager.getLogger(PassiveScanTaskHelper.class);
 
     private static Set<Integer> optedInHistoryTypes = new HashSet<>();
 
@@ -154,7 +154,7 @@ public class PassiveScanTaskHelper {
                 // Disable the plugin
                 PassiveScanner scanner = getPassiveScannerList().getScanner(alert.getPluginId());
                 if (scanner != null) {
-                    logger.info(
+                    LOGGER.info(
                             "Disabling passive scan rule {} as it has raised more than {} alerts.",
                             scanner.getName(),
                             this.pscanParams.getMaxAlertsPerRule());
@@ -179,7 +179,7 @@ public class PassiveScanTaskHelper {
                 href.addTag(tag);
             }
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScannerList.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScannerList.java
@@ -30,7 +30,7 @@ import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
 
 public class PassiveScannerList {
 
-    private static final Logger logger = LogManager.getLogger(PassiveScannerList.class);
+    private static final Logger LOGGER = LogManager.getLogger(PassiveScannerList.class);
 
     private List<PassiveScanner> passiveScanners = new CopyOnWriteArrayList<>();
     private Set<String> scannerNames = new HashSet<>();
@@ -64,7 +64,7 @@ public class PassiveScannerList {
 
         for (PassiveScanner scanner : autoTagScanners) {
             if (scannerNames.contains(scanner.getName())) {
-                logger.error("Duplicate passive scan rule name: {}", scanner.getName());
+                LOGGER.error("Duplicate passive scan rule name: {}", scanner.getName());
             } else {
                 tempScanners.add(scanner);
                 scannerNames.add(scanner.getName());

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/ScriptsPassiveScanner.java
@@ -36,7 +36,7 @@ import org.zaproxy.zap.extension.script.ScriptsCache.Configuration;
 
 public class ScriptsPassiveScanner extends PluginPassiveScanner {
 
-    private static final Logger logger = LogManager.getLogger(ScriptsPassiveScanner.class);
+    private static final Logger LOGGER = LogManager.getLogger(ScriptsPassiveScanner.class);
 
     private final ScriptsCache<PassiveScript> scripts;
 
@@ -102,8 +102,8 @@ public class ScriptsPassiveScanner extends PluginPassiveScanner {
             // use the default method).
             if (e.getCause() instanceof NoSuchMethodException
                     && "appliesToHistoryType".equals(e.getCause().getMessage())) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug(
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(
                             "Script [Name={}, Engine={}]  does not implement the optional method appliesToHistoryType: ",
                             wrapper.getName(),
                             wrapper.getEngineName(),

--- a/zap/src/main/java/org/zaproxy/zap/extension/ruleconfig/OptionsRuleConfigPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ruleconfig/OptionsRuleConfigPanel.java
@@ -39,7 +39,7 @@ import org.zaproxy.zap.view.MultipleOptionsTablePanel;
 public class OptionsRuleConfigPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;
-    private static final Logger logger = LogManager.getLogger(OptionsRuleConfigPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(OptionsRuleConfigPanel.class);
 
     private ExtensionRuleConfig extension;
     private RuleConfigOptionsPanel ruleConfigOptionsPanel;
@@ -111,7 +111,7 @@ public class OptionsRuleConfigPanel extends AbstractParamPanel {
     public void saveParam(Object obj) throws Exception {
         for (RuleConfig rc : getRuleConfigModel().getElements()) {
             if (rc.isChanged()) {
-                logger.debug("Setting rule config {} to {}", rc.getKey(), rc.getValue());
+                LOGGER.debug("Setting rule config {} to {}", rc.getKey(), rc.getValue());
                 extension.setRuleConfigValue(rc.getKey(), rc.getValue());
             }
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/DefaultEngineWrapper.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/DefaultEngineWrapper.java
@@ -35,7 +35,7 @@ public class DefaultEngineWrapper extends ScriptEngineWrapper {
 
     private Map<String, String> templateMap = new HashMap<>();
 
-    private static Logger logger = LogManager.getLogger(DefaultEngineWrapper.class);
+    private static final Logger LOGGER = LogManager.getLogger(DefaultEngineWrapper.class);
 
     /**
      * Constructs a {@code DefaultEngineWrapper} with the given engine (to obtain a factory).
@@ -89,13 +89,13 @@ public class DefaultEngineWrapper extends ScriptEngineWrapper {
 
         File file = new File(ExtensionScript.TEMPLATES_DIR, resourceName);
         if (!file.exists()) {
-            logger.debug("No template at: {}", file.getAbsolutePath());
+            LOGGER.debug("No template at: {}", file.getAbsolutePath());
             file =
                     new File(
                             Constant.getZapHome() + File.separator + ExtensionScript.TEMPLATES_DIR,
                             resourceName);
             if (!file.exists()) {
-                logger.debug("No template at: {}", file.getAbsolutePath());
+                LOGGER.debug("No template at: {}", file.getAbsolutePath());
                 return "";
             }
         }
@@ -110,7 +110,7 @@ public class DefaultEngineWrapper extends ScriptEngineWrapper {
             return sb.toString();
 
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             return "";
         }
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -134,7 +134,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
     private CommandLineArgument[] arguments = new CommandLineArgument[1];
     private static final int ARG_SCRIPT_IDX = 0;
 
-    private static final Logger logger = LogManager.getLogger(ExtensionScript.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionScript.class);
 
     /**
      * Flag that indicates if the scripts/templates should be loaded when a new script type is
@@ -175,7 +175,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
         if (se != null) {
             this.registerScriptEngineWrapper(new JavascriptEngineWrapper(se.getFactory()));
         } else {
-            logger.warn(
+            LOGGER.warn(
                     "No default JavaScript/ECMAScript engine found, some scripts might no longer work.");
         }
     }
@@ -295,7 +295,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
      * @see ScriptWrapper#setEngine(ScriptEngineWrapper)
      */
     public void registerScriptEngineWrapper(ScriptEngineWrapper wrapper) {
-        logger.debug(
+        LOGGER.debug(
                 "registerEngineWrapper {} : {}",
                 wrapper.getLanguageName(),
                 wrapper.getEngineName());
@@ -321,7 +321,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
             try {
                 scriptUI.engineAdded(wrapper);
             } catch (Exception e) {
-                logger.error("An error occurred while notifying ScriptUI:", e);
+                LOGGER.error("An error occurred while notifying ScriptUI:", e);
             }
         }
     }
@@ -429,7 +429,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
      * @see ScriptWrapper#setEngine(ScriptEngineWrapper)
      */
     public void removeScriptEngineWrapper(ScriptEngineWrapper wrapper) {
-        logger.debug(
+        LOGGER.debug(
                 "Removing script engine: {} : {}",
                 wrapper.getLanguageName(),
                 wrapper.getEngineName());
@@ -438,7 +438,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
                 try {
                     scriptUI.engineRemoved(wrapper);
                 } catch (Exception e) {
-                    logger.error("An error occurred while notifying ScriptUI:", e);
+                    LOGGER.error("An error occurred while notifying ScriptUI:", e);
                 }
             }
 
@@ -582,11 +582,11 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
                 loadScript(script);
                 addScript(script, false, false);
             } catch (MalformedInputException e) {
-                logger.warn(
+                LOGGER.warn(
                         "Failed to add script \"{}\", contains invalid character sequence (UTF-8).",
                         script.getName());
             } catch (InvalidParameterException | IOException e) {
-                logger.error("Failed to add script: {}", script.getName(), e);
+                LOGGER.error("Failed to add script: {}", script.getName(), e);
             }
         }
     }
@@ -657,12 +657,12 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
     private void reloadIfChangedOnDisk(ScriptWrapper script) {
         if (script.hasChangedOnDisk() && !script.isChanged()) {
             try {
-                logger.debug(
+                LOGGER.debug(
                         "Reloading script as its been changed on disk {}",
                         script.getFile().getAbsolutePath());
                 script.reloadScript();
             } catch (IOException e) {
-                logger.error("Failed to reload script {}", script.getFile().getAbsolutePath(), e);
+                LOGGER.error("Failed to reload script {}", script.getFile().getAbsolutePath(), e);
             }
         }
     }
@@ -722,7 +722,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
             ScriptEventListener listener, ScriptWrapper script, Exception e) {
         String classname = listener.getClass().getCanonicalName();
         String scriptName = script.getName();
-        logger.error(
+        LOGGER.error(
                 "Error while notifying '{}' with script '{}', cause: {}",
                 classname,
                 scriptName,
@@ -804,7 +804,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
                     ecmaScriptEngineWrapper = getEcmaScriptEngineWrapper();
                 }
                 if (ecmaScriptEngineWrapper != null) {
-                    logger.info(
+                    LOGGER.info(
                             "Changing [{}] (ECMAScript) script engine from [{}] to [{}].",
                             script.getName(),
                             script.getEngineName(),
@@ -818,7 +818,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
                 if (script.getType() != null) {
                     this.addScript(script, false, false);
                 } else {
-                    logger.warn(
+                    LOGGER.warn(
                             "Failed to add script \"{}\", provided script type \"{}\" not found, available: {}",
                             script.getName(),
                             script.getTypeName(),
@@ -834,7 +834,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
                 }
 
             } catch (MalformedInputException e) {
-                logger.warn(
+                LOGGER.warn(
                         "Failed to add script \"{}\", contains invalid character sequence (UTF-8).",
                         script.getName());
                 scriptsNotAdded.add(
@@ -845,7 +845,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
                                     "script.info.scriptsNotAdded.error.invalidChars")
                         });
             } catch (InvalidParameterException | IOException e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
                 scriptsNotAdded.add(
                         new String[] {
                             script.getName(),
@@ -862,7 +862,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
         for (File dir : this.getScriptParam().getScriptDirs()) {
             // Load the scripts from subdirectories of each directory configured
             int numAdded = addScriptsFromDir(dir);
-            logger.debug("Added {} scripts from dir: {}", numAdded, dir.getAbsolutePath());
+            LOGGER.debug("Added {} scripts from dir: {}", numAdded, dir.getAbsolutePath());
         }
         shouldLoadScriptsOnScriptTypeRegistration = true;
 
@@ -873,7 +873,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
                 try {
                     Files.createDirectories(scriptTypeDir);
                 } catch (IOException e) {
-                    logger.warn(
+                    LOGGER.warn(
                             "Failed to create directory for script type: {}",
                             scriptType.getName(),
                             e);
@@ -999,7 +999,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
      * @see #removeScriptsFromDir(File)
      */
     public int addScriptsFromDir(File dir) {
-        logger.debug("Adding scripts from dir: {}", dir.getAbsolutePath());
+        LOGGER.debug("Adding scripts from dir: {}", dir.getAbsolutePath());
         trackedDirs.add(dir);
         int addedScripts = 0;
         for (ScriptType type : this.getScriptTypes()) {
@@ -1030,7 +1030,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
                     try {
                         if (f.canWrite()) {
                             String scriptName = this.getUniqueScriptName(f.getName(), ext);
-                            logger.debug("Loading script {}", scriptName);
+                            LOGGER.debug("Loading script {}", scriptName);
                             ScriptWrapper sw =
                                     new ScriptWrapper(
                                             scriptName,
@@ -1044,7 +1044,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
                         } else {
                             // Cant write so add as a template
                             String scriptName = this.getUniqueTemplateName(f.getName(), ext);
-                            logger.debug("Loading script {}", scriptName);
+                            LOGGER.debug("Loading script {}", scriptName);
                             ScriptWrapper sw =
                                     new ScriptWrapper(
                                             scriptName,
@@ -1058,10 +1058,10 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
                         }
                         addedScripts++;
                     } catch (Exception e) {
-                        logger.error(e.getMessage(), e);
+                        LOGGER.error(e.getMessage(), e);
                     }
                 } else {
-                    logger.debug("Ignoring {}", f.getName());
+                    LOGGER.debug("Ignoring {}", f.getName());
                 }
             }
         }
@@ -1080,7 +1080,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
      * @see #addScriptsFromDir(File)
      */
     public int removeScriptsFromDir(File dir) {
-        logger.debug("Removing scripts from dir: {}", dir.getAbsolutePath());
+        LOGGER.debug("Removing scripts from dir: {}", dir.getAbsolutePath());
         trackedDirs.remove(dir);
         int removedScripts = 0;
 
@@ -1266,10 +1266,10 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
                         this.addTemplate(template);
                     } catch (InvalidParameterException e) {
                         if (!ignoreDuplicates) {
-                            logger.error(e.getMessage(), e);
+                            LOGGER.error(e.getMessage(), e);
                         }
                     } catch (IOException e) {
-                        logger.error(e.getMessage(), e);
+                        LOGGER.error(e.getMessage(), e);
                     }
                 }
             }
@@ -1298,7 +1298,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
                 throw e;
             }
 
-            logger.debug(
+            LOGGER.debug(
                     "Failed to load script [{}] using [{}], falling back to [{}].",
                     script.getName(),
                     DEFAULT_CHARSET,
@@ -1418,7 +1418,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
      * @see Invocable
      */
     public Invocable invokeScript(ScriptWrapper script) throws ScriptException {
-        logger.debug("invokeScript {}", script.getName());
+        LOGGER.debug("invokeScript {}", script.getName());
         preInvokeScript(script);
 
         ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
@@ -1524,7 +1524,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
      * @see Invocable
      */
     public Invocable invokeScriptWithOutAddOnLoader(ScriptWrapper script) throws ScriptException {
-        logger.debug("invokeScriptWithOutAddOnLoader {}", script.getName());
+        LOGGER.debug("invokeScriptWithOutAddOnLoader {}", script.getName());
         preInvokeScript(script);
 
         return invokeScriptImpl(script);
@@ -1574,7 +1574,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
         try {
             writer.append(cause.toString());
         } catch (IOException ignore) {
-            logger.error(cause.getMessage(), cause);
+            LOGGER.error(cause.getMessage(), cause);
         }
         this.setError(script, cause);
         this.setEnabled(script, false);
@@ -1698,8 +1698,8 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
         try {
             writer.append(errorMessage);
         } catch (IOException e) {
-            logger.debug("Failed to append script error message because of an exception:", e);
-            logger.warn("Failed to append error message: {}", errorMessage);
+            LOGGER.debug("Failed to append script error message because of an exception:", e);
+            LOGGER.warn("Failed to append error message: {}", errorMessage);
         }
         this.setError(script, errorMessage);
         this.setEnabled(script, false);
@@ -2125,7 +2125,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
         try {
             openCmdLineFile(file);
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             return false;
         }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptParam.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptParam.java
@@ -47,7 +47,7 @@ public class ScriptParam extends AbstractParam {
     private static final String SCRIPT_DIRS = "dirs";
     private static final String SCRIPT_CONFIRM_REMOVE_DIR = "confRemdir";
 
-    private static final Logger logger = LogManager.getLogger(ScriptParam.class);
+    private static final Logger LOGGER = LogManager.getLogger(ScriptParam.class);
 
     private String defaultScript = null;
     private String defaultDir = null;
@@ -75,7 +75,7 @@ public class ScriptParam extends AbstractParam {
 
                         File file = new File(sub.getString(SCRIPT_FILE_KEY));
                         if (!file.exists()) {
-                            logger.error("Script '{}' does not exist", file.getAbsolutePath());
+                            LOGGER.error("Script '{}' does not exist", file.getAbsolutePath());
                             continue;
                         }
 
@@ -93,11 +93,11 @@ public class ScriptParam extends AbstractParam {
                         scripts.add(script);
                     }
                 } catch (Exception e) {
-                    logger.error("Error while loading the script: {}", name, e);
+                    LOGGER.error("Error while loading the script: {}", name, e);
                 }
             }
         } catch (Exception e) {
-            logger.error("Error while loading the scripts: {}", e.getMessage(), e);
+            LOGGER.error("Error while loading the scripts: {}", e.getMessage(), e);
         }
 
         try {
@@ -105,14 +105,14 @@ public class ScriptParam extends AbstractParam {
             for (Object dirName : getConfig().getList(SCRIPT_DIRS)) {
                 File f = new File((String) dirName);
                 if (!f.exists() || !f.isDirectory()) {
-                    logger.error("Not a valid script directory: {}", dirName);
+                    LOGGER.error("Not a valid script directory: {}", dirName);
                 } else {
                     scriptDirs.add(f);
                 }
             }
 
         } catch (Exception e) {
-            logger.error("Error while loading the script dirs: {}", e.getMessage(), e);
+            LOGGER.error("Error while loading the script dirs: {}", e.getMessage(), e);
         }
         confirmRemoveDir = getBoolean(SCRIPT_CONFIRM_REMOVE_DIR, true);
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/search/SearchAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/search/SearchAPI.java
@@ -51,7 +51,7 @@ import org.zaproxy.zap.utils.HarUtils;
 
 public class SearchAPI extends ApiImplementor {
 
-    private static Logger log = LogManager.getLogger(SearchAPI.class);
+    private static final Logger LOGGER = LogManager.getLogger(SearchAPI.class);
 
     private static final String PREFIX = "search";
 
@@ -224,7 +224,7 @@ public class SearchAPI extends ApiImplementor {
             search(params, searchType, processor);
 
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             throw new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
         }
         return result;
@@ -284,7 +284,7 @@ public class SearchAPI extends ApiImplementor {
             responseBody = HarUtils.harLogToByteArray(harLog);
 
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
 
             ApiException apiException =
                     new ApiException(ApiException.Type.INTERNAL_ERROR, e.getMessage());
@@ -299,7 +299,7 @@ public class SearchAPI extends ApiImplementor {
                     API.getDefaultResponseHeader(
                             "application/json; charset=UTF-8", responseBody.length));
         } catch (HttpMalformedHeaderException e) {
-            log.error("Failed to create response header: {}", e.getMessage(), e);
+            LOGGER.error("Failed to create response header: {}", e.getMessage(), e);
         }
         msg.setResponseBody(responseBody);
 
@@ -335,7 +335,7 @@ public class SearchAPI extends ApiImplementor {
             try {
                 processor.processRecordHistory(tableHistory.read(hRefId));
             } catch (DatabaseException | HttpMalformedHeaderException e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/search/SearchThread.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/search/SearchThread.java
@@ -54,7 +54,7 @@ public class SearchThread extends Thread {
 
     private boolean searchAllOccurrences;
 
-    private static Logger log = LogManager.getLogger(SearchThread.class);
+    private static final Logger LOGGER = LogManager.getLogger(SearchThread.class);
 
     public SearchThread(
             String filter,
@@ -404,14 +404,14 @@ public class SearchThread extends Thread {
                     }
 
                 } catch (HttpMalformedHeaderException e1) {
-                    log.error(e1.getMessage(), e1);
+                    LOGGER.error(e1.getMessage(), e1);
                 }
                 if (pcc.hasPageEnded()) {
                     break;
                 }
             }
         } catch (DatabaseException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/sessions/ContextSessionManagementPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/sessions/ContextSessionManagementPanel.java
@@ -54,7 +54,7 @@ public class ContextSessionManagementPanel extends AbstractContextPropertiesPane
     private static final String CONFIG_NOT_NEEDED =
             Constant.messages.getString("sessionmanagement.panel.label.noConfigPanel");
 
-    private static final Logger log = LogManager.getLogger(ContextSessionManagementPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(ContextSessionManagementPanel.class);
 
     /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 6125457981814742851L;
@@ -140,7 +140,7 @@ public class ContextSessionManagementPanel extends AbstractContextPropertiesPane
             return;
         }
 
-        log.debug("Creating new panel for configuring: {}", newMethodType.getName());
+        LOGGER.debug("Creating new panel for configuring: {}", newMethodType.getName());
         this.getConfigContainerPanel().removeAll();
 
         // show the panel according to whether the session management type needs configuration
@@ -180,7 +180,8 @@ public class ContextSessionManagementPanel extends AbstractContextPropertiesPane
                         public void itemStateChanged(ItemEvent e) {
                             if (e.getStateChange() == ItemEvent.SELECTED) {
                                 // Prepare the new session management method
-                                log.debug("Selected new Session Management type: {}", e.getItem());
+                                LOGGER.debug(
+                                        "Selected new Session Management type: {}", e.getItem());
                                 SessionManagementMethodType type =
                                         ((SessionManagementMethodType) e.getItem());
 
@@ -231,7 +232,7 @@ public class ContextSessionManagementPanel extends AbstractContextPropertiesPane
     @Override
     public void initContextData(Session session, Context uiSharedContext) {
         selectedMethod = uiSharedContext.getSessionManagementMethod();
-        log.debug(
+        LOGGER.debug(
                 "Initializing configuration panel for session management method: {}  for context {}",
                 selectedMethod,
                 uiSharedContext.getName());

--- a/zap/src/main/java/org/zaproxy/zap/extension/sessions/ExtensionSessionManagement.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/sessions/ExtensionSessionManagement.java
@@ -54,7 +54,7 @@ public class ExtensionSessionManagement extends ExtensionAdaptor
     public static final String CONTEXT_CONFIG_SESSION_TYPE = CONTEXT_CONFIG_SESSION + ".type";
 
     /** The Constant log. */
-    private static final Logger log = LogManager.getLogger(ExtensionSessionManagement.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionSessionManagement.class);
 
     /** The automatically loaded session management method types. */
     List<SessionManagementMethodType> sessionManagementMethodTypes;
@@ -138,7 +138,7 @@ public class ExtensionSessionManagement extends ExtensionAdaptor
             t.hook(extensionHook);
         }
 
-        log.info("Loaded session management method types: {}", sessionManagementMethodTypes);
+        LOGGER.info("Loaded session management method types: {}", sessionManagementMethodTypes);
     }
 
     @Override
@@ -178,7 +178,7 @@ public class ExtensionSessionManagement extends ExtensionAdaptor
                 }
             }
         } catch (DatabaseException e) {
-            log.error("Unable to load Session Management method.", e);
+            LOGGER.error("Unable to load Session Management method.", e);
         }
     }
 
@@ -193,7 +193,7 @@ public class ExtensionSessionManagement extends ExtensionAdaptor
             t.persistMethodToSession(
                     session, context.getId(), context.getSessionManagementMethod());
         } catch (DatabaseException e) {
-            log.error("Unable to persist Session Management method.", e);
+            LOGGER.error("Unable to persist Session Management method.", e);
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/sessions/SessionManagementAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/sessions/SessionManagementAPI.java
@@ -47,7 +47,7 @@ import org.zaproxy.zap.utils.ApiUtils;
  */
 public class SessionManagementAPI extends ApiImplementor {
 
-    private static final Logger log = LogManager.getLogger(SessionManagementAPI.class);
+    private static final Logger LOGGER = LogManager.getLogger(SessionManagementAPI.class);
 
     private static final String PREFIX = "sessionManagement";
 
@@ -102,7 +102,7 @@ public class SessionManagementAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiView(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiView {} {}", name, params);
+        LOGGER.debug("handleApiView {} {}", name, params);
 
         switch (name) {
             case VIEW_GET_SESSION_MANAGEMENT_METHOD:
@@ -124,7 +124,7 @@ public class SessionManagementAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiAction {} {} ", name, params);
+        LOGGER.debug("handleApiAction {} {} ", name, params);
 
         switch (name) {
             case ACTION_SET_METHOD:

--- a/zap/src/main/java/org/zaproxy/zap/extension/stats/ExtensionStats.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stats/ExtensionStats.java
@@ -40,7 +40,7 @@ public class ExtensionStats extends ExtensionAdaptor implements OptionsChangedLi
     private OptionsStatsPanel optionsStatsPanel;
     private StatsParam statsParam;
 
-    private static final Logger LOG = LogManager.getLogger(ExtensionStats.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionStats.class);
 
     public ExtensionStats() {
         super();
@@ -123,11 +123,11 @@ public class ExtensionStats extends ExtensionAdaptor implements OptionsChangedLi
         if (inMemStatsInit != this.getStatsParam().isInMemoryEnabled()) {
             // Somethings changed
             if (!inMemStatsInit) {
-                LOG.info("Start recording in memory stats");
+                LOGGER.info("Start recording in memory stats");
                 inMemStats = new InMemoryStats();
                 Stats.addListener(inMemStats);
             } else {
-                LOG.info("Stop recording in memory stats");
+                LOGGER.info("Stop recording in memory stats");
                 Stats.removeListener(inMemStats);
                 inMemStats.allCleared();
                 inMemStats = null;
@@ -138,15 +138,15 @@ public class ExtensionStats extends ExtensionAdaptor implements OptionsChangedLi
         if (statsdInit != this.getStatsParam().isStatsdEnabled()) {
             // Somethings changed
             if (!statsdInit) {
-                LOG.info("Start sending stats to statsd server");
+                LOGGER.info("Start sending stats to statsd server");
                 try {
                     statsd = newStatsD(this.getStatsParam());
                     Stats.addListener(statsd);
                 } catch (Exception e) {
-                    LOG.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             } else {
-                LOG.info("Stop sending stats to statsd server");
+                LOGGER.info("Stop sending stats to statsd server");
                 Stats.removeListener(statsd);
                 statsd = null;
             }
@@ -154,13 +154,13 @@ public class ExtensionStats extends ExtensionAdaptor implements OptionsChangedLi
             if (!StringUtils.equals(this.getStatsParam().getStatsdHost(), statsd.getHost())
                     || this.getStatsParam().getStatsdPort() != statsd.getPort()) {
                 // Have to re-initialise it
-                LOG.info("Restart sending stats to statsd server");
+                LOGGER.info("Restart sending stats to statsd server");
                 try {
                     Stats.removeListener(statsd);
                     statsd = newStatsD(this.getStatsParam());
                     Stats.addListener(statsd);
                 } catch (Exception e) {
-                    LOG.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             } else if (!StringUtils.equals(
                     this.getStatsParam().getStatsdPrefix(), statsd.getPrefix())) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/stats/StatsdClient.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stats/StatsdClient.java
@@ -87,7 +87,7 @@ public class StatsdClient extends TimerTask {
     private boolean multi_metrics = false;
 
 	private static final Random RNG = new Random();
-	private static final Logger log = LogManager.getLogger(StatsdClient.class.getName());
+	private static final Logger LOGGER = LogManager.getLogger(StatsdClient.class.getName());
 
 	private final InetSocketAddress _address;
 	private final DatagramChannel _channel;
@@ -260,7 +260,7 @@ public class StatsdClient extends TimerTask {
             return true;
 
 		} catch (IOException e) {
-			log.error(
+			LOGGER.error(
 				String.format("Could not send stat %s to host %s:%d", sendBuffer.toString(), _address.getHostName(),
 						_address.getPort()), e);
 			return false;
@@ -282,7 +282,7 @@ public class StatsdClient extends TimerTask {
 			if (sizeOfBuffer == nbSentBytes) {
 				return true;
 			} else {
-				log.error(String.format(
+				LOGGER.error(String.format(
 					"Could not send entirely stat %s to host %s:%d. Only sent %d bytes out of %d bytes", sendBuffer.toString(),
 					_address.getHostName(), _address.getPort(), nbSentBytes, sizeOfBuffer));
 				return false;
@@ -290,7 +290,7 @@ public class StatsdClient extends TimerTask {
 
 		} catch (IOException e) {
 			/* This would be a good place to close the channel down and recreate it. */
-			log.error(
+			LOGGER.error(
 				String.format("Could not send stat %s to host %s:%d", sendBuffer.toString(), _address.getHostName(),
 					_address.getPort()), e);
 			return false;

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
@@ -72,7 +72,7 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
 
     // Still being developed
     // private PopupMenuShowResponseInBrowser popupMenuShowResponseInBrowser = null;
-    private static Logger log = LogManager.getLogger(ExtensionStdMenus.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionStdMenus.class);
 
     public ExtensionStdMenus() {
         super();
@@ -319,7 +319,7 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
             try {
                 return (String) contents.getTransferData(DataFlavor.stringFlavor);
             } catch (UnsupportedFlavorException | IOException e) {
-                log.error("Unable to get data from clipboard");
+                LOGGER.error("Unable to get data from clipboard");
             }
         }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuItemIncludeSiteInContext.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/PopupMenuItemIncludeSiteInContext.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.stdmenus;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.model.SiteNode;
@@ -30,7 +28,6 @@ import org.zaproxy.zap.view.popup.PopupMenuItemIncludeInContext;
 class PopupMenuItemIncludeSiteInContext extends PopupMenuItemIncludeInContext {
 
     private static final long serialVersionUID = 1L;
-    private static Logger log = LogManager.getLogger(PopupMenuItemIncludeSiteInContext.class);
 
     PopupMenuItemIncludeSiteInContext() {
         super();

--- a/zap/src/main/java/org/zaproxy/zap/extension/users/ExtensionUserManagement.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/users/ExtensionUserManagement.java
@@ -69,7 +69,7 @@ public class ExtensionUserManagement extends ExtensionAdaptor
     public static final String NAME = "ExtensionUserManagement";
 
     /** The Constant log. */
-    private static final Logger log = LogManager.getLogger(ExtensionUserManagement.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionUserManagement.class);
 
     /** The user panels, mapped to each context. */
     private Map<Integer, ContextUsersPanel> userPanelsMap = new HashMap<>();
@@ -111,7 +111,7 @@ public class ExtensionUserManagement extends ExtensionAdaptor
                             .getExtensionLoader()
                             .getExtension(ExtensionHttpSessions.class);
             if (extensionHttpSessions == null)
-                log.error(
+                LOGGER.error(
                         "Http Sessions Extension should be enabled for the {} to work.",
                         ExtensionUserManagement.class.getSimpleName());
         }
@@ -243,7 +243,7 @@ public class ExtensionUserManagement extends ExtensionAdaptor
                 usersManager.addUser(u);
             }
         } catch (Exception ex) {
-            log.error("Unable to load Users.", ex);
+            LOGGER.error("Unable to load Users.", ex);
         }
     }
 
@@ -259,7 +259,7 @@ public class ExtensionUserManagement extends ExtensionAdaptor
                 session.setContextData(context.getId(), RecordContext.TYPE_USER, encodedUsers);
             }
         } catch (Exception ex) {
-            log.error("Unable to persist Users.", ex);
+            LOGGER.error("Unable to persist Users.", ex);
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/users/UsersAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/users/UsersAPI.java
@@ -60,7 +60,7 @@ import org.zaproxy.zap.utils.ApiUtils;
 /** The API for manipulating {@link User Users}. */
 public class UsersAPI extends ApiImplementor {
 
-    private static final Logger log = LogManager.getLogger(UsersAPI.class);
+    private static final Logger LOGGER = LogManager.getLogger(UsersAPI.class);
 
     private static final String PREFIX = "users";
 
@@ -193,7 +193,7 @@ public class UsersAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiView(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiView {} {}", name, params);
+        LOGGER.debug("handleApiView {} {}", name, params);
 
         switch (name) {
             case VIEW_USERS_LIST:
@@ -242,7 +242,7 @@ public class UsersAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
-        log.debug("handleApiAction {} {}", name, params);
+        LOGGER.debug("handleApiAction {} {}", name, params);
 
         User user;
         Context context;
@@ -332,7 +332,7 @@ public class UsersAPI extends ApiImplementor {
                                                             user.getAuthenticationState())));
                             return responseSet;
                         } catch (Exception e) {
-                            log.error("Failed to read auth request from db {}", hId2, e);
+                            LOGGER.error("Failed to read auth request from db {}", hId2, e);
                             throw new ApiException(Type.INTERNAL_ERROR, e);
                         }
                     }
@@ -492,7 +492,7 @@ public class UsersAPI extends ApiImplementor {
             credList.addItem(new ApiResponseSet<>("credentials", credMap));
             list.addItem(credList);
         } catch (Exception e) {
-            log.error("Failed to access HttpState credMap", e);
+            LOGGER.error("Failed to access HttpState credMap", e);
         }
         return list;
     }

--- a/zap/src/main/java/org/zaproxy/zap/model/Context.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/Context.java
@@ -71,7 +71,7 @@ public class Context {
             CONTEXT_CONFIG_POSTPARSER + ".config";
     public static final String CONTEXT_CONFIG_DATA_DRIVEN_NODES = CONTEXT_CONFIG + ".ddns";
 
-    private static Logger log = LogManager.getLogger(Context.class);
+    private static final Logger LOGGER = LogManager.getLogger(Context.class);
 
     private Session session;
     private int id;
@@ -193,7 +193,7 @@ public class Context {
         try {
             return this.isInContext(href.getURI().toString());
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
         return false;
     }
@@ -598,13 +598,13 @@ public class Context {
                             }
                         });
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
 
     private void restructureSiteTreeEventHandler() {
-        log.debug("Restructure site tree for context: {}", this.getName());
+        LOGGER.debug("Restructure site tree for context: {}", this.getName());
         List<SiteNode> nodes = this.getTopNodesInContextFromSiteTree();
         for (SiteNode sn : nodes) {
             checkNode(sn);
@@ -654,7 +654,7 @@ public class Context {
                 // log.debug("Didn't need to move " + sn.getHierarchicNodeName());	// Useful for
                 // debugging
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
         return false;
@@ -687,7 +687,8 @@ public class Context {
 
         // Add into the right place
         SiteNode sn2 = sitesTree.addPath(sn.getHistoryReference());
-        log.debug("Moved node {} to {}", sn.getHierarchicNodeName(), sn2.getHierarchicNodeName());
+        LOGGER.debug(
+                "Moved node {} to {}", sn.getHierarchicNodeName(), sn2.getHierarchicNodeName());
 
         // And sort out the alerts
         for (Alert alert : alerts) {
@@ -696,7 +697,7 @@ public class Context {
     }
 
     private void deleteNode(SiteMap sitesTree, SiteNode sn) {
-        log.debug("Deleting node {}", sn.getHierarchicNodeName());
+        LOGGER.debug("Deleting node {}", sn.getHierarchicNodeName());
         sn.deleteAlerts(sn.getAlerts());
 
         // Remove old one

--- a/zap/src/main/java/org/zaproxy/zap/model/SessionStructure.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/SessionStructure.java
@@ -51,7 +51,7 @@ public class SessionStructure {
     private static final String MULTIPART_FORM_DATA = "multipart/form-data";
     private static final String MULTIPART_FORM_DATA_DISPLAY = "(" + MULTIPART_FORM_DATA + ")";
 
-    private static final Logger log = LogManager.getLogger(SessionStructure.class);
+    private static final Logger LOGGER = LogManager.getLogger(SessionStructure.class);
 
     /**
      * Adds the message to the Sites tree
@@ -131,7 +131,7 @@ public class SessionStructure {
                     return null;
                 }
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
                 return null;
             }
         }
@@ -150,7 +150,7 @@ public class SessionStructure {
                     return path;
                 }
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
         URI uri = msg.getRequestHeader().getURI();
@@ -324,7 +324,7 @@ public class SessionStructure {
                     return name;
                 }
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
 
@@ -642,7 +642,7 @@ public class SessionStructure {
 
             return newMsg;
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
         return null;
     }
@@ -729,7 +729,7 @@ public class SessionStructure {
                 return new StructuralTableNode(rs);
             }
         } catch (DatabaseException e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
         return null;
     }

--- a/zap/src/main/java/org/zaproxy/zap/model/StandardParameterParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/StandardParameterParser.java
@@ -58,7 +58,7 @@ public class StandardParameterParser implements ParameterParser {
     private String keyValueSeparators;
     private List<String> structuralParameters = new ArrayList<>();
 
-    private static Logger log = LogManager.getLogger(StandardParameterParser.class);
+    private static final Logger LOGGER = LogManager.getLogger(StandardParameterParser.class);
 
     public StandardParameterParser(String keyValuePairSeparators, String keyValueSeparators)
             throws PatternSyntaxException {
@@ -97,7 +97,7 @@ public class StandardParameterParser implements ParameterParser {
                 this.structuralParameters.add(obj.toString());
             }
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 
@@ -257,7 +257,7 @@ public class StandardParameterParser implements ParameterParser {
                         map.put(keyEqValue[0], keyEqValue[1]);
                     }
                 } catch (Exception e) {
-                    log.error(e.getMessage(), e);
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
         }
@@ -360,7 +360,7 @@ public class StandardParameterParser implements ParameterParser {
                     }
                 }
                 if (changed) {
-                    log.debug("Changed path from {} to {}", uri.getPath(), path);
+                    LOGGER.debug("Changed path from {} to {}", uri.getPath(), path);
                 }
             }
 

--- a/zap/src/main/java/org/zaproxy/zap/model/VulnerabilitiesLoader.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/VulnerabilitiesLoader.java
@@ -49,7 +49,7 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
  */
 public class VulnerabilitiesLoader {
 
-    private static final Logger logger = LogManager.getLogger(VulnerabilitiesLoader.class);
+    private static final Logger LOGGER = LogManager.getLogger(VulnerabilitiesLoader.class);
 
     private final Path directory;
     private final String fileName;
@@ -99,7 +99,7 @@ public class VulnerabilitiesLoader {
                         locale,
                         candidateFilename -> {
                             if (filenames.contains(candidateFilename)) {
-                                logger.debug(
+                                LOGGER.debug(
                                         "loading vulnerabilities from {} for locale {}",
                                         candidateFilename,
                                         locale);
@@ -125,7 +125,7 @@ public class VulnerabilitiesLoader {
         try (InputStream is = new BufferedInputStream(Files.newInputStream(file))) {
             return loadVulnerabilities(is);
         } catch (IOException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             return null;
         }
     }
@@ -135,7 +135,7 @@ public class VulnerabilitiesLoader {
         try {
             config = new ZapXmlConfiguration(is);
         } catch (ConfigurationException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             return null;
         }
 
@@ -143,7 +143,7 @@ public class VulnerabilitiesLoader {
         try {
             test = config.getStringArray("vuln_items");
         } catch (ConversionException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             return null;
         }
         final int numberOfVulns = test.length;
@@ -159,7 +159,7 @@ public class VulnerabilitiesLoader {
                 references =
                         new ArrayList<>(Arrays.asList(config.getStringArray(name + ".reference")));
             } catch (ConversionException e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
                 references = new ArrayList<>(0);
             }
 
@@ -185,7 +185,7 @@ public class VulnerabilitiesLoader {
      */
     List<String> getListOfVulnerabilitiesFiles() {
         if (!Files.exists(directory)) {
-            logger.debug(
+            LOGGER.debug(
                     "Skipping read of vulnerabilities, the directory does not exist: {}",
                     directory.toAbsolutePath());
             return Collections.emptyList();
@@ -211,7 +211,7 @@ public class VulnerabilitiesLoader {
                         }
                     });
         } catch (IOException e) {
-            logger.error("An error occurred while walking directory: {}", directory, e);
+            LOGGER.error("An error occurred while walking directory: {}", directory, e);
         }
         return fileNames;
     }

--- a/zap/src/main/java/org/zaproxy/zap/network/HttpResponseBody.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/HttpResponseBody.java
@@ -30,7 +30,7 @@ import org.parosproxy.paros.network.HttpBody;
 
 public class HttpResponseBody extends HttpBody {
 
-    private static final Logger log = LogManager.getLogger(HttpResponseBody.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpResponseBody.class);
 
     // private static Pattern patternCharset = Pattern.compile("<META
     // +[^>]+charset=['\"]*([^>'\"])+['\"]*>", Pattern.CASE_INSENSITIVE| Pattern.MULTILINE);
@@ -94,7 +94,7 @@ public class HttpResponseBody extends HttpBody {
             try {
                 return Charset.forName(matcher.group(1));
             } catch (IllegalArgumentException e) {
-                log.warn(
+                LOGGER.warn(
                         "Unable to determine (valid) charset with the (X)HTML meta charset: {}",
                         e.getMessage());
             }
@@ -140,8 +140,8 @@ public class HttpResponseBody extends HttpBody {
                 }
             }
         } catch (UnsupportedEncodingException e) {
-            log.error("Unable to encode with the (X)HTML meta charset: {}", e.getMessage());
-            log.warn("Using default charset: {}", DEFAULT_CHARSET);
+            LOGGER.error("Unable to encode with the (X)HTML meta charset: {}", e.getMessage());
+            LOGGER.warn("Using default charset: {}", DEFAULT_CHARSET);
 
             result = resultDefaultCharset;
         }

--- a/zap/src/main/java/org/zaproxy/zap/session/CookieBasedSessionManagementHelper.java
+++ b/zap/src/main/java/org/zaproxy/zap/session/CookieBasedSessionManagementHelper.java
@@ -35,7 +35,7 @@ import org.zaproxy.zap.extension.httpsessions.HttpSessionTokensSet;
 /** Helper for Cookie-based session management. */
 public class CookieBasedSessionManagementHelper {
 
-    private static final Logger log =
+    private static final Logger LOGGER =
             LogManager.getLogger(CookieBasedSessionManagementHelper.class);
 
     /**
@@ -77,7 +77,7 @@ public class CookieBasedSessionManagementHelper {
             // If the cookie is a token
             if (tokensSet.isSessionToken(cookieName)) {
                 String tokenValue = session.getTokenValue(cookieName);
-                log.debug("Changing value of token '{}' to: {}", cookieName, tokenValue);
+                LOGGER.debug("Changing value of token '{}' to: {}", cookieName, tokenValue);
 
                 // Change it's value to the one in the active session, if any
                 if (tokenValue != null) {
@@ -99,7 +99,7 @@ public class CookieBasedSessionManagementHelper {
             String tokenValue = session.getTokenValue(token);
             // Change it's value to the one in the active session, if any
             if (tokenValue != null) {
-                log.debug("Adding token '{}' with value: {}", token, tokenValue);
+                LOGGER.debug("Adding token '{}' with value: {}", token, tokenValue);
                 HttpCookie cookie = new HttpCookie(token, tokenValue);
                 requestCookies.add(cookie);
             }
@@ -153,7 +153,8 @@ public class CookieBasedSessionManagementHelper {
         // Return the matching session
         if (matchingSessions.size() >= 1) {
             if (matchingSessions.size() > 1) {
-                log.warn("Multiple sessions matching the cookies from response. Using first one.");
+                LOGGER.warn(
+                        "Multiple sessions matching the cookies from response. Using first one.");
             }
             return matchingSessions.get(0);
         }

--- a/zap/src/main/java/org/zaproxy/zap/session/CookieBasedSessionManagementMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/session/CookieBasedSessionManagementMethodType.java
@@ -53,8 +53,6 @@ import org.zaproxy.zap.utils.ApiUtils;
 public class CookieBasedSessionManagementMethodType extends SessionManagementMethodType {
 
     private static final int METHOD_IDENTIFIER = 0;
-    private static final Logger log =
-            LogManager.getLogger(CookieBasedSessionManagementMethod.class);
 
     /** The Constant METHOD_NAME. */
     private static final String METHOD_NAME =
@@ -65,6 +63,9 @@ public class CookieBasedSessionManagementMethodType extends SessionManagementMet
      * cookies for session management.
      */
     public static class CookieBasedSessionManagementMethod implements SessionManagementMethod {
+
+        private static final Logger LOGGER =
+                LogManager.getLogger(CookieBasedSessionManagementMethod.class);
 
         private int contextId;
 
@@ -166,13 +167,14 @@ public class CookieBasedSessionManagementMethodType extends SessionManagementMet
         @Override
         public void clearWebSessionIdentifiers(HttpMessage msg) {
             if (getHttpSessionsExtension() == null) {
-                log.info("No tokens will be removed, the HTTP Sessions Extension is not enabled.");
+                LOGGER.info(
+                        "No tokens will be removed, the HTTP Sessions Extension is not enabled.");
                 return;
             }
             HttpSessionTokensSet tokens =
                     getHttpSessionsExtension().getHttpSessionTokensSetForContext(getContext());
             if (tokens == null) {
-                log.info("No tokens to clear.");
+                LOGGER.info("No tokens to clear.");
                 return;
             }
             List<HttpCookie> requestCookies = msg.getRequestHeader().getHttpCookies();

--- a/zap/src/main/java/org/zaproxy/zap/session/HttpAuthSessionManagementMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/session/HttpAuthSessionManagementMethodType.java
@@ -23,8 +23,6 @@ import net.sf.json.JSONObject;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.httpclient.HttpState;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.extension.ExtensionHook;
@@ -45,9 +43,6 @@ import org.zaproxy.zap.utils.ApiUtils;
 public class HttpAuthSessionManagementMethodType extends SessionManagementMethodType {
 
     private static final int METHOD_IDENTIFIER = 1;
-
-    @SuppressWarnings("unused")
-    private static final Logger log = LogManager.getLogger(HttpAuthSessionManagementMethod.class);
 
     /** The Constant METHOD_NAME. */
     private static final String METHOD_NAME =

--- a/zap/src/main/java/org/zaproxy/zap/session/ScriptBasedSessionManagementMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/session/ScriptBasedSessionManagementMethodType.java
@@ -88,7 +88,7 @@ public class ScriptBasedSessionManagementMethodType extends SessionManagementMet
 
     private static final int METHOD_IDENTIFIER = 2;
 
-    private static final Logger LOG =
+    private static final Logger LOGGER =
             LogManager.getLogger(ScriptBasedSessionManagementMethodType.class);
 
     private static final String METHOD_NAME =
@@ -361,7 +361,7 @@ public class ScriptBasedSessionManagementMethodType extends SessionManagementMet
             SessionScript script = getScriptInterface(scriptW);
 
             if (script == null) {
-                LOG.warn(
+                LOGGER.warn(
                         "The script {} does not properly implement the Session Script interface.",
                         scriptW.getName());
                 warnAndResetPanel(
@@ -381,7 +381,7 @@ public class ScriptBasedSessionManagementMethodType extends SessionManagementMet
                 Map<String, String> oldValues = null;
                 if (adaptOldValues && dynamicFieldsPanel != null) {
                     oldValues = dynamicFieldsPanel.getFieldValues();
-                    LOG.debug("Trying to adapt old values: {}", oldValues);
+                    LOGGER.debug("Trying to adapt old values: {}", oldValues);
                 }
 
                 this.dynamicFieldsPanel = new DynamicFieldsPanel(requiredParams, optionalParams);
@@ -396,7 +396,7 @@ public class ScriptBasedSessionManagementMethodType extends SessionManagementMet
 
             } catch (Exception e) {
                 getScriptsExtension().handleScriptException(scriptW, e);
-                LOG.error("Error while calling session management script", e);
+                LOGGER.error("Error while calling session management script", e);
                 warnAndResetPanel(
                         Constant.messages.getString(
                                 "session.method.script.dialog.error.text.loading",
@@ -451,7 +451,7 @@ public class ScriptBasedSessionManagementMethodType extends SessionManagementMet
     public void hook(ExtensionHook extensionHook) {
         // Hook up the Script Type
         if (getScriptsExtension() != null) {
-            LOG.debug("Registering Script...");
+            LOGGER.debug("Registering Script...");
             getScriptsExtension()
                     .registerScriptType(
                             new ScriptType(
@@ -539,7 +539,7 @@ public class ScriptBasedSessionManagementMethodType extends SessionManagementMet
         if (scriptName != null) {
             ScriptWrapper script = getScriptsExtension().getScript(scriptName);
             if (script == null) {
-                LOG.error(
+                LOGGER.error(
                         "Unable to find script while loading Script Based Session Management Method for name: {}",
                         scriptName);
                 if (View.isInitialised()) {
@@ -551,13 +551,13 @@ public class ScriptBasedSessionManagementMethodType extends SessionManagementMet
                 }
                 return;
             }
-            LOG.info("Loaded script:{}", script.getName());
+            LOGGER.info("Loaded script:{}", script.getName());
             method.script = script;
 
             // Check script interface
             SessionScript s = getScriptInterface(script);
             if (s == null) {
-                LOG.error(
+                LOGGER.error(
                         "Unable to load Script Based Session Management method. The script {} does not properly implement the Session Management Script interface.",
                         scriptName);
                 return;
@@ -571,7 +571,7 @@ public class ScriptBasedSessionManagementMethodType extends SessionManagementMet
             method.paramValues = paramValues;
         } else {
             method.paramValues = new HashMap<>();
-            LOG.error(
+            LOGGER.error(
                     "Unable to load script parameter values loading Script Based Session Management Method for name: {}",
                     scriptName);
         }
@@ -625,19 +625,19 @@ public class ScriptBasedSessionManagementMethodType extends SessionManagementMet
                 // Load the script and make sure it exists and follows the required interface
                 ScriptWrapper script = getScriptsExtension().getScript(scriptName);
                 if (script == null) {
-                    LOG.error(
+                    LOGGER.error(
                             "Unable to find script while loading Script Based Session Management Method for name: {}",
                             scriptName);
                     throw new ApiException(ApiException.Type.SCRIPT_NOT_FOUND, scriptName);
                 } else {
-                    LOG.info("Loaded script for API:{}", script.getName());
+                    LOGGER.info("Loaded script for API:{}", script.getName());
                 }
                 method.script = script;
 
                 SessionScript sessionScript = getScriptInterface(script);
                 String[] requiredParams = sessionScript.getRequiredParamsNames();
                 String[] optionalParams = sessionScript.getOptionalParamsNames();
-                LOG.debug(
+                LOGGER.debug(
                         "Loaded session management script - required parameters: {} - optial parameters: {}",
                         Arrays.toString(requiredParams),
                         Arrays.toString(optionalParams));
@@ -653,7 +653,7 @@ public class ScriptBasedSessionManagementMethodType extends SessionManagementMet
                 for (String op : optionalParams)
                     paramValues.put(op, ApiUtils.getOptionalStringParam(params, op));
                 method.paramValues = paramValues;
-                LOG.debug("Loaded session management script parameters:{}", paramValues);
+                LOGGER.debug("Loaded session management script parameters:{}", paramValues);
 
                 context.setSessionManagementMethod(method);
             }

--- a/zap/src/main/java/org/zaproxy/zap/users/User.java
+++ b/zap/src/main/java/org/zaproxy/zap/users/User.java
@@ -40,7 +40,7 @@ import org.zaproxy.zap.utils.Enableable;
 public class User extends Enableable {
 
     /** The Constant log. */
-    private static final Logger log = LogManager.getLogger(User.class);
+    private static final Logger LOGGER = LogManager.getLogger(User.class);
 
     /** The id source. */
     private static int ID_SOURCE = 0;
@@ -169,7 +169,7 @@ public class User extends Enableable {
             if (this.requiresAuthentication()) {
                 this.authenticate();
                 if (this.requiresAuthentication()) {
-                    log.info("Authentication failed for user: {}", name);
+                    LOGGER.info("Authentication failed for user: {}", name);
                     return;
                 }
             }
@@ -262,7 +262,7 @@ public class User extends Enableable {
      * @see Context
      */
     public void authenticate() {
-        log.info("Authenticating user: {}", this.name);
+        LOGGER.info("Authenticating user: {}", this.name);
         WebSession result = null;
         try {
             result =
@@ -273,9 +273,9 @@ public class User extends Enableable {
                                     this.authenticationCredentials,
                                     this);
         } catch (UnsupportedAuthenticationCredentialsException e) {
-            log.error("User does not have the expected type of credentials:", e);
+            LOGGER.error("User does not have the expected type of credentials:", e);
         } catch (Exception e) {
-            log.error("An error occurred while authenticating:", e);
+            LOGGER.error("An error occurred while authenticating:", e);
             return;
         }
         // no issues appear if a simultaneous call to #queueAuthentication() is made
@@ -314,7 +314,7 @@ public class User extends Enableable {
         out.append(user.getContext().getAuthenticationMethod().getType().getUniqueIdentifier())
                 .append(FIELD_SEPARATOR);
         out.append(user.authenticationCredentials.encode(FIELD_SEPARATOR));
-        log.debug("Encoded user: {}", out);
+        LOGGER.debug("Encoded user: {}", out);
         return out.toString();
     }
 
@@ -359,10 +359,10 @@ public class User extends Enableable {
             cred.decode(pieces[4]);
             user.setAuthenticationCredentials(cred);
         } catch (Exception ex) {
-            log.error("An error occured while decoding user from: {}", encodedString, ex);
+            LOGGER.error("An error occured while decoding user from: {}", encodedString, ex);
             return null;
         }
-        log.debug("Decoded user: {}", user);
+        LOGGER.debug("Decoded user: {}", user);
         return user;
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/utils/ByteBuilder.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/ByteBuilder.java
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.Logger;
 
 public class ByteBuilder {
 
-    private static final Logger logger = LogManager.getLogger(ByteBuilder.class);
+    private static final Logger LOGGER = LogManager.getLogger(ByteBuilder.class);
 
     private byte[] array;
     private int size;
@@ -229,7 +229,7 @@ public class ByteBuilder {
                 | IllegalAccessException
                 | InvocationTargetException e) {
             // shouldn't happen but in case it does log it.
-            logger.debug(e.getMessage(), e);
+            LOGGER.debug(e.getMessage(), e);
         } catch (NoSuchMethodException e) {
             // will happen, a lot
         }

--- a/zap/src/main/java/org/zaproxy/zap/utils/DesktopUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/DesktopUtils.java
@@ -34,7 +34,7 @@ public class DesktopUtils {
     private static BrowserInvoker invoker =
             Desktop.isDesktopSupported() ? BrowserInvoker.desktop : BrowserInvoker.none;
 
-    private static Logger log = LogManager.getLogger(DesktopUtils.class);
+    private static final Logger LOGGER = LogManager.getLogger(DesktopUtils.class);
 
     public static boolean openUrlInBrowser(URI uri) {
 
@@ -44,7 +44,7 @@ public class DesktopUtils {
                 return true;
             }
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             invoker = BrowserInvoker.none;
         }
         return false;
@@ -54,7 +54,7 @@ public class DesktopUtils {
         try {
             return openUrlInBrowser(new URI(uri));
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             invoker = BrowserInvoker.none;
         }
         return false;
@@ -64,7 +64,7 @@ public class DesktopUtils {
         try {
             return openUrlInBrowser(uri.toString());
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             invoker = BrowserInvoker.none;
         }
         return false;

--- a/zap/src/main/java/org/zaproxy/zap/utils/I18N.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/I18N.java
@@ -76,7 +76,7 @@ public class I18N {
      */
     private URLClassLoader langClassLoader;
 
-    private static final Logger logger = LogManager.getLogger(I18N.class);
+    private static final Logger LOGGER = LogManager.getLogger(I18N.class);
 
     public I18N(Locale locale) {
         langClassLoader = createLangClassLoader();
@@ -89,7 +89,7 @@ public class I18N {
             try {
                 return new URLClassLoader(new URL[] {langDir.toUri().toURL()});
             } catch (MalformedURLException e) {
-                logger.warn("Failed to convert path {}", langDir, e);
+                LOGGER.warn("Failed to convert path {}", langDir, e);
             }
         }
         return null;
@@ -106,9 +106,9 @@ public class I18N {
     }
 
     public void addMessageBundle(String prefix, ResourceBundle bundle) {
-        logger.debug("Adding message bundle with prefix: {}", prefix);
+        LOGGER.debug("Adding message bundle with prefix: {}", prefix);
         if (addonMessages.containsKey(prefix)) {
-            logger.error("Adding message bundle with duplicate prefix: {}", prefix);
+            LOGGER.error("Adding message bundle with duplicate prefix: {}", prefix);
         }
         addonMessages.put(prefix, bundle);
     }
@@ -116,11 +116,11 @@ public class I18N {
     public void removeMessageBundle(String prefix) {
         missingKeys.removeIf(k -> k.startsWith(prefix));
 
-        logger.debug("Removing message bundle with prefix: {}", prefix);
+        LOGGER.debug("Removing message bundle with prefix: {}", prefix);
         if (addonMessages.containsKey(prefix)) {
             addonMessages.remove(prefix);
         } else {
-            logger.debug("Message bundle not found, prefix: {}", prefix);
+            LOGGER.debug("Message bundle not found, prefix: {}", prefix);
         }
     }
 
@@ -153,7 +153,7 @@ public class I18N {
     }
 
     private String handleMissingResourceException(MissingResourceException e) {
-        logger.error("Failed to load a message:", e);
+        LOGGER.error("Failed to load a message:", e);
         String key = e.getKey();
         missingKeys.add(key);
         return missingKeyReplacement(key);
@@ -238,15 +238,15 @@ public class I18N {
         ResourceBundle fsRb = loadFsResourceBundle(rbc);
         if (fsRb != null) {
             this.stdMessages = fsRb;
-            logger.debug("Using file system Messages resource bundle.");
+            LOGGER.debug("Using file system Messages resource bundle.");
             try {
                 this.fallbackStdMessages = loadBundledResourceBundle(rbc);
             } catch (MissingResourceException e) {
-                logger.warn("Failed to find bundled Messages resource bundle.");
+                LOGGER.warn("Failed to find bundled Messages resource bundle.");
             }
         } else {
             this.stdMessages = loadBundledResourceBundle(rbc);
-            logger.debug("Using bundled Messages resource bundle.");
+            LOGGER.debug("Using bundled Messages resource bundle.");
         }
     }
 
@@ -259,7 +259,7 @@ public class I18N {
         try {
             return loadResourceBundle(Constant.MESSAGES_PREFIX, langClassLoader, rbc);
         } catch (MissingResourceException e) {
-            logger.debug("Failed to load file system Messages resource bundle.", e);
+            LOGGER.debug("Failed to load file system Messages resource bundle.", e);
         }
         return null;
     }

--- a/zap/src/main/java/org/zaproxy/zap/utils/LocaleUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/LocaleUtils.java
@@ -40,7 +40,7 @@ import org.zaproxy.zap.view.ViewLocale;
 
 public final class LocaleUtils {
 
-    private static final Logger logger = LogManager.getLogger(LocaleUtils.class);
+    private static final Logger LOGGER = LogManager.getLogger(LocaleUtils.class);
 
     private static final String MESSAGES_BASE_FILENAME = Constant.MESSAGES_PREFIX + "_";
 
@@ -401,7 +401,7 @@ public final class LocaleUtils {
     private static List<String> readAvailableLocales() {
         File dir = new File(Constant.getZapInstall(), Constant.LANG_DIR);
         if (!dir.exists()) {
-            logger.debug(
+            LOGGER.debug(
                     "Skipping read of available locales, the directory does not exist: {}",
                     dir.getAbsolutePath());
             return new ArrayList<>(0);
@@ -411,7 +411,7 @@ public final class LocaleUtils {
         String[] files = dir.list(filter);
 
         if (files == null || files.length == 0) {
-            logger.warn("No Messages files in directory {}", dir.getAbsolutePath());
+            LOGGER.warn("No Messages files in directory {}", dir.getAbsolutePath());
             return new ArrayList<>(0);
         }
 

--- a/zap/src/main/java/org/zaproxy/zap/utils/NetworkUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/NetworkUtils.java
@@ -33,7 +33,7 @@ public final class NetworkUtils {
 
     private NetworkUtils() {}
 
-    private static final Logger LOG = LogManager.getLogger(NetworkUtils.class);
+    private static final Logger LOGGER = LogManager.getLogger(NetworkUtils.class);
 
     public static List<String> getAvailableAddresses(boolean remoteOnly) {
         List<String> list = new ArrayList<>();
@@ -59,7 +59,7 @@ public final class NetworkUtils {
                 }
             }
         } catch (SocketException e1) {
-            LOG.error(e1.getMessage(), e1);
+            LOGGER.error(e1.getMessage(), e1);
         }
         return list;
     }

--- a/zap/src/main/java/org/zaproxy/zap/utils/PagingTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/PagingTableModel.java
@@ -62,7 +62,7 @@ import org.apache.logging.log4j.Logger;
 public abstract class PagingTableModel<T> extends AbstractTableModel {
     private static final long serialVersionUID = -6353414328926478100L;
 
-    private static final Logger logger = LogManager.getLogger(PagingTableModel.class);
+    private static final Logger LOGGER = LogManager.getLogger(PagingTableModel.class);
 
     /** Default segment loader thread name. */
     public static final String DEFAULT_SEGMENT_LOADER_THREAD_NAME =
@@ -418,7 +418,7 @@ public abstract class PagingTableModel<T> extends AbstractTableModel {
             try {
                 page = loadPage(segment.getBase(), segment.getLength());
             } catch (Exception e) {
-                logger.warn("error retrieving page at {}: aborting", segment.getBase(), e);
+                LOGGER.warn("error retrieving page at {}: aborting", segment.getBase(), e);
                 pending.remove(segment);
                 return;
             }

--- a/zap/src/main/java/org/zaproxy/zap/utils/Stats.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/Stats.java
@@ -28,7 +28,7 @@ public final class Stats {
 
     private static final List<StatsListener> listeners = new ArrayList<>();
 
-    private static final Logger logger = LogManager.getLogger(Stats.class);
+    private static final Logger LOGGER = LogManager.getLogger(Stats.class);
 
     private Stats() {}
 
@@ -37,7 +37,7 @@ public final class Stats {
             try {
                 listener.counterInc(key);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -47,7 +47,7 @@ public final class Stats {
             try {
                 listener.counterInc(site, key);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -57,7 +57,7 @@ public final class Stats {
             try {
                 listener.counterInc(key, inc);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -67,7 +67,7 @@ public final class Stats {
             try {
                 listener.counterInc(site, key, inc);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -77,7 +77,7 @@ public final class Stats {
             try {
                 listener.counterDec(key);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -87,7 +87,7 @@ public final class Stats {
             try {
                 listener.counterDec(site, key);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -97,7 +97,7 @@ public final class Stats {
             try {
                 listener.counterDec(key, dec);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -107,7 +107,7 @@ public final class Stats {
             try {
                 listener.counterDec(site, key, dec);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -117,7 +117,7 @@ public final class Stats {
             try {
                 listener.highwaterMarkSet(key, value);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -127,7 +127,7 @@ public final class Stats {
             try {
                 listener.highwaterMarkSet(site, key, value);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -137,7 +137,7 @@ public final class Stats {
             try {
                 listener.lowwaterMarkSet(key, value);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -147,7 +147,7 @@ public final class Stats {
             try {
                 listener.lowwaterMarkSet(site, key, value);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -157,7 +157,7 @@ public final class Stats {
             try {
                 listener.allCleared();
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -167,7 +167,7 @@ public final class Stats {
             try {
                 listener.allCleared(site);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -177,7 +177,7 @@ public final class Stats {
             try {
                 listener.cleared(keyPrefix);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -187,7 +187,7 @@ public final class Stats {
             try {
                 listener.cleared(site, keyPrefix);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }

--- a/zap/src/main/java/org/zaproxy/zap/view/LocaleDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/LocaleDialog.java
@@ -41,7 +41,7 @@ public class LocaleDialog extends AbstractDialog {
     private OptionsLocalePanel localePanel = null;
     private OptionsParam options = null;
     private JButton btnOK = null;
-    private Logger logger = LogManager.getLogger(LocaleDialog.class);
+    private static final Logger LOGGER = LogManager.getLogger(LocaleDialog.class);
 
     /**
      * Constructs an {@code LocaleDialog} with no owner and not modal.
@@ -120,7 +120,7 @@ public class LocaleDialog extends AbstractDialog {
         try {
             localePanel.saveParam(options);
         } catch (Exception e1) {
-            logger.error(e1.getMessage(), e1);
+            LOGGER.error(e1.getMessage(), e1);
         }
 
         LocaleDialog.this.dispose();

--- a/zap/src/main/java/org/zaproxy/zap/view/MainToolbarPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/MainToolbarPanel.java
@@ -47,7 +47,7 @@ public class MainToolbarPanel extends JPanel {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Logger logger = LogManager.getLogger(MainToolbarPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(MainToolbarPanel.class);
 
     private JToolBar toolbar = null;
     private JComboBox<String> modeSelect = null;
@@ -295,7 +295,7 @@ public class MainToolbarPanel extends JPanel {
                             try {
                                 Control.getSingleton().getMenuFileControl().newSession(true);
                             } catch (Exception ex) {
-                                logger.error(ex.getMessage(), ex);
+                                LOGGER.error(ex.getMessage(), ex);
                                 View.getSingleton()
                                         .showWarningDialog(
                                                 Constant.messages.getString(
@@ -327,7 +327,7 @@ public class MainToolbarPanel extends JPanel {
                             try {
                                 Control.getSingleton().getMenuFileControl().openSession();
                             } catch (Exception ex) {
-                                logger.error(ex.getMessage(), ex);
+                                LOGGER.error(ex.getMessage(), ex);
                                 View.getSingleton()
                                         .showWarningDialog(
                                                 Constant.messages.getString(
@@ -366,7 +366,7 @@ public class MainToolbarPanel extends JPanel {
                                                             "menu.file.sessionExists.error"));
                                 }
                             } catch (Exception ex) {
-                                logger.error(ex.getMessage(), ex);
+                                LOGGER.error(ex.getMessage(), ex);
                                 View.getSingleton()
                                         .showWarningDialog(
                                                 Constant.messages.getString(
@@ -406,7 +406,7 @@ public class MainToolbarPanel extends JPanel {
                                     Control.getSingleton().getMenuFileControl().saveSnapshot();
                                 }
                             } catch (Exception ex) {
-                                logger.error(ex.getMessage(), ex);
+                                LOGGER.error(ex.getMessage(), ex);
                                 View.getSingleton()
                                         .showWarningDialog(
                                                 Constant.messages.getString(

--- a/zap/src/main/java/org/zaproxy/zap/view/ScanPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ScanPanel.java
@@ -100,7 +100,7 @@ public abstract class ScanPanel extends AbstractPanel {
     private ScanStatus scanStatus = null;
     private Mode mode = Control.getSingleton().getMode();
 
-    private static Logger log = LogManager.getLogger(ScanPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(ScanPanel.class);
 
     /**
      * Constructs a {@code ScanPanel} with the given message resources prefix, tab icon, extension
@@ -118,7 +118,7 @@ public abstract class ScanPanel extends AbstractPanel {
         this.extension = extension;
         this.scanParam = scanParam;
         initialize(icon);
-        log.debug("Constructor {}", prefix);
+        LOGGER.debug("Constructor {}", prefix);
     }
 
     /** This method initializes this */
@@ -289,7 +289,7 @@ public abstract class ScanPanel extends AbstractPanel {
                             }
                         });
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -466,7 +466,7 @@ public abstract class ScanPanel extends AbstractPanel {
     }
 
     public void scanAllInScope() {
-        log.debug("scanSite (all in scope)");
+        LOGGER.debug("scanSite (all in scope)");
         this.setTabFocus();
         if (this.getStartScanButton().isEnabled()) {
             this.startScan(null, true, true, null, null);
@@ -478,7 +478,7 @@ public abstract class ScanPanel extends AbstractPanel {
     }
 
     public void scanAllInContext(Context context, User user) {
-        log.debug("Scan all in context: {}", context.getName());
+        LOGGER.debug("Scan all in context: {}", context.getName());
         this.setTabFocus();
         if (this.getStartScanButton().isEnabled()) {
 
@@ -487,7 +487,7 @@ public abstract class ScanPanel extends AbstractPanel {
     }
 
     public void scanSite(SiteNode node, boolean incPort) {
-        log.debug("scanSite {} node={}", prefix, node.getNodeName());
+        LOGGER.debug("scanSite {} node={}", prefix, node.getNodeName());
         this.setTabFocus();
         nodeSelected(node, incPort);
         if (currentSite != null && this.getStartScanButton().isEnabled()) {
@@ -515,7 +515,7 @@ public abstract class ScanPanel extends AbstractPanel {
      * @param user the user
      */
     public void scanNode(SiteNode node, boolean incPort, User user) {
-        log.debug("scanNode{} node={}", prefix, node.getNodeName());
+        LOGGER.debug("scanNode{} node={}", prefix, node.getNodeName());
         this.setTabFocus();
         nodeSelected(node, incPort);
         if (currentSite != null && this.getStartScanButton().isEnabled()) {
@@ -546,7 +546,7 @@ public abstract class ScanPanel extends AbstractPanel {
     }
 
     private void addSite(String site) {
-        log.debug("addSite {}", site);
+        LOGGER.debug("addSite {}", site);
         siteModel.addElement(new ScanTarget(site));
     }
 
@@ -730,7 +730,7 @@ public abstract class ScanPanel extends AbstractPanel {
             Context scanContext,
             User scanUser,
             Object[] contextSpecificObjects) {
-        log.debug("startScan {} {}", prefix, startNode);
+        LOGGER.debug("startScan {} {}", prefix, startNode);
         this.getStartScanButton().setEnabled(false);
         this.getStopScanButton().setEnabled(true);
         this.getPauseScanButton().setEnabled(true);
@@ -782,7 +782,7 @@ public abstract class ScanPanel extends AbstractPanel {
     }
 
     public void stopScan(String site) {
-        log.debug("stopScan {} on {}", prefix, site);
+        LOGGER.debug("stopScan {} on {}", prefix, site);
         GenericScanner scan = scanMap.get(site);
         if (scan != null) {
             scan.stopScan();
@@ -790,7 +790,7 @@ public abstract class ScanPanel extends AbstractPanel {
     }
 
     public void pauseScan(String site) {
-        log.debug("pauseScan {} on  {}", prefix, site);
+        LOGGER.debug("pauseScan {} on  {}", prefix, site);
         GenericScanner scan = scanMap.get(site);
         if (scan != null) {
             if (scan.isPaused()) {
@@ -814,13 +814,13 @@ public abstract class ScanPanel extends AbstractPanel {
                             }
                         });
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
 
     private void scanFinshedEventHandler(String host) {
-        log.debug("scanFinished {} on {}", prefix, currentSite);
+        LOGGER.debug("scanFinished {} on {}", prefix, currentSite);
         if (host != null && host.equals(currentSite)) {
             resetScanButtonsAndProgressBarStates(true);
         }
@@ -852,9 +852,9 @@ public abstract class ScanPanel extends AbstractPanel {
                             }
                         });
             } catch (InterruptedException e) {
-                log.info("Interrupt scan progress update on GUI.");
+                LOGGER.info("Interrupt scan progress update on GUI.");
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
@@ -868,7 +868,7 @@ public abstract class ScanPanel extends AbstractPanel {
     }
 
     public void reset() {
-        log.debug("reset {}", prefix);
+        LOGGER.debug("reset {}", prefix);
         stopAllScans();
 
         resetSiteSelect();

--- a/zap/src/main/java/org/zaproxy/zap/view/ScanPanel2.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ScanPanel2.java
@@ -89,7 +89,7 @@ public abstract class ScanPanel2<GS extends GenericScanner2, SC extends ScanCont
     private ScanStatus scanStatus = null;
     private Mode mode = Control.getSingleton().getMode();
 
-    private static Logger log = LogManager.getLogger(ScanPanel2.class);
+    private static final Logger LOGGER = LogManager.getLogger(ScanPanel2.class);
 
     /**
      * Constructs a {@code ScanPanel2} with the given message resources prefix, tab icon and scan
@@ -107,7 +107,7 @@ public abstract class ScanPanel2<GS extends GenericScanner2, SC extends ScanCont
         selectScanEntry =
                 new ScanEntry<>(Constant.messages.getString(prefix + ".toolbar.progress.select"));
         initialize(icon);
-        log.debug("Constructor {}", prefix);
+        LOGGER.debug("Constructor {}", prefix);
     }
 
     /** This method initializes this */
@@ -531,13 +531,13 @@ public abstract class ScanPanel2<GS extends GenericScanner2, SC extends ScanCont
                             }
                         });
             } catch (Exception e) {
-                log.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
         }
     }
 
     private void scanFinshedEventHandler(int id, String host) {
-        log.debug("scanFinished {} on {}", prefix, host);
+        LOGGER.debug("scanFinished {} on {}", prefix, host);
         if (this.getSelectedScanner() != null && this.getSelectedScanner().getScanId() == id) {
             updateProgressAndButtonsState(getSelectedScanner());
         }
@@ -601,7 +601,7 @@ public abstract class ScanPanel2<GS extends GenericScanner2, SC extends ScanCont
     }
 
     public void reset() {
-        log.debug("reset {}", prefix);
+        LOGGER.debug("reset {}", prefix);
 
         progressModel.removeAllElements();
         progressSelect.addItem(selectScanEntry);

--- a/zap/src/main/java/org/zaproxy/zap/view/SiteMapTreeCellRenderer.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/SiteMapTreeCellRenderer.java
@@ -85,7 +85,7 @@ public class SiteMapTreeCellRenderer extends DefaultTreeCellRenderer {
 
     private static final long serialVersionUID = -4278691012245035225L;
 
-    private static Logger log = LogManager.getLogger(SiteMapPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(SiteMapTreeCellRenderer.class);
 
     private List<SiteMapListener> listeners;
     private JPanel component;
@@ -208,7 +208,7 @@ public class SiteMapTreeCellRenderer extends DefaultTreeCellRenderer {
                 try {
                     return node.getHistoryReference();
                 } catch (Exception e) {
-                    log.warn(e.getMessage(), e);
+                    LOGGER.warn(e.getMessage(), e);
                 }
             }
         }

--- a/zap/src/main/java/org/zaproxy/zap/view/StandardFieldsDialog.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/StandardFieldsDialog.java
@@ -83,7 +83,7 @@ import org.zaproxy.zap.view.widgets.ContextSelectComboBox;
 @SuppressWarnings("serial")
 public abstract class StandardFieldsDialog extends AbstractDialog {
 
-    private static final Logger logger = LogManager.getLogger(StandardFieldsDialog.class);
+    private static final Logger LOGGER = LogManager.getLogger(StandardFieldsDialog.class);
 
     private static final long serialVersionUID = 1L;
     private static final EmptyBorder FULL_BORDER = new EmptyBorder(8, 8, 8, 8);
@@ -1177,14 +1177,14 @@ public abstract class StandardFieldsDialog extends AbstractDialog {
             }
         } else if (c == null) {
             // Ignore - could be during init
-            logger.debug("No field for {}", fieldLabel);
+            LOGGER.debug("No field for {}", fieldLabel);
         } else {
             handleUnexpectedFieldClass(fieldLabel, c);
         }
     }
 
     private static void handleUnexpectedFieldClass(String fieldLabel, Component component) {
-        logger.error(
+        LOGGER.error(
                 "Unexpected field class {}: {}\n\t{}",
                 fieldLabel,
                 component.getClass().getCanonicalName(),
@@ -1205,7 +1205,7 @@ public abstract class StandardFieldsDialog extends AbstractDialog {
             }
         } else if (c == null) {
             // Ignore - could be during init
-            logger.debug("No field for {}", fieldLabel);
+            LOGGER.debug("No field for {}", fieldLabel);
         } else {
             handleUnexpectedFieldClass(fieldLabel, c);
         }
@@ -1232,7 +1232,7 @@ public abstract class StandardFieldsDialog extends AbstractDialog {
             comboBox.setModel(comboBoxModel);
         } else if (c == null) {
             // Ignore - could be during init
-            logger.debug("No field for {}", fieldLabel);
+            LOGGER.debug("No field for {}", fieldLabel);
         } else {
             handleUnexpectedFieldClass(fieldLabel, c);
         }

--- a/zap/src/main/java/org/zaproxy/zap/view/TabbedPanel2.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/TabbedPanel2.java
@@ -67,7 +67,7 @@ public class TabbedPanel2 extends TabbedPanel {
     // A fake component that never actually get displayed - used for the 'hidden tab list tab'
     private Component hiddenComponent = new JLabel();
 
-    private final Logger logger = LogManager.getLogger(TabbedPanel2.class);
+    private static final Logger LOGGER = LogManager.getLogger(TabbedPanel2.class);
 
     private int prevTabIndex = -1;
 
@@ -204,7 +204,7 @@ public class TabbedPanel2 extends TabbedPanel {
         try {
             Model.getSingleton().getOptionsParam().getConfig().save();
         } catch (ConfigurationException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/view/panels/AbstractContextSelectToolbarStatusPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/panels/AbstractContextSelectToolbarStatusPanel.java
@@ -51,7 +51,7 @@ public abstract class AbstractContextSelectToolbarStatusPanel extends AbstractPa
         implements OnContextsChangedListener {
 
     private static final long serialVersionUID = 7164298579345445108L;
-    private static final Logger log =
+    private static final Logger LOGGER =
             LogManager.getLogger(AbstractContextSelectToolbarStatusPanel.class);
 
     /**
@@ -229,7 +229,7 @@ public abstract class AbstractContextSelectToolbarStatusPanel extends AbstractPa
      * @param context the context that was selected
      */
     protected void contextSelected(Context context) {
-        log.debug("Selected new context: {}", context);
+        LOGGER.debug("Selected new context: {}", context);
         switchViewForContext(context);
     }
 
@@ -244,20 +244,20 @@ public abstract class AbstractContextSelectToolbarStatusPanel extends AbstractPa
 
     @Override
     public void contextAdded(Context context) {
-        log.debug("Context added...");
+        LOGGER.debug("Context added...");
         contextSelectBox.reloadContexts(true);
     }
 
     @Override
     public void contextDeleted(Context context) {
-        log.debug("Context deleted...");
+        LOGGER.debug("Context deleted...");
         contextSelectBox.reloadContexts(false);
         contextSelectBox.setSelectedIndex(-1);
     }
 
     @Override
     public void contextsChanged() {
-        log.debug("Contexts changed...");
+        LOGGER.debug("Contexts changed...");
         contextSelectBox.reloadContexts(false);
         contextSelectBox.setSelectedIndex(-1);
     }

--- a/zap/src/main/java/org/zaproxy/zap/view/panels/AbstractScanToolbarStatusPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/panels/AbstractScanToolbarStatusPanel.java
@@ -65,7 +65,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
         implements ScanListener {
 
     private static final long serialVersionUID = -2351280081989616482L;
-    private static final Logger log = LogManager.getLogger(AbstractScanToolbarStatusPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(AbstractScanToolbarStatusPanel.class);
 
     /**
      * Location provided to {@link #addToolBarElements(JToolBar, short, int)} to add items after the
@@ -313,7 +313,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
      * @param context the context whose scan should be paused
      */
     protected void pauseScan(Context context) {
-        log.debug("Access Control pause on Context: {}", context);
+        LOGGER.debug("Access Control pause on Context: {}", context);
         threadManager.getScannerThread(context.getId()).pauseScan();
     }
 
@@ -325,7 +325,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
      * @param context the context whose scan should be resumed
      */
     protected void resumeScan(Context context) {
-        log.debug("Access Control resume on Context: {}", context);
+        LOGGER.debug("Access Control resume on Context: {}", context);
         threadManager.getScannerThread(context.getId()).resumeScan();
     }
 
@@ -337,7 +337,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
      * @param context the context whose scan should be stopped
      */
     protected void stopScan(Context context) {
-        log.debug("Access Control stop on Context: {}", context);
+        LOGGER.debug("Access Control stop on Context: {}", context);
         threadManager.getScannerThread(context.getId()).stopScan();
     }
 
@@ -395,7 +395,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
                 new Runnable() {
                     @Override
                     public void run() {
-                        log.debug("ScanStarted {} on context {}", panelPrefix, contextId);
+                        LOGGER.debug("ScanStarted {} on context {}", panelPrefix, contextId);
                         if (getSelectedContext() != null
                                 && contextId == getSelectedContext().getId()) {
                             setScanButtonsAndProgressBarStates(true, false, false);
@@ -407,7 +407,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
         try {
             ThreadUtils.invokeAndWait(handler);
         } catch (InvocationTargetException | InterruptedException e) {
-            log.error("Error while starting scan: {}", e.getMessage(), e);
+            LOGGER.error("Error while starting scan: {}", e.getMessage(), e);
         }
     }
 
@@ -417,7 +417,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
                 new Runnable() {
                     @Override
                     public void run() {
-                        log.debug("ScanFinished {} on context {}", panelPrefix, contextId);
+                        LOGGER.debug("ScanFinished {} on context {}", panelPrefix, contextId);
                         if (getSelectedContext() != null
                                 && contextId == getSelectedContext().getId()) {
                             setScanButtonsAndProgressBarStates(false, false, true);
@@ -428,7 +428,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
         try {
             ThreadUtils.invokeAndWait(handler);
         } catch (InvocationTargetException | InterruptedException e) {
-            log.error("Error while finishing scan: {}", e.getMessage(), e);
+            LOGGER.error("Error while finishing scan: {}", e.getMessage(), e);
         }
     }
 
@@ -438,7 +438,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
                 new Runnable() {
                     @Override
                     public void run() {
-                        log.debug(
+                        LOGGER.debug(
                                 "scanProgress {} on context {} {}",
                                 panelPrefix,
                                 contextId,
@@ -454,7 +454,7 @@ public abstract class AbstractScanToolbarStatusPanel extends AbstractContextSele
         try {
             ThreadUtils.invokeAndWait(handler);
         } catch (InvocationTargetException | InterruptedException e) {
-            log.error("Error while updating progress: {}", e.getMessage(), e);
+            LOGGER.error("Error while updating progress: {}", e.getMessage(), e);
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/view/panelsearch/Highlighter.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/panelsearch/Highlighter.java
@@ -42,7 +42,7 @@ import org.zaproxy.zap.view.panelsearch.items.TreeNodeElementSearch;
 
 public class Highlighter {
 
-    private Logger LOGGER = LogManager.getLogger(Highlighter.class);
+    private static final Logger LOGGER = LogManager.getLogger(Highlighter.class);
 
     public static final List<ComponentHighlighter> DefaultComponentHighlighterItems =
             Arrays.asList(

--- a/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemHttpMessageContainer.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemHttpMessageContainer.java
@@ -52,7 +52,7 @@ public abstract class PopupMenuItemHttpMessageContainer
 
     private static final long serialVersionUID = -4769111731197641466L;
 
-    private static final Logger logger =
+    private static final Logger LOGGER =
             LogManager.getLogger(PopupMenuItemHttpMessageContainer.class);
 
     /** The invokers of the the pop up menu. */
@@ -593,7 +593,7 @@ public abstract class PopupMenuItemHttpMessageContainer
 
         @Override
         public void actionPerformed(ActionEvent evt) {
-            logger.debug(
+            LOGGER.debug(
                     "actionPerformed {} {}",
                     invoker != null ? invoker.name() : "null invoker",
                     evt.getActionCommand());
@@ -601,7 +601,7 @@ public abstract class PopupMenuItemHttpMessageContainer
             try {
                 performActions(httpMessageContainer);
             } catch (Exception e) {
-                logger.error(e.getMessage(), e);
+                LOGGER.error(e.getMessage(), e);
             }
 
             resetState();


### PR DESCRIPTION
Make them private, static, and final.
Normalise the name, use `LOGGER`.
Use the correct class when getting the logger.
Remove commented out and unused loggers.
Use loggers provided by base classes.