### PR TITLE
Skip deleted msgs in the messages API endpoints

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -1726,6 +1726,9 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
             PaginationConstraintsChecker pcc = new PaginationConstraintsChecker(start, count);
             for (Integer id : historyIds) {
                 RecordHistory recHistory = tableHistory.read(id);
+                if (recHistory == null) {
+                    continue;
+                }
 
                 HttpMessage msg = recHistory.getHttpMessage();
 


### PR DESCRIPTION
Handle messages that no longer exist when processing the messages for one of the messages API endpoints.
It's possible that from the moment the IDs of the messages were obtained to when the messages are actually read from the DB that they no longer exist (e.g. spider tasks or other temporary messages were deleted in the meantime).

---
From ZAP User Group: https://groups.google.com/g/zaproxy-users/c/cZlBW9cLazs/m/anCsFNdQAAAJ