### PR TITLE
ITests: add auth with JS cookie test

### DIFF
--- a/docker/integration_tests/configs/plans/auth-json-bearer-cookie.yaml
+++ b/docker/integration_tests/configs/plans/auth-json-bearer-cookie.yaml
@@ -10,7 +10,7 @@ env:
     authentication:
       method: "browser"
       parameters:
-        loginPageUrl: "http://localhost:9091/auth/simple-json-bearer-cookie/ "
+        loginPageUrl: "http://localhost:9091/auth/simple-json-bearer-cookie/"
         loginPageWait: 5
         browserId: "firefox-headless"
       verification:

--- a/docker/integration_tests/configs/plans/auth-json-bearer-js-cookie.yaml
+++ b/docker/integration_tests/configs/plans/auth-json-bearer-js-cookie.yaml
@@ -1,20 +1,19 @@
 ---
 env:
   contexts:
-  - name: "password-added-json"
+  - name: "simple-json-bearer-js-cookie"
     urls:
-    - "http://localhost:9091/auth/password-added-json"
+    - "http://localhost:9091/auth/simple-json-bearer-js-cookie"
     includePaths:
-    - "http://localhost:9091/auth/password-added-json.*"
+    - "http://localhost:9091/auth/simple-json-bearer-js-cookie.*"
     excludePaths: []
     authentication:
       method: "browser"
       parameters:
-        loginPageUrl: "http://localhost:9091/auth/password-added-json/"
+        loginPageUrl: "http://localhost:9091/auth/simple-json-js-bearer-js-cookie/"
         loginPageWait: 5
         browserId: "firefox-headless"
       verification:
-        # Checking 2.13+ compatibility
         method: "autodetect"
     sessionManagement:
       method: "autodetect"
@@ -53,7 +52,7 @@ jobs:
 - parameters:
     user: "test"
   requests:
-  - url: "http://localhost:9091/auth/password-added-json/user"
+  - url: "http://localhost:9091/auth/simple-json-bearer-js-cookie/user"
     name: ""
     method: ""
     httpVersion: ""

--- a/docker/integration_tests/configs/plans/auth-json-bearer.yaml
+++ b/docker/integration_tests/configs/plans/auth-json-bearer.yaml
@@ -10,7 +10,7 @@ env:
     authentication:
       method: "browser"
       parameters:
-        loginPageUrl: "http://localhost:9091/auth/simple-json-bearer/ "
+        loginPageUrl: "http://localhost:9091/auth/simple-json-bearer/"
         loginPageWait: 5
         browserId: "firefox-headless"
       verification:

--- a/docker/integration_tests/configs/plans/auth-non-std-json-bearer.yaml
+++ b/docker/integration_tests/configs/plans/auth-non-std-json-bearer.yaml
@@ -10,7 +10,7 @@ env:
     authentication:
       method: "browser"
       parameters:
-        loginPageUrl: "http://localhost:9091/auth/non-std-json-bearer/ "
+        loginPageUrl: "http://localhost:9091/auth/non-std-json-bearer/"
         loginPageWait: 5
         browserId: "firefox-headless"
       verification:

--- a/docker/integration_tests/configs/plans/auth-password-hidden-json.yaml
+++ b/docker/integration_tests/configs/plans/auth-password-hidden-json.yaml
@@ -10,7 +10,7 @@ env:
     authentication:
       method: "browser"
       parameters:
-        loginPageUrl: "http://localhost:9091/auth/password-hidden-json/ "
+        loginPageUrl: "http://localhost:9091/auth/password-hidden-json/"
         loginPageWait: 5
         browserId: "firefox-headless"
       verification:

--- a/docker/integration_tests/configs/plans/auth-simple-json.yaml
+++ b/docker/integration_tests/configs/plans/auth-simple-json.yaml
@@ -10,7 +10,7 @@ env:
     authentication:
       method: "browser"
       parameters:
-        loginPageUrl: "http://localhost:9091/auth/simple-json/ "
+        loginPageUrl: "http://localhost:9091/auth/simple-json/"
         loginPageWait: 5
         browserId: "firefox-headless"
       verification:


### PR DESCRIPTION
Depends on https://github.com/zaproxy/zap-extensions/pull/5206 
Also removed some spurious spaces from login URLs.