### PR TITLE
Include other required add-ons in Core package

### DIFF
--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/distributions.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/distributions.gradle.kts
@@ -115,17 +115,20 @@ tasks.register<Zip>("distCore") {
             "callhome",
             "commonlib",
             "coreLang",
+            "database",
             "diff",
             "gettingStarted",
             "help",
             "invoke",
             "network",
+            "oast",
             "onlineMenu",
             "plugnhack",
             "pscanrules",
             "quickstart",
             "reports",
             "reveal",
+            "spider",
             "tips")
     val topLevelDir = "ZAP_${project.version}"
 


### PR DESCRIPTION
The Spider, Database, and OAST are all needed for the Active scanner rules and Quick Start add-ons.