### PR TITLE
Remove log level flag when executing chalk

### DIFF
--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -160,7 +160,7 @@ listOf("jar", "jarDaily", "jarWithBom").forEach {
                 exec {
                     workingDir(rootDir)
                     executable("chalk")
-                    args("--warn", "insert", archiveFile.get().asFile)
+                    args("insert", archiveFile.get().asFile)
                 }
             }
         }


### PR DESCRIPTION
Rely on default behavior to make it easier to debug when needed.