### PR TITLE
Support decode response body through the `Variant`

### DIFF
--- a/zap/gradle/japicmp.yaml
+++ b/zap/gradle/japicmp.yaml
@@ -6,6 +6,7 @@ packageExcludes: []
 fieldExcludes: []
 classExcludes: []
 methodExcludes:
+  - "org.parosproxy.paros.core.scanner.Variant#decodeResponseBody(org.parosproxy.paros.network.HttpMessage)"
   - "org.zaproxy.zap.control.CoreFunctionality#getBuiltInActiveScanRules()"
   - "org.zaproxy.zap.extension.AddOnInstallationStatusListener#update(org.zaproxy.zap.extension.AddOnInstallationStatusListener$StatusUpdate)"
   - "org.zaproxy.zap.view.popup.ExtensionPopupMenuComponent#getWeight()"

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractAppParamPlugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractAppParamPlugin.java
@@ -46,6 +46,7 @@
 // ZAP: 2023/01/10 Use logger provided by base class.
 package org.parosproxy.paros.core.scanner;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -135,6 +136,12 @@ public abstract class AbstractAppParamPlugin extends AbstractAppPlugin {
                 }
             }
         }
+    }
+
+    @Override
+    protected void sendAndReceive(HttpMessage message) throws IOException {
+        sendAndReceive(message, true);
+        variant.decodeResponseBody(message);
     }
 
     /**

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractAppParamPlugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractAppParamPlugin.java
@@ -141,6 +141,10 @@ public abstract class AbstractAppParamPlugin extends AbstractAppPlugin {
     @Override
     protected void sendAndReceive(HttpMessage message) throws IOException {
         sendAndReceive(message, true);
+        decodeResponseBody(message);
+    }
+
+    protected void decodeResponseBody(HttpMessage message) {
         variant.decodeResponseBody(message);
     }
 

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractAppParamPlugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractAppParamPlugin.java
@@ -46,7 +46,6 @@
 // ZAP: 2023/01/10 Use logger provided by base class.
 package org.parosproxy.paros.core.scanner;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -139,11 +138,6 @@ public abstract class AbstractAppParamPlugin extends AbstractAppPlugin {
     }
 
     @Override
-    protected void sendAndReceive(HttpMessage message) throws IOException {
-        sendAndReceive(message, true);
-        decodeResponseBody(message);
-    }
-
     protected void decodeResponseBody(HttpMessage message) {
         variant.decodeResponseBody(message);
     }

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -329,6 +329,7 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
      * payload to clear text to allow to do text/string comparisons of the content.
      *
      * @param message the HTTP message whose response body will be decoded
+     * @since 2.15.0
      */
     protected void decodeResponseBody(HttpMessage message) {}
 

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -316,12 +316,21 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
             parent.getHttpSender().sendAndReceive(message, false);
         }
 
+        decodeResponseBody(message);
         // ZAP: Notify parent
         parent.notifyNewMessage(this, message);
 
         // ZAP: Set the history reference back and run the "afterScan" methods of any ScannerHooks
         parent.performScannerHookAfterScan(message, this);
     }
+
+    /**
+     * Decodes the response body of the given {@code HttpMessage}. for example, to change a binary
+     * payload to clear text to allow to do text/string comparisons of the content.
+     *
+     * @param message the HTTP message whose response body will be decoded
+     */
+    protected void decodeResponseBody(HttpMessage message) {}
 
     @SuppressWarnings("removal")
     private void delayRequest() {

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Variant.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Variant.java
@@ -102,4 +102,6 @@ public interface Variant {
     default List<String> getTreePath(HttpMessage msg) throws URIException {
         return null;
     }
+
+    default void decodeResponseBody(HttpMessage msg) {}
 }

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Variant.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Variant.java
@@ -103,5 +103,12 @@ public interface Variant {
         return null;
     }
 
-    default void decodeResponseBody(HttpMessage msg) {}
+    /**
+     * Decodes the response body of the given {@code HttpMessage}. for example, to change a binary
+     * payload to clear text to allow to do text/string comparisons of the content.
+     *
+     * @param msg the HTTP message whose response body will be decoded
+     * @since 2.15.0
+     */
+    void decodeResponseBody(HttpMessage msg);
 }

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Variant.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Variant.java
@@ -111,5 +111,4 @@ public interface Variant {
      * @since 2.15.0
      */
     default void decodeResponseBody(HttpMessage msg) {}
-    ;
 }

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Variant.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Variant.java
@@ -110,5 +110,6 @@ public interface Variant {
      * @param msg the HTTP message whose response body will be decoded
      * @since 2.15.0
      */
-    void decodeResponseBody(HttpMessage msg);
+    default void decodeResponseBody(HttpMessage msg) {}
+    ;
 }


### PR DESCRIPTION
## Overview
This add decoding response body support of variants

## Related Issues
https://github.com/zaproxy/zaproxy/issues/7695

@thc202 


## Checklist
- [ ] Update help
- [ ] Update changelog
- [x] Run `./gradlew spotlessApply` for code formatting
- [ ] Write tests
- [ ] Check code coverage
- [x] Sign-off commits
- [ ] Squash commits
- [x] Use a descriptive title
