### PR TITLE
Integration tests - add user/next/pwd auth cases

### DIFF
--- a/docker/integration_tests/af_context_tests.sh
+++ b/docker/integration_tests/af_context_tests.sh
@@ -41,5 +41,5 @@ done
 # Tidy up
 rm ~/.ZAP_D/config.xml
 
-echo "End result: $RES"
+echo "Exit Code: $RES"
 exit $RES

--- a/docker/integration_tests/af_plan_tests.sh
+++ b/docker/integration_tests/af_plan_tests.sh
@@ -16,6 +16,8 @@ export JIGSAW_PWORD="guest"
 # Install dev add-on
 /zap/zap.sh -cmd -addoninstall dev
 
+summary="\nSummary:\n"
+
 for file in *.yaml
 do
 	echo
@@ -27,14 +29,17 @@ do
 	if [ "$RET" != 0 ] 
 	then
 	    echo "ERROR"
+		summary="${summary}  Plan: $file\tERROR\n"
 		RES=1
 	else
     	echo "PASS"
+		summary="${summary}  Plan: $file\tPASS\n"
 	fi
     sleep 2
     # Tidy up
     rm ~/.ZAP_D/config.xml
 done
 
-echo "End result: $RES"
+echo -e $summary
+echo "Exit Code: $RES"
 exit $RES

--- a/docker/integration_tests/configs/plans/auth-password-added-json.yaml
+++ b/docker/integration_tests/configs/plans/auth-password-added-json.yaml
@@ -1,0 +1,98 @@
+---
+env:
+  contexts:
+  - name: "password-added-json"
+    urls:
+    - "http://localhost:9091/auth/password-added-json"
+    includePaths:
+    - "http://localhost:9091/auth/password-added-json.*"
+    excludePaths: []
+    authentication:
+      method: "browser"
+      parameters:
+        loginPageUrl: "http://localhost:9091/auth/password-added-json/ "
+        loginPageWait: 5
+        browserId: "firefox-headless"
+      verification:
+        # Checking 2.13+ compatibility
+        method: "autodetect"
+    sessionManagement:
+      method: "autodetect"
+      parameters: {}
+    technology:
+      exclude: []
+    users:
+    - name: "test"
+      credentials:
+        username: "test@test.com"
+        password: "password123"
+  parameters:
+    failOnError: true
+    failOnWarning: false
+    progressToStdout: true
+  vars: {}
+jobs:
+- parameters:
+    maxAlertsPerRule: 0
+    scanOnlyInScope: true
+    maxBodySizeInBytesToScan: 0
+    enableTags: false
+    disableAllRules: true
+  rules:
+  - id: 10111
+    name: "Authentication Request Identified"
+    threshold: "medium"
+  - id: 10112
+    name: "Session Management Response Identified"
+    threshold: "medium"
+  - id: 10113
+    name: "Verification Request Identified"
+    threshold: "medium"
+  name: "passiveScan-config"
+  type: "passiveScan-config"
+- parameters:
+    user: "test"
+  requests:
+  - url: "http://localhost:9091/auth/password-added-json/user"
+    name: ""
+    method: ""
+    httpVersion: ""
+    headers: []
+    data: ""
+  name: "requestor"
+  type: "requestor"
+  tests:
+  - type: "stats"
+    statistic: "stats.auth.success"
+    site: "http://localhost:9091"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.state.loggedin"
+    site: "http://localhost:9091"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.sessiontoken.accesstoken"
+    site: "http://localhost:9091"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.configure.session.header"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.configure.verification"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.detect.auth.json"
+    operator: ">="
+    value: 1
+    onFail: "error"
+

