### PR TITLE
Use HTTP method in NodeJs API client generator

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/NodeJSAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/NodeJSAPIGenerator.java
@@ -33,6 +33,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.stream.Collectors;
+import org.parosproxy.paros.network.HttpRequestHeader;
 
 public class NodeJSAPIGenerator extends AbstractAPIGenerator {
 
@@ -202,6 +203,12 @@ public class NodeJSAPIGenerator extends AbstractAPIGenerator {
         }
         if (type.equals(OTHER_ENDPOINT)) {
             out.write(", 'other'");
+        }
+        String httpMethod = element.getDefaultMethod();
+        if (!HttpRequestHeader.GET.equalsIgnoreCase(httpMethod)) {
+            out.write(", '");
+            out.write(httpMethod);
+            out.write('\'');
         }
         out.write(")\n");
         out.write("}\n\n");


### PR DESCRIPTION
Update the NodeJs API generator to specify the method, if not GET.