### PR TITLE
[NodeJS API] remove await from nodejs generator

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/NodeJSAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/NodeJSAPIGenerator.java
@@ -191,7 +191,7 @@ public class NodeJSAPIGenerator extends AbstractAPIGenerator {
             }
         }
         out.write(
-                "    return await this.api.request"
+                "    return this.api.request"
                         + "('/"
                         + component
                         + "/"

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/NodeJSAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/NodeJSAPIGenerator.java
@@ -147,7 +147,7 @@ public class NodeJSAPIGenerator extends AbstractAPIGenerator {
                 className
                         + ".prototype."
                         + createMethodName(element.getName())
-                        + " = async function (");
+                        + " = function (");
 
         if (hasParams) {
             out.write("args");

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/NodeJSAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/NodeJSAPIGenerator.java
@@ -144,10 +144,7 @@ public class NodeJSAPIGenerator extends AbstractAPIGenerator {
         }
 
         out.write(
-                className
-                        + ".prototype."
-                        + createMethodName(element.getName())
-                        + " = function (");
+                className + ".prototype." + createMethodName(element.getName()) + " = function (");
 
         if (hasParams) {
             out.write("args");


### PR DESCRIPTION
Await has been removed from the return function to let the users be able to use promises as well.