### PR TITLE
Deprecate `ValueGenerator`

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/spider/ExtensionSpider.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/spider/ExtensionSpider.java
@@ -43,12 +43,10 @@ import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteNode;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
 import org.zaproxy.zap.model.Context;
-import org.zaproxy.zap.model.DefaultValueGenerator;
 import org.zaproxy.zap.model.ScanController;
 import org.zaproxy.zap.model.StructuralNode;
 import org.zaproxy.zap.model.StructuralSiteNode;
 import org.zaproxy.zap.model.Target;
-import org.zaproxy.zap.model.ValueGenerator;
 import org.zaproxy.zap.users.User;
 import org.zaproxy.zap.view.ZapMenuItem;
 
@@ -58,10 +56,12 @@ import org.zaproxy.zap.view.ZapMenuItem;
  * @deprecated (2.12.0) See the spider add-on in zap-extensions instead.
  */
 @Deprecated
+@SuppressWarnings("removal")
 public class ExtensionSpider extends ExtensionAdaptor
         implements SessionChangedListener, ScanController<SpiderScan> {
 
-    private ValueGenerator generator = new DefaultValueGenerator();
+    private org.zaproxy.zap.model.ValueGenerator generator =
+            new org.zaproxy.zap.model.DefaultValueGenerator();
 
     public static final int EXTENSION_ORDER = 30;
 
@@ -121,14 +121,14 @@ public class ExtensionSpider extends ExtensionAdaptor
         this.scanController = new SpiderScanController(this);
     }
 
