### PR TITLE
fix: Context API including a parent Tech should include children

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ContextAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ContextAPI.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import net.sf.json.JSONArray;
@@ -314,9 +315,7 @@ public class ContextAPI extends ApiImplementor {
                 context = getContext(params);
                 techSet = context.getTechSet();
                 techNames = getParam(params, PARAM_TECH_NAMES, "").split(",");
-                for (String techName : techNames) {
-                    techSet.include(getTech(techName));
-                }
+                handleTechs(techNames, techSet::includeAll);
                 context.save();
                 break;
             case ACTION_INCLUDE_ALL_TECHS:
@@ -329,9 +328,7 @@ public class ContextAPI extends ApiImplementor {
                 context = getContext(params);
                 techSet = context.getTechSet();
                 techNames = getParam(params, PARAM_TECH_NAMES, "").split(",");
-                for (String techName : techNames) {
-                    techSet.exclude(getTech(techName));
-                }
+                handleTechs(techNames, techSet::excludeAll);
                 context.save();
                 break;
             case ACTION_EXCLUDE_ALL_TECHS:
@@ -347,6 +344,13 @@ public class ContextAPI extends ApiImplementor {
         }
 
         return ApiResponseElement.OK;
+    }
+
+    private void handleTechs(String[] techNames, Consumer<Tech> handler) throws ApiException {
+        for (String techName : techNames) {
+            Tech tech = getTech(techName);
+            handler.accept(tech);
+        }
     }
 
     private void addExcludeToContext(Context context, String regex) {

--- a/zap/src/main/java/org/zaproxy/zap/model/TechSet.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/TechSet.java
@@ -66,9 +66,33 @@ public class TechSet {
         includeTech.add(tech);
     }
 
+    /**
+     * Includes the {@link Tech} and its children (if any) to the {@code TechSet}.
+     *
+     * @param tech the {@code Tech} from which the parent/child set should be established
+     * @since 2.15.0
+     */
+    public void includeAll(Tech tech) {
+        Set<Tech> techs = getAll(tech);
+        includeTech.addAll(techs);
+        excludeTech.removeAll(techs);
+    }
+
     public void exclude(Tech tech) {
         includeTech.remove(tech);
         excludeTech.add(tech);
+    }
+
+    /**
+     * Excludes the {@link Tech} and its children (if any) from the {@code TechSet}.
+     *
+     * @param tech the {@code Tech} from which the parent/child set should be established
+     * @since 2.15.0
+     */
+    public void excludeAll(Tech tech) {
+        Set<Tech> techs = getAll(tech);
+        excludeTech.addAll(techs);
+        includeTech.removeAll(techs);
     }
 
     public boolean includes(Tech tech) {
@@ -154,5 +178,26 @@ public class TechSet {
         TechSet other = (TechSet) obj;
         return Objects.equals(excludeTech, other.excludeTech)
                 && Objects.equals(includeTech, other.includeTech);
+    }
+
+    /**
+     * Gets the {@link Tech} and its children (if any), returning a {@code Set} of individual {@code
+     * Tech}.
+     *
+     * @param aTech the {@code Tech} from which the parent/child set should be established
+     * @return the {@code Set} of {@code Tech} represented by this {@code Tech} and its children (if
+     *     any)
+     */
+    static Set<Tech> getAll(Tech aTech) {
+        Set<Tech> techs = new TreeSet<>();
+        for (Tech tech : Tech.getAll()) {
+            while (tech != null) {
+                if (tech.is(aTech)) {
+                    techs.add(tech);
+                }
+                tech = tech.getParent();
+            }
+        }
+        return techs;
     }
 }

--- a/zap/src/test/java/org/zaproxy/zap/model/TechSetUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/model/TechSetUnitTest.java
@@ -22,8 +22,16 @@ package org.zaproxy.zap.model;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /** Unit test for {@link TechSet}. */
 class TechSetUnitTest {
@@ -32,5 +40,40 @@ class TechSetUnitTest {
     void getAllTechShouldHaveTech() {
         assertThat(TechSet.getAllTech().getIncludeTech(), contains(Tech.getTopLevel().toArray()));
         assertThat(TechSet.getAllTech().getExcludeTech(), empty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("shouldReturnTestableTechs")
+    void shouldExcludeTechsFromTechSetBasedOnSubset(Tech tech) {
+        // Given
+        TechSet full = new TechSet();
+        Set<Tech> techsToExclude = TechSet.getAll(tech);
+        // When
+        full.excludeAll(tech);
+        // Then
+        Set<Tech> excludedSet = full.getExcludeTech();
+        int langSize = techsToExclude.size();
+        assertThat(excludedSet.size(), is(equalTo(langSize)));
+        assertTrue(excludedSet.containsAll(techsToExclude));
+    }
+
+    @ParameterizedTest
+    @MethodSource("shouldReturnTestableTechs")
+    void shouldIncludeTechsInTechSetBasedOnSubset(Tech tech) {
+        // Given
+        TechSet full = new TechSet();
+        Set<Tech> techsToInclude = TechSet.getAll(tech);
+        // When
+        full.includeAll(tech);
+        // Then
+        Set<Tech> includeSet = full.getIncludeTech();
+        int langSize = techsToInclude.size();
+        assertThat(includeSet.size(), is(equalTo(langSize)));
+        assertTrue(includeSet.containsAll(techsToInclude));
+    }
+
+    private static Stream<Arguments> shouldReturnTestableTechs() {
+        return Stream.of(
+                Arguments.of(Tech.Lang), Arguments.of(Tech.JAVA), Arguments.of(Tech.SPRING));
     }
 }

--- a/zap/src/test/java/org/zaproxy/zap/model/TechUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/model/TechUnitTest.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.model;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
@@ -36,8 +37,11 @@ class TechUnitTest {
 
     private static final String SUB_LEVEL = "SubLevel";
 
-    private static final Tech newTopLevelTech = new Tech(TOP_LEVEL);
+    private static final String A_TOP_LEVEL = "aTopLevel";
+    private static final String A_SECOND_LEVEL = "aSecondLevel";
+    private static final String A_THIRD_LEVEL = "aThirdLevel";
 
+    private static final Tech newTopLevelTech = new Tech(TOP_LEVEL);
     private static final Tech newTech = new Tech(Tech.Db, SUB_LEVEL);
 
     @Test
@@ -117,5 +121,43 @@ class TechUnitTest {
         // cleanup
         Tech.remove(newTopLevelTech);
         Tech.remove(newTech);
+    }
+
+    @Test
+    void isShouldMatchVariousLevels() {
+        // Given
+        setupThreeLevels();
+        Tech topLevel = Tech.get(A_TOP_LEVEL);
+        Tech secondLevel = Tech.get(String.join(".", A_TOP_LEVEL, A_SECOND_LEVEL));
+        Tech thirdLevel = Tech.get(String.join(".", A_TOP_LEVEL, A_SECOND_LEVEL, A_THIRD_LEVEL));
+        // When
+        boolean topIsTop = topLevel.is(topLevel);
+        boolean secondIsTop = secondLevel.is(topLevel);
+        boolean secondIsSecond = secondLevel.is(secondLevel);
+        boolean thirdIsTop = thirdLevel.is(topLevel);
+        boolean thirdIsSecond = thirdLevel.is(secondLevel);
+        boolean thirdIsThird = thirdLevel.is(thirdLevel);
+
+        boolean topIsNotOtherTop = topLevel.is(Tech.Db);
+        boolean thirdIsNotOtherTop = thirdLevel.is(Tech.Db);
+        // Then
+        assertThat(topIsTop, is(equalTo(true)));
+        assertThat(secondIsTop, is(equalTo(true)));
+        assertThat(secondIsSecond, is(equalTo(true)));
+        assertThat(thirdIsTop, is(equalTo(true)));
+        assertThat(thirdIsSecond, is(equalTo(true)));
+        assertThat(thirdIsThird, is(equalTo(true)));
+
+        assertThat(topIsNotOtherTop, is(equalTo(false)));
+        assertThat(thirdIsNotOtherTop, is(equalTo(false)));
+    }
+
+    private void setupThreeLevels() {
+        Tech newTopLevel = new Tech(A_TOP_LEVEL);
+        Tech newTech = new Tech(newTopLevel, A_SECOND_LEVEL);
+        Tech otherTech = new Tech(newTech, A_THIRD_LEVEL);
+        Tech.add(newTopLevel);
+        Tech.add(newTech);
+        Tech.add(otherTech);
     }
 }


### PR DESCRIPTION
- ContextAPI > Adjust code to process child technologies when including and excluding.
- TechSet > Add a method that gets the wanted Tech and its children as a Set of Techs. Add new includeAll/excludeAll methods that accept Tech (as parent).
- TechUnitTest > Added a test for the existing Tech.is(Tech) method.
- TechSetUnitTest > Added tests for the new methods.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>


Fixes zaproxy/zaproxy#6292