### PR TITLE
Improve release tasks

### DIFF
--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/UpdateMainAddOns.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/UpdateMainAddOns.java
@@ -19,12 +19,7 @@
  */
 package org.zaproxy.zap.tasks;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.IOException;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import org.gradle.api.DefaultTask;
@@ -63,7 +58,10 @@ public abstract class UpdateMainAddOns extends DefaultTask {
         MainAddOnsData data = Utils.parseData(getAddOnsData().get().getAsFile().toPath());
         updateAddOns(data, marketplace);
 
-        save(data);
+        Utils.updateYaml(
+                data,
+                getAddOnsData().get().getAsFile().toPath(),
+                getAddOnsDataUpdated().get().getAsFile().toPath());
     }
 
     private void updateAddOns(MainAddOnsData data, Map<String, MarketplaceAddOn> marketplace)
@@ -77,19 +75,6 @@ public abstract class UpdateMainAddOns extends DefaultTask {
 
             mainAddOn.setUrl(marketplaceAddOn.getUrl());
             mainAddOn.setHash(marketplaceAddOn.getHash());
-        }
-    }
-
-    private void save(MainAddOnsData data) throws IOException {
-        Path outputFile = getAddOnsDataUpdated().get().getAsFile().toPath();
-        String header =
-                new String(
-                        Files.readAllBytes(getAddOnsData().get().getAsFile().toPath()),
-                        StandardCharsets.UTF_8);
-        header = header.substring(0, header.indexOf("---"));
-        try (Writer writer = Files.newBufferedWriter(outputFile, StandardCharsets.UTF_8)) {
-            writer.write(header);
-            new ObjectMapper(new YAMLFactory()).writer().writeValue(writer, data);
         }
     }
 }

--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/internal/JapicmpExcludedData.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/internal/JapicmpExcludedData.java
@@ -1,0 +1,58 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.tasks.internal;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class JapicmpExcludedData {
+
+    private final List<String> packageExcludes = List.of();
+    private final List<String> fieldExcludes = List.of();
+    private final List<String> classExcludes = List.of();
+    private final List<String> methodExcludes = List.of();
+
+    public List<String> getPackageExcludes() {
+        return packageExcludes;
+    }
+
+    public List<String> getFieldExcludes() {
+        return fieldExcludes;
+    }
+
+    public List<String> getClassExcludes() {
+        return classExcludes;
+    }
+
+    public List<String> getMethodExcludes() {
+        return methodExcludes;
+    }
+
+    public static JapicmpExcludedData from(String file) throws IOException {
+        try (Reader reader = Files.newBufferedReader(Paths.get(file))) {
+            return new ObjectMapper(new YAMLFactory()).readValue(reader, JapicmpExcludedData.class);
+        }
+    }
+}

