### PR TITLE
fix: Double word typos

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/API.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/API.java
@@ -287,7 +287,7 @@ public class API {
      * @param requestHeader the request header
      * @param httpIn the HTTP input stream
      * @param httpOut the HTTP output stream
-     * @param force if set then always handle an an API request (will not return null)
+     * @param force if set then always handle an API request (will not return null)
      * @return null if its not an API request, an empty message if it was silently dropped or the
      *     API response sent.
      * @throws IOException

--- a/zap/src/main/java/org/zaproxy/zap/view/popup/ExtensionPopupMenuComponent.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/popup/ExtensionPopupMenuComponent.java
@@ -127,8 +127,8 @@ public interface ExtensionPopupMenuComponent {
     boolean isSafe();
 
     /**
-     * Called after the pop up menu in which this pop up menu component is is dismissed, indicating
-     * the menu component that was selected or {@code null} if none.
+     * Called after the pop up menu in which this pop up menu component is dismissed, indicating the
+     * menu component that was selected or {@code null} if none.
      *
      * <p>Can be used to free any resources no longer needed (e.g. references to UI components)
      * after being shown in the pop up menu.


### PR DESCRIPTION
Based on the search:
`\bthe the\b|\bthat that\b|\bin in\b|\bis is\b|\band and\b|\bare are\b|\bon on\b|\bout out\b|\ba a\b|\bit it\b|\bor or\b|\bas as\b|\ban an\b` in `*.java, *.html, Messages.properties`