### PR TITLE
Update content-length in auth template scripts

### DIFF
--- a/zap/src/main/dist/scripts/templates/authentication/Authentication default template.js
+++ b/zap/src/main/dist/scripts/templates/authentication/Authentication default template.js
@@ -20,6 +20,11 @@ function authenticate(helper, paramsValues, credentials) {
 	
 	// TODO: Process message to match the authentication needs
 
+	// For example, add a request payload
+	// msg.setRequestBody("a payload with user credentials")
+	// And set/update the content-length header field accordingly.
+	// msg.getRequestHeader().setContentLength(msg.getRequestBody().length())
+
 	// Configurations on how the messages are sent/handled:
 	// Set to follow redirects when sending messages (default is false).
 	// helper.getHttpSender().setFollowRedirect(true)

--- a/zap/src/main/dist/scripts/templates/authentication/BodgeIt Store Authentication.js
+++ b/zap/src/main/dist/scripts/templates/authentication/BodgeIt Store Authentication.js
@@ -32,6 +32,7 @@ function authenticate(helper, paramsValues, credentials) {
 	var msg=helper.prepareMessage();
 	msg.setRequestHeader(new HttpRequestHeader(requestMethod, requestUri, HttpHeader.HTTP10));
 	msg.setRequestBody(requestBody);
+	msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
 
 	// Send the authentication message and return it
 	helper.sendAndReceive(msg);

--- a/zap/src/main/dist/scripts/templates/authentication/Simple Form-Based Authentication.js
+++ b/zap/src/main/dist/scripts/templates/authentication/Simple Form-Based Authentication.js
@@ -42,6 +42,7 @@ function authenticate(helper, paramsValues, credentials) {
 	var msg = helper.prepareMessage();
 	msg.setRequestHeader(new HttpRequestHeader(requestMethod, requestUri, HttpHeader.HTTP10));
 	msg.setRequestBody(requestBody);
+	msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
 
 	// Send the authentication message and return it
 	helper.sendAndReceive(msg);

--- a/zap/src/main/dist/scripts/templates/authentication/Wordpress Authentication.js
+++ b/zap/src/main/dist/scripts/templates/authentication/Wordpress Authentication.js
@@ -49,6 +49,7 @@ function authenticate(helper, paramsValues, credentials) {
 	var msg = helper.prepareMessage();
 	msg.setRequestHeader(requestHeader);
 	msg.setRequestBody(requestBody);
+	msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
 
 	// Send the authentication message and return it
 	helper.sendAndReceive(msg);


### PR DESCRIPTION
Change the auth template scripts to update the content-length header field after setting the request body.
Also, add example to default template to make it clear that the user is expected to do that.

From #7614.