### PR TITLE
Use the current database body size values

### DIFF
--- a/zap/gradle/japicmp.yaml
+++ b/zap/gradle/japicmp.yaml
@@ -6,6 +6,8 @@ packageExcludes: []
 fieldExcludes: []
 classExcludes: []
 methodExcludes:
+  - org.parosproxy.paros.db.Database#setDatabaseOptions(org.parosproxy.paros.extension.option.DatabaseParam)
+  - org.parosproxy.paros.db.TableHistory#setDatabaseOptions(org.parosproxy.paros.extension.option.DatabaseParam)
   - org.zaproxy.zap.extension.script.ScriptUI#displayScript(org.zaproxy.zap.extension.script.ScriptWrapper, boolean)
   - org.zaproxy.zap.extension.script.ScriptUI#selectNode(org.zaproxy.zap.extension.script.ScriptNode, boolean, boolean)
 

--- a/zap/src/main/java/org/parosproxy/paros/db/Database.java
+++ b/zap/src/main/java/org/parosproxy/paros/db/Database.java
@@ -19,6 +19,7 @@
  */
 package org.parosproxy.paros.db;
 
+import org.parosproxy.paros.extension.option.DatabaseParam;
 import org.zaproxy.zap.db.TableAlertTag;
 
 /**
@@ -31,6 +32,15 @@ public interface Database {
 
     /** The default HyperSQL Db: http://hsqldb.org/ */
     public static final String DB_TYPE_HSQLDB = "hsqldb";
+
+    /**
+     * Sets the database options.
+     *
+     * @param options the database options, must not be {@code null}.
+     * @throws NullPointerException if the {@code options} is {@code null}.
+     * @since 2.14.0
+     */
+    default void setDatabaseOptions(DatabaseParam options) {}
 
     DatabaseServer getDatabaseServer();
 

--- a/zap/src/main/java/org/parosproxy/paros/db/TableHistory.java
+++ b/zap/src/main/java/org/parosproxy/paros/db/TableHistory.java
@@ -26,11 +26,21 @@ package org.parosproxy.paros.db;
  * @author psiinon
  */
 import java.util.List;
