### PR TITLE
Remove Crawljax log config

### DIFF
--- a/zap/src/main/resources/org/zaproxy/zap/resources/log4j2-home.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/log4j2-home.properties
@@ -19,20 +19,6 @@ appender.rolling.type = RollingFile
 logger.commonshttpclient.level = error
 logger.commonshttpclient.name = org.apache.commons.httpclient
 
-# Prevent Crawljax from logging too many, not so useful, INFO messages.
-# For example:
-# INFO  Crawler - New DOM is a new state! crawl depth is now 10
-# INFO  Crawler - Crawl depth is now 1
-# INFO  Crawler - Crawl depth is now 2
-logger.crawljaxCrawler.level = warn
-logger.crawljaxCrawler.name = com.crawljax.core.Crawler
-# INFO  UnfiredCandidateActions - There are 64 states with unfired actions
-logger.crawljaxStateMachine.level = warn
-logger.crawljaxStateMachine.name = com.crawljax.core.state.StateMachine
-# INFO  StateMachine - State state106 added to the StateMachine.
-logger.crawljaxUnfired.level = warn
-logger.crawljaxUnfired.name = com.crawljax.core.UnfiredCandidateActions
-
 # Disable Jericho log, it logs HTML parsing issues as errors.
 logger.jericho.level = off
 logger.jericho.name = net.htmlparser.jericho

--- a/zap/src/test/java/org/zaproxy/zap/resources/Log4jHomeConfigurationTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/resources/Log4jHomeConfigurationTest.java
@@ -36,8 +36,6 @@ import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 /** Test for home Log4j configuration. */
 class Log4jHomeConfigurationTest {
@@ -120,20 +118,5 @@ class Log4jHomeConfigurationTest {
         // Then
         assertThat(loggerConfig, is(notNullValue()));
         assertThat(loggerConfig.getLevel(), is(equalTo(Level.OFF)));
-    }
-
-    @ParameterizedTest
-    @ValueSource(
-            strings = {
-                "com.crawljax.core.Crawler",
-                "com.crawljax.core.state.StateMachine",
-                "com.crawljax.core.UnfiredCandidateActions"
-            })
-    void shouldHaveCrawljaxChattyClassesSetToWarn(String nname) {
-        // Given / When
-        LoggerConfig loggerConfig = configuration.getLoggerConfig(nname);
-        // Then
-        assertThat(loggerConfig, is(notNullValue()));
-        assertThat(loggerConfig.getLevel(), is(equalTo(Level.WARN)));
     }
 }


### PR DESCRIPTION
Let the `spiderAjax` add-on configure the log instead, which knows better what classes need to be adjusted (i.e. they might change with Crawljax updates).

Depends on zaproxy/zap-extensions#4612.