### PR TITLE
Allow to display script without focusing

### DIFF
--- a/zap/gradle/japicmp.yaml
+++ b/zap/gradle/japicmp.yaml
@@ -5,4 +5,6 @@
 packageExcludes: []
 fieldExcludes: []
 classExcludes: []
-methodExcludes: []
+methodExcludes:
+  - org.zaproxy.zap.extension.script.ScriptUI#displayScript(org.zaproxy.zap.extension.script.ScriptWrapper, boolean)
+

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptUI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptUI.java
@@ -129,7 +129,26 @@ public interface ScriptUI {
      */
     void removeScriptTreeTransferHandler(Class<?> klass);
 
+    /**
+     * Displays the provided script with focus.
+     *
+     * @param script The script to be displayed.
+     */
     void displayScript(ScriptWrapper script);
+
+    /**
+     * Displays the provided script with/without focusing on it. By default, this method delegates
+     * to {@link #displayScript(ScriptWrapper)}.
+     *
+     * @param script The script to be displayed.
+     * @param allowFocus {@code true} to allow focusing on the script display, {@code false}
+     *     otherwise.
+     * @since 2.14.0
+     * @see #displayScript(ScriptWrapper)
+     */
+    default void displayScript(ScriptWrapper script, boolean allowFocus) {
+        displayScript(script);
+    }
 
     boolean isScriptDisplayed(ScriptWrapper script);
 


### PR DESCRIPTION
- overload display script method to support focus as optional which will be helpful for client-side recording
Related to: zaproxy/zap-extensions/pull/4768