### PR TITLE
Check for script exception after running it

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -2091,6 +2091,11 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
             // Only invoke if run from the command line
             // if the GUI is present then its up to the user to invoke it
             this.invokeScript(sw);
+
+            Exception e = sw.getLastException();
+            if (e != null) {
+                CommandLine.error(e.getMessage(), e);
+            }
         }
     }
 


### PR DESCRIPTION
Log/print possible errors when running the scripts specified through the command line (e.g. `-script`, direct file path).

Fix #8403.