### PR TITLE
Update snap version when preparing release

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,7 +30,6 @@ These tasks use checkboxes so that they can be copied into an issue.
      - [ ] Add new add-ons.
      - [ ] Remove add-ons no longer needed.
      - [ ] Update add-ons with the task mentioned in `main-add-ons.yml`.
-  - [ ] Update the version of the snap and the source file in [snapcraft.yaml](https://github.com/zaproxy/zaproxy/blob/main/snap/snapcraft.yaml).
 - [ ] Merge the pull request, to create the tag and the draft release (done by [Release Main Version](https://github.com/zaproxy/zaproxy/actions/workflows/release-main-version.yml));
 - [ ] Verify the draft release.
 - [ ] Publish the release.

--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/PrepareMainRelease.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/PrepareMainRelease.java
@@ -44,11 +44,16 @@ public abstract class PrepareMainRelease extends DefaultTask {
     @Input
     public abstract Property<File> getSecurityFile();
 
+    @Input
+    public abstract Property<File> getSnapcraftFile();
+
     @TaskAction
     public void prepare() throws Exception {
         ProjectProperties properties = new ProjectProperties(getPropertiesFile().get().toPath());
         String newVersion = updatePropertiesFile(properties);
-        updateSecurityFile(properties, newVersion);
+        String oldVersion = properties.getProperty(getOldVersionProperty().get());
+        replaceVersion(getSecurityFile().get().toPath(), oldVersion, newVersion);
+        replaceVersion(getSnapcraftFile().get().toPath(), oldVersion, newVersion);
     }
 
     private String updatePropertiesFile(ProjectProperties properties) throws IOException {
@@ -59,12 +64,10 @@ public abstract class PrepareMainRelease extends DefaultTask {
         return newVersion;
     }
 
-    private void updateSecurityFile(ProjectProperties properties, String newVersion)
+    private void replaceVersion(Path path, String oldVersion, String newVersion)
             throws IOException {
-        Path securityFile = getSecurityFile().get().toPath();
-        String content = Files.readString(securityFile);
-        String oldVersion = properties.getProperty(getOldVersionProperty().get());
-        Files.writeString(securityFile, content.replace(oldVersion, newVersion));
+        String content = Files.readString(path);
+        Files.writeString(path, content.replace(oldVersion, newVersion));
     }
 
     private static String removePreReleaseVersion(String version) {

--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/github-releases.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/github-releases.gradle.kts
@@ -65,6 +65,7 @@ val createPullRequestNextDevIter by tasks.registering(CreatePullRequest::class) 
 val prepareMainRelease by tasks.registering(PrepareMainRelease::class) {
     propertiesFile.set(File(projectDir, "gradle.properties"))
     securityFile.set(File(rootDir, "SECURITY.md"))
+    snapcraftFile.set(File(rootDir, "snap/snapcraft.yaml"))
 
     oldVersionProperty.set("zap.japicmp.baseversion")
     versionProperty.set("version")
@@ -79,6 +80,7 @@ val createPullRequestMainRelease by tasks.registering(CreatePullRequest::class) 
     commitDescription.set("""
     |Remove `-SNAPSHOT` from the version.
     |Update version in `SECURITY.md` file.
+    |Update version for snap.
     """.trimMargin())
 
     pullRequestTitle.set("Release version ${project.version}")


### PR DESCRIPTION
Update the version of the snap and the ZAP package (plain text replacement).
Remove corresponding release task from the release doc.
Update zapbot's commit message to mention the change.

---
I thought initially on parsing the YAML file for accurate update of the version and download link but there are no other version numbers in the file (and we can always correct any issues before merging zapbot's PR).