### PR TITLE
Update gradle-launch4j plugin

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     implementation("com.diffplug.spotless:spotless-plugin-gradle:6.14.1")
     implementation("com.netflix.nebula:gradle-ospackage-plugin:11.0.0")
     implementation("de.undercouch:gradle-download-task:5.3.1")
-    implementation("edu.sc.seis.launch4j:launch4j:2.5.4")
+    implementation("edu.sc.seis.launch4j:launch4j:3.0.3")
     implementation("gradle.plugin.install4j.install4j.buildtools:gradle_publish:10.0.4")
     implementation("me.champeau.gradle:japicmp-gradle-plugin:0.4.1")
 }

--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/installers.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/installers.gradle.kts
@@ -24,29 +24,28 @@ install4j {
 }
 
 launch4j {
-    libraryDir = ""
-    copyConfigurable = listOf<String>()
+    libraryDir.set(".")
+    copyConfigurable.set(listOf<String>())
 
-    mainClassName = "org.zaproxy.zap.ZAP"
+    mainClassName.set("org.zaproxy.zap.ZAP")
 
-    dontWrapJar = true
+    dontWrapJar.set(true)
 
-    version = "${project.version}"
-    textVersion = "${project.version}"
+    version.set("${project.version}")
+    textVersion.set("${project.version}")
 
-    outfile = "ZAP.exe"
-    chdir = ""
-    icon = file("src/main/resources/resource/zap.ico").toString()
+    outfile.set("ZAP.exe")
+    chdir.set("")
+    icon.set(file("src/main/resources/resource/zap.ico").toString())
 
-    jdkPreference = "preferJdk"
-    maxHeapSize = 512
-    maxHeapPercent = 25
+    maxHeapSize.set(512)
+    maxHeapPercent.set(25)
 
-    fileDescription = "OWASP Zed Attack Proxy"
-    copyright = "The OWASP Zed Attack Proxy Project"
-    productName = "OWASP Zed Attack Proxy"
-    companyName = "OWASP"
-    internalName = "ZAP"
+    fileDescription.set("OWASP Zed Attack Proxy")
+    copyright.set("The OWASP Zed Attack Proxy Project")
+    productName.set("OWASP Zed Attack Proxy")
+    companyName.set("OWASP")
+    internalName.set("ZAP")
 }
 
 val installerDataDir = file("$buildDir/installerData/")

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -247,7 +247,7 @@ listOf(
 }
 
 launch4j {
-    jar = tasks.named<Jar>("jar").get().archiveFileName.get()
+    setJarTask(tasks.named<Jar>("jar").get())
 }
 
 class ToString(private val callable: Callable<String>) {


### PR DESCRIPTION
Update gradle-launch4j to 3.0.3 which uses a newer version of Launch4j that improves the Java search algorithm.

Fix #5368.

---
Tested with [Windows 11 64bit (WinDev2305Eval)](https://developer.microsoft.com/en-us/windows/downloads/virtual-machines/), `2.13-SNAPSHOT` is able to find Java (Temurin) installed with default settings while 2.12 failed to find it.