### PR TITLE
Update version for 2.13.0

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/Constant.java
+++ b/zap/src/main/java/org/parosproxy/paros/Constant.java
@@ -191,7 +191,7 @@ public final class Constant {
     private static final String VERSION_ELEMENT = "version";
 
     // Accessible for tests
-    static final long VERSION_TAG = 20012000;
+    static final long VERSION_TAG = 20013000;
 
     // Old version numbers - for upgrade
     private static final long V_2_12_0_TAG = 20012000;


### PR DESCRIPTION
Change `VERSION_TAG` to 2.13.0.
The `upgradeFrom*` method was not added, no updates required.