### PR TITLE
Allow to disable modification of multiple options

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/view/AbstractMultipleOptionsTablePanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/AbstractMultipleOptionsTablePanel.java
@@ -40,7 +40,20 @@ public abstract class AbstractMultipleOptionsTablePanel<E extends EnableableInte
     private JButton disableAllButton;
 
     public AbstractMultipleOptionsTablePanel(AbstractMultipleOptionsTableModel<E> model) {
-        super(model);
+        this(model, true);
+    }
+
+    /**
+     * Constructs an {@code AbstractMultipleOptionsTablePanel} with the given model and whether
+     * modifications are allowed.
+     *
+     * @param model the model.
+     * @param allowModification {@code true} if modifications are allowed, {@code false} otherwise.
+     * @since 2.14.0
+     */
+    protected AbstractMultipleOptionsTablePanel(
+            AbstractMultipleOptionsTableModel<E> model, boolean allowModification) {
+        super(model, allowModification);
 
         final boolean buttonsEnabled = getModel().getRowCount() > 0;
 


### PR DESCRIPTION
Add constructor to specify whether modifications are allowed or not.

Related to zaproxy/zap-extensions#3331.