### PR TITLE
Update baseline integration test results

### DIFF
--- a/docker/integration_tests/results/baseline1-1.out
+++ b/docker/integration_tests/results/baseline1-1.out
@@ -8,4 +8,4 @@ WARN-NEW: Content Security Policy (CSP) Header Not Set [10038] x X
 WARN-NEW: Storable and Cacheable Content [10049] x X 
 WARN-NEW: Retrieved from Cache [10050] x X 
 WARN-NEW: Permissions Policy Header Not Set [10063] x X 
-FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 9	WARN-INPROG: 0	INFO: 0	IGNORE: 0	PASS: 54
+FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 9	WARN-INPROG: 0	INFO: 0	IGNORE: 0	PASS: 56

--- a/docker/integration_tests/results/baseline2-1.out
+++ b/docker/integration_tests/results/baseline2-1.out
@@ -8,4 +8,4 @@ WARN-NEW: Content Security Policy (CSP) Header Not Set [10038] x X
 WARN-NEW: Storable and Cacheable Content [10049] x X 
 WARN-NEW: Permissions Policy Header Not Set [10063] x X 
 FAIL-NEW: Missing Anti-clickjacking Header [10020] x X 
-FAIL-NEW: 1	FAIL-INPROG: 0	WARN-NEW: 6	WARN-INPROG: 0	INFO: 1	IGNORE: 1	PASS: 54
+FAIL-NEW: 1	FAIL-INPROG: 0	WARN-NEW: 6	WARN-INPROG: 0	INFO: 1	IGNORE: 1	PASS: 56

--- a/docker/integration_tests/results/baseline3-1.out
+++ b/docker/integration_tests/results/baseline3-1.out
@@ -8,4 +8,4 @@ WARN-NEW: Content Security Policy (CSP) Header Not Set [10038] x X
 WARN-NEW: Storable and Cacheable Content [10049] x X 
 WARN-NEW: Permissions Policy Header Not Set [10063] x X 
 FAIL-NEW: Missing Anti-clickjacking Header [10020] x X Custom X-Frame-Options option message
-FAIL-NEW: 1	FAIL-INPROG: 0	WARN-NEW: 6	WARN-INPROG: 0	INFO: 1	IGNORE: 1	PASS: 54
+FAIL-NEW: 1	FAIL-INPROG: 0	WARN-NEW: 6	WARN-INPROG: 0	INFO: 1	IGNORE: 1	PASS: 56

--- a/docker/integration_tests/results/baseline3-2.out
+++ b/docker/integration_tests/results/baseline3-2.out
@@ -7,4 +7,4 @@ WARN-NEW: Content Security Policy (CSP) Header Not Set [10038] x X
 WARN-NEW: Storable and Cacheable Content [10049] x X 
 WARN-NEW: Permissions Policy Header Not Set [10063] x X 
 FAIL-NEW: Missing Anti-clickjacking Header [10020] x X Custom X-Frame-Options option message
-FAIL-NEW: 1	FAIL-INPROG: 0	WARN-NEW: 5	WARN-INPROG: 0	INFO: 1	IGNORE: 1	PASS: 54
+FAIL-NEW: 1	FAIL-INPROG: 0	WARN-NEW: 5	WARN-INPROG: 0	INFO: 1	IGNORE: 1	PASS: 56

--- a/docker/integration_tests/results/baseline4-1.out
+++ b/docker/integration_tests/results/baseline4-1.out
@@ -8,4 +8,4 @@ WARN-NEW: Content Security Policy (CSP) Header Not Set [10038] x X
 WARN-NEW: Storable and Cacheable Content [10049] x X 
 WARN-NEW: Permissions Policy Header Not Set [10063] x X 
 FAIL-NEW: Missing Anti-clickjacking Header [10020] x X Custom X-Frame-Options option message
-FAIL-NEW: 1	FAIL-INPROG: 0	WARN-NEW: 6	WARN-INPROG: 0	INFO: 1	IGNORE: 1	PASS: 54
+FAIL-NEW: 1	FAIL-INPROG: 0	WARN-NEW: 6	WARN-INPROG: 0	INFO: 1	IGNORE: 1	PASS: 56


### PR DESCRIPTION
Take into account the two passive scan rules that were promoted to beta in the 2.13 release, which are reported as passes.

---
e.g.: https://github.com/zaproxy/zaproxy/actions/runs/5605853668/jobs/10255426101