### PR TITLE
Update Docker release workflows

### DIFF
--- a/.github/workflows/release-live-docker.yml
+++ b/.github/workflows/release-live-docker.yml
@@ -38,11 +38,12 @@ jobs:
           file: docker/Dockerfile-live
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: false
           tags: |
             owasp/zap2docker-live:latest
             ghcr.io/zaproxy/zaproxy:nightly
-          build-args: |
-            WEBSWING_URL=${{ secrets.WEBSWING_URL }}
+          secrets: |
+            webswing_url=${{ secrets.WEBSWING_URL }}
           outputs: "type=image,name=target,\
             annotation-index.org.opencontainers.image.source=https://github.com/zaproxy/zaproxy,\
             annotation-index.org.opencontainers.image.description=The nightly Docker image for the world’s most widely used web app scanner.,\

--- a/.github/workflows/release-main-docker.yml
+++ b/.github/workflows/release-main-docker.yml
@@ -43,6 +43,7 @@ jobs:
           file: docker/Dockerfile-stable
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: false
           tags: |
             owasp/zap2docker-stable:s${{ env.REL_DATE }}
             owasp/zap2docker-stable:${{ env.REL_VERSION }}
@@ -51,8 +52,8 @@ jobs:
             ghcr.io/zaproxy/zaproxy:${{ env.REL_VERSION }}
             ghcr.io/zaproxy/zaproxy:stable
             ghcr.io/zaproxy/zaproxy:latest
-          build-args: |
-            WEBSWING_URL=${{ secrets.WEBSWING_URL }}
+          secrets: |
+            webswing_url=${{ secrets.WEBSWING_URL }}
           outputs: "type=image,name=target,\
             annotation-index.org.opencontainers.image.source=https://github.com/zaproxy/zaproxy,\
             annotation-index.org.opencontainers.image.description=The stable Docker image for the world’s most widely used web app scanner.,\
@@ -65,6 +66,7 @@ jobs:
           file: docker/Dockerfile-bare
           platforms: linux/amd64
           push: true
+          provenance: false
           tags: |
             owasp/zap2docker-bare:b${{ env.REL_DATE }}
             owasp/zap2docker-bare:${{ env.REL_VERSION }}

--- a/.github/workflows/release-weekly-docker.yml
+++ b/.github/workflows/release-weekly-docker.yml
@@ -40,13 +40,14 @@ jobs:
           file: docker/Dockerfile-weekly
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: false
           tags: |
             owasp/zap2docker-weekly:w${{ env.REL_DATE }}
             owasp/zap2docker-weekly:latest
             ghcr.io/zaproxy/zaproxy:${{ env.REL_DATE_SHORT }}-weekly
             ghcr.io/zaproxy/zaproxy:weekly
-          build-args: |
-            WEBSWING_URL=${{ secrets.WEBSWING_URL }}
+          secrets: |
+            webswing_url=${{ secrets.WEBSWING_URL }}
           outputs: "type=image,name=target,\
             annotation-index.org.opencontainers.image.source=https://github.com/zaproxy/zaproxy,\
             annotation-index.org.opencontainers.image.description=The weekly Docker image for the world’s most widely used web app scanner.,\

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -32,12 +32,14 @@ jobs:
           file: docker/Dockerfile-tests
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: false
           tags: |
             ghcr.io/zaproxy/zaproxy:tests
-          build-args: |
-            WEBSWING_URL=${{ secrets.WEBSWING_URL }}
+          secrets: |
+            webswing_url=${{ secrets.WEBSWING_URL }}
           outputs: "type=image,name=target,\
             annotation-index.org.opencontainers.image.source=https://github.com/zaproxy/zaproxy,\
+            annotation-index.org.opencontainers.image.description=Docker image used for ZAP integration tests.,\
             annotation-index.org.opencontainers.image.licenses=Apache-2.0"
       - 
         name: Run install tests

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -24,8 +24,9 @@ WORKDIR /zap
 
 # Setup Webswing
 ENV WEBSWING_VERSION 22.2.4
-ARG WEBSWING_URL=""
-RUN if [ -z "$WEBSWING_URL" ] ; \
+RUN --mount=type=secret,id=webswing_url \
+	WEBSWING_URL=$(cat /run/secrets/webswing_url) \
+	if [ -z "$WEBSWING_URL" ] ; \
 	then curl -s -L  "https://dev.webswing.org/files/public/webswing-examples-eval-${WEBSWING_VERSION}-distribution.zip" > webswing.zip; \
 	else curl -s -L  "$WEBSWING_URL-${WEBSWING_VERSION}-distribution.zip" > webswing.zip; fi && \
 	unzip webswing.zip && \

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -24,8 +24,9 @@ RUN cp /root/.ZAP/plugin/*.zap plugin/ || :
 
 # Setup Webswing
 ENV WEBSWING_VERSION 22.2.4
-ARG WEBSWING_URL=""
-RUN if [ -z "$WEBSWING_URL" ] ; \
+RUN --mount=type=secret,id=webswing_url \
+	WEBSWING_URL=$(cat /run/secrets/webswing_url) \
+	if [ -z "$WEBSWING_URL" ] ; \
 	then curl -s -L  "https://dev.webswing.org/files/public/webswing-examples-eval-${WEBSWING_VERSION}-distribution.zip" > webswing.zip; \
 	else curl -s -L  "$WEBSWING_URL-${WEBSWING_VERSION}-distribution.zip" > webswing.zip; fi && \
 	unzip webswing.zip && \

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -11,8 +11,9 @@ WORKDIR /zap
 
 # Setup Webswing
 ENV WEBSWING_VERSION 22.2.4
-ARG WEBSWING_URL=""
-RUN if [ -z "$WEBSWING_URL" ] ; \
+RUN --mount=type=secret,id=webswing_url \
+	WEBSWING_URL=$(cat /run/secrets/webswing_url) \
+	if [ -z "$WEBSWING_URL" ] ; \
 	then curl -s -L  "https://dev.webswing.org/files/public/webswing-examples-eval-${WEBSWING_VERSION}-distribution.zip" > webswing.zip; \
 	else curl -s -L  "$WEBSWING_URL-${WEBSWING_VERSION}-distribution.zip" > webswing.zip; fi && \
 	unzip webswing.zip && \


### PR DESCRIPTION
- Disable [provenance attestations](https://docs.docker.com/build/attestations/slsa-provenance/).
- Use a Docker secret for the Webswing URL.