### PR TITLE
Include pluginId in alert events

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertEventPublisher.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertEventPublisher.java
@@ -43,6 +43,7 @@ public class AlertEventPublisher implements EventPublisher {
     public static final String HISTORY_REFERENCE_ID = "historyId";
 
     public static final String NAME = "name";
+    public static final String PLUGIN_ID = "pluginId";
     public static final String URI = "uri";
     public static final String PARAM = "param";
     public static final String RISK = "risk";

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -364,6 +364,7 @@ public class ExtensionAlert extends ExtensionAdaptor
                 AlertEventPublisher.HISTORY_REFERENCE_ID,
                 Integer.toString(alert.getSourceHistoryId()));
         map.put(AlertEventPublisher.NAME, alert.getName());
+        map.put(AlertEventPublisher.PLUGIN_ID, Integer.toString(alert.getPluginId()));
         map.put(AlertEventPublisher.URI, alert.getUri().toString());
         map.put(AlertEventPublisher.PARAM, alert.getParam());
         map.put(AlertEventPublisher.RISK, Integer.toString(alert.getRisk()));


### PR DESCRIPTION
This means event consumers will be able to reliably identify alerts. 
Right now they only have access to the alert names, with are i18ned.