### PR TITLE
Correct overridden method in `AddOnLoader`

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/control/AddOnLoader.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/AddOnLoader.java
@@ -366,11 +366,15 @@ public class AddOnLoader extends URLClassLoader {
         addOnLoaders.put(ao.getId(), addOnClassLoader);
     }
 
+    Class<?> loadClassNoAddOns(String name, boolean resolve) throws ClassNotFoundException {
+        return super.loadClass(name, resolve);
+    }
+
     @Override
-    public Class<?> loadClass(String name) throws ClassNotFoundException {
+    public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
         synchronized (getClassLoadingLock(name)) {
             try {
-                return loadClass(name, false);
+                return super.loadClass(name, resolve);
             } catch (ClassNotFoundException e) {
                 // Continue for now
             }


### PR DESCRIPTION
Override `loadClass(String, boolean)` instead of `loadClass(String)` which can be called directly by other class loaders. Adjust `AddOnClassLoader` to call the main parent class loader without going through the add-ons as it should be accessing only core classes and dependencies.

Fix #7960.