### PR TITLE
Remove CFU checks in Docker scripts

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2023-07-07
+- Remove checks for CFU initiator in HTTP Sender scripts, no longer needed.
+
 ### 2023-06-08
 - Start publishing images to the GitHub Container Registry. Use tags instead of image names for various flavours of the
   images; some examples are:

--- a/docker/scripts/scripts/httpsender/Alert_on_HTTP_Response_Code_Errors.js
+++ b/docker/scripts/scripts/httpsender/Alert_on_HTTP_Response_Code_Errors.js
@@ -15,7 +15,7 @@ function sendingRequest(msg, initiator, helper) {
 }
 
 function responseReceived(msg, initiator, helper) {
-	if (isGloballyExcluded(msg) || initiator == 7) { // CHECK_FOR_UPDATES_INITIATOR
+	if (isGloballyExcluded(msg)) {
 		// Not of interest.
 		return
 	}

--- a/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
+++ b/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
@@ -35,7 +35,7 @@ function sendingRequest(msg, initiator, helper) {
 }
 
 function responseReceived(msg, initiator, helper) {
-	if (isGloballyExcluded(msg) || initiator == 7) { // CHECK_FOR_UPDATES_INITIATOR
+	if (isGloballyExcluded(msg)) {
 		// Not of interest.
 		return
 	}


### PR DESCRIPTION
No longer check for CFU HTTP Sender initiator, there are no longer any notifications.

---
WIP this can only be merged when closer to the 2.13 release.