### PR TITLE
workflows: Adjust packaged scans python version matrix

### DIFF
--- a/.github/workflows/test-packaged-scans.yml
+++ b/.github/workflows/test-packaged-scans.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2023-08-23
+- Python 3.6 and 3.7 are no longer supported.
+
 ### 2023-08-09
 - Install the newer Python ZAP API client directly, `python-owasp-zap-v2.4` was renamed to `zaproxy`.
 


### PR DESCRIPTION
Spurred by
https://github.blog/changelog/2023-08-17-deprecation-dependabot-updates-drop-support-for-python-3-6-and-3-7/