### PR TITLE
Update zap.sh script to get memory usage in containers

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2024-09-13
+- Update the zap.sh script to use the cgroup memory limit when the IS_CONTAINERIZED environment variable is set to "true".
+
 ### 2024-08-30
 - Updated the API-Minimal scan policy.
 

--- a/docker/Dockerfile-bare
+++ b/docker/Dockerfile-bare
@@ -44,5 +44,6 @@ ENV PATH=$JAVA_HOME/bin:/zap/:$PATH
 ENV ZAP_PATH=/zap/zap.sh
 ENV HOME=/home/zap/
 ENV ZAP_PORT=8080
+ENV IS_CONTAINERIZED=true
 
 HEALTHCHECK CMD curl --silent --output /dev/null --fail http://localhost:$ZAP_PORT/ || exit 1

--- a/zap/src/main/dist/zap.sh
+++ b/zap/src/main/dist/zap.sh
@@ -65,7 +65,24 @@ if [ -f "$JVMPROPS" ]; then
   # Local jvm properties file present
   JMEM=$(head -1 "$JVMPROPS")
 elif [ "$OS" = "Linux" ]; then
-  MEM=$(expr $(sed -n 's/MemTotal:[ ]\{1,\}\([0-9]\{1,\}\) kB/\1/p' /proc/meminfo) / 1024)
+    HOSTMEM=$(expr $(sed -n 's/MemTotal:[ ]\{1,\}\([0-9]\{1,\}\) kB/\1/p' /proc/meminfo) / 1024)
+    if [ "$IS_CONTAINERIZED" = "true" ]; then
+        # Check if memory.stat exists so it can be used to determine the memory limit
+        if [ -f /sys/fs/cgroup/memory/memory.stat ]; then
+            # If we are running in a container, we need to use the cgroup memory limit
+            MEMLIMIT=$(grep hierarchical_memory_limit /sys/fs/cgroup/memory/memory.stat | cut -d' ' -f2)
+            # If the cgroup memory limit is not set, use the host memory
+            if [ "$MEMLIMIT" -eq "9223372036854771712" ]; then
+                MEM=$HOSTMEM
+            else
+                MEM=$(expr $MEMLIMIT / 1024 / 1024)
+            fi
+        else
+            MEM=$HOSTMEM
+        fi
+    else
+        MEM=$HOSTMEM
+    fi
 elif [ "$OS" = "Darwin" ]; then
   MEM=$(system_profiler SPMemoryDataType | sed -n -e 's/.*Size: \([0-9]\{1,\}\) GB/\1/p' | awk '{s+=$0} END {print s*1024}')
   if [ "$MEM" = "0" ]; then


### PR DESCRIPTION
Currently when hard limits are configured on memory in a containerized environment, zap.sh gets the host memory to calculate the memory available to Java, causing unexpected OOM errors.

Since all ZAP container images are given the environment var `IS_CONTAINERIZED`, i think this is currently the best method to detect if we are containerized, and thus use a different method of determining the memory available.

This has been tested in Docker Desktop and Amazon ECS Fargate and works properly. No limits or soft limits will return a linux default value ( 9223372036854771712 ), so there's a fallback to the current method.