### PR TITLE
Update timing assertion

### DIFF
--- a/zap/src/test/java/org/zaproxy/zap/extension/pscan/PassiveScanControllerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/pscan/PassiveScanControllerUnitTest.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.pscan;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.BDDMockito.given;
@@ -262,7 +263,7 @@ class PassiveScanControllerUnitTest extends TestUtils {
         assertThat(oldestTask.getCurrentScanner().getName(), is(equalTo("TPS")));
         assertThat(oldestTask.getURI().toString(), is(equalTo(exampleUrl1)));
         assertThat(oldestTask.getStartTime(), is(greaterThan(testStartTime)));
-        assertThat(testEndTime, is(greaterThan(oldestTask.getStartTime())));
+        assertThat(testEndTime, is(greaterThanOrEqualTo(oldestTask.getStartTime())));
         assertThat(tasks.size(), is(equalTo(2)));
         assertThat(recordsToScan, is(equalTo(2)));
         assertThat(tasks.get(0).getCurrentScanner().getName(), is(equalTo("TPS")));


### PR DESCRIPTION
Allow the time to be equal not just greater when asserting the time the passive task took to execute, it might take less than a millisecond, e.g.:
```
Expected: is a value greater than <1680237962023L>
     but: <1680237962023L> was equal to <1680237962023L>
```