### PR TITLE
Fix exceptions for no/empty path in path variant

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantURLPath.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantURLPath.java
@@ -122,6 +122,9 @@ public class VariantURLPath implements Variant {
         }
         // Attack new path at the end
         stringParam.add(new NameValuePair(NameValuePair.TYPE_URL_PATH, "", "", i));
+        if (segments == null || segments.length == 0) {
+            segments = new String[] {""};
+        }
     }
 
     // Adapted from URLCodec#decodeUrl

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantURLPathUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantURLPathUnitTest.java
@@ -104,6 +104,20 @@ class VariantURLPathUnitTest {
                         parameter("", 6)));
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"", "/"})
+    void shouldInjectSegmentModificationToNoPathAndEmptyPath(String path) {
+        // Given
+        VariantURLPath variantUrlPath = new VariantURLPath();
+        HttpMessage message = createMessageWithPath(path);
+        variantUrlPath.setMessage(message);
+        // When
+        String injectedValue = variantUrlPath.setParameter(message, parameter("", 1), "", "Value");
+        // Then
+        assertThat(injectedValue, is(equalTo("Value")));
+        assertThat(message, containsPath("/Value"));
+    }
+
     @Test
     void shouldInjectSegmentModification() {
         // Given


### PR DESCRIPTION
Ensure there's at least one path segment for the extra parameter, otherwise it would fail when setting the value as there would be no segments to process (either null or invalid position).