### PR TITLE
Tidy up JavaDoc and use more `List` in HttpBody

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/network/HttpBody.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpBody.java
@@ -30,6 +30,7 @@
 // ZAP: 2020/12/09 Add content encoding.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
 // ZAP: 2023/01/10 Tidy up logger.
+// ZAP: 2023/10/25 JavaDoc fixes and use of List.
 package org.parosproxy.paros.network;
 
 import java.io.IOException;
@@ -37,9 +38,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.apache.commons.lang.StringUtils;
@@ -79,7 +78,7 @@ public abstract class HttpBody {
     private boolean determineCharset = true;
     private boolean contentEncodingErrors;
 
-    private List<HttpEncoding> encodings = Collections.emptyList();
+    private List<HttpEncoding> encodings = List.of();
 
     /** Constructs a {@code HttpBody} with no contents (that is, zero length). */
     public HttpBody() {
@@ -451,7 +450,7 @@ public abstract class HttpBody {
      * to avoid more memory allocations.
      *
      * @return the content of the body.
-     * @since TOOD add version
+     * @since 2.10.0
      * @see #getContentEncodings()
      * @see #hasContentEncodingErrors()
      * @see #toString()
@@ -469,7 +468,7 @@ public abstract class HttpBody {
      *
      * @return {@code true} if there are errors while using the content encodings, {@code false}
      *     otherwise.
-     * @since TOOD add version
+     * @since 2.10.0
      * @see #getContent()
      */
     public boolean hasContentEncodingErrors() {
@@ -479,7 +478,8 @@ public abstract class HttpBody {
     /**
      * Sets the content of the body as bytes, applying any content encodings of the body, if any.
      *
-     * @since TOOD add version
+     * @param content the content of the body.
+     * @since 2.10.0
      * @see #getContentEncodings()
      */
     public void setContent(byte[] content) {
@@ -596,10 +596,7 @@ public abstract class HttpBody {
         Objects.requireNonNull(encodings);
         encodings.forEach(Objects::requireNonNull);
 
-        this.encodings =
-                encodings.isEmpty()
-                        ? Collections.emptyList()
-                        : Collections.unmodifiableList(new ArrayList<>(encodings));
+        this.encodings = List.copyOf(encodings);
         resetCachedValues();
     }
 


### PR DESCRIPTION
Add the version to since JavaDoc tags and document a parameter.
Use `List` for immutable lists.