### PR TITLE
Update installers and Windows executable

### DIFF
--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/installers.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/installers.gradle.kts
@@ -16,7 +16,7 @@ var install4jHomeDirValidated = false
 val install4jHomeDir: String? by project
 val install4jLicense: String? by project
 
-val install4jVersion = "10.0.4"
+val install4jVersion = "10.0.6"
 
 install4j {
     installDir = file("$install4jHomeDir")
@@ -41,10 +41,10 @@ launch4j {
     maxHeapSize.set(512)
     maxHeapPercent.set(25)
 
-    fileDescription.set("OWASP Zed Attack Proxy")
-    copyright.set("The OWASP Zed Attack Proxy Project")
-    productName.set("OWASP Zed Attack Proxy")
-    companyName.set("OWASP")
+    fileDescription.set("Zed Attack Proxy")
+    copyright.set("The Zed Attack Proxy Project")
+    productName.set("Zed Attack Proxy")
+    companyName.set("ZAP")
     internalName.set("ZAP")
 
     downloadUrl.set("https://adoptium.net/")
@@ -143,7 +143,7 @@ if (install4jHomeDir == null && Os.isFamily(Os.FAMILY_UNIX)) {
         dependsOn(downloadInstall4jBin)
         src(install4jBinFile)
         algorithm("SHA-256")
-        checksum("df5a7a945d3f64ee191d162a0c1db56bf5e89dae5e190573e284fd70b921542b")
+        checksum("db8144cfcb442f98dfb12fa4ce05330964104a6c65159a7d8358f9f5c5da8e55")
     }
 
     val unpackInstall4jBin by tasks.registering(Copy::class) {

--- a/python/scripts/generic-pytest/test_zap.py
+++ b/python/scripts/generic-pytest/test_zap.py
@@ -100,10 +100,10 @@ def test_zap(zapconfig):
 		if (len(zapInstall) == 0):
 			if (platform.system() == "Windows"):
 				# Win 7 default path
-				zapInstall = "C:\Program Files (x86)\OWASP\Zed Attack Proxy";
+				zapInstall = "C:\Program Files (x86)\ZAP\Zed Attack Proxy";
 				if ( not os.path.exists(zapInstall)):
 					# Win XP default path
-					zapInstall = "C:\Program Files\OWASP\Zed Attack Proxy";
+					zapInstall = "C:\Program Files\ZAP\Zed Attack Proxy";
 			else:
 				# No default path for Mac OS or Linux
 				print("Installation directory must be set in " + zapconfig)

--- a/zap/src/main/dist/README
+++ b/zap/src/main/dist/README
@@ -21,7 +21,7 @@ There are 3 options on Windows:
 
 * Via the desktop icon (assuming you selected this option during installation)
 * Via the 'Start' menu:
-    All Programs / OWASP / Zed Attack Proxy / ZAP <version> 
+    All Programs / ZAP / Zed Attack Proxy / ZAP <version> 
 * Via the 'zap.bat' command line script in the installation directory 
 
 Linux

--- a/zap/src/main/installer/zap.install4j
+++ b/zap/src/main/installer/zap.install4j
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<install4j version="10.0.3" transformSequenceNumber="10">
-  <application name="OWASP Zed Attack Proxy" applicationId="OWASP ZAP" mediaFilePattern="${compiler:sys.shortName}_${compiler:sys.version}_${compiler:sys.platform}" shortName="ZAP" publisher="OWASP ZAP" publisherWeb="https://www.zaproxy.org/" version="${compiler:version}" allPathsRelative="true" backupOnSave="true" macVolumeId="1369b1f423bb47f8" javaMinVersion="11">
+<install4j version="10.0.6" transformSequenceNumber="10">
+  <application name="Zed Attack Proxy" applicationId="ZAP" mediaFilePattern="${compiler:sys.shortName}_${compiler:sys.version}_${compiler:sys.platform}" shortName="ZAP" publisher="ZAP" publisherWeb="https://www.zaproxy.org/" version="${compiler:version}" allPathsRelative="true" backupOnSave="true" macVolumeId="1369b1f423bb47f8" javaMinVersion="11">
     <languages skipLanguageSelection="true">
       <principalLanguage id="en" customLocalizationFile="./resources/Messages.properties" />
       <additionalLanguages>
@@ -20,7 +20,7 @@
     </languages>
     <variables>
       <variable name="longName" value="Zed Attack Proxy" />
-      <variable name="groupName" value="OWASP" />
+      <variable name="groupName" value="ZAP" />
       <variable name="unixDirName" value="zaproxy" />
       <variable name="symlinkDir" value="/usr/local/bin" />
     </variables>
@@ -50,7 +50,7 @@
     </entries>
   </files>
   <launchers>
-    <launcher name="Linux" id="26" external="true" menuName="OWASP ZAP" externalFile="zap.sh" />
+    <launcher name="Linux" id="26" external="true" menuName="ZAP" externalFile="zap.sh" />
     <launcher name="Windows (.exe)" id="79" external="true" menuName="${compiler:sys.shortName} ${compiler:sys.version}" externalFile="ZAP.exe" />
   </launchers>
   <installerGui>
@@ -130,6 +130,21 @@ if (Util.isWindows()) {
 } else if (Util.isLinux()) {
     context.setVariable("sys.symlinkDir", context.getCompilerVariable("symlinkDir"));
 } 
+
+return true;</property>
+                    </object>
+                  </property>
+                </serializedBean>
+              </action>
+              <action id="821" beanClass="com.install4j.runtime.beans.actions.control.RunScriptAction" rollbackBarrierExitCode="0">
+                <serializedBean>
+                  <property name="script">
+                    <object class="com.install4j.api.beans.ScriptProperty">
+                      <property name="value" type="string">ApplicationRegistry.ApplicationInfo[] applicationInfos = ApplicationRegistry.getApplicationInfoById("OWASP ZAP");
+
+if (applicationInfos.length &gt; 0) {
+   context.setVariable("uninstallOldDir", applicationInfos[0].getInstallationDirectory().getPath());
+}
 
 return true;</property>
                     </object>
@@ -576,6 +591,16 @@ return;</preActivation>
           </screen>
           <screen id="8" beanClass="com.install4j.runtime.beans.screens.InstallationScreen" rollbackBarrier="true">
             <actions>
+              <action id="820" beanClass="com.install4j.runtime.beans.actions.UninstallPreviousAction" actionElevationType="none" rollbackBarrierExitCode="0">
+                <serializedBean>
+                  <property name="installationDirectory">
+                    <object class="java.io.File">
+                      <string>${installer:uninstallOldDir}</string>
+                    </object>
+                  </property>
+                  <property name="onlyIfSameApplicationId" type="boolean" value="false" />
+                </serializedBean>
+              </action>
               <action id="169" beanClass="com.install4j.runtime.beans.actions.UninstallPreviousAction" actionElevationType="none" />
               <action id="9" beanClass="com.install4j.runtime.beans.actions.InstallFilesAction" actionElevationType="elevated" failureStrategy="quit" errorMessage="${i18n:FileCorrupted}" />
               <action id="10" beanClass="com.install4j.runtime.beans.actions.desktop.CreateProgramGroupAction" actionElevationType="elevated">
@@ -606,7 +631,7 @@ return;</preActivation>
                     </object>
                   </property>
                   <property name="macSingleBundleTarget" type="boolean" value="false" />
-                  <property name="name" type="string">${compiler:groupName} ${compiler:sys.shortName} ${compiler:sys.version}</property>
+                  <property name="name" type="string">${compiler:sys.shortName} ${compiler:sys.version}</property>
                   <property name="unixIconFile">
                     <object class="com.install4j.api.beans.ExternalFile">
                       <string>../resources/resource/zap1024x1024.png</string>
@@ -653,7 +678,7 @@ return;</preActivation>
                   <property name="escaped" type="boolean" value="false" />
                   <property name="file">
                     <object class="java.io.File">
-                      <string>${compiler:groupName} ${compiler:sys.shortName}.desktop</string>
+                      <string>${compiler:sys.shortName}.desktop</string>
                     </object>
                   </property>
                   <property name="logText" type="boolean" value="false" />


### PR DESCRIPTION
Remove OWASP references.
Change installation dir and group to ZAP.
Update install4j to latest version.
Update paths in doc and script.