### PR TITLE
Prevent encoding of [] in the host part of IPv6 reference URIs

### DIFF
--- a/zap/src/main/java/org/apache/commons/httpclient/URI.java
+++ b/zap/src/main/java/org/apache/commons/httpclient/URI.java
@@ -2240,9 +2240,7 @@ public class URI implements Cloneable, Comparable<Object>, Serializable {
                 next++;
             }
             // In IPv6reference, '[', ']' should be excluded
-            _host = (escaped) ? original.substring(from, next).toCharArray() 
-                : encode(original.substring(from, next), allowed_IPv6reference,
-                        charset);
+            _host = original.substring(from, next).toCharArray();
             // Set flag
             _is_IPv6reference = true;
         } else { // only for !_is_IPv6reference


### PR DESCRIPTION
Currently proxying IPv6 reference URIs is not possible. This is because `HttpRequestHeader.parseURI` first attempts to repair URIs containing unencoded characters by encoding them before calling `new URI` with `encoded=true`. This includes the `[]` characters that are part of the authority section and so `http://[::1]/` becomes `http://%5B::1%5C`.
Here I want to avoid having to add parsing of the authority section to HttpRequestHeader while keeping the URI repairing behavior the same (would be different if using `encoded=false` ). First call `new URI` with `encoded=false` if this was an IPv6 reference then apply repairing to the rest of URI. Otherwise repair the whole URI. Finally call `new URI` with `encoded=true`.