### PR TITLE
Use newer Python ZAP API client

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2023-08-09
+- Install the newer Python ZAP API client directly, `python-owasp-zap-v2.4` was renamed to `zaproxy`.
+
 ### 2023-08-04
 - The packaged scans, when executed directly, will now use the image from the GitHub Container Registry.
 

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -66,7 +66,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	mkdir /zap  && \
 	chown zap:zap /zap
 
-RUN pip3 install --no-cache-dir --upgrade awscli pip python-owasp-zap-v2.4 pyyaml requests urllib3
+RUN pip3 install --no-cache-dir --upgrade awscli pip zaproxy pyyaml requests urllib3
 
 #Change to the zap user so things get done as the right person (apart from copy)
 USER zap

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -60,7 +60,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	x11vnc && \
 	rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --no-cache-dir --upgrade awscli pip python-owasp-zap-v2.4 pyyaml urllib3
+RUN pip3 install --no-cache-dir --upgrade awscli pip zaproxy pyyaml urllib3
 
 RUN useradd -u 1000 -d /home/zap -m -s /bin/bash zap
 RUN echo zap:zap | chpasswd

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -50,7 +50,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
     mkdir /zap  && \
     chown zap:zap /zap
 
-RUN pip3 install --no-cache-dir --upgrade awscli pip python-owasp-zap-v2.4 pyyaml requests urllib3 
+RUN pip3 install --no-cache-dir --upgrade awscli pip zaproxy pyyaml requests urllib3 
 
 WORKDIR /zap
 

--- a/docker/zap-api-scan.py
+++ b/docker/zap-api-scan.py
@@ -21,7 +21,7 @@
 # or GraphQL using ZAP.
 #
 # It can either be run 'standalone', in which case depends on
-# https://pypi.python.org/pypi/python-owasp-zap-v2.4 and Docker, or it can be run
+# https://pypi.python.org/pypi/zaproxy and Docker, or it can be run
 # inside one of the ZAP docker containers. It automatically detects if it is
 # running in docker so the parameters are the same.
 #

--- a/docker/zap-baseline.py
+++ b/docker/zap-baseline.py
@@ -20,7 +20,7 @@
 # This script runs a baseline scan against a target URL using ZAP
 #
 # It can either be run 'standalone', in which case depends on
-# https://pypi.python.org/pypi/python-owasp-zap-v2.4 and Docker, or it can be run
+# https://pypi.python.org/pypi/zaproxy and Docker, or it can be run
 # inside one of the ZAP docker containers. It automatically detects if it is
 # running in docker so the parameters are the same.
 #

--- a/docker/zap-full-scan.py
+++ b/docker/zap-full-scan.py
@@ -20,7 +20,7 @@
 # This script runs a full scan against a target URL using ZAP
 #
 # It can either be run 'standalone', in which case depends on
-# https://pypi.python.org/pypi/python-owasp-zap-v2.4 and Docker, or it can be run
+# https://pypi.python.org/pypi/zaproxy and Docker, or it can be run
 # inside one of the ZAP docker containers. It automatically detects if it is
 # running in docker so the parameters are the same.
 #

--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -520,7 +520,7 @@ def get_latest_zap_client_version():
     version_info = None
 
     try:
-        version_info = urlopen('https://pypi.python.org/pypi/python-owasp-zap-v2.4/json', timeout=10)
+        version_info = urlopen('https://pypi.python.org/pypi/zaproxy/json', timeout=10)
     except Exception as e:
         logging.warning('Error fetching latest ZAP Python API client version: %s' % e)
         return None


### PR DESCRIPTION
Install `zaproxy` instead of `python-owasp-zap-v2.4`, the latter was renamed to the former.
Update links to the newer package.