### PR TITLE
Docker: ignore config lines that contain only whitespaces

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2023-12-12
+- Parsing the config file ignores empty lines that are containing whitespaces only
+
 ### 2023-12-07
 - Give better error on failing to parse the config file.
 

--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -152,7 +152,7 @@ def load_config(config, config_dict, config_msg, out_of_scope_dict):
     out_of_scope_dict - a dictionary which maps plugin_ids to out of scope regexes
     """
     for line in config:
-        if line.startswith('#') or len(line) == 0:
+        if line.startswith('#') or len(line.strip()) == 0:
           # Ignore
           pass
         elif line.count('\t') < 2:


### PR DESCRIPTION
Closes: zaproxy/zaproxy#8237

This fix in config file parsing adds stripping whitespaces from the lines, as new line char in empty lines leads to a line length of 1, failing with an error about config file formatting a descibed in the issue