### PR TITLE
Update dependencies

### DIFF
--- a/LEGALNOTICE.md
+++ b/LEGALNOTICE.md
@@ -32,23 +32,23 @@ and subject to their respective licenses.
 | Library                             | License                   |
 |-------------------------------------|---------------------------|
 | commons-beanutils-1.9.4.jar         | Apache 2.0                |
-| commons-codec-1.16.0.jar            | Apache 2.0                |
+| commons-codec-1.16.1.jar            | Apache 2.0                |
 | commons-collections-3.2.2.jar       | Apache 2.0                |
 | commons-configuration-1.10.jar      | Apache 2.0                |
 | commons-csv-1.10.0.jar              | Apache 2.0                |
 | commons-httpclient-3.1.jar          | Apache 2.0                |
-| commons-io-2.15.0.jar               | Apache 2.0                |
+| commons-io-2.16.1.jar               | Apache 2.0                |
 | commons-lang-2.6.jar                | Apache 2.0                |
 | commons-lang3-3.14.0.jar            | Apache 2.0                |
-| commons-logging-1.2.jar             | Apache 2.0                |
-| commons-text-1.11.0.jar             | Apache 2.0                |
+| commons-logging-1.3.1.jar           | Apache 2.0                |
+| commons-text-1.12.0.jar             | Apache 2.0                |
 | ezmorph-1.0.6.jar                   | Apache 2.0                |
 | flatlaf-3.4.1.jar                   | Apache 2.0                |
 | harlib-1.1.3.jar                    | Apache 2.0                |
 | hsqldb-2.7.2.jar                    | BSD                       |
 | jackson-core-asl-1.9.13.jar         | Apache 2.0                |
 | javahelp-2.0.05.jar                 | GPL + classpath exception |
-| java-semver-0.9.0.jar               | MIT                       |
+| java-semver-0.10.2.jar              | MIT                       |
 | jericho-html-3.4.jar                | EPL / LGPL dual license   |
 | jfreechart-1.5.4.jar                | LGPL                      |
 | jgrapht-core-0.9.0.jar              | LGPL 2.1                  |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import net.ltgt.gradle.errorprone.errorprone
 
 plugins {
     id("com.diffplug.spotless")
-    id("org.sonarqube") version "4.3.0.3225"
+    id("org.sonarqube") version "5.0.0.4638"
     id("com.github.ben-manes.versions") version "0.50.0"
     id("net.ltgt.errorprone") version "3.1.0"
 }
@@ -22,7 +22,7 @@ subprojects {
 
     project.plugins.withType(JavaPlugin::class) {
         dependencies {
-            "errorprone"("com.google.errorprone:error_prone_core:2.23.0")
+            "errorprone"("com.google.errorprone:error_prone_core:2.26.1")
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/Version.java
+++ b/zap/src/main/java/org/zaproxy/zap/Version.java
@@ -43,7 +43,7 @@ public final class Version implements Comparable<Version> {
         validateNotEmpty(version, "Parameter version must not be null nor empty.");
 
         try {
-            impl = new com.github.zafarkhaja.semver.Version.Builder(version).build();
+            impl = com.github.zafarkhaja.semver.Version.parse(version);
         } catch (com.github.zafarkhaja.semver.ParseException e) {
             throw new IllegalArgumentException(
                     "Parameter version [" + version + "] is not valid: " + e.getMessage());
@@ -62,7 +62,7 @@ public final class Version implements Comparable<Version> {
      * @return the major version
      */
     public int getMajorVersion() {
-        return impl.getMajorVersion();
+        return (int) impl.majorVersion();
     }
 
     /**
@@ -71,7 +71,7 @@ public final class Version implements Comparable<Version> {
      * @return the minor version
      */
     public int getMinorVersion() {
-        return impl.getMinorVersion();
+        return (int) impl.minorVersion();
     }
 
     /**
@@ -80,7 +80,7 @@ public final class Version implements Comparable<Version> {
      * @return the patch version
      */
     public int getPatchVersion() {
-        return impl.getPatchVersion();
+        return (int) impl.patchVersion();
     }
 
     /**

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -84,16 +84,16 @@ tasks.withType<JavaCompile>().configureEach {
 
 dependencies {
     api("com.fifesoft:rsyntaxtextarea:3.4.0")
-    api("com.github.zafarkhaja:java-semver:0.9.0")
+    api("com.github.zafarkhaja:java-semver:0.10.2")
     api("commons-beanutils:commons-beanutils:1.9.4")
-    api("commons-codec:commons-codec:1.16.0")
+    api("commons-codec:commons-codec:1.16.1")
     api("commons-collections:commons-collections:3.2.2")
     api("commons-configuration:commons-configuration:1.10")
     api("commons-httpclient:commons-httpclient:3.1")
-    api("commons-io:commons-io:2.15.0")
+    api("commons-io:commons-io:2.16.1")
     api("commons-lang:commons-lang:2.6")
     api("org.apache.commons:commons-lang3:3.14.0")
-    api("org.apache.commons:commons-text:1.11.0")
+    api("org.apache.commons:commons-text:1.12.0")
     api("edu.umass.cs.benchlab:harlib:1.1.3")
     api("javax.help:javahelp:2.0.05")
     val log4jVersion = "2.20.0"
@@ -111,12 +111,12 @@ dependencies {
 
     implementation("com.formdev:flatlaf:3.4.1")
 
-    runtimeOnly("commons-logging:commons-logging:1.2")
+    runtimeOnly("commons-logging:commons-logging:1.3.1")
     runtimeOnly("xom:xom:1.3.9") {
         setTransitive(false)
     }
 
-    testImplementation("net.bytebuddy:byte-buddy:1.14.10")
+    testImplementation("net.bytebuddy:byte-buddy:1.14.14")
     testImplementation("org.hamcrest:hamcrest-core:2.2")
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")


### PR DESCRIPTION
Update:
 - Commons Codec to 1.16.1.
 - Commons IO to 1.16.1.
 - Commons Logging to 1.3.1.
 - Commons Text to 1.12.0.
 - Java SemVer to 0.10.2.

Address deprecation/warns with Java SemVer classes. Update some build and test dependencies.