### PR TITLE
Docker: Add ZAP client profile

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2023-10-30
+- Add the ZAP client profile to stable, weekly, and live images.
+
 ### 2023-08-23
 - Python 3.6 and 3.7 are no longer supported.
 

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -94,6 +94,7 @@ COPY --link --chown=1000:1000 policies /home/zap/.ZAP_D/policies/
 COPY --link --chown=1000:1000 policies /root/.ZAP_D/policies/
 COPY --link --chown=1000:1000 scripts /home/zap/.ZAP_D/scripts/
 COPY --link --chown=1000:1000 .xinitrc /home/zap/
+COPY --link --chown=1000:1000 firefox /home/zap/.mozilla/firefox/
 
 RUN echo "zap2docker-live" > /zap/container && \
     chmod a+x /home/zap/.xinitrc && \

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -98,6 +98,7 @@ COPY --link --chown=1000:1000 policies /root/.ZAP/policies/
 # The scan script loads the scripts from dev home dir.
 COPY --link --chown=1000:1000 scripts /home/zap/.ZAP_D/scripts/
 COPY --link --chown=1000:1000 .xinitrc /home/zap/
+COPY --link --chown=1000:1000 firefox /home/zap/.mozilla/firefox/
 
 RUN echo "zap2docker-stable" > /zap/container && \
     chmod a+x /home/zap/.xinitrc

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -85,6 +85,7 @@ COPY --link --chown=1000:1000 policies /home/zap/.ZAP_D/policies/
 COPY --link --chown=1000:1000 policies /root/.ZAP_D/policies/
 COPY --link --chown=1000:1000 scripts /home/zap/.ZAP_D/scripts/
 COPY --link --chown=1000:1000 .xinitrc /home/zap/
+COPY --link --chown=1000:1000 firefox /home/zap/.mozilla/firefox/
 
 RUN echo "zap2docker-weekly" > /zap/container && \
     chmod a+x /home/zap/.xinitrc

--- a/docker/firefox/1337hack.zap-client-profile/firefox-extension-preferences.json
+++ b/docker/firefox/1337hack.zap-client-profile/firefox-extension-preferences.json
@@ -1,0 +1,1 @@
+{"browser-extensionV3@zaproxy.org":{"permissions":["<all_urls>"],"origins":["<all_urls>","*://*/*"]}}

--- a/docker/firefox/profiles.ini
+++ b/docker/firefox/profiles.ini
@@ -1,0 +1,4 @@
+[Profile0]
+Name=zap-client-profile
+IsRelative=1
+Path=1337hack.zap-client-profile


### PR DESCRIPTION
This will prevent us (and users) from having to do these sort of horrible things: https://github.com/zapbot/zap-mgmt-scripts/blob/a1623ba93d69e10458f386f2a01a281e36882caa/.github/workflows/zap-vs-crawlmaze.yml#L44-L48

The files are very small and should have no impact unless the client add-on is used with the AJAX spider.