### PR TITLE
Add application/hal+json to expected API types

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2023-02-03
+ - Alert_on_Unexpected_Content_Types.js > Added Content-Type application/hal+json to the list of expected types.
+
 ### 2023-01-27
  - Updated to use Webswing 22.2.4 (Issue 7704).
 

--- a/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
+++ b/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
@@ -13,6 +13,7 @@ var pluginid = 100001	// https://github.com/zaproxy/zaproxy/blob/main/docs/scann
 var extensionAlert = control.getExtensionLoader().getExtension(org.zaproxy.zap.extension.alert.ExtensionAlert.NAME)
 
 var expectedTypes = [
+		"application/hal+json",
 		"application/health+json",
 		"application/json",
 		"application/octet-stream",


### PR DESCRIPTION
Add application/hal+json to the list of expected content types.
Ref:
https://docs.spring.io/spring-data/rest/docs/current/reference/html/#repository-resources.collection-resource

Fix #7677.