### PR TITLE
handle scheme check if host override has localhost

### DIFF
--- a/docker/zap-api-scan.py
+++ b/docker/zap-api-scan.py
@@ -421,7 +421,8 @@ def main(argv):
                 urls = zap.core.urls()
 
                 if host_override:
-                    if urlparse(host_override).scheme:
+                    parsed_url = urlparse(host_override)
+                    if parsed_url.scheme and parsed_url.scheme != 'localhost':
                         target = host_override
                     else:
                         target = urljoin(target_url, '//' + host_override)


### PR DESCRIPTION
if host override has localhost like:
host_override = 'localhost:3000'

then urlparse(host_override).scheme returns "localhost" and then the target is set as localhost:3000. 


**with current changes:**
```
target_url = 'https://dummy.com'
host_override = 'localhost:3000'

if host_override:
    if urlparse(host_override).scheme:
        target = host_override
    else:
        target = urljoin(target_url, '//' + host_override)
                       
print(target)
```
**output:**
localhost:3000

**proposed change:**
```
if host_override:
    parsed_url = urlparse(host_override)
    if parsed_url.scheme and parsed_url.scheme != 'localhost':
        target = host_override
    else:
        target = urljoin(target_url, '//' + host_override)
```