--- a/docker/integration_tests/configs/plans/auth-password-hidden-json.yaml
+++ b/docker/integration_tests/configs/plans/auth-password-hidden-json.yaml
@@ -1,0 +1,98 @@
+---
+env:
+  contexts:
+  - name: "password-hidden-json"
+    urls:
+    - "http://localhost:9091/auth/password-hidden-json"
+    includePaths:
+    - "http://localhost:9091/auth/password-hidden-json.*"
+    excludePaths: []
+    authentication:
+      method: "browser"
+      parameters:
+        loginPageUrl: "http://localhost:9091/auth/password-hidden-json/ "
+        loginPageWait: 5
+        browserId: "firefox-headless"
+      verification:
+        # Checking 2.13+ compatibility
+        method: "autodetect"
+    sessionManagement:
+      method: "autodetect"
+      parameters: {}
+    technology:
+      exclude: []
+    users:
+    - name: "test"
+      credentials:
+        username: "test@test.com"
+        password: "password123"
+  parameters:
+    failOnError: true
+    failOnWarning: false
+    progressToStdout: true
+  vars: {}
+jobs:
+- parameters:
+    maxAlertsPerRule: 0
+    scanOnlyInScope: true
+    maxBodySizeInBytesToScan: 0
+    enableTags: false
+    disableAllRules: true
+  rules:
+  - id: 10111
+    name: "Authentication Request Identified"
+    threshold: "medium"
+  - id: 10112
+    name: "Session Management Response Identified"
+    threshold: "medium"
+  - id: 10113
+    name: "Verification Request Identified"
+    threshold: "medium"
+  name: "passiveScan-config"
+  type: "passiveScan-config"
+- parameters:
+    user: "test"
+  requests:
+  - url: "http://localhost:9091/auth/password-hidden-json/user"
+    name: ""
+    method: ""
+    httpVersion: ""
+    headers: []
+    data: ""
+  name: "requestor"
+  type: "requestor"
+  tests:
+  - type: "stats"
+    statistic: "stats.auth.success"
+    site: "http://localhost:9091"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.state.loggedin"
+    site: "http://localhost:9091"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.sessiontoken.accesstoken"
+    site: "http://localhost:9091"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.configure.session.header"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.configure.verification"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.detect.auth.json"
+    operator: ">="
+    value: 1
+    onFail: "error"
+

--- a/docker/integration_tests/configs/plans/auth-password-new-json.yaml
+++ b/docker/integration_tests/configs/plans/auth-password-new-json.yaml
@@ -1,0 +1,96 @@
+---
+env:
+  contexts:
+  - name: "password-new-page"
+    urls:
+    - "http://localhost:9091/auth/password-new-page"
+    includePaths:
+    - "http://localhost:9091/auth/password-new-page.*"
+    excludePaths: []
+    authentication:
+      method: "browser"
+      parameters:
+        loginPageUrl: "http://localhost:9091/auth/password-new-page/"
+        loginPageWait: 5
+        browserId: "firefox-headless"
+      verification:
+        # Checking 2.13+ compatibility
+        method: "autodetect"
+    sessionManagement:
+      method: "autodetect"
+      parameters: {}
+    technology:
+      exclude: []
+    users:
+    - name: "test"
+      credentials:
+        username: "test@test.com"
+        password: "password123"
+  parameters:
+    failOnError: true
+    failOnWarning: false
+    progressToStdout: true
+  vars: {}
+jobs:
+- parameters:
+    maxAlertsPerRule: 0
+    scanOnlyInScope: true
+    maxBodySizeInBytesToScan: 0
+    enableTags: false
+    disableAllRules: true
+  rules:
+  - id: 10111
+    name: "Authentication Request Identified"
+    threshold: "medium"
+  - id: 10112
+    name: "Session Management Response Identified"
+    threshold: "medium"
+  - id: 10113
+    name: "Verification Request Identified"
+    threshold: "medium"
+  name: "passiveScan-config"
+  type: "passiveScan-config"
+- parameters:
+    user: "test"
+  requests:
+  - url: "http://localhost:9091/auth/password-new-page/user"
+    name: ""
+    method: ""
+    httpVersion: ""
+    headers: []
+    data: ""
+  name: "requestor"
+  type: "requestor"
+  tests:
+  - type: "stats"
+    statistic: "stats.auth.success"
+    site: "http://localhost:9091"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.state.loggedin"
+    site: "http://localhost:9091"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.session.set.header"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.configure.session.header"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.configure.verification"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.detect.auth.form"
+    operator: ">="
+    value: 1
+    onFail: "error"


### PR DESCRIPTION
Also added a summary which makes it easier to see what passed with all of the browser output 😁 
Example (end of) output:
```
Summary:
 Plan: auth-json-bearer-cookie.yaml	PASS
 Plan: auth-json-bearer.yaml	PASS
 Plan: auth-non-std-json-bearer.yaml	PASS
 Plan: auth-password-added-json.yaml	PASS
 Plan: auth-password-hidden-json.yaml	PASS
 Plan: auth-password-new-json.yaml	PASS
 Plan: auth-simple-json.yaml	PASS
 Plan: jigsaw-basic-user.yaml	PASS
 Plan: petstore-openapi.yaml	PASS
 Plan: testfire-form-user.yaml	PASS

End result: 0
```