### PR TITLE
Improve logs related to loading of pscanrules

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -262,11 +262,12 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
 
             added = addPassiveScannerImpl(scanner);
 
-            if (hasView()) {
-                getPolicyPanel().getPassiveScanTableModel().addScanner(scanner);
+            if (added) {
+                if (hasView()) {
+                    getPolicyPanel().getPassiveScanTableModel().addScanner(scanner);
+                }
+                LOGGER.info("Loaded passive scan rule: {}", scanner.getName());
             }
-
-            LOGGER.info("loaded passive scan rule: {}", scanner.getName());
             if (scanner.getPluginId() == -1) {
                 LOGGER.error(
                         "The passive scan rule \"{}\" [{}] does not have a defined ID.",
@@ -294,7 +295,12 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
             listTest.addAll(ExtensionFactory.getAddOnLoader().getPassiveScanRules());
 
             for (PluginPassiveScanner scanner : listTest) {
-                addPluginPassiveScannerImpl(scanner);
+                if (scanner instanceof RegexAutoTagScanner) {
+                    continue;
+                }
+                if (!addPluginPassiveScannerImpl(scanner)) {
+                    LOGGER.error("Failed to install pscanrule: {}", scanner.getName());
+                }
             }
         }
         return scannerList;

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScannerList.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScannerList.java
@@ -37,7 +37,10 @@ public class PassiveScannerList {
 
     protected boolean add(PassiveScanner scanner) {
         if (scannerNames.contains(scanner.getName())) {
-            // Prevent duplicates, log error?
+            LOGGER.warn(
+                    "A scan rule with the name \"{}\" already exists. The rule \"{}\" will not be loaded.",
+                    scanner.getName(),
+                    scanner.getClass().getName());
             return false;
         }
         passiveScanners.add(scanner);


### PR DESCRIPTION
Also, don't show the passive scan rule in the UI if it wasn't installed
successfully.
