### PR TITLE
Do not use null domain in auth credentials

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/authentication/HttpAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/HttpAuthenticationMethodType.java
@@ -170,7 +170,7 @@ public class HttpAuthenticationMethodType extends AuthenticationMethodType {
                                 userCredentials.getUsername(),
                                 userCredentials.getPassword(),
                                 InetAddress.getLocalHost().getCanonicalHostName(),
-                                this.realm);
+                                realm == null ? "" : realm);
                 session.getHttpState().setCredentials(stateAuthScope, stateCredentials);
             } catch (UnknownHostException e1) {
                 user.getAuthenticationState().setLastAuthFailure(e1.getMessage());


### PR DESCRIPTION
Use an empty string for the domain when creating the auth credentials as null is not allowed.