### PR TITLE
Add application/yaml to expected API types

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2024-03-19
+- Alert_on_Unexpected_Content_Types.js > Added Content-Type application/yaml to the list of expected types (Issue 8366).
+
 ### 2024-03-05
 - ZAP images no longer pushed to the OWASP Docker Hub.
 

--- a/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
+++ b/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
@@ -20,6 +20,7 @@ var expectedTypes = [
 		"application/xml",
 		"application/x-ndjson",
 		"application/x-yaml",
+		"application/yaml",
 		"text/x-json",
 		"text/json",
 		"text/yaml",


### PR DESCRIPTION
## This PR

- support application/yaml

- Fix #8366

## Notes

It should be investigated whether other unregistered, deprecated media types for YAML should return a warning or an error.
