### PR TITLE
scripts: Persist enable state automatically

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -1856,6 +1856,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
         }
 
         script.setEnabled(enabled);
+        getScriptParam().saveScriptProperties(script);
         this.getTreeModel().nodeStructureChanged(script);
 
         notifyScriptChanged(script);

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptParam.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptParam.java
@@ -150,6 +150,19 @@ public class ScriptParam extends AbstractParam {
         return scripts;
     }
 
+    /**
+     * Saves the properties of the provided script to the configuration file. Currently, only the
+     * `enabled` property of the script is saved.
+     */
+    void saveScriptProperties(ScriptWrapper script) {
+        List<HierarchicalConfiguration> fields =
+                ((HierarchicalConfiguration) getConfig()).configurationsAt(ALL_SCRIPTS_KEY);
+        fields.stream()
+                .filter(config -> script.getName().equals(config.getString(SCRIPT_NAME_KEY)))
+                .findAny()
+                .ifPresent(config -> config.setProperty(SCRIPT_ENABLED_KEY, script.isEnabled()));
+    }
+
     public void addScriptDir(File dir) {
         this.scriptDirs.add(dir);
         saveScriptDirs();

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptWrapper.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptWrapper.java
@@ -242,11 +242,7 @@ public class ScriptWrapper {
         if (enabled && engine == null) {
             return;
         }
-
-        if (this.enabled != enabled) {
-            this.enabled = enabled;
-            this.changed = true;
-        }
+        this.enabled = enabled;
     }
 
     public String getLastErrorDetails() {

--- a/zap/src/test/java/org/zaproxy/zap/extension/script/ExtensionScriptUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/script/ExtensionScriptUnitTest.java
@@ -24,6 +24,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,6 +58,22 @@ class ExtensionScriptUnitTest {
         ScriptsCache<Script> scriptsCache = extensionScript.createScriptsCache(configuration);
         // Then
         assertThat(scriptsCache, is(not(nullValue())));
+    }
+
+    @Test
+    void shouldPersistScriptPropertiesWhenItIsEnabled() {
+        // Given
+        var extensionScript = spy(new ExtensionScript());
+        var scriptParam = mock(ScriptParam.class);
+        when(extensionScript.getScriptParam()).thenReturn(scriptParam);
+        var script = spy(new ScriptWrapper());
+        script.setType(new ScriptType("scriptType", "scriptType", null, true));
+        script.setEngine(mock(ScriptEngineWrapper.class));
+        // When
+        extensionScript.setEnabled(script, true);
+        // Then
+        verify(script).setEnabled(true);
+        verify(scriptParam).saveScriptProperties(script);
     }
 
     private interface Script {}

--- a/zap/src/test/java/org/zaproxy/zap/extension/script/ScriptParamUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/script/ScriptParamUnitTest.java
@@ -1,0 +1,81 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2023 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.script;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.junit.jupiter.api.Test;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link ScriptParam}. */
+class ScriptParamUnitTest {
+
+    @Test
+    void shouldSaveScriptProperties() throws Exception {
+        // Given
+        var script = new ScriptWrapper();
+        script.setEngine(mock(ScriptEngineWrapper.class));
+        script.setName("script.js");
+        ZapXmlConfiguration config = mock(ZapXmlConfiguration.class);
+        var scriptConfigs =
+                List.of(
+                        mock(HierarchicalConfiguration.class),
+                        mock(HierarchicalConfiguration.class));
+        when(config.configurationsAt("script.scripts")).thenReturn(scriptConfigs);
+        when(scriptConfigs.get(0).getString("name")).thenReturn(script.getName());
+        when(scriptConfigs.get(1).getString("name")).thenReturn("differentScript.js");
+        var param = new ScriptParam();
+        param.load(config);
+        // When
+        script.setEnabled(true);
+        param.saveScriptProperties(script);
+        // Then
+        verify(scriptConfigs.get(0)).setProperty("enabled", true);
+        verify(scriptConfigs.get(1), times(0)).setProperty(anyString(), any());
+    }
+
+    @Test
+    void shouldNotSaveScriptPropertiesIfScriptIsNotFound() {
+        // Given
+        var script = new ScriptWrapper();
+        script.setEngine(mock(ScriptEngineWrapper.class));
+        script.setName("differentScript.js");
+        var config = new ZapXmlConfiguration();
+        config.setProperty("script.scripts(0).name", "script.js");
+        config.setProperty("script.scripts(0).enabled", false);
+        var param = new ScriptParam();
+        param.load(config);
+        // When
+        script.setEnabled(true);
+        param.saveScriptProperties(script);
+        // Then
+        assertThat(config.configurationsAt("script.scripts").size(), is(1));
+        assertThat(config.getBoolean("script.scripts(0).enabled"), is(false));
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/script/ScriptWrapperUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/script/ScriptWrapperUnitTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 /** Unit test for {@link ScriptWrapper}. */
 class ScriptWrapperUnitTest {
@@ -63,5 +64,32 @@ class ScriptWrapperUnitTest {
         scriptWrapper.setContents(contents);
         // Then
         assertThat(scriptWrapper.getModCount(), is(equalTo(oldModCount)));
+    }
+
+    @Test
+    void shouldNotChangeScriptWhenEnabled() {
+        // Given
+        var scriptWrapper = new ScriptWrapper();
+        scriptWrapper.setEngine(Mockito.mock(ScriptEngineWrapper.class));
+        scriptWrapper.setChanged(false);
+        scriptWrapper.setEnabled(false);
+        // When
+        scriptWrapper.setEnabled(true);
+        // Then
+        assertThat(scriptWrapper.isEnabled(), is(true));
+        assertThat(scriptWrapper.isChanged(), is(false));
+    }
+
+    @Test
+    void shouldNotEnableScriptWithNullEngine() {
+        // Given
+        var scriptWrapper = new ScriptWrapper();
+        scriptWrapper.setEngine(null);
+        scriptWrapper.setChanged(false);
+        scriptWrapper.setEnabled(false);
+        // When
+        scriptWrapper.setEnabled(true);
+        // Then
+        assertThat(scriptWrapper.isEnabled(), is(false));
     }
 }


### PR DESCRIPTION
The enabled property of the script is persisted to the configuration
automatically when it is toggled, and does not require the user to save
the script manually to persist the change.

This only happens for scripts which have "Load on Start" enabled.

Fixes https://github.com/zaproxy/zaproxy/issues/2189.