+import org.parosproxy.paros.extension.option.DatabaseParam;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
 public interface TableHistory extends DatabaseListener {
+
+    /**
+     * Sets the database options.
+     *
+     * @param options the database options, must not be {@code null}.
+     * @throws NullPointerException if the {@code options} is {@code null}.
+     * @since 2.14.0
+     */
+    default void setDatabaseOptions(DatabaseParam options) {}
 
     RecordHistory read(int historyId) throws HttpMalformedHeaderException, DatabaseException;
 

--- a/zap/src/main/java/org/parosproxy/paros/db/paros/ParosDatabase.java
+++ b/zap/src/main/java/org/parosproxy/paros/db/paros/ParosDatabase.java
@@ -44,12 +44,14 @@
 // ZAP: 2021/08/24 Remove the "(non-Javadoc)" comments.
 // ZAP: 2021/09/27 Added support for Alert Tags.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
+// ZAP: 2023/09/12 Implement setDatabaseOptions(DatabaseParam).
 package org.parosproxy.paros.db.paros;
 
 import java.io.File;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.parosproxy.paros.db.AbstractDatabase;
 import org.parosproxy.paros.db.Database;
 import org.parosproxy.paros.db.DatabaseException;
@@ -293,12 +295,20 @@ public class ParosDatabase extends AbstractDatabase {
      * @param databaseOptions the object that holds the database options, must not be {@code null}
      * @throws IllegalArgumentException if the given parameter is {@code null}.
      * @since 2.5.0
+     * @deprecated (2.14.0) Use {@link #setDatabaseOptions(DatabaseParam)} instead.
      */
+    @Deprecated(since = "2.14.0", forRemoval = true)
     public void setDatabaseParam(DatabaseParam databaseOptions) {
         if (databaseOptions == null) {
             throw new IllegalArgumentException("Parameter databaseOptions must not be null.");
         }
-        this.databaseOptions = databaseOptions;
+        setDatabaseOptions(databaseOptions);
+    }
+
+    @Override
+    public void setDatabaseOptions(DatabaseParam options) {
+        this.databaseOptions = Objects.requireNonNull(options);
+        tableHistory.setDatabaseOptions(databaseOptions);
     }
 
     @Override

--- a/zap/src/main/java/org/parosproxy/paros/extension/option/DatabaseParam.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/option/DatabaseParam.java
@@ -40,6 +40,13 @@ public class DatabaseParam extends AbstractParam {
     public static final int NEW_SESSION_USER_SPECIFIED = 2;
     public static final int NEW_SESSION_TEMPORARY = 3;
 
+    /**
+     * The default size of request/response bodies.
+     *
+     * @since 2.14.0
+     */
+    public static final int DEFAULT_BODY_SIZE = 16777216;
+
     /** The base configuration key for all database configurations. */
     private static final String PARAM_BASE_KEY = "database";
 
@@ -62,7 +69,6 @@ public class DatabaseParam extends AbstractParam {
     private static final String PARAM_RECOVERY_LOG_ENABLED = PARAM_BASE_KEY + ".recoverylog";
 
     private static final boolean DEFAULT_COMPACT_DATABASE = false;
-    private static final int DEFAULT_BODY_SIZE = 16777216;
     private static final int DEFAULT_NEW_SESSION_OPTION = NEW_SESSION_NOT_SPECIFIED;
     private static final boolean DEFAULT_NEW_SESSION_PROMPT = true;
     private static final boolean DEFAULT_RECOVERY_LOG_ENABLED = true;

--- a/zap/src/main/java/org/parosproxy/paros/model/Model.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/Model.java
@@ -206,10 +206,9 @@ public class Model {
             LOGGER.info("Using experimental database :/");
             db = DbSQL.getSingleton().initDatabase();
         } else {
-            ParosDatabase parosDb = new ParosDatabase();
-            parosDb.setDatabaseParam(getOptionsParam().getDatabaseParam());
-            db = parosDb;
+            db = new ParosDatabase();
         }
+        db.setDatabaseOptions(getOptionsParam().getDatabaseParam());
 
         createAndOpenUntitledDb();
 

--- a/zap/src/main/java/org/zaproxy/zap/db/sql/DbSQL.java
+++ b/zap/src/main/java/org/zaproxy/zap/db/sql/DbSQL.java
@@ -67,6 +67,18 @@ public class DbSQL implements DatabaseListener {
         return singleton;
     }
 
+    static void reset() {
+        dbProperties = null;
+        sqlProperties = null;
+        dbType = null;
+        singleton = null;
+        dbServer = null;
+    }
+
+    static void setSqlProperties(Properties properties) {
+        sqlProperties = properties;
+    }
+
     protected String getDbUser() {
         if (dbProperties == null) {
             throw new IllegalStateException("Database not initialised");

--- a/zap/src/main/java/org/zaproxy/zap/db/sql/SqlDatabase.java
+++ b/zap/src/main/java/org/zaproxy/zap/db/sql/SqlDatabase.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.db.sql;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.parosproxy.paros.db.AbstractDatabase;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.db.DatabaseListener;
@@ -34,6 +35,7 @@ import org.parosproxy.paros.db.TableSession;
 import org.parosproxy.paros.db.TableSessionUrl;
 import org.parosproxy.paros.db.TableStructure;
 import org.parosproxy.paros.db.TableTag;
+import org.parosproxy.paros.extension.option.DatabaseParam;
 import org.zaproxy.zap.db.TableAlertTag;
 
 public class SqlDatabase extends AbstractDatabase {
@@ -82,6 +84,12 @@ public class SqlDatabase extends AbstractDatabase {
         internalDatabaseListeners.add(tableParam);
         internalDatabaseListeners.add(tableContext);
         internalDatabaseListeners.add(tableStructure);
+    }
+
+    @Override
+    public void setDatabaseOptions(DatabaseParam options) {
+        Objects.requireNonNull(options);
+        tableHistory.setDatabaseOptions(options);
     }
 
     /**

--- a/zap/src/main/java/org/zaproxy/zap/extension/compare/ExtensionCompare.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/compare/ExtensionCompare.java
@@ -231,7 +231,7 @@ public class ExtensionCompare extends ExtensionAdaptor
 
                 // TODO support other implementations in the future
                 ParosDatabase db = new ParosDatabase();
-                db.setDatabaseParam(new DatabaseParam());
+                db.setDatabaseOptions(new DatabaseParam());
                 db.open(file.getAbsolutePath());
 
                 Map<String, String> curMap = new HashMap<>();

--- a/zap/src/test/java/org/parosproxy/paros/db/paros/ParosDatabaseUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/db/paros/ParosDatabaseUnitTest.java
@@ -1,0 +1,54 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.db.paros;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.extension.option.DatabaseParam;
+
+/** Unit test for {@link ParosDatabase}. */
+class ParosDatabaseUnitTest {
+
+    private ParosDatabase database;
+
+    @BeforeEach
+    void setUp() {
+        database = new ParosDatabase();
+    }
+
+    @Test
+    void shouldSetDatabaseOptions() {
+        // Given
+        DatabaseParam options = new DatabaseParam();
+        // When / Then
+        assertDoesNotThrow(() -> database.setDatabaseOptions(options));
+    }
+
+    @Test
+    void shouldThrowWhenSettingNullDatabaseOptions() {
+        // Given
+        DatabaseParam options = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> database.setDatabaseOptions(options));
+    }
+}

--- a/zap/src/test/java/org/parosproxy/paros/db/paros/ParosTableHistoryUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/db/paros/ParosTableHistoryUnitTest.java
@@ -1,0 +1,70 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.db.paros;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.sql.Connection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.extension.option.DatabaseParam;
+
+/** Unit test for {@link ParosTableHistory}. */
+class ParosTableHistoryUnitTest {
+
+    private ParosTableHistory table;
+
+    @BeforeEach
+    void setUp() {
+        table = new ParosTableHistory();
+    }
+
+    @Test
+    void shouldSetDatabaseOptions() {
+        // Given
+        DatabaseParam options = new DatabaseParam();
+        // When / Then
+        assertDoesNotThrow(() -> table.setDatabaseOptions(options));
+    }
+
+    @Test
+    void shouldThrowWhenSettingNullDatabaseOptions() {
+        // Given
+        DatabaseParam options = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> table.setDatabaseOptions(options));
+    }
+
+    @Test
+    void shouldReadDatabaseOptionsOnReconnect() {
+        // Given
+        DatabaseParam options = mock(DatabaseParam.class);
+        table.setDatabaseOptions(options);
+        Connection conn = mock(Connection.class);
+        // When
+        assertThrows(NullPointerException.class, () -> table.reconnect(conn));
+        // Then
+        verify(options).getRequestBodySize();
+        verify(options).getResponseBodySize();
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/db/sql/SqlDatabaseUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/db/sql/SqlDatabaseUnitTest.java
@@ -1,0 +1,63 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.db.sql;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Properties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.extension.option.DatabaseParam;
+
+/** Unit test for {@link SqlDatabase}. */
+class SqlDatabaseUnitTest {
+
+    private SqlDatabase database;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        DbSQL.setSqlProperties(new Properties());
+
+        database = new SqlDatabase();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        DbSQL.reset();
+    }
+
+    @Test
+    void shouldSetDatabaseOptions() {
+        // Given
+        DatabaseParam options = new DatabaseParam();
+        // When / Then
+        assertDoesNotThrow(() -> database.setDatabaseOptions(options));
+    }
+
+    @Test
+    void shouldThrowWhenSettingNullDatabaseOptions() {
+        // Given
+        DatabaseParam options = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> database.setDatabaseOptions(options));
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/db/sql/SqlTableHistoryUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/db/sql/SqlTableHistoryUnitTest.java
@@ -1,0 +1,79 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.db.sql;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.sql.Connection;
+import java.util.Properties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.extension.option.DatabaseParam;
+
+/** Unit test for {@link SqlTableHistory}. */
+class SqlTableHistoryUnitTest {
+
+    private SqlTableHistory table;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        DbSQL.setSqlProperties(new Properties());
+
+        table = new SqlTableHistory();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        DbSQL.reset();
+    }
+
+    @Test
+    void shouldSetDatabaseOptions() {
+        // Given
+        DatabaseParam options = new DatabaseParam();
+        // When / Then
+        assertDoesNotThrow(() -> table.setDatabaseOptions(options));
+    }
+
+    @Test
+    void shouldThrowWhenSettingNullDatabaseOptions() {
+        // Given
+        DatabaseParam options = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> table.setDatabaseOptions(options));
+    }
+
+    @Test
+    void shouldReadDatabaseOptionsOnReconnect() {
+        // Given
+        DatabaseParam options = mock(DatabaseParam.class);
+        table.setDatabaseOptions(options);
+        Connection conn = mock(Connection.class);
+        // When
+        assertThrows(NullPointerException.class, () -> table.reconnect(conn));
+        // Then
+        verify(options).getRequestBodySize();
+        verify(options).getResponseBodySize();
+    }
+}


### PR DESCRIPTION
Use the current options rather than reading the configuration file directly, which would miss changes done during runtime.

---
From ZAP User Group: https://groups.google.com/g/zaproxy-users/c/syQEhnY03k0/m/kEyvaSsEAgAJ