### PR TITLE
Override `host` in `VariantHeader`

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantHeader.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantHeader.java
@@ -22,9 +22,11 @@ package org.parosproxy.paros.core.scanner;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import org.parosproxy.paros.network.HttpHeaderField;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
@@ -143,6 +145,9 @@ public class VariantHeader implements Variant {
     @Override
     public String setParameter(
             HttpMessage msg, NameValuePair originalPair, String name, String value) {
+        if (HttpRequestHeader.HOST.equalsIgnoreCase(originalPair.getName())) {
+            getProperties(msg).put(HttpRequestHeader.HOST, value);
+        }
         msg.getRequestHeader().setHeader(originalPair.getName(), value);
         if (value == null) {
             return "";
@@ -154,5 +159,15 @@ public class VariantHeader implements Variant {
     public String setEscapedParameter(
             HttpMessage msg, NameValuePair originalPair, String name, String value) {
         return setParameter(msg, originalPair, name, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> getProperties(HttpMessage message) {
+        Object userObject = message.getUserObject();
+        if (!(userObject instanceof Map)) {
+            userObject = new HashMap<>();
+            message.setUserObject(userObject);
+        }
+        return (Map<String, Object>) userObject;
     }
 }

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantHeaderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantHeaderUnitTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
+import java.util.Map;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -198,6 +199,21 @@ class VariantHeaderUnitTest {
         // Then
         assertThat(injectedHeader, is(equalTo("X-Header-A: Value")));
         assertThat(message, containsHeader("X-Header-A", "Value"));
+    }
+
+    @Test
+    void shouldOverrideHostHeaderOnValueModification() {
+        // Given
+        VariantHeader variantHeader = new VariantHeader();
+        HttpMessage message = createMessageWithHeaders(header("host", "X"));
+        variantHeader.setMessage(message);
+        // When
+        String injectedHeader =
+                variantHeader.setParameter(message, header("host", "X", 0), "host", "Value");
+        // Then
+        assertThat(injectedHeader, is(equalTo("host: Value")));
+        assertThat(message, containsHeader("host", "Value"));
+        assertThat(message.getUserObject(), is(Map.of("host", "Value")));
     }
 
     @Test


### PR DESCRIPTION
Change `VariantHeader` to override the `host` header so the injected payloads are sent as expected.

Part of #1318.