### PR TITLE
Add task to generate .NET ZAP API endpoints

### DIFF
--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -228,6 +228,7 @@ val generateAllApiEndpoints by tasks.registering {
 }
 
 listOf(
+    "org.zaproxy.zap.extension.api.DotNetAPIGenerator",
     "org.zaproxy.zap.extension.api.GoAPIGenerator",
     "org.zaproxy.zap.extension.api.JavaAPIGenerator",
     "org.zaproxy.zap.extension.api.NodeJSAPIGenerator",


### PR DESCRIPTION
Add the generator to the list of generators to have a task for it.