### PR TITLE
host override and local openapi spec pathing

### DIFF
--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -266,6 +266,10 @@ def cp_to_docker(cid, file, dir):
     params = ['docker', 'cp', file, cid + ':' + dir + file]
     logging.debug (subprocess.check_output(params))
 
+def cp_to_docker_dest(cid, file, dir, dest):
+    logging.debug ('Copy ' + file)
+    params = ['docker', 'cp', file, cid + ':' + dest]
+    logging.debug (subprocess.check_output(params))
 
 def running_in_docker():
     return os.path.exists('/.dockerenv') or os.path.exists('/run/.containerenv') or os.environ.get("IS_CONTAINERIZED") == "true"


### PR DESCRIPTION
Hello and thanks for all of your amazing work you do on ZAP! 

This Pull request adds support for 2 edge-cases that I encountered related to specifying a local openapi spec file and passing a host name override.

1. When specifying openapi spec as a local file, the host override parameter `-O` was ignored. 
2. When specifying an absolute file path for the openapi spec file with the `-t` argument, the `zap-api-scan.py` is expecting the file to be written to `/zap/` but would be written to `/zap/local/file/absolutepath` 

You can reproduce the error with 
 `python zap-api-scan.py -d -t /local/file/absolutepath/openapi.yml -J zap-api-report.json -f openapi -O api.example.us`

