### PR TITLE
Search auth messages

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/search/SearchThread.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/search/SearchThread.java
@@ -207,7 +207,8 @@ public class SearchThread extends Thread {
                                     HistoryReference.TYPE_PROXIED,
                                     HistoryReference.TYPE_ZAP_USER,
                                     HistoryReference.TYPE_SPIDER,
-                                    HistoryReference.TYPE_SPIDER_AJAX);
+                                    HistoryReference.TYPE_SPIDER_AJAX,
+                                    HistoryReference.TYPE_AUTHENTICATION);
             int last = list.size();
             int currentRecordId = 0;
             for (int index = 0; index < last; index++) {


### PR DESCRIPTION
Auth messages are shown in the history.
Being able to search them is really useful, esp when investigating auth issues 😉 