### PR TITLE
Anti-CSRF Handling should always account for partial matching

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRF.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRF.java
@@ -368,13 +368,13 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
 
                         String attId = inputElement.getAttributeValue("ID");
                         boolean found = false;
-                        if (isKnownAntiCsrfToken(attId)) {
+                        if (isAntiCsrfToken(attId)) {
                             list.add(new AntiCsrfToken(msg, attId, value, formIndex));
                             found = true;
                         }
                         if (!found) {
                             String name = inputElement.getAttributeValue("NAME");
-                            if (isKnownAntiCsrfToken(name)) {
+                            if (isAntiCsrfToken(name)) {
                                 list.add(new AntiCsrfToken(msg, name, value, formIndex));
                             }
                         }
@@ -384,20 +384,6 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
             }
         }
         return list;
-    }
-
-    private boolean isKnownAntiCsrfToken(String name) {
-        if (name == null) {
-            return false;
-        }
-        for (String tokenName : this.getAntiCsrfTokenNames()) {
-            if (this.getParam().isPartialMatchingEnabled()
-                            && StringUtils.containsIgnoreCase(name, tokenName)
-                    || tokenName.equalsIgnoreCase(name)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     @Override
@@ -445,7 +431,14 @@ public class ExtensionAntiCSRF extends ExtensionAdaptor implements SessionChange
         if (name == null) {
             return false;
         }
-        return this.getParam().getTokensNames().contains(name.toLowerCase());
+        for (String tokenName : this.getAntiCsrfTokenNames()) {
+            if (this.getParam().isPartialMatchingEnabled()
+                            && StringUtils.containsIgnoreCase(name, tokenName)
+                    || tokenName.equalsIgnoreCase(name)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/zap/src/test/java/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRFUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRFUnitTest.java
@@ -44,6 +44,8 @@ import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
@@ -290,6 +292,16 @@ class ExtensionAntiCSRFUnitTest {
             List<AntiCsrfToken> tokens = extensionAntiCSRF.getTokensFromResponse(message, source);
             // Then
             assertThat(tokens, hasSize(0));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {KNOWN_TOKEN_1, KNOWN_TOKEN_1 + "-abc123"})
+        void shouldIdentifyTokenAsKnownWhenPartialMatching(String token) {
+            // Given
+            String extendedToken = token;
+            given(antiCsrfParam.isPartialMatchingEnabled()).willReturn(true);
+            // When / Then
+            assertThat(extensionAntiCSRF.isAntiCsrfToken(extendedToken), is(equalTo(true)));
         }
     }
 

--- a/zap/src/test/java/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRFUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/anticsrf/ExtensionAntiCSRFUnitTest.java
@@ -63,7 +63,7 @@ class ExtensionAntiCSRFUnitTest {
         private static final String NO_ID = null;
         private static final String NO_NAME = null;
         private static final String NO_VALUE = null;
-        private static final String UNKOWN_TOKEN = "UnkownToken";
+        private static final String UNKNOWN_TOKEN = "UnknownToken";
         private static final String KNOWN_TOKEN_1 = "AcsrfToken 1";
         private static final String KNOWN_TOKEN_2 = "AcsrfToken 2";
         private static final String KNOWN_TOKEN_3 = "AcsrfToken 3";
@@ -143,7 +143,7 @@ class ExtensionAntiCSRFUnitTest {
         @Test
         void shouldNotGetTokensFromInputFieldsIfIdIsNotAKnownToken() {
             // Given
-            String input = input(UNKOWN_TOKEN, NO_NAME, "value");
+            String input = input(UNKNOWN_TOKEN, NO_NAME, "value");
             Source source = createSource(form(input, input), form(input));
             // When
             List<AntiCsrfToken> tokens = extensionAntiCSRF.getTokensFromResponse(message, source);
@@ -154,7 +154,7 @@ class ExtensionAntiCSRFUnitTest {
         @Test
         void shouldNotGetTokensFromInputFieldsIfNameIsNotAKnownToken() {
             // Given
-            String input = input(NO_ID, UNKOWN_TOKEN, "value");
+            String input = input(NO_ID, UNKNOWN_TOKEN, "value");
             Source source = createSource(form(input, input), form(input));
             // When
             List<AntiCsrfToken> tokens = extensionAntiCSRF.getTokensFromResponse(message, source);
@@ -168,9 +168,9 @@ class ExtensionAntiCSRFUnitTest {
             Source source =
                     createSource(
                             form(
-                                    input(KNOWN_TOKEN_1, UNKOWN_TOKEN, "value1"),
-                                    input(KNOWN_TOKEN_2, UNKOWN_TOKEN, "value2")),
-                            form(input(KNOWN_TOKEN_3, UNKOWN_TOKEN, "value3")));
+                                    input(KNOWN_TOKEN_1, UNKNOWN_TOKEN, "value1"),
+                                    input(KNOWN_TOKEN_2, UNKNOWN_TOKEN, "value2")),
+                            form(input(KNOWN_TOKEN_3, UNKNOWN_TOKEN, "value3")));
             // When
             List<AntiCsrfToken> tokens = extensionAntiCSRF.getTokensFromResponse(message, source);
             // Then
@@ -186,9 +186,9 @@ class ExtensionAntiCSRFUnitTest {
             Source source =
                     createSource(
                             form(
-                                    input(UNKOWN_TOKEN, KNOWN_TOKEN_1, "value1"),
-                                    input(UNKOWN_TOKEN, KNOWN_TOKEN_2, "value2")),
-                            form(input(UNKOWN_TOKEN, KNOWN_TOKEN_3, "value3")));
+                                    input(UNKNOWN_TOKEN, KNOWN_TOKEN_1, "value1"),
+                                    input(UNKNOWN_TOKEN, KNOWN_TOKEN_2, "value2")),
+                            form(input(UNKNOWN_TOKEN, KNOWN_TOKEN_3, "value3")));
             // When
             List<AntiCsrfToken> tokens = extensionAntiCSRF.getTokensFromResponse(message, source);
             // Then
@@ -204,9 +204,9 @@ class ExtensionAntiCSRFUnitTest {
             Source source =
                     createSource(
                             form(
-                                    input(UNKOWN_TOKEN, KNOWN_TOKEN_1, "value1"),
-                                    input(KNOWN_TOKEN_2, UNKOWN_TOKEN, "value2")),
-                            form(input(UNKOWN_TOKEN, KNOWN_TOKEN_3, "value3")));
+                                    input(UNKNOWN_TOKEN, KNOWN_TOKEN_1, "value1"),
+                                    input(KNOWN_TOKEN_2, UNKNOWN_TOKEN, "value2")),
+                            form(input(UNKNOWN_TOKEN, KNOWN_TOKEN_3, "value3")));
             // When
             List<AntiCsrfToken> tokens = extensionAntiCSRF.getTokensFromResponse(message, source);
             // Then
@@ -234,12 +234,12 @@ class ExtensionAntiCSRFUnitTest {
                     createSource(
                             form(
                                     input(
-                                            UNKOWN_TOKEN,
+                                            UNKNOWN_TOKEN,
                                             KNOWN_TOKEN_1.toLowerCase(Locale.ROOT),
                                             "value1"),
                                     input(
                                             KNOWN_TOKEN_2.toLowerCase(Locale.ROOT),
-                                            UNKOWN_TOKEN,
+                                            UNKNOWN_TOKEN,
                                             "value2")));
             // When
             List<AntiCsrfToken> tokens = extensionAntiCSRF.getTokensFromResponse(message, source);
@@ -262,9 +262,9 @@ class ExtensionAntiCSRFUnitTest {
             Source source =
                     createSource(
                             form(
-                                    input(UNKOWN_TOKEN, stringWithKnownToken1, "value1"),
-                                    input(stringWithKnownToken2, UNKOWN_TOKEN, "value2")),
-                            form(input(UNKOWN_TOKEN, stringWithKnownToken3, "value3")));
+                                    input(UNKNOWN_TOKEN, stringWithKnownToken1, "value1"),
+                                    input(stringWithKnownToken2, UNKNOWN_TOKEN, "value2")),
+                            form(input(UNKNOWN_TOKEN, stringWithKnownToken3, "value3")));
             // When
             List<AntiCsrfToken> tokens = extensionAntiCSRF.getTokensFromResponse(message, source);
             // Then
@@ -285,9 +285,9 @@ class ExtensionAntiCSRFUnitTest {
             Source source =
                     createSource(
                             form(
-                                    input(UNKOWN_TOKEN, stringWithKnownToken1, "value1"),
-                                    input(stringWithKnownToken2, UNKOWN_TOKEN, "value2")),
-                            form(input(UNKOWN_TOKEN, stringWithKnownToken3, "value3")));
+                                    input(UNKNOWN_TOKEN, stringWithKnownToken1, "value1"),
+                                    input(stringWithKnownToken2, UNKNOWN_TOKEN, "value2")),
+                            form(input(UNKNOWN_TOKEN, stringWithKnownToken3, "value3")));
             // When
             List<AntiCsrfToken> tokens = extensionAntiCSRF.getTokensFromResponse(message, source);
             // Then


### PR DESCRIPTION
- ExtensionAntiCSRF - Ensure public method always accounts for partial matching.
- ExtensionAntiCSRFUnitTest - Add a method to assert the behavior.

Related to:
- zaproxy/zap-extensions#5196
- zaproxy/zaproxy#8280