### PR TITLE
Allow to build weekly with normal output

### DIFF
--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -23,4 +23,5 @@ jobs:
         ZAP_RELEASE: 1
         ZAP_JAVA_VERSION: 11
         ZAP_WEEKLY_ADDONS_NO_TEST: ${{ vars.ZAP_WEEKLY_ADDONS_NO_TEST }}
+        ZAP_WEEKLY_QUIET: ${{ vars.ZAP_WEEKLY_QUIET }}
       run: ./gradlew "-Dorg.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m" :zap:createWeeklyRelease

--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/distributions.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/distributions.gradle.kts
@@ -347,6 +347,7 @@ val buildWeeklyAddOns by tasks.registering(GradleBuildWithGitRepos::class) {
     repositoriesDirectory.set(temporaryDir)
     repositoriesDataFile.set(file("src/main/weekly-add-ons.json"))
     clean.set(true)
+    quiet.set(System.getenv("ZAP_WEEKLY_QUIET") != "false")
 
     tasks {
         if (System.getenv("ZAP_WEEKLY_ADDONS_NO_TEST") != "true") {


### PR DESCRIPTION
Expose the quiet state through an env var so it can be tweaked anytime.
Update weekly workflow to pass the env var.