### PR TITLE
Update `SECURITY.md` when preparing release

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,7 +30,6 @@ These tasks use checkboxes so that they can be copied into an issue.
      - [ ] Add new add-ons.
      - [ ] Remove add-ons no longer needed.
      - [ ] Update add-ons with the task mentioned in `main-add-ons.yml`.
-  - [ ] Update [SECURITY.md](https://github.com/zaproxy/zaproxy/blob/main/SECURITY.md) to mention the latest version.
   - [ ] Update the version of the snap and the source file in [snapcraft.yaml](https://github.com/zaproxy/zaproxy/blob/main/snap/snapcraft.yaml).
 - [ ] Merge the pull request, to create the tag and the draft release (done by [Release Main Version](https://github.com/zaproxy/zaproxy/actions/workflows/release-main-version.yml));
 - [ ] Verify the draft release.

--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/github-releases.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/github-releases.gradle.kts
@@ -64,7 +64,9 @@ val createPullRequestNextDevIter by tasks.registering(CreatePullRequest::class) 
 
 val prepareMainRelease by tasks.registering(PrepareMainRelease::class) {
     propertiesFile.set(File(projectDir, "gradle.properties"))
+    securityFile.set(File(rootDir, "SECURITY.md"))
 
+    oldVersionProperty.set("zap.japicmp.baseversion")
     versionProperty.set("version")
 }
 
@@ -74,7 +76,10 @@ val createPullRequestMainRelease by tasks.registering(CreatePullRequest::class) 
     branchName.set("release")
 
     commitSummary.set("Update version to ${project.version}")
-    commitDescription.set("Remove `-SNAPSHOT` from the version.")
+    commitDescription.set("""
+    |Remove `-SNAPSHOT` from the version.
+    |Update version in `SECURITY.md` file.
+    """.trimMargin())
 
     pullRequestTitle.set("Release version ${project.version}")
     pullRequestDescription.set("")


### PR DESCRIPTION
Replace the old version with the new one.
Remove corresponding release task from the release doc.
Update zapbot's commit message to mention the change.