### PR TITLE
Do not remove headers when proxying

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/history/ProxyListenerLog.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/ProxyListenerLog.java
@@ -38,10 +38,10 @@
 // ZAP: 2020/08/04 Changed to use new SessionStructure method
 // ZAP: 2020/11/26 Use Log4j 2 classes for logging.
 // ZAP: 2023/01/10 Tidy up logger.
+// ZAP: 2023/08/22 Do not modify the requests being proxied (Issue 7353).
 package org.parosproxy.paros.extension.history;
 
 import java.awt.EventQueue;
-import org.apache.commons.httpclient.URIException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -56,7 +56,6 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.zap.model.SessionStructure;
-import org.zaproxy.zap.model.StructuralNode;
 
 public class ProxyListenerLog implements ProxyListener, ConnectRequestProxyListener {
 
@@ -90,34 +89,6 @@ public class ProxyListenerLog implements ProxyListener, ConnectRequestProxyListe
 
     @Override
     public boolean onHttpRequestSend(HttpMessage msg) {
-        //	    if (msg.getRequestHeader().isImage()) {
-        //	        return;
-        //	    }
-
-        try {
-            StructuralNode node = SessionStructure.find(model, msg);
-            if (node != null) {
-                HttpMessage existingMsg = node.getHistoryReference().getHttpMessage();
-                // check if a msg of the same type exist
-                if (existingMsg != null && !existingMsg.getResponseHeader().isEmpty()) {
-                    if (HttpStatusCode.isSuccess(existingMsg.getResponseHeader().getStatusCode())) {
-                        // exist, no modification necessary
-                        return true;
-                    }
-                }
-            }
-        } catch (URIException | DatabaseException | HttpMalformedHeaderException e) {
-            LOGGER.warn("Failed to check if message already exists:", e);
-        }
-
-        // if not, make sure a new copy will be obtained
-        if (msg.getRequestHeader().getHeader(HttpHeader.IF_MODIFIED_SINCE) != null) {
-            msg.getRequestHeader().setHeader(HttpHeader.IF_MODIFIED_SINCE, null);
-        }
-
-        if (msg.getRequestHeader().getHeader(HttpHeader.IF_NONE_MATCH) != null) {
-            msg.getRequestHeader().setHeader(HttpHeader.IF_NONE_MATCH, null);
-        }
         return true;
     }
 

--- a/zap/src/test/java/org/parosproxy/paros/extension/history/ProxyListenerLogUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/extension/history/ProxyListenerLogUnitTest.java
@@ -1,0 +1,68 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.extension.history;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.extension.ViewDelegate;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.utils.I18N;
+
+/** Unit test for {@link ProxyListenerLog}. */
+class ProxyListenerLogUnitTest {
+
+    private Model model;
+    private ViewDelegate view;
+    private ExtensionHistory extension;
+
+    private ProxyListenerLog listener;
+
+    @BeforeEach
+    void setUp() {
+        Constant.messages = mock(I18N.class);
+
+        model = mock(Model.class);
+        view = mock(ViewDelegate.class);
+        extension = mock(ExtensionHistory.class);
+
+        listener = new ProxyListenerLog(model, view, extension);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        Constant.messages = null;
+    }
+
+    @Test
+    void shouldNotModifyProxiedRequest() {
+        // Given
+        HttpMessage msg = mock(HttpMessage.class);
+        // When
+        listener.onHttpRequestSend(msg);
+        // Then
+        verifyNoInteractions(msg);
+    }
+}


### PR DESCRIPTION
Change the listener to no longer remove headers, if the client tool or user needs a fresh copy of the message they can do so themselves.

Fix #7353.

---
This behaviour was not documented, though it might affect the active scanner if the user scans 304 messages.