### PR TITLE
Allow to hook param panels with parents

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/ExtensionHookView.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/ExtensionHookView.java
@@ -25,12 +25,14 @@
 // ZAP: 2018/10/05 Lazily initialise the lists and add JavaDoc.
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2023/11/14 Allow to hook AbstractParamPanel with parents.
 package org.parosproxy.paros.extension;
 
 import java.awt.Component;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import org.parosproxy.paros.view.AbstractParamPanel;
 import org.zaproxy.zap.extension.httppanel.DisplayedMessageChangedListener;
 import org.zaproxy.zap.view.ContextPanelFactory;
@@ -85,7 +87,7 @@ public class ExtensionHookView {
      * @see #addSessionPanel(AbstractParamPanel)
      * @see #getSessionPanel()
      */
-    private List<AbstractParamPanel> sessionPanelList;
+    private List<AbstractParamPanelEntry> sessionPanelList;
 
     /**
      * The options panels added to this extension hook.
@@ -95,7 +97,7 @@ public class ExtensionHookView {
      * @see #addOptionPanel(AbstractParamPanel)
      * @see #getOptionsPanel()
      */
-    private List<AbstractParamPanel> optionPanelList;
+    private List<AbstractParamPanelEntry> optionPanelList;
 
     /**
      * The {@link ContextPanelFactory}s added to this extension hook.
@@ -192,13 +194,30 @@ public class ExtensionHookView {
      * org.parosproxy.paros.view.SessionDialog Session Properties dialogue}.
      *
      * @param panel the {@code AbstractParamPanel} that will be added to the Options dialogue.
+     * @see #addSessionPanel(List, AbstractParamPanel)
      * @see org.parosproxy.paros.view.View#getSessionDialog()
      */
     public void addSessionPanel(AbstractParamPanel panel) {
+        addSessionPanel(List.of(), panel);
+    }
+
+    /**
+     * Adds the given {@link AbstractParamPanel} to the view hook, to be later added to the {@link
+     * org.parosproxy.paros.view.SessionDialog Session Properties dialogue} with the given parents.
+     *
+     * @param parents the parents of the panel, must not be {@code null}.
+     * @param panel the {@code AbstractParamPanel} that will be added to the Options dialogue.
+     * @throws NullPointerException if the given {@code parents} is {@code null}.
+     * @since 2.15.0
+     * @see #addSessionPanel(AbstractParamPanel)
+     * @see org.parosproxy.paros.view.View#getSessionDialog()
+     */
+    public void addSessionPanel(List<String> parents, AbstractParamPanel panel) {
+        Objects.requireNonNull(parents);
         if (sessionPanelList == null) {
             sessionPanelList = createList();
         }
-        sessionPanelList.add(panel);
+        sessionPanelList.add(new AbstractParamPanelEntry(parents, panel));
     }
 
     /**
@@ -206,13 +225,30 @@ public class ExtensionHookView {
      * org.parosproxy.paros.view.OptionsDialog Options dialogue}.
      *
      * @param panel the {@code AbstractParamPanel} that will be added to the Options dialogue.
+     * @see #addOptionPanel(List, AbstractParamPanel)
      * @see org.parosproxy.paros.view.View#getOptionsDialog(String)
      */
     public void addOptionPanel(AbstractParamPanel panel) {
+        addOptionPanel(List.of(), panel);
+    }
+
+    /**
+     * Adds the given {@link AbstractParamPanel} to the view hook, to be later added to the {@link
+     * org.parosproxy.paros.view.OptionsDialog Options dialogue} with the given parents.
+     *
+     * @param parents the parents of the panel, must not be {@code null}.
+     * @param panel the {@code AbstractParamPanel} that will be added to the Options dialogue.
+     * @throws NullPointerException if the given {@code parents} is {@code null}.
+     * @since 2.15.0
+     * @see #addOptionPanel(AbstractParamPanel)
+     * @see org.parosproxy.paros.view.View#getOptionsDialog(String)
+     */
+    public void addOptionPanel(List<String> parents, AbstractParamPanel panel) {
+        Objects.requireNonNull(parents);
         if (optionPanelList == null) {
             optionPanelList = createList();
         }
-        optionPanelList.add(panel);
+        optionPanelList.add(new AbstractParamPanelEntry(parents, panel));
     }
 
     List<AbstractPanel> getWorkPanel() {
@@ -227,11 +263,11 @@ public class ExtensionHookView {
         return unmodifiableList(statusPanelList);
     }
 
-    List<AbstractParamPanel> getSessionPanel() {
+    List<AbstractParamPanelEntry> getSessionPanel() {
         return unmodifiableList(sessionPanelList);
     }
 
-    List<AbstractParamPanel> getOptionsPanel() {
+    List<AbstractParamPanelEntry> getOptionsPanel() {
         return unmodifiableList(optionPanelList);
     }
 
@@ -369,5 +405,27 @@ public class ExtensionHookView {
      */
     List<DisplayedMessageChangedListener> getResponsePanelDisplayedMessageChangedListeners() {
         return unmodifiableList(responsePanelDisplayedMessageChangedListener);
+    }
+
+    static class AbstractParamPanelEntry {
+
+        private static final String[] EMPTY_ARRAY = {};
+
+        private final String[] parents;
+
+        private final AbstractParamPanel panel;
+
+        private AbstractParamPanelEntry(List<String> parents, AbstractParamPanel panel) {
+            this.parents = parents.toArray(EMPTY_ARRAY);
+            this.panel = panel;
+        }
+
+        String[] getParents() {
+            return parents;
+        }
+
+        AbstractParamPanel getPanel() {
+            return panel;
+        }
     }
 }

--- a/zap/src/main/java/org/parosproxy/paros/extension/ExtensionLoader.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/ExtensionLoader.java
@@ -101,6 +101,7 @@
 // ZAP: 2023/01/10 Tidy up logger.
 // ZAP: 2023/04/28 Deprecate Proxy and ProxyServer related methods.
 // ZAP: 2023/08/25 Set view to ExtensionAdaptor.
+// ZAP: 2023/11/14 Hook AbstractParamPanel with parents.
 package org.parosproxy.paros.extension;
 
 import java.awt.Component;
@@ -898,11 +899,11 @@ public class ExtensionLoader {
     }
 
     // ZAP: Added the type argument.
-    private void addParamPanel(List<AbstractParamPanel> panelList, AbstractParamDialog dialog) {
-        String[] ROOT = {};
-        for (AbstractParamPanel panel : panelList) {
+    private void addParamPanel(
+            List<ExtensionHookView.AbstractParamPanelEntry> panelList, AbstractParamDialog dialog) {
+        for (ExtensionHookView.AbstractParamPanelEntry entry : panelList) {
             try {
-                dialog.addParamPanel(ROOT, panel, true);
+                dialog.addParamPanel(entry.getParents(), entry.getPanel(), true);
 
             } catch (Exception e) {
                 LOGGER.error(e.getMessage(), e);
@@ -910,10 +911,11 @@ public class ExtensionLoader {
         }
     }
 
-    private void removeParamPanel(List<AbstractParamPanel> panelList, AbstractParamDialog dialog) {
-        for (AbstractParamPanel panel : panelList) {
+    private void removeParamPanel(
+            List<ExtensionHookView.AbstractParamPanelEntry> panelList, AbstractParamDialog dialog) {
+        for (ExtensionHookView.AbstractParamPanelEntry entry : panelList) {
             try {
-                dialog.removeParamPanel(panel);
+                dialog.removeParamPanel(entry.getPanel());
 
             } catch (Exception e) {
                 LOGGER.error(e.getMessage(), e);


### PR DESCRIPTION
Allow to hook option and session panels with parents, to not require add-ons to manually add/remove them.