### PR TITLE
Workaround sonar issue

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -22,4 +22,4 @@ jobs:
     - name: Sonarcloud Scan
       env:
         SONAR_TOKEN: ${{ secrets.ZAPBOT_SONARCLOUD_TOKEN }}
-      run: ./gradlew -Dorg.gradle.jvmargs=-Xmx4g sonarqube --stacktrace
+      run: ./gradlew -Dorg.gradle.jvmargs=-Xmx4g sonar --stacktrace

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,5 +54,7 @@ sonarqube {
         property("sonar.projectKey", "zaproxy_zaproxy")
         property("sonar.organization", "zaproxy")
         property("sonar.host.url", "https://sonarcloud.io")
+        // Workaround https://sonarsource.atlassian.net/browse/SONARGRADL-126
+        property("sonar.exclusions", "**/*.gradle.kts")
     }
 }


### PR DESCRIPTION
Exclude build files as they are being indexed twice causing the build to fail.
Use newer task to run the sonar scan.

---
https://github.com/zaproxy/zaproxy/actions/runs/5701200462/job/15451683431#step:5:39