### PR TITLE
search: Deprecate HAR related APIs

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/search/SearchAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/search/SearchAPI.java
@@ -32,6 +32,7 @@ import java.util.regex.PatternSyntaxException;
 import net.sf.json.JSONObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.db.RecordHistory;
 import org.parosproxy.paros.db.TableHistory;
@@ -39,6 +40,7 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.api.API;
+import org.zaproxy.zap.extension.api.ApiElement;
 import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiImplementor;
 import org.zaproxy.zap.extension.api.ApiOther;
@@ -122,16 +124,29 @@ public class SearchAPI extends ApiImplementor {
                         searchOptionalParams));
 
         this.addApiOthers(
-                new ApiOther(OTHER_HAR_BY_URL_REGEX, searchMandatoryParams, searchOptionalParams));
+                deprecatedEximApi(
+                        new ApiOther(
+                                OTHER_HAR_BY_URL_REGEX,
+                                searchMandatoryParams,
+                                searchOptionalParams)));
         this.addApiOthers(
-                new ApiOther(
-                        OTHER_HAR_BY_REQUEST_REGEX, searchMandatoryParams, searchOptionalParams));
+                deprecatedEximApi(
+                        new ApiOther(
+                                OTHER_HAR_BY_REQUEST_REGEX,
+                                searchMandatoryParams,
+                                searchOptionalParams)));
         this.addApiOthers(
-                new ApiOther(
-                        OTHER_HAR_BY_RESPONSE_REGEX, searchMandatoryParams, searchOptionalParams));
+                deprecatedEximApi(
+                        new ApiOther(
+                                OTHER_HAR_BY_RESPONSE_REGEX,
+                                searchMandatoryParams,
+                                searchOptionalParams)));
         this.addApiOthers(
-                new ApiOther(
-                        OTHER_HAR_BY_HEADER_REGEX, searchMandatoryParams, searchOptionalParams));
+                deprecatedEximApi(
+                        new ApiOther(
+                                OTHER_HAR_BY_HEADER_REGEX,
+                                searchMandatoryParams,
+                                searchOptionalParams)));
     }
 
     @Override
@@ -308,6 +323,12 @@ public class SearchAPI extends ApiImplementor {
 
     private boolean incErrorDetails() {
         return Model.getSingleton().getOptionsParam().getApiParam().isIncErrorDetails();
+    }
+
+    private <T extends ApiElement> T deprecatedEximApi(T element) {
+        element.setDeprecated(true);
+        element.setDeprecatedDescription(Constant.messages.getString("search.api.deprecated.exim"));
+        return element;
     }
 
     private void search(

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -2529,6 +2529,7 @@ script.type.standalone = Stand Alone
 script.type.standalone.desc = Stand Alone scripts are self contained scripts that can only be run manually.\n\nYou run them using the 'Run' button in the above toolbar.
 script.type.targeted = Targeted
 script.type.targeted.desc = Targeted scripts are scripts that act on a specified URL or set of URLs.\n\nYou typically invoke them by right-clicking on a node in the Sites tree or on a record in a list of responses and selecting 'Run with Script'.
+search.api.deprecated.exim = Use the API endpoints with the same name in the 'exim' add-on instead.
 
 search.api.desc = 
 search.api.other.harByHeaderRegex = Returns the HTTP messages, in HAR format, that match the given regular expression in the header(s) optionally filtered by URL and paginated with 'start' position and 'count' of messages.


### PR DESCRIPTION
The plan is to migrate these to exim.

Related to zaproxy/zaproxy#7433