### PR TITLE
Update dependencies

### DIFF
--- a/LEGALNOTICE.md
+++ b/LEGALNOTICE.md
@@ -32,30 +32,30 @@ and subject to their respective licenses.
 | Library                             | License                   |
 |-------------------------------------|---------------------------|
 | commons-beanutils-1.9.4.jar         | Apache 2.0                |
-| commons-codec-1.15.jar              | Apache 2.0                |
+| commons-codec-1.16.0.jar            | Apache 2.0                |
 | commons-collections-3.2.2.jar       | Apache 2.0                |
 | commons-configuration-1.10.jar      | Apache 2.0                |
-| commons-csv-1.9.0.jar               | Apache 2.0                |
+| commons-csv-1.10.0.jar              | Apache 2.0                |
 | commons-httpclient-3.1.jar          | Apache 2.0                |
-| commons-io-2.11.0.jar               | Apache 2.0                |
+| commons-io-2.13.0.jar               | Apache 2.0                |
 | commons-lang-2.6.jar                | Apache 2.0                |
 | commons-lang3-3.12.0.jar            | Apache 2.0                |
 | commons-logging-1.2.jar             | Apache 2.0                |
 | commons-text-1.10.0.jar             | Apache 2.0                |
 | ezmorph-1.0.6.jar                   | Apache 2.0                |
-| flatlaf-3.1.jar                     | Apache 2.0                |
+| flatlaf-3.1.1.jar                   | Apache 2.0                |
 | harlib-1.1.3.jar                    | Apache 2.0                |
-| hsqldb-2.7.1.jar                    | BSD                       |
+| hsqldb-2.7.2.jar                    | BSD                       |
 | jackson-core-asl-1.9.13.jar         | Apache 2.0                |
 | javahelp-2.0.05.jar                 | GPL + classpath exception |
 | java-semver-0.9.0.jar               | MIT                       |
 | jericho-html-3.4.jar                | EPL / LGPL dual license   |
-| jfreechart-1.5.3.jar                | LGPL                      |
+| jfreechart-1.5.4.jar                | LGPL                      |
 | jgrapht-core-0.9.0.jar              | LGPL 2.1                  |
 | json-lib-2.4-jdk15.jar              | MIT + "Good, Not Evil"    |
-| log4j-1.2-api-2.19.0.jar            | Apache 2.0                |
-| log4j-api-2.19.0.jar                | Apache 2.0                |
-| log4j-core-2.19.0.jar               | Apache 2.0                |
+| log4j-1.2-api-2.20.0.jar            | Apache 2.0                |
+| log4j-api-2.20.0.jar                | Apache 2.0                |
+| log4j-core-2.20.0.jar               | Apache 2.0                |
 | rsyntaxtextarea-3.3.3.jar           | BSD-3 clause              |
 | swingx-all-1.6.5-1.jar              | LGPL 2.1                  |
-| xom-1.3.8.jar                       | LGPL                      |
+| xom-1.3.9.jar                       | LGPL                      |

--- a/zap/src/main/java/org/zaproxy/zap/ZAP.java
+++ b/zap/src/main/java/org/zaproxy/zap/ZAP.java
@@ -190,7 +190,7 @@ public class ZAP {
         private final PrintStream delegatee;
 
         public DelegatorPrintStream(PrintStream delegatee) {
-            super(NullOutputStream.NULL_OUTPUT_STREAM);
+            super(NullOutputStream.INSTANCE);
             this.delegatee = delegatee;
         }
 

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -61,32 +61,32 @@ dependencies {
     api("com.fifesoft:rsyntaxtextarea:3.3.3")
     api("com.github.zafarkhaja:java-semver:0.9.0")
     api("commons-beanutils:commons-beanutils:1.9.4")
-    api("commons-codec:commons-codec:1.15")
+    api("commons-codec:commons-codec:1.16.0")
     api("commons-collections:commons-collections:3.2.2")
     api("commons-configuration:commons-configuration:1.10")
     api("commons-httpclient:commons-httpclient:3.1")
-    api("commons-io:commons-io:2.11.0")
+    api("commons-io:commons-io:2.13.0")
     api("commons-lang:commons-lang:2.6")
     api("org.apache.commons:commons-lang3:3.12.0")
     api("org.apache.commons:commons-text:1.10.0")
     api("edu.umass.cs.benchlab:harlib:1.1.3")
     api("javax.help:javahelp:2.0.05")
-    val log4jVersion = "2.19.0"
+    val log4jVersion = "2.20.0"
     api("org.apache.logging.log4j:log4j-api:$log4jVersion")
     api("org.apache.logging.log4j:log4j-1.2-api:$log4jVersion")
     implementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
     api("net.htmlparser.jericho:jericho-html:3.4")
     api("net.sf.json-lib:json-lib:2.4:jdk15")
-    api("org.apache.commons:commons-csv:1.9.0")
-    api("org.hsqldb:hsqldb:2.7.1")
-    api("org.jfree:jfreechart:1.5.3")
+    api("org.apache.commons:commons-csv:1.10.0")
+    api("org.hsqldb:hsqldb:2.7.2")
+    api("org.jfree:jfreechart:1.5.4")
     api("org.jgrapht:jgrapht-core:0.9.0")
     api("org.swinglabs.swingx:swingx-all:1.6.5-1")
 
-    implementation("com.formdev:flatlaf:3.1")
+    implementation("com.formdev:flatlaf:3.1.1")
 
     runtimeOnly("commons-logging:commons-logging:1.2")
-    runtimeOnly("xom:xom:1.3.8") {
+    runtimeOnly("xom:xom:1.3.9") {
         setTransitive(false)
     }
 


### PR DESCRIPTION
Update:
 - Commons Codec to 1.16.0.
 - Commons CSV to 1.10.0.
 - Commons IO to 1.13.0.
 - FlatLaf to 3.1.1.
 - JFreeChart to 1.5.4.
 - HSQLDB to 2.7.2.
 - Log4j 2 to 2.20.0.
 - XOM to 1.3.9.

Address deprecation with Commons IO class.