### PR TITLE
Grpc: gRPC-web-text constant added in NameValuePair

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/NameValuePair.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/NameValuePair.java
@@ -82,6 +82,13 @@ public class NameValuePair implements Comparable<NameValuePair> {
      */
     public static final int TYPE_GRAPHQL_INLINE = 38;
 
+    /**
+     * The application/grpc-web-text content-type of a web application
+     *
+     * @since 2.15.0
+     */
+    public static final int TYPE_GRPC_WEB_TEXT = 39;
+
     public static final int TYPE_UNDEFINED = -1;
 
     private final int targetType;

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/NameValuePair.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/NameValuePair.java
@@ -85,7 +85,7 @@ public class NameValuePair implements Comparable<NameValuePair> {
     /**
      * The application/grpc-web-text content-type of a web application
      *
-     * @since 2.15.0
+     * @since 2.16.0
      */
     public static final int TYPE_GRPC_WEB_TEXT = 39;
 


### PR DESCRIPTION
## Related Issues
[zaproxy/zaproxy#7695](https://github.com/zaproxy/zaproxy/issues/7695)

## Checklist
- [x] Run `./gradlew spotlessApply` for code formatting