### PR TITLE
Stop adding API key param to API calls in Python

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/PythonAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/PythonAPIGenerator.java
@@ -149,17 +149,6 @@ public class PythonAPIGenerator extends AbstractAPIGenerator {
                             .map(name -> "'" + name + "': " + name.toLowerCase(Locale.ROOT))
                             .collect(Collectors.joining(", "));
             reqParams.append(mandatoryParameters);
-            if (type.equals(ACTION_ENDPOINT) || type.equals(OTHER_ENDPOINT)) {
-                // Always add the API key - we've no way of knowing if it will be required or not
-                if (!mandatoryParameters.isEmpty()) {
-                    reqParams.append(", ");
-                }
-                reqParams
-                        .append("'")
-                        .append(API.API_KEY_PARAM)
-                        .append("': ")
-                        .append(API.API_KEY_PARAM);
-            }
             reqParams.append("}");
 
             List<ApiParameter> optionalParameters =


### PR DESCRIPTION
The API key is expected to be set at the client level and is sent in a header of each API call.
For the time being the parameter is still added to the function declaration, to not break code that might still specify it.