### PR TITLE
fix: add text/xml to expected API content types

### DIFF
--- a/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
+++ b/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
@@ -23,7 +23,8 @@ var expectedTypes = [
 		"text/x-json",
 		"text/json",
 		"text/yaml",
-		"text/plain"
+		"text/plain",
+		"text/xml"
 	]
 
 function sendingRequest(msg, initiator, helper) {


### PR DESCRIPTION
fixes: https://github.com/zaproxy/zaproxy/issues/8226