### PR TITLE
Feat: Support URL input for hostname override (issue #8312)

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2024-01-23
+- Allow host_override to be a URL (Issue 8312)
+
 ### 2023-12-14
 - Updated to use Webswing 23.2.2 (Issue 8244).
 

--- a/docker/zap-api-scan.py
+++ b/docker/zap-api-scan.py
@@ -58,7 +58,8 @@ import subprocess
 import sys
 import time
 from datetime import datetime
-from six.moves.urllib.parse import urljoin
+
+from six.moves.urllib.parse import urljoin, urlparse
 from zapv2 import ZAPv2
 from zap_common import *
 
@@ -110,7 +111,7 @@ def usage():
     print('    -S                safe mode this will skip the active scan and perform a baseline scan')
     print('    -T                max time in minutes to wait for ZAP to start and the passive scan to run')
     print('    -U user           username to use for authenticated scans - must be defined in the given context file')
-    print('    -O                the hostname to override in the (remote) OpenAPI spec')
+    print('    -O                the hostname or URL to override in the (remote) OpenAPI spec')
     print('    -z zap_options    ZAP command line options e.g. -z "-config aaa=bbb -config ccc=ddd"')
     print('    --hook            path to python file that define your custom hooks')
     print('    --schema          GraphQL schema location, URL or file, e.g. https://www.example.com/schema.graphqls')
@@ -418,9 +419,14 @@ def main(argv):
                 logging.debug('Import OpenAPI URL ' + target_url)
                 res = zap.openapi.import_url(target, host_override)
                 urls = zap.core.urls()
+
                 if host_override:
-                    target = urljoin(target_url, '//' + host_override)
-                    logging.info('Using host override, new target: {0}'.format(target))
+                    if urlparse(host_override).scheme:
+                        target = host_override
+                    else:
+                        target = urljoin(target_url, '//' + host_override)
+                    logging.info(
+                        'Using override, new target: {0}'.format(target))
             else:
                 logging.debug('Import OpenAPI File ' + target_file)
                 res = zap.openapi.import_file(target_file)


### PR DESCRIPTION
Closes #8312 

This PR provides for overriding the hostname with a URL and resolves the issue created when a remote openapi definition is specified whose scheme does match that of the host override.