### PR TITLE
Requests parallel processing:

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakPanelToolbarFactory.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakPanelToolbarFactory.java
@@ -202,7 +202,12 @@ public class BreakPanelToolbarFactory {
         }
 
         // This could have been via a breakpoint, so force the serialisation
-        resetRequestSerialization(true);
+        /*
+        keindel: breaks are serialized thanks to synch-block on SEMAPHOR of BreakpointMessageHandler2
+        - method handleMessageReceivedFromServer. Other requests shall not be serialized.
+        So the line below is commented-out for good:
+        */
+//        resetRequestSerialization(true);
 
         // Set the active icon and reset the continue button
         this.setActiveIcon(true);
@@ -467,6 +472,12 @@ public class BreakPanelToolbarFactory {
             // They've pressed the continue button, stop stepping
             stepping = false;
             resetRequestSerialization(false);
+            /*
+            keindel: cont == false is the default value and behavior.
+            It seems strange to leave cont == true AFTER processing break. It affects further breaks in line.
+             So we change that.
+            * */
+            setContinue(false);
             return false;
         }
         if (drop) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakpointMessageHandler2.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/BreakpointMessageHandler2.java
@@ -118,9 +118,13 @@ public class BreakpointMessageHandler2 {
                 setBreakDisplay(aMessage, false);
                 waitUntilContinue(aMessage, false);
                 BreakEventPublisher.getPublisher().publishInactiveEvent(aMessage);
+                /*
+                keindel: breakMgmt.clearAndDisableResponse() - shall be in sync
+                otherwise Race-condition: Thread1 can clear AFTER Thread2 shows its response display
+                * */
+                breakMgmt.clearAndDisableResponse();
             }
         }
-        breakMgmt.clearAndDisableResponse();
         return !breakMgmt.isToBeDropped();
     }
 


### PR DESCRIPTION
This PR is 2nd step to address https://github.com/zaproxy/zaproxy/issues/8146
Issue needs network addon modification!!! (network thread-sync logic modification) see 1st step PR to zap-extensions https://github.com/zaproxy/zap-extensions/pull/5057

Server-threads in breakpoints: sync, serialization and continue-button logic modified.
Assumptions made are described in comments.

I tried proposed changes - they seem to be working fine. Requests are being processed in parallel, breakpoints wait for user interaction, not blocking other requests.
Probably there are some scenarios requiring further code changes? Please take a look.