### PR TITLE
Fix NPE in `AbstractAppParamPlugin`

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractAppParamPlugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractAppParamPlugin.java
@@ -139,6 +139,10 @@ public abstract class AbstractAppParamPlugin extends AbstractAppPlugin {
 
     @Override
     protected void decodeResponseBody(HttpMessage message) {
+        if (variant == null) {
+            return;
+        }
+
         variant.decodeResponseBody(message);
     }
 


### PR DESCRIPTION
Check that the `variant` is non-null before attempting to decode the body, as it can be if the extending class sends requests before (indirectly) initializing the `variant`.

From logs in #8460.