### PR TITLE
Set the view to `ExtensionAdaptor` sooner

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/ExtensionAdaptor.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/ExtensionAdaptor.java
@@ -48,6 +48,7 @@
 // ZAP: 2019/09/12 Remove getURL().
 // ZAP: 2019/09/30 Add hasView().
 // ZAP: 2020/03/09 Handle extensions without package.
+// ZAP: 2023/08/25 Add setter for the view and remove from initView.
 package org.parosproxy.paros.extension;
 
 import java.util.Collections;
@@ -141,10 +142,16 @@ public abstract class ExtensionAdaptor implements Extension {
         this.model = model;
     }
 
-    @Override
-    public void initView(ViewDelegate view) {
+    void setView(ViewDelegate view) {
         this.view = view;
     }
+
+    /**
+     * Since 2.14.0 the default implementation does nothing (the view is set directly to the
+     * extension).
+     */
+    @Override
+    public void initView(ViewDelegate view) {}
 
     @Override
     public void initXML(Session session, OptionsParam options) {}

--- a/zap/src/main/java/org/parosproxy/paros/extension/ExtensionLoader.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/ExtensionLoader.java
@@ -100,6 +100,7 @@
 // ZAP: 2022/11/23 Refresh tabs menu when tabs are removed.
 // ZAP: 2023/01/10 Tidy up logger.
 // ZAP: 2023/04/28 Deprecate Proxy and ProxyServer related methods.
+// ZAP: 2023/08/25 Set view to ExtensionAdaptor.
 package org.parosproxy.paros.extension;
 
 import java.awt.Component;
@@ -814,6 +815,8 @@ public class ExtensionLoader {
      */
     public void startLifeCycle(Extension ext)
             throws DatabaseException, DatabaseUnsupportedException {
+        setExtensionAdaptorView(ext);
+
         ext.init();
         ext.databaseOpen(model.getDb());
         ext.initModel(model);
@@ -874,6 +877,12 @@ public class ExtensionLoader {
 
         if (hasView()) {
             hookSiteMapListeners(view.getSiteTreePanel(), extHook.getSiteMapListenerList());
+        }
+    }
+
+    private void setExtensionAdaptorView(Extension extension) {
+        if (hasView() && extension instanceof ExtensionAdaptor) {
+            ((ExtensionAdaptor) extension).setView(view);
         }
     }
 
@@ -1429,6 +1438,8 @@ public class ExtensionLoader {
         for (int i = 0; i < getExtensionCount(); i++) {
             Extension extension = getExtension(i);
             try {
+                setExtensionAdaptorView(extension);
+
                 extension.init();
                 extension.databaseOpen(Model.getSingleton().getDb());
                 if (hasView()) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/help/ExtensionHelp.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/help/ExtensionHelp.java
@@ -146,8 +146,6 @@ public class ExtensionHelp extends ExtensionAdaptor {
 
     @Override
     public void initView(ViewDelegate view) {
-        super.initView(view);
-
         SwingHelpUtilities.setContentViewerUI(BasicOnlineContentViewerUI.class.getCanonicalName());
         UIManager.getDefaults()
                 .put(

--- a/zap/src/main/java/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/uiutils/ExtensionUiUtils.java
@@ -59,8 +59,6 @@ public class ExtensionUiUtils extends ExtensionAdaptor implements SessionChanged
 
     @Override
     public void initView(ViewDelegate view) {
-        super.initView(view);
-
         Arrays.asList(
                         new LookAndFeelInfo("Flat Light", "com.formdev.flatlaf.FlatLightLaf"),
                         new LookAndFeelInfo("Flat Dark", "com.formdev.flatlaf.FlatDarkLaf"),
@@ -73,7 +71,7 @@ public class ExtensionUiUtils extends ExtensionAdaptor implements SessionChanged
     public void hook(ExtensionHook extensionHook) {
         super.hook(extensionHook);
 
-        if (getView() != null) {
+        if (hasView()) {
             extensionHook.addSessionListener(this);
         }
     }

--- a/zap/src/test/java/org/parosproxy/paros/extension/ExtensionLoaderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/extension/ExtensionLoaderUnitTest.java
@@ -52,6 +52,30 @@ class ExtensionLoaderUnitTest {
     }
 
     @Test
+    void shouldNotSetViewToExtensionAdaptorWhenStartLifeCycleWithoutView() throws Exception {
+        // Given
+        ExtensionAdaptor extension = mock(ExtensionAdaptor.class);
+        extensionLoader.addExtension(extension);
+        // When
+        extensionLoader.startLifeCycle();
+        // Then
+        verify(extension, times(0)).setView(any());
+    }
+
+    @Test
+    void shouldSetViewToExtensionAdaptorWhenStartLifeCycleWithView() throws Exception {
+        // Given
+        View view = mock(View.class);
+        extensionLoader = new ExtensionLoader(model, view);
+        ExtensionAdaptor extension = mock(ExtensionAdaptor.class);
+        extensionLoader.addExtension(extension);
+        // When
+        extensionLoader.startLifeCycle();
+        // Then
+        verify(extension).setView(view);
+    }
+
+    @Test
     void shouldNotInitViewWhenStartingExtensionWithoutView() throws Exception {
         // Given
         Extension extension = mock(Extension.class);
@@ -59,6 +83,18 @@ class ExtensionLoaderUnitTest {
         extensionLoader.startLifeCycle(extension);
         // Then
         verify(extension, times(0)).initView(any());
+    }
+
+    @Test
+    void shouldSetViewToExtensionAdaptorWhenStartingExtensionWithView() throws Exception {
+        // Given
+        View view = mock(View.class);
+        extensionLoader = new ExtensionLoader(model, view);
+        ExtensionAdaptor extension = mock(ExtensionAdaptor.class);
+        // When
+        extensionLoader.startLifeCycle(extension);
+        // Then
+        verify(extension).setView(view);
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/extension/uiutils/ExtensionUiUtilsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/uiutils/ExtensionUiUtilsUnitTest.java
@@ -20,10 +20,8 @@
 package org.zaproxy.zap.extension.uiutils;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,15 +43,5 @@ class ExtensionUiUtilsUnitTest {
         ViewDelegate view = extension.getView();
         // When
         assertThat(view, is(nullValue()));
-    }
-
-    @Test
-    void shouldHaveViewAfterInitView() {
-        // Given
-        ViewDelegate view = mock(ViewDelegate.class);
-        // When
-        extension.initView(view);
-        // When
-        assertThat(extension.getView(), is(equalTo(view)));
     }
 }


### PR DESCRIPTION
Set the view before starting to initialize the extension to ensure the `hasView()` checks work throughout the extension initialization.
Remove now redundant calls to base implementation of `initView` and replace a null check with `hasView()` call.

Related to zaproxy/zap-extensions#4840.