### PR TITLE
Use host normalization flag in break panel

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakPanel.java
@@ -43,7 +43,6 @@ import org.parosproxy.paros.extension.AbstractPanel;
 import org.parosproxy.paros.extension.option.OptionsParamView;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.httppanel.HttpPanel;
 import org.zaproxy.zap.extension.httppanel.HttpPanelRequest;
@@ -426,13 +425,10 @@ public class BreakPanel extends AbstractPanel implements BreakpointManagementInt
                 properties = (Map<String, Object>) msg.getUserObject();
             } else {
                 properties = new HashMap<>();
-            }
-
-            String host = msg.getRequestHeader().getHeader(HttpRequestHeader.HOST);
-            if (host != null) {
-                properties.put("host", host);
                 msg.setUserObject(properties);
             }
+
+            properties.put("host.normalization", Boolean.FALSE);
         }
     }
 


### PR DESCRIPTION
Use the flag to disable the host normalization in the break panel to allow the user to send any number of host headers.

Related to zaproxy/zap-extensions#4956.