### PR TITLE
Use Adoptium for Java download in the executable

### DIFF
--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/installers.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/installers.gradle.kts
@@ -46,6 +46,8 @@ launch4j {
     productName.set("OWASP Zed Attack Proxy")
     companyName.set("OWASP")
     internalName.set("ZAP")
+
+    downloadUrl.set("https://adoptium.net/")
 }
 
 val installerDataDir = file("$buildDir/installerData/")


### PR DESCRIPTION
The previous URL offered Java 8 while 11 is now the minimum required to run ZAP, also that JRE has license constraints.
Link instead to Adoptium OpenJDK builds, it has newer Java versions and it has no license constraints.