### PR TITLE
Include whole `org.zaproxy` package in log config

### DIFF
--- a/zap/src/main/resources/org/zaproxy/zap/resources/log4j2-home.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/log4j2-home.properties
@@ -27,7 +27,7 @@ logger.paros.level = info
 logger.paros.name = org.parosproxy.paros
 
 logger.zap.level = info
-logger.zap.name = org.zaproxy.zap
+logger.zap.name = org.zaproxy
 
 name = ZAP Home Config
 


### PR DESCRIPTION
For convenience when debugging include the whole package by default as newer add-ons are under `org.zaproxy.addon` not `org.zaproxy.zap`.
Pointed out by @psiinon in IRC channel.