### PR TITLE
Ensure passive scan runs even with high traffic

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanController.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanController.java
@@ -109,7 +109,6 @@ public class PassiveScanController extends Thread implements ProxyListener {
                         if (shutDown) {
                             return;
                         }
-                        lastId = this.getLastHistoryId();
                     } catch (InterruptedException e) {
                         // New URL, but give it a chance to be processed first
                         try {
@@ -118,6 +117,7 @@ public class PassiveScanController extends Thread implements ProxyListener {
                             // Ignore
                         }
                     }
+                    lastId = this.getLastHistoryId();
                 }
                 href = getHistoryReference(currentId);
 


### PR DESCRIPTION
Obtain the ID of the last message to scan after any interruption.

The `PassiveScanController` is interrupted when responses are received, with high/constant traffic it can be interrupted often that it would not be able to get the ID of the last message after the first interrupt preventing the new messages from being scanned.
This only happens with new sessions, ones that had no messages persisted.

---
Reported in IRC.