### PR TITLE
Prevent NPE if no user creds

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/users/User.java
+++ b/zap/src/main/java/org/zaproxy/zap/users/User.java
@@ -313,7 +313,11 @@ public class User extends Enableable {
         out.append(Base64.encodeBase64String(user.name.getBytes())).append(FIELD_SEPARATOR);
         out.append(user.getContext().getAuthenticationMethod().getType().getUniqueIdentifier())
                 .append(FIELD_SEPARATOR);
-        out.append(user.authenticationCredentials.encode(FIELD_SEPARATOR));
+        if (user.authenticationCredentials != null) {
+            out.append(user.authenticationCredentials.encode(FIELD_SEPARATOR));
+        } else {
+            out.append(FIELD_SEPARATOR);
+        }
         LOGGER.debug("Encoded user: {}", out);
         return out.toString();
     }

--- a/zap/src/test/java/org/zaproxy/zap/users/UserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/users/UserUnitTest.java
@@ -117,6 +117,21 @@ class UserUnitTest {
     }
 
     @Test
+    void shouldEncodeAndDecodeProperlyWithNoCreds() {
+        // Given
+        User user = spy(new User(CONTEXT_ID, USER_NAME));
+        doReturn(mockedContext).when(user).getContext();
+        // When
+        String encoded = User.encode(user);
+        User result = User.decode(CONTEXT_ID, encoded, mockedExtension);
+        // Then
+        assertEquals(user.getName(), result.getName());
+        assertEquals(user.isEnabled(), result.isEnabled());
+        assertEquals(user.getId(), result.getId());
+        assertEquals(user.getContextId(), result.getContextId());
+    }
+
+    @Test
     void shouldGenerateUniqueIds() {
         // Given
         User u1 = new User(CONTEXT_ID, USER_NAME);


### PR DESCRIPTION
Seen when a user ran an AF plan with all auth/session/verification set to auto-detect.
They should have used auth = Browser Based, but we still shouldnt NPE.