### PR TITLE
Prevent exception when uninstalling add-on's help

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/help/ExtensionHelp.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/help/ExtensionHelp.java
@@ -514,7 +514,8 @@ public class ExtensionHelp extends ExtensionAdaptor {
 
         @Override
         public void addOnUninstalled(AddOn addOn, boolean successfully) {
-            if (hb == null) {
+            HelpBroker hbLocal = hb;
+            if (hbLocal == null) {
                 return;
             }
 
@@ -524,7 +525,8 @@ public class ExtensionHelp extends ExtensionAdaptor {
                 addOnHelpSets.computeIfPresent(
                         addOn,
                         (k, helpsets) -> {
-                            EventQueue.invokeLater(() -> helpsets.forEach(hb.getHelpSet()::remove));
+                            EventQueue.invokeLater(
+                                    () -> helpsets.forEach(hbLocal.getHelpSet()::remove));
                             return null;
                         });
             }


### PR DESCRIPTION
Use a local variable to reference the `HelpBroker` as it might be accessed asynchronously in the EDT, otherwise it could lead to a NPE when it's removed before removing the add-on's `HelpSet`s.

e.g.:
```
[AWT-EventQueue-0] ERROR UncaughtExceptionLogger - Exception in thread "AWT-EventQueue-0"
java.lang.NullPointerException: null
	at org.zaproxy.zap.extension.help.ExtensionHelp$AddOnInstallationStatusListenerImpl.lambda$1(ExtensionHelp.java:527) ~[main/:?]
	at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:313) ~[?:?]
```