### PR TITLE
Set `uploadFile` as a POST endpoint

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ApiElement.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ApiElement.java
@@ -27,9 +27,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import org.parosproxy.paros.network.HttpRequestHeader;
 
 public class ApiElement {
 
+    private final String defaultMethod;
     private String name = null;
     private String descriptionTag = "";
     private List<ApiParameter> parameters = new ArrayList<>();
@@ -57,8 +59,7 @@ public class ApiElement {
     }
 
     public ApiElement(String name) {
-        super();
-        this.name = name;
+        this(name, List.of());
     }
 
     public ApiElement(String name, List<String> mandatoryParamNames) {
@@ -67,8 +68,21 @@ public class ApiElement {
 
     public ApiElement(
             String name, List<String> mandatoryParamNames, List<String> optionalParamNames) {
+        this(name, HttpRequestHeader.GET, mandatoryParamNames, optionalParamNames);
+    }
+
+    public ApiElement(
+            String name,
+            String defaultMethod,
+            List<String> mandatoryParamNames,
+            List<String> optionalParamNames) {
         super();
         this.name = name;
+        if (defaultMethod == null || defaultMethod.isBlank()) {
+            throw new IllegalArgumentException(
+                    "The ApiElement " + name + " has null or blank default method.");
+        }
+        this.defaultMethod = defaultMethod;
 
         setParameters(mandatoryParamNames, optionalParamNames);
     }
@@ -83,6 +97,16 @@ public class ApiElement {
 
     private static List<String> asList(String[] elements) {
         return elements != null ? Arrays.asList(elements) : null;
+    }
+
+    /**
+     * Gets the default (HTTP) method supported by this API element.
+     *
+     * @return the default method, never {@code null}.
+     * @since 2.15.0
+     */
+    public String getDefaultMethod() {
+        return defaultMethod;
     }
 
     public void setMandatoryParamNames(String[] paramNames) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ApiOther.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ApiOther.java
@@ -60,6 +60,14 @@ public class ApiOther extends ApiElement {
 
     public ApiOther(
             String name,
+            String defaultMethod,
+            List<String> mandatoryParamNames,
+            List<String> optionalParamNames) {
+        super(name, defaultMethod, mandatoryParamNames, optionalParamNames);
+    }
+
+    public ApiOther(
+            String name,
             List<String> mandatoryParamNames,
             List<String> optionalParamNames,
             boolean requiresApiKey) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -420,7 +420,11 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                                 new String[] {PARAM_FOLLOW_REDIRECTS})));
         this.addApiOthers(new ApiOther(OTHER_FILE_DOWNLOAD, new String[] {PARAM_FILENAME}));
         this.addApiOthers(
-                new ApiOther(OTHER_FILE_UPLOAD, new String[] {PARAM_FILENAME, PARAM_CONTENTS}));
+                new ApiOther(
+                        OTHER_FILE_UPLOAD,
+                        HttpRequestHeader.POST,
+                        List.of(PARAM_FILENAME, PARAM_CONTENTS),
+                        List.of()));
 
         this.addApiShortcut(OTHER_SCRIPT_JS);
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/PythonAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/PythonAPIGenerator.java
@@ -34,6 +34,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.stream.Collectors;
+import org.parosproxy.paros.network.HttpRequestHeader;
 
 public class PythonAPIGenerator extends AbstractAPIGenerator {
 
@@ -191,6 +192,13 @@ public class PythonAPIGenerator extends AbstractAPIGenerator {
         // , {'url': url}))
         if (hasParams) {
             out.write(", ");
+            String httpMethod = element.getDefaultMethod();
+            if (!HttpRequestHeader.GET.equalsIgnoreCase(httpMethod)) {
+                out.write("method=\"");
+                out.write(httpMethod);
+                out.write('"');
+                out.write(", body=");
+            }
             out.write(reqParams.toString());
             out.write(")");
             if (!type.equals(OTHER_ENDPOINT)) {

--- a/zap/src/test/java/org/zaproxy/zap/extension/api/ApiElementUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/api/ApiElementUnitTest.java
@@ -30,6 +30,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /** Unit test for {@link ApiElement}. */
 class ApiElementUnitTest {
@@ -108,6 +111,24 @@ class ApiElementUnitTest {
             assertThat(
                     ex.getMessage(),
                     allOf(containsString(ELEMENT_NAME), containsString(duplicatedParam)));
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {" ", "  "})
+        void shouldNotAllowNullOrBlankDefaultMethod(String defaultMethod) {
+            Exception ex =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () ->
+                                    new ApiElement(
+                                            ELEMENT_NAME,
+                                            defaultMethod,
+                                            DEFAULT_MANDATORY_PARAMS,
+                                            DEFAULT_OPTIONAL_PARAMS));
+            assertThat(
+                    ex.getMessage(),
+                    allOf(containsString(ELEMENT_NAME), containsString("default method")));
         }
     }
 


### PR DESCRIPTION
Change `ApiElement` to allow to specify the default method to be used.
Set the `uploadFile` as a POST.
Update Python API generator to use the default method (and body).