### PR TITLE
Add application/x-x509-ca-cert to expected API content types

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2023-12-08
+- Alert_on_Unexpected_Content_Types.js > Added Content-Type application/x-x509-ca-cert to the list of expected types. 
+
 ### 2023-12-07
 - Give better error on failing to parse the config file.
 

--- a/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
+++ b/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
@@ -20,6 +20,7 @@ var expectedTypes = [
 		"application/xml",
 		"application/x-ndjson",
 		"application/x-yaml",
+		"application/x-x509-ca-cert",
 		"text/x-json",
 		"text/json",
 		"text/yaml",


### PR DESCRIPTION
fixes: https://github.com/zaproxy/zaproxy/issues/8231

`application/x-x509-ca-cert` is the default response from our Spring-Boot application when there is an error like 404 and it was trying to get a cert file that doesn't exist: https://example.com/key.pem

But it is a valid response type when looking at https://www.iana.org/assignments/media-types/application/x-x509-ca-cert and https://datatracker.ietf.org/doc/html/rfc5280 

>4.2.1.1. CA Certificate Response Message Format
If the CA does not have any intermediate CA certificates, the response consists of a single X.509 CA certificate. The response will have a Content-Type of "application/x-x509-ca-cert".
"Content-Type: application/x-x509-ca-cert"