### PR TITLE
Update docs and image used in packaged scans

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,9 @@ If you have a suggestion for new functionality then you can raise an issue on th
 Its worth checking to see if its already been requested, and including as much information as you can so that we can fully understand your requirements.
 
 ## Translate ZAP to Other Languages
-You can help translate the ZAP UI via the [Crowdin owasp-zap](https://crowdin.com/project/zaproxy) project.
+You can help translate the ZAP UI via the [Crowdin zaproxy](https://crowdin.com/project/zaproxy) project.
 
-You can help translate the ZAP User Guide via the [Crowdin owasp-zap-help](https://crowdin.com/project/zap-help) project.
+You can help translate the ZAP User Guide via the [Crowdin zap-help](https://crowdin.com/project/zap-help) project.
 
 ## Become a ZAP Evangelist
 For information about the ZAP Evangelists and how to join up see the [ZAP Evangelists page](https://www.zaproxy.org/evangelists/)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -85,11 +85,10 @@ will trigger the update of the marketplace with the new release.
 
 ## Docker Images
 
-The image `owasp/zap2docker-live` is automatically built from the default branch.
+The Nightly image is automatically built from the default branch.
 
-The images `owasp/zap2docker-weekly`, `owasp/zap2docker-stable`, and `owasp/zap2docker-bare` are automatically built
-after the corresponding release to the marketplace.  
-The images `owasp/zap2docker-stable` and `owasp/zap2docker-bare` are built at the same time.
+The images Weekly, Stable, and Bare are automatically built after the corresponding release to the marketplace.  
+The images Stable and Bare are built at the same time.
 
 They can still be manually built by running the corresponding workflow:
  - [Release Weekly Docker](https://github.com/zaproxy/zaproxy/actions/workflows/release-weekly-docker.yml)

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2023-08-04
+- The packaged scans, when executed directly, will now use the image from the GitHub Container Registry.
+
 ### 2023-08-02
 - Start publishing images under the `softwaresecurityproject` organization on Docker Hub, in addition to the existing images.
 

--- a/docker/zap-api-scan.py
+++ b/docker/zap-api-scan.py
@@ -368,7 +368,7 @@ def main(argv):
         add_zap_options(params, zap_options)
 
         try:
-            cid = start_docker_zap('owasp/zap2docker-weekly', port, params, mount_dir)
+            cid = start_docker_zap('ghcr.io/zaproxy/zaproxy:weekly', port, params, mount_dir)
             zap_ip = ipaddress_for_cid(cid)
             logging.debug('Docker ZAP IP Addr: ' + zap_ip)
 

--- a/docker/zap-baseline.py
+++ b/docker/zap-baseline.py
@@ -493,7 +493,7 @@ def main(argv):
         add_zap_options(params, zap_options)
 
         try:
-            cid = start_docker_zap('owasp/zap2docker-weekly', port, params, mount_dir)
+            cid = start_docker_zap('ghcr.io/zaproxy/zaproxy:weekly', port, params, mount_dir)
             zap_ip = ipaddress_for_cid(cid)
             logging.debug('Docker ZAP IP Addr: ' + zap_ip)
         except OSError:

--- a/docker/zap-full-scan.py
+++ b/docker/zap-full-scan.py
@@ -322,7 +322,7 @@ def main(argv):
         add_zap_options(params, zap_options)
 
         try:
-            cid = start_docker_zap('owasp/zap2docker-weekly', port, params, mount_dir)
+            cid = start_docker_zap('ghcr.io/zaproxy/zaproxy:weekly', port, params, mount_dir)
             zap_ip = ipaddress_for_cid(cid)
             logging.debug('Docker ZAP IP Addr: ' + zap_ip)
         except OSError:

--- a/zap/src/main/dist/README
+++ b/zap/src/main/dist/README
@@ -37,8 +37,7 @@ You can use the 'zap.sh' script, as per linux.
 
 Docker
 
-ZAP is available on https://hub.docker.com/r/owasp/zap2docker-stable/
-For more details of how you can use it see 
+ZAP is available as Docker images. For more details of how you can use them see 
 https://www.zaproxy.org/docs/docker/ 
 
 Headless Environment

--- a/zap/src/main/dist/README.weekly
+++ b/zap/src/main/dist/README.weekly
@@ -36,8 +36,7 @@ Both of these files are in the installation directory.
 Docker
 ------
 
-The weekly release is also available on Docker:
-https://hub.docker.com/r/owasp/zap2docker-weekly/
+The weekly release is also available as Docker image.
 For more details of how you can use it see 
 https://www.zaproxy.org/docs/docker/ 
 


### PR DESCRIPTION
Use the weekly from GHCR in packaged scans (when executed directly).
Update the release doc and READMEs to use the generic image names instead of one specifically, they are now published to several places with different image names/tags.
Fix labels of some links.