### PR TITLE
Use name of enum as default value for configs

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/common/AbstractParam.java
+++ b/zap/src/main/java/org/parosproxy/paros/common/AbstractParam.java
@@ -42,6 +42,8 @@ package org.parosproxy.paros.common;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.configuration.ConfigurationUtils;
 import org.apache.commons.configuration.ConversionException;
 import org.apache.commons.configuration.FileConfiguration;
@@ -246,7 +248,7 @@ public abstract class AbstractParam implements Cloneable {
      * @since 2.13.0
      */
     protected <T extends Enum<T>> T getEnum(String key, T defaultValue) {
-        String value = getString(key, defaultValue.toString());
+        String value = getString(key, defaultValue.name());
         @SuppressWarnings("unchecked")
         Class<T> enumType = (Class<T>) defaultValue.getClass();
         try {
@@ -261,12 +263,12 @@ public abstract class AbstractParam implements Cloneable {
         return defaultValue;
     }
 
-    private static <T extends Enum<T>> List<T> getValues(Class<T> enumType) {
+    private static <T extends Enum<T>> List<String> getValues(Class<T> enumType) {
         try {
             Method valuesMethod = enumType.getDeclaredMethod("values");
             @SuppressWarnings("unchecked")
             T[] values = (T[]) valuesMethod.invoke(enumType);
-            return List.of(values);
+            return Stream.of(values).map(Enum::name).collect(Collectors.toList());
         } catch (Exception e) {
             LOGGER.error("Error getting enum values:", e);
         }

--- a/zap/src/test/java/org/parosproxy/paros/common/AbstractParamUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/common/AbstractParamUnitTest.java
@@ -130,7 +130,7 @@ class AbstractParamUnitTest {
         AbstractParam param = new TestParam();
         String key = "enum";
         TestEnum defaultValue = TestEnum.C;
-        param.getConfig().setProperty(key, enumValue.toString());
+        param.getConfig().setProperty(key, enumValue.name());
         // When
         TestEnum value = param.getEnum(key, defaultValue);
         // Then
@@ -187,7 +187,12 @@ class AbstractParamUnitTest {
     private enum TestEnum {
         A,
         B,
-        C,
+        C;
+
+        @Override
+        public String toString() {
+            return "toString: " + name();
+        }
     }
 
     private static class TestParam extends AbstractParam {


### PR DESCRIPTION
Use the name of the enum instead of the string representation otherwise it would fail to convert the string to enum when overridden, while the default value would still be used a warning would be logged.

---
From log shared in ZAP User Group: https://groups.google.com/g/zaproxy-users/c/oaR0MvG1BPQ/m/HSSFj9NQAwAJ