### PR TITLE
Add TAGs for yaml, xml, extended json

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/Constant.java
+++ b/zap/src/main/java/org/parosproxy/paros/Constant.java
@@ -124,6 +124,7 @@
 // ZAP: 2023/08/21 Deprecate vulnerabilities constants.
 // ZAP: 2023/08/28 Update paths in config file to match the renamed home dir.
 // ZAP: 2023/09/14 Lock home directory.
+// ZAP: 2024/04/25 Add new autoTagScanner regex patterns when upgrading from 2.14 or earlier.
 package org.parosproxy.paros;
 
 import java.io.File;
@@ -208,6 +209,7 @@ public final class Constant {
     static final long VERSION_TAG = 20014000;
 
     // Old version numbers - for upgrade
+    private static final long V_2_14_0_TAG = 20014000;
     private static final long V_2_12_0_TAG = 20012000;
     private static final long V_2_11_1_TAG = 20011001;
     private static final long V_2_9_0_TAG = 2009000;
@@ -754,6 +756,9 @@ public final class Constant {
                     if (ver <= V_2_12_0_TAG) {
                         upgradeFrom2_12(config);
                     }
+                    if (ver <= V_2_14_0_TAG) {
+                        upgradeFrom2_14_0(config);
+                    }
 
                     // Execute always to pick installer choices.
                     updateCfuFromDefaultConfig(config);
@@ -1269,6 +1274,55 @@ public final class Constant {
         config.setProperty("view.largeRequest", null);
         config.setProperty("view.largeResponse", null);
         config.setProperty("hud.enableTelemetry", null);
+    }
+
+    static void upgradeFrom2_14_0(XMLConfiguration config) throws ConfigurationException {
+        List<HierarchicalConfiguration> existingTagScanners =
+                config.configurationsAt("pscans.autoTagScanners.scanner");
+        List<Object> existingNames = config.getList("pscans.autoTagScanners.scanner.name");
+
+        String leadingAutoTagScannersKey = "pscans.autoTagScanners.scanner(";
+        String trailingNameKey = ").name";
+        String trailingTypeKey = ").type";
+        String trailingConfigKey = ").config";
+        String trailingResHeadRegex = ").resHeadRegex";
+        String trailingEnableKey = ").enabled";
+
+        int index = existingTagScanners.size(); // Size is next index due to 0th start
+
+        if (!existingNames.contains("json_extended")) {
+            config.addProperty(
+                    leadingAutoTagScannersKey + index + trailingNameKey, "json_extended");
+            config.addProperty(leadingAutoTagScannersKey + index + trailingTypeKey, "TAG");
+            config.addProperty(leadingAutoTagScannersKey + index + trailingConfigKey, "JSON");
+            config.addProperty(
+                    leadingAutoTagScannersKey + index + trailingResHeadRegex,
+                    "content-type:\\s{0,10}.{1,20}\\/.{0,100}json");
+            config.addProperty(leadingAutoTagScannersKey + index + trailingEnableKey, false);
+            ++index;
+        }
+
+        if (!existingNames.contains("response_yaml")) {
+            config.addProperty(
+                    leadingAutoTagScannersKey + index + trailingNameKey, "response_yaml");
+            config.addProperty(leadingAutoTagScannersKey + index + trailingTypeKey, "TAG");
+            config.addProperty(leadingAutoTagScannersKey + index + trailingConfigKey, "YAML");
+            config.addProperty(
+                    leadingAutoTagScannersKey + index + trailingResHeadRegex,
+                    "content-type:\\s{0,10}.{1,20}\\/.{0,100}yaml");
+            config.addProperty(leadingAutoTagScannersKey + index + trailingEnableKey, false);
+            ++index;
+        }
+
+        if (!existingNames.contains("response_xml")) {
+            config.addProperty(leadingAutoTagScannersKey + index + trailingNameKey, "response_xml");
+            config.addProperty(leadingAutoTagScannersKey + index + trailingTypeKey, "TAG");
+            config.addProperty(leadingAutoTagScannersKey + index + trailingConfigKey, "XML");
+            config.addProperty(
+                    leadingAutoTagScannersKey + index + trailingResHeadRegex,
+                    "content-type:\\s{0,10}.{1,20}\\/.{0,100}xml");
+            config.addProperty(leadingAutoTagScannersKey + index + trailingEnableKey, false);
+        }
     }
 
     private static void updateDefaultInt(

--- a/zap/src/main/resources/org/zaproxy/zap/resources/config.xml
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/config.xml
@@ -123,6 +123,36 @@
 				<resBodyRegex/>
 				<enabled>true</enabled>
 			</scanner>
+			<scanner>
+				<name>json_extended</name>
+				<type>TAG</type>
+				<config>JSON</config>
+				<reqUrlRegex/>
+				<reqHeadRegex/>
+				<resHeadRegex>content-type:\s{0,10}.{1,20}\/.{0,100}json</resHeadRegex>
+				<resBodyRegex/>
+				<enabled>false</enabled>
+			</scanner>
+			<scanner>
+				<name>response_yaml</name>
+				<type>TAG</type>
+				<config>YAML</config>
+				<reqUrlRegex/>
+				<reqHeadRegex/>
+				<resHeadRegex>content-type:\s{0,10}.{1,20}\/.{0,100}yaml</resHeadRegex>
+				<resBodyRegex/>
+				<enabled>false</enabled>
+			</scanner>
+			<scanner>
+				<name>response_xml</name>
+				<type>TAG</type>
+				<config>XML</config>
+				<reqUrlRegex/>
+				<reqHeadRegex/>
+				<resHeadRegex>content-type:\s{0,10}.{1,20}\/.{0,100}xml</resHeadRegex>
+				<resBodyRegex/>
+				<enabled>false</enabled>
+			</scanner>
 		</autoTagScanners>
 	</pscans>
 


### PR DESCRIPTION
- config.xml > Add new patterns. Disabled by default.
- Constant > Update version info, add upgrade method.
- ConstantUnitTest > Add test to ensure new patterns are added on upgrade.
- DefaultRegexAutoTagScannerTest > Added tests for the new patterns and modulized initial test(s).

Character length restrictions in the patterns are based on http://www.iana.org/assignments/media-types/media-types.xhtml plus extra. Mainly to prevent any possible ReDOS or just stupid processing on an invalid input.

Related to zaproxy/zaproxy#8399 and zaproxy/zaproxy#8456