--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/internal/ProjectProperties.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/internal/ProjectProperties.java
@@ -1,0 +1,150 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.tasks.internal;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+public class ProjectProperties {
+
+    private final Path file;
+    private final Properties properties;
+
+    public ProjectProperties(Path file) throws IOException {
+        this.file = file;
+        this.properties = new OrderedProperties();
+
+        try (Reader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+            properties.load(reader);
+        }
+    }
+
+    public void setProperty(String key, String value) {
+        properties.setProperty(key, value);
+    }
+
+    public String getProperty(String key) {
+        return properties.getProperty(key);
+    }
+
+    public void store() throws IOException {
+        try (Writer writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
+            properties.store(writer, null);
+        }
+    }
+
+    private static class OrderedProperties extends Properties {
+
+        private static final long serialVersionUID = 1L;
+
+        @SuppressWarnings("serial")
+        private Map<Object, Object> properties;
+
+        @Override
+        public synchronized void load(Reader reader) throws IOException {
+            properties = new LinkedHashMap<>();
+            super.load(reader);
+        }
+
+        @Override
+        public synchronized void load(InputStream inStream) throws IOException {
+            properties = new LinkedHashMap<>();
+            super.load(inStream);
+        }
+
+        @Override
+        public synchronized Object setProperty(String key, String value) {
+            return properties.put(key, value);
+        }
+
+        @Override
+        public String getProperty(String key) {
+            return (String) get(key);
+        }
+
+        @Override
+        public synchronized Object put(Object key, Object value) {
+            return properties.put(key, value);
+        }
+
+        @Override
+        public void store(Writer writer, String comments) throws IOException {
+            super.store(new BufferedWriterSkipLine(writer), comments);
+        }
+
+        @Override
+        public synchronized Object get(Object key) {
+            return properties.get(key);
+        }
+
+        @Override
+        public Set<Object> keySet() {
+            return properties.keySet();
+        }
+
+        @Override
+        public Set<Map.Entry<Object, Object>> entrySet() {
+            return properties.entrySet();
+        }
+
+        @Override
+        public synchronized Enumeration<Object> keys() {
+            return Collections.enumeration(properties.keySet());
+        }
+
+        private static class BufferedWriterSkipLine extends BufferedWriter {
+
+            private boolean skipLine = true;
+
+            BufferedWriterSkipLine(Writer out) {
+                super(out);
+            }
+
+            @Override
+            public void write(String str) throws IOException {
+                if (skipLine) {
+                    return;
+                }
+                super.write(str);
+            }
+
+            @Override
+            public void newLine() throws IOException {
+                if (skipLine) {
+                    skipLine = false;
+                    return;
+                }
+                super.newLine();
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/internal/Utils.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/internal/Utils.java
@@ -25,6 +25,8 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
@@ -90,6 +92,15 @@ public final class Utils {
             return sb.toString();
         } catch (NoSuchAlgorithmException e) {
             throw new IOException(e);
+        }
+    }
+
+    public static void updateYaml(Object data, Path from, Path to) throws IOException {
+        String header = new String(Files.readAllBytes(from), StandardCharsets.UTF_8);
+        header = header.substring(0, header.indexOf("---"));
+        try (Writer writer = Files.newBufferedWriter(to, StandardCharsets.UTF_8)) {
+            writer.write(header);
+            new ObjectMapper(new YAMLFactory()).writer().writeValue(writer, data);
         }
     }
 }

--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/github-releases.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/github-releases.gradle.kts
@@ -42,20 +42,13 @@ tasks.register<CreateTagAndGitHubRelease>("createWeeklyRelease") {
     }
 }
 
-val buildFileVersionPattern = Pattern.compile("""version = "([^"]+)"""")
-
 val prepareNextDevIter by tasks.registering(PrepareNextDevIter::class) {
-    buildFile.set(File(projectDir, "zap.gradle.kts"))
+    propertiesFile.set(File(projectDir, "gradle.properties"))
 
-    versionPattern.set(buildFileVersionPattern)
-    versionBcPattern.set(Pattern.compile("""val versionBC = "([^"]+)""""))
+    versionProperty.set("version")
+    versionBcProperty.set("zap.japicmp.baseversion")
 
-    val listOfExpression = """(?sm)listOf\((.*?)\)$"""
-    clearDataPatterns.set(listOf(
-        Pattern.compile("packageExcludes = $listOfExpression"),
-        Pattern.compile("fieldExcludes = $listOfExpression"),
-        Pattern.compile("classExcludes = $listOfExpression"),
-        Pattern.compile("methodExcludes = $listOfExpression")))
+    japicmpExcludedDataFile.set(File(projectDir, "gradle/japicmp.yaml"))
 }
 
 val createPullRequestNextDevIter by tasks.registering(CreatePullRequest::class) {
@@ -70,9 +63,9 @@ val createPullRequestNextDevIter by tasks.registering(CreatePullRequest::class) 
 }
 
 val prepareMainRelease by tasks.registering(PrepareMainRelease::class) {
-    buildFile.set(File(projectDir, "zap.gradle.kts"))
+    propertiesFile.set(File(projectDir, "gradle.properties"))
 
-    versionPattern.set(buildFileVersionPattern)
+    versionProperty.set("version")
 }
 
 val createPullRequestMainRelease by tasks.registering(CreatePullRequest::class) {

--- a/zap/gradle.properties
+++ b/zap/gradle.properties
@@ -1,0 +1,2 @@
+version=2.13.0-SNAPSHOT
+zap.japicmp.baseversion=2.12.0

--- a/zap/gradle/japicmp.yaml
+++ b/zap/gradle/japicmp.yaml
@@ -1,0 +1,11 @@
+# Exclusions for japicmp.
+#
+# Any binary incompatible changes deemed acceptable should be added to this file.
+---
+packageExcludes: []
+fieldExcludes: []
+classExcludes:
+ - "org.zaproxy.zap.network.HttpSenderImpl"
+methodExcludes:
+ - "org.parosproxy.paros.extension.ViewDelegate#getOptionsButton(java.lang.String, java.lang.String)"
+ - "org.parosproxy.paros.extension.ViewDelegate#getHelpButton(java.lang.String)"

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -2,6 +2,7 @@ import japicmp.model.JApiChangeStatus
 import me.champeau.gradle.japicmp.JapicmpTask
 import org.zaproxy.zap.japicmp.AcceptMethodAbstractNowDefaultRule
 import org.zaproxy.zap.tasks.GradleBuildWithGitRepos
+import org.zaproxy.zap.tasks.internal.JapicmpExcludedData
 import java.time.LocalDate
 import java.util.stream.Collectors
 
@@ -21,8 +22,7 @@ plugins {
 }
 
 group = "org.zaproxy"
-version = "2.13.0-SNAPSHOT"
-val versionBC = "2.12.0"
+val versionBC = project.property("zap.japicmp.baseversion") as String
 
 val versionLangFile = "1"
 val creationDate by extra { project.findProperty("creationDate") ?: LocalDate.now().toString() }
@@ -141,22 +141,14 @@ val japicmp by tasks.registering(JapicmpTask::class) {
     newClasspath.from(tasks.named<Jar>(JavaPlugin.JAR_TASK_NAME))
     ignoreMissingClasses.set(true)
 
-    packageExcludes.set(listOf())
+    var excludedDataFile = "$projectDir/gradle/japicmp.yaml"
+    inputs.file(excludedDataFile)
 
-    fieldExcludes.set(listOf())
-
-    classExcludes.set(
-        listOf(
-            "org.zaproxy.zap.network.HttpSenderImpl",
-        ),
-    )
-
-    methodExcludes.set(
-        listOf(
-            "org.parosproxy.paros.extension.ViewDelegate#getOptionsButton(java.lang.String, java.lang.String)",
-            "org.parosproxy.paros.extension.ViewDelegate#getHelpButton(java.lang.String)",
-        ),
-    )
+    var excludedData = JapicmpExcludedData.from(excludedDataFile)
+    packageExcludes.set(excludedData.packageExcludes)
+    fieldExcludes.set(excludedData.fieldExcludes)
+    classExcludes.set(excludedData.classExcludes)
+    methodExcludes.set(excludedData.methodExcludes)
 
     richReport {
         destinationDir.set(file("$buildDir/reports/japicmp/"))


### PR DESCRIPTION
Move dynamic data (e.g. versions, japicmp exclusions) to external files to allow update them more reliably programmatically.
Update build and tasks accordingly.
Release tasks should no longer fail when preparing the release or next version.