### PR TITLE
Fix rendering of Physical fonts

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/utils/FontUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/FontUtils.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.EnumMap;
 import javax.swing.JLabel;
 import javax.swing.UIManager;
+import javax.swing.text.StyleContext;
 
 public class FontUtils {
 
@@ -114,7 +115,7 @@ public class FontUtils {
         }
 
         defaultFontSets.put(fontType, (name != null && !name.isEmpty()));
-        setDefaultFont(fontType, new Font(name, Font.PLAIN, size));
+        setDefaultFont(fontType, getFont(name, Font.PLAIN, size));
     }
 
     private static Font getDefaultFont() {
@@ -186,7 +187,7 @@ public class FontUtils {
      * @return the named font with the specified style, correctly scaled
      */
     public static Font getFont(String name, int style) {
-        return new Font(name, style, getDefaultFont().getSize());
+        return getFont(name, style, getDefaultFont().getSize());
     }
 
     /**
@@ -259,6 +260,13 @@ public class FontUtils {
                 break;
         }
         return font.deriveFont(s);
+    }
+
+    /**
+     * @since 2.15.0
+     */
+    public static Font getFont(String name, int style, int size) {
+        return StyleContext.getDefaultStyleContext().getFont(name, style, size);
     }
 
     public static float getScale() {


### PR DESCRIPTION
Closes zaproxy#8018.

Fonts using actual font libraries, e.g. TrueType or PostScript Type 1 fonts were not being rendered correctly.

The original issue is for Windows, but I'm seeing it on Linux too.

Using `StyleContext#getFont` works because it checks if the requested font is a Physical font and handles it correctly.

### Before
<img src="https://github.com/zaproxy/zaproxy/assets/16446369/98f24170-8be7-4f8d-a612-d5333c3a5e23" width="500">

### After
<img src="https://github.com/zaproxy/zaproxy/assets/16446369/bc0356fc-31b1-4842-96d7-4b28d17b0973" width="500">

### References:
- https://docs.oracle.com/javase/tutorial/2d/text/fonts.html
- https://github.com/openjdk/jdk/blob/da75f3c4ad5bdf25167a3ed80e51f567ab3dbd01/src/java.desktop/share/classes/javax/swing/text/StyleContext.java#L267-L269