### PR TITLE
Do not remove add-ons from installation dir

### DIFF
--- a/zap/src/test/java/org/zaproxy/zap/control/AddOnTestUtils.java
+++ b/zap/src/test/java/org/zaproxy/zap/control/AddOnTestUtils.java
@@ -152,6 +152,7 @@ class AddOnTestUtils extends WithConfigsTest {
             Consumer<StringBuilder> manifestConsumer,
             Consumer<ZipOutputStream> addOnConsumer) {
         try {
+            Files.createDirectories(dir);
             Path file = dir.resolve(fileName);
             try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(file))) {
                 ZipEntry manifest = new ZipEntry(AddOn.MANIFEST_FILE_NAME);


### PR DESCRIPTION
Allow different homes to share the same base add-ons including the mandatory ones.
Block the add-ons that are not mandatory when not being updated.

Fix #7703.