### PR TITLE
Docker: better parse error

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2023-12-07
+- Give better error on failing to parse the config file.
+
 ### 2023-12-06
 - Alert_on_Unexpected_Content_Types.js > Added Content-Type text/xml to the list of expected types. 
 

--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -152,7 +152,12 @@ def load_config(config, config_dict, config_msg, out_of_scope_dict):
     out_of_scope_dict - a dictionary which maps plugin_ids to out of scope regexes
     """
     for line in config:
-        if not line.startswith('#') and len(line) > 1:
+        if line.startswith('#') or len(line) == 0:
+          # Ignore
+          pass
+        elif line.count('\t') < 2:
+          raise ValueError("Unexpected number of tokens on line - there should be at least 3, tab separated: {0}".format(line))
+        else:
             (key, val, optional) = line.rstrip().split('\t', 2)
             if val == 'OUTOFSCOPE':
                 for plugin_id in key.split(','):


### PR DESCRIPTION
Example output:

* 2023-12-07 17:43:52,079 Failed to load config file /zap/wrk/gen.conf Unexpected number of tokens on line - there should be at least 3, tab separated 10026 WARN	(HTTP Parameter Override)
