### PR TITLE
Wrap message panel's header components

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/HttpPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/HttpPanel.java
@@ -48,6 +48,7 @@ import javax.swing.text.JTextComponent;
 import org.apache.commons.configuration.FileConfiguration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jdesktop.swingx.WrapLayout;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
 import org.parosproxy.paros.extension.edit.ExtensionEdit;
@@ -162,25 +163,12 @@ public abstract class HttpPanel extends AbstractPanel {
 
         endAllOptions = new JPanel();
 
-        JPanel panel1 = new JPanel(new BorderLayout(0, 0));
-
-        JPanel panelFlow = new JPanel(new FlowLayout(FlowLayout.CENTER, 0, 0));
-
-        panelFlow.add(allOptions);
-        panelFlow.add(componentOptions);
-        panelFlow.add(toolBarComponents);
-        panelFlow.add(moreOptionsComponent);
-        panelFlow.add(toolBarMoreOptions);
-        panel1.add(panelFlow, BorderLayout.WEST);
-
-        panelFlow = new JPanel(new FlowLayout(FlowLayout.CENTER, 0, 0));
-        panelFlow.add(endAllOptions);
-
-        panel1.add(panelFlow, BorderLayout.EAST);
-
-        panelHeader.add(panel1, BorderLayout.NORTH);
-
-        // getPanelContent().add(new EmptyComponent(), "");
+        panelHeader.add(allOptions);
+        panelHeader.add(componentOptions);
+        panelHeader.add(toolBarComponents);
+        panelHeader.add(moreOptionsComponent);
+        panelHeader.add(toolBarMoreOptions);
+        panelHeader.add(endAllOptions);
 
         initComponents();
 
@@ -196,7 +184,7 @@ public abstract class HttpPanel extends AbstractPanel {
 
     private JPanel getPanelHeader() {
         if (panelHeader == null) {
-            panelHeader = new JPanel(new BorderLayout());
+            panelHeader = new JPanel(new WrapLayout(FlowLayout.LEADING, 0, 0));
         }
         return panelHeader;
     }


### PR DESCRIPTION
Wrap the components to allow to properly resize the panels, as side effect the Send button is no longer positioned at the end.

Improves #3961.

---
Worth trying to see how it behaves… (IMO it's better than not allowing to resize).