### PR TITLE
Fix release of macOS dist in CI

### DIFF
--- a/.github/workflows/release-main-version.yml
+++ b/.github/workflows/release-main-version.yml
@@ -28,7 +28,7 @@ jobs:
         ZAPBOT_TOKEN: ${{ secrets.ZAPBOT_TOKEN }}
         ZAP_RELEASE: 1
         ZAP_JAVA_VERSION: 11
-      run: ./gradlew "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m" :zap:createMainRelease
+      run: ./gradlew -Dorg.gradle.jvmargs=-Xmx4g :zap:createMainRelease
 
   upload-macos:
     needs: release
@@ -48,4 +48,4 @@ jobs:
         ZAPBOT_TOKEN: ${{ secrets.ZAPBOT_TOKEN }}
         ZAP_RELEASE: 1
         ZAP_JAVA_VERSION: 11
-      run: ./gradlew "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m" :zap:uploadMacDist
+      run: ./gradlew -Dorg.gradle.jvmargs=-Xmx4g :zap:uploadMacDist

--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/distributions.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/distributions.gradle.kts
@@ -1,5 +1,7 @@
 package org.zaproxy.zap
 
+import java.nio.file.Files
+import java.nio.file.Paths
 import de.undercouch.gradle.tasks.download.Download
 import de.undercouch.gradle.tasks.download.Verify
 import org.apache.tools.ant.filters.ReplaceTokens
@@ -248,11 +250,6 @@ listOf(
         doFirst {
             delete(macOsDistDataDir)
         }
-        doLast {
-            ant.withGroovyBuilder {
-                "symlink"(mapOf("link" to "$macOsDistDataDir/Applications", "resource" to "/Applications"))
-            }
-        }
     }
 
     tasks.register<CreateDmg>("distMac${it.suffix}") {
@@ -263,6 +260,13 @@ listOf(
 
         workingDir.set(macOsDistDataDir)
         dmg.set(file("$buildDir/distributions/ZAP_$version${it.fileNameSuffix}.dmg"))
+
+        doFirst {
+            val symlink = Paths.get("$macOsDistDataDir/Applications")
+            if (Files.notExists(symlink)) {
+                Files.createSymbolicLink(symlink, Paths.get("/Applications"))
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Move the creation of the symlink to the DMG task, being in the copy task makes Gradle check it, leading to out of memory errors.
Correct update of the release:
 - Search the release by name if not found by tag, since it might still be in draft state.
 - Use expected newline char in the table header, otherwise the checksums would not be included.

Increase the max memory in the release tasks to ensure there are no memory errors when creating and uploading the dists/installers.