### PR TITLE
Bump Nightly Docker image to Debian Bookworm and use Java 17

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2024-07-15
+- Change Nightly Docker image to use `debian:bookworm-slim` instead of `bullseye-slim`, it will now start using Java 17.
+
 ### 2024-06-19
 - Alert_on_Unexpected_Content_Types.js > Now handles JSON, YAML, and XML related types more generically (Issue 8522).
 

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1
 # This dockerfile builds a 'live' zap docker image using the latest files in the repos
-FROM --platform=linux/amd64 debian:bullseye-slim AS builder
+FROM --platform=linux/amd64 debian:bookworm-slim AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
-	openjdk-11-jdk \
+	openjdk-17-jdk \
 	wget \
 	curl \
 	unzip \
@@ -34,7 +34,7 @@ RUN --mount=type=secret,id=webswing_url \
 	# Remove Webswing bundled examples
 	rm -Rf webswing/apps/
 
-FROM debian:bullseye-slim AS final
+FROM debian:bookworm-slim AS final
 LABEL maintainer="psiinon@gmail.com"
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -45,7 +45,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	automake \
 	autoconf \
 	gcc g++ \
-	openjdk-11-jdk \
+	openjdk-17-jdk \
 	wget \
 	curl \
 	xmlstarlet \
@@ -66,7 +66,16 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	mkdir /zap  && \
 	chown zap:zap /zap
 
-RUN pip3 install --no-cache-dir --upgrade awscli pip zaproxy pyyaml requests urllib3
+RUN pip3 install \
+	--break-system-packages \
+	--no-cache-dir \
+	--upgrade \
+	awscli \
+	pip \
+	zaproxy \
+	pyyaml \
+	requests \
+	urllib3
 
 #Change to the zap user so things get done as the right person (apart from copy)
 USER zap
@@ -74,7 +83,7 @@ USER zap
 RUN mkdir /home/zap/.vnc
 
 ARG TARGETARCH
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-$TARGETARCH
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-$TARGETARCH
 ENV PATH $JAVA_HOME/bin:/zap/:$PATH
 
 ENV ZAP_PATH /zap/zap.sh


### PR DESCRIPTION
This PR bumps the base image for zaproxy from Debian Bullseye (11) to Debian Bookworm (12).
It also bumps openjdk from openjdk-11 to openjdk-17 - as 17 is the current default in Bookworm, and openjdk-11 is not _directly_ available in Bookworm.

Resolves #8211.