### PR TITLE
Sort Sites nodes with different case consistently

### DIFF
--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/spotless.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/spotless.gradle.kts
@@ -63,6 +63,7 @@ spotless {
                 "src/main/java/org/parosproxy/paros/model/HttpMessageCachedData.java",
                 "src/main/java/org/parosproxy/paros/model/HistoryReferenceEventPublisher.java",
                 "src/main/java/org/parosproxy/paros/model/SiteMapEventPublisher.java",
+                "src/main/java/org/parosproxy/paros/model/SiteNodeStringComparator.java",
                 "src/main/java/org/parosproxy/paros/network/ProxyExcludedDomainMatcher.java",
                 "src/main/java/org/parosproxy/paros/network/HtmlParameter.java",
                 "src/main/java/org/parosproxy/paros/network/HttpHeaderField.java",

--- a/zap/src/main/java/org/parosproxy/paros/model/SiteMap.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/SiteMap.java
@@ -867,20 +867,3 @@ class SortedTreeModel extends DefaultTreeModel {
         return findIndexFor(child, parent, half + 1, idx2);
     }
 }
-
-class SiteNodeStringComparator implements Comparator<SiteNode> {
-    @Override
-    public int compare(SiteNode sn1, SiteNode sn2) {
-        String s1 = sn1.getName();
-        String s2 = sn2.getName();
-        int initialComparison = s1.compareToIgnoreCase(s2);
-
-        if (initialComparison == 0) {
-            s1 = sn1.getNodeName();
-            s2 = sn2.getNodeName();
-
-            return s1.compareToIgnoreCase(s2);
-        }
-        return initialComparison;
-    }
-}

--- a/zap/src/main/java/org/parosproxy/paros/model/SiteNodeStringComparator.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/SiteNodeStringComparator.java
@@ -1,0 +1,34 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.model;
+
+import java.util.Comparator;
+
+class SiteNodeStringComparator implements Comparator<SiteNode> {
+
+    @Override
+    public int compare(SiteNode sn1, SiteNode sn2) {
+        int result = sn1.getName().compareTo(sn2.getName());
+        if (result != 0) {
+            return result;
+        }
+        return sn1.getNodeName().compareTo(sn2.getNodeName());
+    }
+}

--- a/zap/src/test/java/org/parosproxy/paros/model/SiteNodeStringComparatorUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/model/SiteNodeStringComparatorUnitTest.java
@@ -1,0 +1,76 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit test for {@link SiteNodeStringComparator}. */
+class SiteNodeStringComparatorUnitTest {
+
+    private SiteNodeStringComparator comparator;
+
+    @BeforeEach
+    void setUp() {
+        comparator = new SiteNodeStringComparator();
+    }
+
+    @Test
+    void shouldHaveSameOrderIfSameMethodAndName() {
+        // Given
+        SiteNode sn1 = createSiteNode("GET", "path");
+        SiteNode sn2 = createSiteNode("GET", "path");
+        // When
+        int result = comparator.compare(sn1, sn2);
+        // Then
+        assertThat(result, is(equalTo(0)));
+    }
+
+    @Test
+    void shouldDifferentiateByCaseInMethod() {
+        // Given
+        SiteNode sn1 = createSiteNode("GET", "path");
+        SiteNode sn2 = createSiteNode("get", "path");
+        // When
+        int result = comparator.compare(sn1, sn2);
+        // Then
+        assertThat(result, is(lessThan(0)));
+    }
+
+    @Test
+    void shouldDifferentiateByCaseInName() {
+        // Given
+        SiteNode sn1 = createSiteNode("GET", "PATH");
+        SiteNode sn2 = createSiteNode("GET", "path");
+        // When
+        int result = comparator.compare(sn1, sn2);
+        // Then
+        assertThat(result, is(lessThan(0)));
+    }
+
+    private static SiteNode createSiteNode(String method, String path) {
+        return new SiteNode(null, -1, method + ":" + path);
+    }
+}


### PR DESCRIPTION
Sort taking into account the case otherwise the nodes do not have a consistent order, they might be before or after each other.
Extract the node comparator to a top level class to be able to import in the tests.

---
This leads to sorting first uppercase and then lowercase, which makes `/PATH` being farther away than `/path` if other paths are in between… but prevents, e.g.: zaproxy/zaproxy-website#1749, zaproxy/zaproxy-website#1780, zaproxy/zaproxy-website#1792
