### PR TITLE
Itests: add missing MariaDB

### DIFF
--- a/docker/integration_tests/configs/plans/contexts/auth-form-poll.context
+++ b/docker/integration_tests/configs/plans/contexts/auth-form-poll.context
@@ -13,6 +13,7 @@
             <include>Db.Firebird</include>
             <include>Db.HypersonicSQL</include>
             <include>Db.IBM DB2</include>
+            <include>Db.MariaDB</include>
             <include>Db.Microsoft Access</include>
             <include>Db.Microsoft SQL Server</include>
             <include>Db.MongoDB</include>

--- a/docker/integration_tests/configs/plans/contexts/auth-http-both.context
+++ b/docker/integration_tests/configs/plans/contexts/auth-http-both.context
@@ -13,6 +13,7 @@
             <include>Db.Firebird</include>
             <include>Db.HypersonicSQL</include>
             <include>Db.IBM DB2</include>
+            <include>Db.MariaDB</include>
             <include>Db.Microsoft Access</include>
             <include>Db.Microsoft SQL Server</include>
             <include>Db.MongoDB</include>

--- a/docker/integration_tests/configs/plans/contexts/auth-http-poll.context
+++ b/docker/integration_tests/configs/plans/contexts/auth-http-poll.context
@@ -13,6 +13,7 @@
             <include>Db.Firebird</include>
             <include>Db.HypersonicSQL</include>
             <include>Db.IBM DB2</include>
+            <include>Db.MariaDB</include>
             <include>Db.Microsoft Access</include>
             <include>Db.Microsoft SQL Server</include>
             <include>Db.MongoDB</include>

--- a/docker/integration_tests/configs/plans/contexts/auth-json-poll.context
+++ b/docker/integration_tests/configs/plans/contexts/auth-json-poll.context
@@ -13,6 +13,7 @@
             <include>Db.Firebird</include>
             <include>Db.HypersonicSQL</include>
             <include>Db.IBM DB2</include>
+            <include>Db.MariaDB</include>
             <include>Db.Microsoft Access</include>
             <include>Db.Microsoft SQL Server</include>
             <include>Db.MongoDB</include>

--- a/docker/integration_tests/configs/plans/contexts/auth-manual-poll.context
+++ b/docker/integration_tests/configs/plans/contexts/auth-manual-poll.context
@@ -13,6 +13,7 @@
             <include>Db.Firebird</include>
             <include>Db.HypersonicSQL</include>
             <include>Db.IBM DB2</include>
+            <include>Db.MariaDB</include>
             <include>Db.Microsoft Access</include>
             <include>Db.Microsoft SQL Server</include>
             <include>Db.MongoDB</include>

--- a/docker/integration_tests/configs/plans/contexts/auth-manual-resp.context
+++ b/docker/integration_tests/configs/plans/contexts/auth-manual-resp.context
@@ -13,6 +13,7 @@
             <include>Db.Firebird</include>
             <include>Db.HypersonicSQL</include>
             <include>Db.IBM DB2</include>
+            <include>Db.MariaDB</include>
             <include>Db.Microsoft Access</include>
             <include>Db.Microsoft SQL Server</include>
             <include>Db.MongoDB</include>

--- a/docker/integration_tests/configs/plans/contexts/basic.context
+++ b/docker/integration_tests/configs/plans/contexts/basic.context
@@ -13,6 +13,7 @@
             <include>Db.Firebird</include>
             <include>Db.HypersonicSQL</include>
             <include>Db.IBM DB2</include>
+            <include>Db.MariaDB</include>
             <include>Db.Microsoft Access</include>
             <include>Db.Microsoft SQL Server</include>
             <include>Db.MongoDB</include>

--- a/docker/integration_tests/configs/plans/contexts/session-http.context
+++ b/docker/integration_tests/configs/plans/contexts/session-http.context
@@ -13,6 +13,7 @@
             <include>Db.Firebird</include>
             <include>Db.HypersonicSQL</include>
             <include>Db.IBM DB2</include>
+            <include>Db.MariaDB</include>
             <include>Db.Microsoft Access</include>
             <include>Db.Microsoft SQL Server</include>
             <include>Db.MongoDB</include>

--- a/docker/integration_tests/configs/plans/contexts/session-script.context
+++ b/docker/integration_tests/configs/plans/contexts/session-script.context
@@ -13,6 +13,7 @@
             <include>Db.Firebird</include>
             <include>Db.HypersonicSQL</include>
             <include>Db.IBM DB2</include>
+            <include>Db.MariaDB</include>
             <include>Db.Microsoft Access</include>
             <include>Db.Microsoft SQL Server</include>
             <include>Db.MongoDB</include>


### PR DESCRIPTION
Failing as per https://github.com/zaproxy/zaproxy/actions/runs/7953280442/job/21709056231

At least one of the AF auth tests are still failing, also looking at that, but it will hopefully address in another PR...