### PR TITLE
Correct macOS upload job

### DIFF
--- a/.github/workflows/release-main-version.yml
+++ b/.github/workflows/release-main-version.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
     paths:
-      - 'zap/zap.gradle.kts'
+      - 'zap/gradle.properties'
 
 jobs:
   release:

--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/UploadAssetsGitHubRelease.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/UploadAssetsGitHubRelease.java
@@ -102,6 +102,12 @@ public abstract class UploadAssetsGitHubRelease extends DefaultTask {
 
     @TaskAction
     public void createRelease() throws IOException {
+        String tagName = tag.get();
+        if (tagName.endsWith("-SNAPSHOT")) {
+            getLogger().lifecycle("Ignoring, version is still SNAPSHOT: {}", tagName);
+            return;
+        }
+
         if (checksumAlgorithm.get().isEmpty()) {
             throw new IllegalArgumentException("The checksum algorithm must not be empty.");
         }
@@ -110,9 +116,9 @@ public abstract class UploadAssetsGitHubRelease extends DefaultTask {
         GHRepository ghRepo =
                 GitHub.connect(ghUser.getName(), ghUser.getAuthToken()).getRepository(repo.get());
 
-        GHRelease release = ghRepo.getReleaseByTagName(tag.get());
+        GHRelease release = ghRepo.getReleaseByTagName(tagName);
         if (release == null) {
-            throw new InvalidUserDataException("Release for tag " + tag + " does not exist.");
+            throw new InvalidUserDataException("Release for tag " + tagName + " does not exist.");
         }
 
         String releaseBody = release.getBody();


### PR DESCRIPTION
Change the task `UploadAssetsGitHubRelease` to not try to upload if the tag is still `SNAPSHOT`, to not fail the build.
Update the workflow  `release-main-version.yml` to check the `gradle.properties` file instead, now where the ZAP version is tracked.