### PR TITLE
Fix build failures

### DIFF
--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/distributions.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/distributions.gradle.kts
@@ -69,6 +69,7 @@ val bundledAddOns: Any = provider {
 }
 
 val distFiles by tasks.registering(Sync::class) {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     destinationDir = layout.buildDirectory.dir("distFiles").get().asFile
     from(jarWithBom)
     from(distDir) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx4096M


### PR DESCRIPTION
This fixes two issues that an average user will have when cloning the repository and attempting to build. 

1. The default gradle heap allocation is insufficient to build this project. The `gradle.property` change simply increases the heap on a project-scope
2. This change fixes an error in the assemble task caused by duplicate resources. This can be mitigated by changes in the structure, but a 'default' installation will have this error. 

Here's the stacktrace of the issue above:
```
peter@host:~/zaproxy^main ±
% git reset --hard && ./gradlew clean                                                                               24-03-18 - 11:50:23
HEAD is now at 1d1e2d6a6 Merge pull request #8404 from thc202/scripts/check-ex

BUILD SUCCESSFUL in 899ms
13 actionable tasks: 4 executed, 5 from cache, 4 up-to-date

peter@host:~/zaproxy^main ±
% ./gradlew assemble                                                                                                24-03-18 - 11:50:33

> Task :zap:cyclonedxRuntimeBom
Unknown keyword additionalItems - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword

> Task :zap:distFiles FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':zap:distFiles'.
> Entry zap.ico is a duplicate but no duplicate handling strategy has been set. Please refer to https://docs.gradle.org/8.5/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 2s
17 actionable tasks: 6 executed, 1 from cache, 10 up-to-date
```