### PR TITLE
Itests: use autodetect instead of poll

### DIFF
--- a/docker/integration_tests/configs/plans/auth-json-bearer-cookie.yaml
+++ b/docker/integration_tests/configs/plans/auth-json-bearer-cookie.yaml
@@ -14,7 +14,6 @@ env:
         loginPageWait: 5
         browserId: "firefox-headless"
       verification:
-        # Checking 2.13+ compatibility
         method: "autodetect"
     sessionManagement:
       method: "autodetect"

--- a/docker/integration_tests/configs/plans/auth-json-bearer.yaml
+++ b/docker/integration_tests/configs/plans/auth-json-bearer.yaml
@@ -14,8 +14,7 @@ env:
         loginPageWait: 5
         browserId: "firefox-headless"
       verification:
-        # Checking 2.12 compatibility
-        method: "poll"
+        method: "autodetect"
     sessionManagement:
       method: "autodetect"
       parameters: {}

--- a/docker/integration_tests/configs/plans/auth-non-std-json-bearer.yaml
+++ b/docker/integration_tests/configs/plans/auth-non-std-json-bearer.yaml
@@ -14,8 +14,7 @@ env:
         loginPageWait: 5
         browserId: "firefox-headless"
       verification:
-        # Checking 2.12 compatibility
-        method: "poll"
+        method: "autodetect"
     sessionManagement:
       method: "autodetect"
       parameters: {}

--- a/docker/integration_tests/configs/plans/auth-password-added-json.yaml
+++ b/docker/integration_tests/configs/plans/auth-password-added-json.yaml
@@ -14,7 +14,6 @@ env:
         loginPageWait: 5
         browserId: "firefox-headless"
       verification:
-        # Checking 2.13+ compatibility
         method: "autodetect"
     sessionManagement:
       method: "autodetect"

--- a/docker/integration_tests/configs/plans/auth-password-hidden-json.yaml
+++ b/docker/integration_tests/configs/plans/auth-password-hidden-json.yaml
@@ -14,7 +14,6 @@ env:
         loginPageWait: 5
         browserId: "firefox-headless"
       verification:
-        # Checking 2.13+ compatibility
         method: "autodetect"
     sessionManagement:
       method: "autodetect"

--- a/docker/integration_tests/configs/plans/auth-password-new-json.yaml
+++ b/docker/integration_tests/configs/plans/auth-password-new-json.yaml
@@ -14,7 +14,6 @@ env:
         loginPageWait: 5
         browserId: "firefox-headless"
       verification:
-        # Checking 2.13+ compatibility
         method: "autodetect"
     sessionManagement:
       method: "autodetect"

--- a/docker/integration_tests/configs/plans/auth-simple-json.yaml
+++ b/docker/integration_tests/configs/plans/auth-simple-json.yaml
@@ -14,7 +14,6 @@ env:
         loginPageWait: 5
         browserId: "firefox-headless"
       verification:
-        # Checking 2.13+ compatibility
         method: "autodetect"
     sessionManagement:
       method: "autodetect"


### PR DESCRIPTION
The poll option was for 2.12 compatibility.
That doesnt seem to work now, and in any case we dont need to support it.