-    public void setValueGenerator(ValueGenerator generator) {
+    public void setValueGenerator(org.zaproxy.zap.model.ValueGenerator generator) {
         if (generator == null) {
             throw new IllegalArgumentException("Parameter generator must not be null.");
         }
         this.generator = generator;
     }
 
-    public ValueGenerator getValueGenerator() {
+    public org.zaproxy.zap.model.ValueGenerator getValueGenerator() {
         return generator;
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/model/DefaultValueGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/DefaultValueGenerator.java
@@ -30,7 +30,10 @@ import org.apache.commons.httpclient.URI;
  * Default implementation of the ValueGenerator
  *
  * @since 2.6.0
+ * @deprecated (2.16.0) Use the classes from the Common Library add-on.
  */
+@SuppressWarnings("removal")
+@Deprecated(since = "2.16.0", forRemoval = true)
 public class DefaultValueGenerator implements ValueGenerator {
 
     private static final String ATTR_TYPE = "type";

--- a/zap/src/main/java/org/zaproxy/zap/model/ValueGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/ValueGenerator.java
@@ -23,6 +23,10 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.httpclient.URI;
 
+/**
+ * @deprecated (2.16.0) Use the classes from the Common Library add-on.
+ */
+@Deprecated(since = "2.16.0", forRemoval = true)
 public interface ValueGenerator {
 
     /**

--- a/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderHtmlFormParser.java
+++ b/zap/src/main/java/org/zaproxy/zap/spider/parser/SpiderHtmlFormParser.java
@@ -43,8 +43,6 @@ import net.htmlparser.jericho.Source;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.lang3.StringUtils;
 import org.parosproxy.paros.network.HttpMessage;
-import org.zaproxy.zap.model.DefaultValueGenerator;
-import org.zaproxy.zap.model.ValueGenerator;
 
 /**
  * The Class SpiderHtmlFormParser is used for parsing HTML files for processing forms.
@@ -52,6 +50,7 @@ import org.zaproxy.zap.model.ValueGenerator;
  * @deprecated (2.12.0) See the spider add-on in zap-extensions instead.
  */
 @Deprecated
+@SuppressWarnings("removal")
 public class SpiderHtmlFormParser extends SpiderParser {
 
     private static final String ENCODING_TYPE = "UTF-8";
@@ -65,7 +64,7 @@ public class SpiderHtmlFormParser extends SpiderParser {
     private Map<String, String> envAttributes = new HashMap<>();
 
     /** Create new Value Generator field */
-    private final ValueGenerator valueGenerator;
+    private final org.zaproxy.zap.model.ValueGenerator valueGenerator;
 
     /**
      * Instantiates a new spider html form parser.
@@ -74,7 +73,7 @@ public class SpiderHtmlFormParser extends SpiderParser {
      * @throws IllegalArgumentException if {@code param} is null.
      */
     public SpiderHtmlFormParser(org.zaproxy.zap.spider.SpiderParam param) {
-        this(param, new DefaultValueGenerator());
+        this(param, new org.zaproxy.zap.model.DefaultValueGenerator());
     }
 
     /**
@@ -86,7 +85,8 @@ public class SpiderHtmlFormParser extends SpiderParser {
      * @throws NullPointerException if {@code param} is null.
      */
     public SpiderHtmlFormParser(
-            org.zaproxy.zap.spider.SpiderParam param, ValueGenerator valueGenerator) {
+            org.zaproxy.zap.spider.SpiderParam param,
+            org.zaproxy.zap.model.ValueGenerator valueGenerator) {
         super(param);
         if (valueGenerator == null) {
             throw new IllegalArgumentException("Parameter valueGenerator must not be null.");

--- a/zap/src/test/java/org/zaproxy/zap/spider/SpiderControllerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/SpiderControllerUnitTest.java
@@ -42,10 +42,9 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpHeaderField;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.zap.WithConfigsTest;
-import org.zaproxy.zap.model.ValueGenerator;
 
 /** Unit test for {@link SpiderController}. */
-@SuppressWarnings("deprecation")
+@SuppressWarnings({"deprecation", "removal"})
 class SpiderControllerUnitTest extends WithConfigsTest {
 
     private org.zaproxy.zap.spider.Spider spider;
@@ -74,7 +73,8 @@ class SpiderControllerUnitTest extends WithConfigsTest {
 
         org.zaproxy.zap.extension.spider.ExtensionSpider extensionSpider =
                 mock(org.zaproxy.zap.extension.spider.ExtensionSpider.class);
-        given(extensionSpider.getValueGenerator()).willReturn(mock(ValueGenerator.class));
+        given(extensionSpider.getValueGenerator())
+                .willReturn(mock(org.zaproxy.zap.model.ValueGenerator.class));
         given(spider.getExtensionSpider()).willReturn(extensionSpider);
 
         spiderController =

--- a/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlFormParserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/spider/parser/SpiderHtmlFormParserUnitTest.java
@@ -39,12 +39,10 @@ import net.htmlparser.jericho.Source;
 import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
-import org.zaproxy.zap.model.DefaultValueGenerator;
-import org.zaproxy.zap.model.ValueGenerator;
 import org.zaproxy.zap.utils.Pair;
 
 /** Unit test for {@link SpiderHtmlFormParser}. */
-@SuppressWarnings("deprecation")
+@SuppressWarnings({"deprecation", "removal"})
 class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
 
     private static final String FORM_METHOD_TOKEN = "%%METHOD%%";
@@ -66,7 +64,8 @@ class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
                 NullPointerException.class,
                 () ->
                         new org.zaproxy.zap.spider.parser.SpiderHtmlFormParser(
-                                undefinedSpiderOptions, new DefaultValueGenerator()));
+                                undefinedSpiderOptions,
+                                new org.zaproxy.zap.model.DefaultValueGenerator()));
     }
 
     @Test
@@ -164,7 +163,7 @@ class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
         spiderOptions.setProcessForm(false);
         org.zaproxy.zap.spider.parser.SpiderHtmlFormParser htmlParser =
                 new org.zaproxy.zap.spider.parser.SpiderHtmlFormParser(
-                        spiderOptions, new DefaultValueGenerator());
+                        spiderOptions, new org.zaproxy.zap.model.DefaultValueGenerator());
         TestSpiderParserListener listener = createTestSpiderParserListener();
         htmlParser.addSpiderParserListener(listener);
         HttpMessage messageHtmlResponse = createMessageWith("PostGetForms.html");
@@ -407,7 +406,7 @@ class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
         spiderOptions.setPostForm(false);
         org.zaproxy.zap.spider.parser.SpiderHtmlFormParser htmlParser =
                 new org.zaproxy.zap.spider.parser.SpiderHtmlFormParser(
-                        spiderOptions, new DefaultValueGenerator());
+                        spiderOptions, new org.zaproxy.zap.model.DefaultValueGenerator());
         TestSpiderParserListener listener = createTestSpiderParserListener();
         htmlParser.addSpiderParserListener(listener);
         HttpMessage messageHtmlResponse = createMessageWith("POST", "Form.html");
@@ -428,7 +427,7 @@ class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
         spiderOptions.setPostForm(false);
         org.zaproxy.zap.spider.parser.SpiderHtmlFormParser htmlParser =
                 new org.zaproxy.zap.spider.parser.SpiderHtmlFormParser(
-                        spiderOptions, new DefaultValueGenerator());
+                        spiderOptions, new org.zaproxy.zap.model.DefaultValueGenerator());
         TestSpiderParserListener listener = createTestSpiderParserListener();
         htmlParser.addSpiderParserListener(listener);
         HttpMessage messageHtmlResponse = createMessageWith("GET", "Form.html");
@@ -492,7 +491,7 @@ class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
         spiderOptions.setPostForm(false);
         org.zaproxy.zap.spider.parser.SpiderHtmlFormParser htmlParser =
                 new org.zaproxy.zap.spider.parser.SpiderHtmlFormParser(
-                        spiderOptions, new DefaultValueGenerator());
+                        spiderOptions, new org.zaproxy.zap.model.DefaultValueGenerator());
         TestSpiderParserListener listener = createTestSpiderParserListener();
         htmlParser.addSpiderParserListener(listener);
         HttpMessage messageHtmlResponse = createMessageWith("NoMethodForm.html");
@@ -850,7 +849,7 @@ class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
         spiderOptions.setPostForm(false);
         org.zaproxy.zap.spider.parser.SpiderHtmlFormParser htmlParser =
                 new org.zaproxy.zap.spider.parser.SpiderHtmlFormParser(
-                        spiderOptions, new DefaultValueGenerator());
+                        spiderOptions, new org.zaproxy.zap.model.DefaultValueGenerator());
         TestSpiderParserListener listener = createTestSpiderParserListener();
         htmlParser.addSpiderParserListener(listener);
         HttpMessage msg = createMessageWith("GET", "OverriddenMethodByButtonForms.html");
@@ -879,7 +878,7 @@ class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
         // Disable POST handling, we need just to retrieve the forms with GET methods
         org.zaproxy.zap.spider.parser.SpiderHtmlFormParser htmlParser =
                 new org.zaproxy.zap.spider.parser.SpiderHtmlFormParser(
-                        spiderOptions, new DefaultValueGenerator());
+                        spiderOptions, new org.zaproxy.zap.model.DefaultValueGenerator());
         TestSpiderParserListener listener = createTestSpiderParserListener();
         htmlParser.addSpiderParserListener(listener);
         HttpMessage msg = createMessageWith("GET", "OverriddenMethodByButtonForms.html");
@@ -1205,7 +1204,8 @@ class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
     @Test
     void shouldSetValuesToFieldsWithNoValueWhenParsingGetForm() {
         // Given
-        DefaultValueGenerator valueGenerator = new DefaultValueGenerator();
+        org.zaproxy.zap.model.DefaultValueGenerator valueGenerator =
+                new org.zaproxy.zap.model.DefaultValueGenerator();
         org.zaproxy.zap.spider.parser.SpiderHtmlFormParser htmlParser =
                 createSpiderHtmlFormParser(valueGenerator);
         TestSpiderParserListener listener = createTestSpiderParserListener();
@@ -1247,7 +1247,8 @@ class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
     @Test
     void shouldSetValuesToFieldsWithNoValueWhenParsingPostForm() {
         // Given
-        DefaultValueGenerator valueGenerator = new DefaultValueGenerator();
+        org.zaproxy.zap.model.DefaultValueGenerator valueGenerator =
+                new org.zaproxy.zap.model.DefaultValueGenerator();
         org.zaproxy.zap.spider.parser.SpiderHtmlFormParser htmlParser =
                 createSpiderHtmlFormParser(valueGenerator);
         TestSpiderParserListener listener = createTestSpiderParserListener();
@@ -1577,11 +1578,11 @@ class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
     }
 
     private static org.zaproxy.zap.spider.parser.SpiderHtmlFormParser createSpiderHtmlFormParser() {
-        return createSpiderHtmlFormParser(new DefaultValueGenerator());
+        return createSpiderHtmlFormParser(new org.zaproxy.zap.model.DefaultValueGenerator());
     }
 
     private static org.zaproxy.zap.spider.parser.SpiderHtmlFormParser createSpiderHtmlFormParser(
-            ValueGenerator valueGenerator) {
+            org.zaproxy.zap.model.ValueGenerator valueGenerator) {
         org.zaproxy.zap.spider.SpiderParam spiderOptions = createSpiderParamWithConfig();
         spiderOptions.setProcessForm(true);
         spiderOptions.setPostForm(true);
@@ -1633,7 +1634,7 @@ class SpiderHtmlFormParserUnitTest extends SpiderParserTestUtils {
         return message;
     }
 
-    private static class TestValueGenerator implements ValueGenerator {
+    private static class TestValueGenerator implements org.zaproxy.zap.model.ValueGenerator {
 
         private final List<FormField> fields;
 


### PR DESCRIPTION
Deprecate the `ValueGenerator` and related code for removal.
Suppress deprecation/removal warnings (all in deprecated code).

Part of #8016.

---
WIP pending addition of the new interface to `commonlib`.