### PR TITLE
ZapXmlConfiguration: Add unit tests & adjust list delimiter 

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/utils/ZapXmlConfiguration.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/ZapXmlConfiguration.java
@@ -55,6 +55,7 @@ public class ZapXmlConfiguration extends XMLConfiguration {
 
         super.setEncoding("UTF-8");
         super.setDelimiterParsingDisabled(true);
+        super.setListDelimiter('\0');
     }
 
     /**
@@ -80,6 +81,19 @@ public class ZapXmlConfiguration extends XMLConfiguration {
     public ZapXmlConfiguration(String fileName) throws ConfigurationException {
         this();
         setFileName(fileName);
+        load();
+    }
+
+    /**
+     * Creates a new instance of {@code ZapXmlConfiguration}. The configuration is loaded from the
+     * specified {@code url}.
+     *
+     * @param url the URL
+     * @throws ConfigurationException if loading the configuration fails
+     */
+    public ZapXmlConfiguration(URL url) throws ConfigurationException {
+        this();
+        setURL(url);
         load();
     }
 
@@ -132,19 +146,6 @@ public class ZapXmlConfiguration extends XMLConfiguration {
         Transformer transformer = super.createTransformer();
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
         return transformer;
-    }
-
-    /**
-     * Creates a new instance of {@code ZapXmlConfiguration}. The configuration is loaded from the
-     * specified {@code url}.
-     *
-     * @param url the URL
-     * @throws ConfigurationException if loading the configuration fails
-     */
-    public ZapXmlConfiguration(URL url) throws ConfigurationException {
-        this();
-        setURL(url);
-        load();
     }
 
     /**

--- a/zap/src/test/java/org/zaproxy/zap/utils/ZapXmlConfigurationUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/ZapXmlConfigurationUnitTest.java
@@ -25,8 +25,11 @@ import static org.hamcrest.Matchers.is;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.apache.commons.configuration.ConfigurationException;
 import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link ZapXmlConfiguration}. */
@@ -42,6 +45,92 @@ class ZapXmlConfigurationUnitTest {
                     + "        <f>2</f>\n"
                     + "    </d>\n"
                     + "</a>\n";
+
+    @Test
+    void shouldBeInstantiatedWithDelimeterParsingDisabledAndSetNullChar() {
+        // Given
+        ZapXmlConfiguration config = new ZapXmlConfiguration();
+        // When
+        boolean isParsingDisabled = config.isDelimiterParsingDisabled();
+        char delimChar = config.getListDelimiter();
+        // Then
+        assertThat(isParsingDisabled, is(equalTo(true)));
+        assertThat(delimChar, is(equalTo('\0')));
+    }
+
+    @Test
+    void shouldSetVariousPropertiesAsExpected()
+            throws ConfigurationException, UnsupportedEncodingException {
+        // Given
+        ZapXmlConfiguration config = new ZapXmlConfiguration();
+        String aString = "Some string 🙂.";
+        String bString = "";
+        String cString = null;
+        int aInt = 120;
+        boolean aBoolean = true;
+        // When
+        config.setProperty("aString", aString);
+        config.setProperty("bString", bString);
+        config.setProperty("cString", cString);
+        config.setProperty("aInt", aInt);
+        config.setProperty("aBoolean", aBoolean);
+        // Then
+        List<Object> aStringList = config.getList("aString");
+        assertThat(aStringList.size(), is(equalTo(1)));
+        assertThat(aStringList.get(0), is(equalTo(aString)));
+
+        List<Object> bStringList = config.getList("bString");
+        assertThat(bStringList.size(), is(equalTo(1)));
+        assertThat(bStringList.get(0), is(equalTo(bString)));
+
+        List<Object> cStringList = config.getList("cString");
+        assertThat(cStringList.size(), is(equalTo(0)));
+
+        List<Object> aIntList = config.getList("aInt");
+        int aActualInt = config.getInt("aInt");
+        assertThat(aIntList.size(), is(equalTo(1)));
+        // Int is string when handled via list
+        assertThat(aIntList.get(0), is(equalTo("120")));
+        assertThat(aActualInt, is(equalTo(120)));
+
+        List<Object> aBooleanList = config.getList("aBoolean");
+        boolean aActualBoolean = config.getBoolean("aBoolean");
+        assertThat(aBooleanList.size(), is(equalTo(1)));
+        // Boolean is string when handled via list
+        assertThat(aBooleanList.get(0), is(equalTo("true")));
+        assertThat(aActualBoolean, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldSetListOfPropertiesAsExpected() {
+        // Given
+        ZapXmlConfiguration config = new ZapXmlConfiguration();
+        String aString = "Some string 🙂.{2,2}";
+        String bString = "Some other string";
+        List<String> aList = List.of(aString, bString);
+        // When
+        config.setProperty("aList", aList);
+        // Then
+        List<Object> readList = config.getList("aList");
+        assertThat(readList.size(), is(equalTo(2)));
+        assertThat(readList.get(0), is(equalTo(aString)));
+    }
+
+    @Test
+    void shouldSetListOfNonPrimitivesAsExpected() throws IOException, ConfigurationException {
+        // Given
+        ZapXmlConfiguration config = new ZapXmlConfiguration();
+        CustomObject coOne = new CustomObject("coOne");
+        String stringTwo = "foo,bar";
+        CustomObject coTwo = new CustomObject(stringTwo);
+        List<CustomObject> customObjects = List.of(coOne, coTwo);
+        // When
+        config.setProperty("customObjects", customObjects);
+        // Then
+        List<Object> readList = config.getList("customObjects");
+        assertThat(readList.size(), is(equalTo(2)));
+        assertThat(((CustomObject) readList.get(1)).getValue(), is(equalTo(stringTwo)));
+    }
 
     @Test
     void shouldSaveNewConfigurationIndented() throws Exception {
@@ -77,5 +166,22 @@ class ZapXmlConfigurationUnitTest {
         return outputStream
                 .toString(StandardCharsets.UTF_8.name())
                 .replaceAll(System.lineSeparator(), "\n");
+    }
+
+    private static class CustomObject {
+        private final String value;
+
+        CustomObject(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
     }
 }


### PR DESCRIPTION
- ZapXmlConfiguration > Always set super.setListDelimiter('\0'), to prevent values containing commas from being stored incorrectly. Also re-group the constructors together.
- ZapXmlConfigurationUnitTest > Add tests to assert the behaviour.


Fixes zaproxy/zaproxy#6957