### PR TITLE
Fix context inclusion issues

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/model/Session.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/Session.java
@@ -94,6 +94,7 @@
 // ZAP: 2023/01/10 Tidy up logger.
 // ZAP: 2023/05/21 Allow context import functionality to accept an XML config as input (Issue 7421).
 // ZAP: 2023/06/02 Allow to set the global exclude URLs.
+// ZAP: 2024/01/19 Use the non-regex hierarchic name of a node to check if it is in scope.
 package org.parosproxy.paros.model;
 
 import java.awt.EventQueue;
@@ -839,7 +840,7 @@ public class Session {
         if (sn == null) {
             return false;
         }
-        return isIncludedInScope(sn.getHierarchicNodeName());
+        return isIncludedInScope(sn.getHierarchicNodeName(false));
     }
 
     private boolean isIncludedInScope(String url) {
@@ -862,7 +863,7 @@ public class Session {
         if (sn == null) {
             return false;
         }
-        return isExcludedFromScope(sn.getHierarchicNodeName());
+        return isExcludedFromScope(sn.getHierarchicNodeName(false));
     }
 
     private boolean isExcludedFromScope(String url) {
@@ -900,7 +901,7 @@ public class Session {
         if (sn == null) {
             return false;
         }
-        return isInScope(sn.getHierarchicNodeName());
+        return isInScope(sn.getHierarchicNodeName(false));
     }
 
     public boolean isInScope(String url) {
@@ -1442,7 +1443,7 @@ public class Session {
         if (sn == null) {
             return new ArrayList<>();
         }
-        return getContextsForUrl(sn.getHierarchicNodeName());
+        return getContextsForUrl(sn.getHierarchicNodeName(false));
     }
 
     public List<Context> getContextsForUrl(String url) {

--- a/zap/src/main/java/org/parosproxy/paros/model/SiteMap.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/SiteMap.java
@@ -78,6 +78,7 @@
 // ZAP: 2022/08/23 Make hrefMap an instance variable.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
 // ZAP: 2023/01/10 Tidy up logger.
+// ZAP: 2024/01/19 Store clean node name when adding leaf node.
 package org.parosproxy.paros.model;
 
 import java.awt.EventQueue;
@@ -567,11 +568,9 @@ public class SiteMap extends SortedTreeModel {
         String leafName = SessionStructure.getLeafName(model, nodeName, msg);
         SiteNode node = findChild(parent, leafName);
         if (node == null) {
+            node = new SiteNode(this, ref.getHistoryType(), leafName, nodeName);
             if (!ref.getCustomIcons().isEmpty()) {
-                node = new SiteNode(this, ref.getHistoryType(), leafName);
                 node.setCustomIcons(ref.getCustomIcons(), ref.getClearIfManual());
-            } else {
-                node = new SiteNode(this, ref.getHistoryType(), leafName);
             }
             node.setHistoryReference(ref);
 

--- a/zap/src/main/java/org/parosproxy/paros/model/SiteNode.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/SiteNode.java
@@ -63,6 +63,7 @@
 // and setExcludedFromScope to short-circuit && operator earlier.
 // ZAP: 2022/09/21 Use format specifiers instead of concatenation when logging.
 // ZAP: 2023/01/10 Tidy up logger.
+// ZAP: 2024/01/19 Accept cleanName via constructor and cache non-regex hierarchic node name.
 package org.parosproxy.paros.model;
 
 import java.awt.EventQueue;
@@ -90,8 +91,10 @@ public class SiteNode extends DefaultMutableTreeNode {
 
     private static final long serialVersionUID = 7987615016786179150L;
 
+    private final String cleanName;
     private String nodeName = null;
     private String hierarchicNodeName = null;
+    private String nonRegexHierarchicNodeName;
     private HistoryReference historyReference = null;
     private Vector<HistoryReference> pastHistoryList = new Vector<>(10);
     // ZAP: Support for linking Alerts to SiteNodes
@@ -122,9 +125,14 @@ public class SiteNode extends DefaultMutableTreeNode {
     private Alert highestAlert;
 
     public SiteNode(SiteMap siteMap, int type, String nodeName) {
+        this(siteMap, type, nodeName, nodeName);
+    }
+
+    public SiteNode(SiteMap siteMap, int type, String nodeName, String cleanName) {
         super();
         this.siteMap = siteMap;
         this.nodeName = nodeName;
+        this.cleanName = cleanName;
         this.dataDriven = nodeName.contains(SessionStructure.DATA_DRIVEN_NODE_PREFIX);
         this.icons = new ArrayList<>();
         this.clearIfManual = new ArrayList<>();
@@ -284,29 +292,11 @@ public class SiteNode extends DefaultMutableTreeNode {
     }
 
     public String getCleanNodeName(boolean specialNodesAsRegex) {
-        String name = this.getNodeName();
         if (specialNodesAsRegex && this.isDataDriven()) {
             // Non-greedy regex pattern
-            name = "(.+?)";
-
-        } else if (this.isLeaf()) {
-            int colonIndex = name.indexOf(":");
-            if (colonIndex > 0) {
-                // Strip the GET/POST/etc. off
-                name = name.substring(colonIndex + 1);
-            }
-            int bracketIndex = name.lastIndexOf("(");
-            if (bracketIndex > 0) {
-                // Strip the param summary off
-                name = name.substring(0, bracketIndex);
-            }
-            int queryIndex = name.indexOf("?");
-            if (queryIndex > 0) {
-                // Strip the parameters off
-                name = name.substring(0, queryIndex);
-            }
+            return "(.+?)";
         }
-        return name;
+        return cleanName;
     }
 
     public String getHierarchicNodeName() {
@@ -315,8 +305,9 @@ public class SiteNode extends DefaultMutableTreeNode {
 
     public String getHierarchicNodeName(boolean specialNodesAsRegex) {
         if (hierarchicNodeName != null && specialNodesAsRegex) {
-            // The regex version is used most frequently, so cache
             return hierarchicNodeName;
+        } else if (nonRegexHierarchicNodeName != null && !specialNodesAsRegex) {
+            return nonRegexHierarchicNodeName;
         }
 
         if (this.isRoot()) {
@@ -333,7 +324,7 @@ public class SiteNode extends DefaultMutableTreeNode {
                 name = this.getParent().getHierarchicNodeName(specialNodesAsRegex) + "/" + nodeName;
             }
             if (!specialNodesAsRegex) {
-                // Dont cache the non regex version
+                nonRegexHierarchicNodeName = name;
                 return name;
             }
             hierarchicNodeName = name;

--- a/zap/src/main/java/org/zaproxy/zap/model/Context.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/Context.java
@@ -123,7 +123,7 @@ public class Context {
         if (sn == null) {
             return false;
         }
-        return isIncluded(sn.getHierarchicNodeName());
+        return isIncluded(sn.getHierarchicNodeName(false));
     }
 
     /*
@@ -164,7 +164,7 @@ public class Context {
         if (sn == null) {
             return false;
         }
-        return isExcluded(sn.getHierarchicNodeName());
+        return isExcluded(sn.getHierarchicNodeName(false));
     }
 
     public boolean isExcluded(String url) {
@@ -202,7 +202,7 @@ public class Context {
         if (sn == null) {
             return false;
         }
-        return isInContext(sn.getHierarchicNodeName());
+        return isInContext(sn.getHierarchicNodeName(false));
     }
 
     public boolean isInContext(String url) {


### PR DESCRIPTION
When a strict regex was used (e.g. when importing OpenAPI specs), there were issues with including or excluding endpoints from the context because of improper parsing of nodeNames. This included:

* Endpoints with path params (Data Driven Nodes)
* Endpoints with both query and form params
