### PR TITLE
Skip unwrap of stats

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/PythonAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/PythonAPIGenerator.java
@@ -67,7 +67,13 @@ public class PythonAPIGenerator extends AbstractAPIGenerator {
                     + "\"\"\"\n\n";
 
     private static final Map<String, Set<String>> NON_WRAPPED_API_ELEMENTS =
-            Map.of("automation", Set.of("planProgress"), "users", Set.of("getUserById"));
+            Map.of(
+                    "automation",
+                    Set.of("planProgress"),
+                    "stats",
+                    Set.of("stats"),
+                    "users",
+                    Set.of("getUserById"));
 
     /** Map any names which are reserved in python to something legal */
     private static final Map<String, String> nameMap;


### PR DESCRIPTION
Exclude `stats/stats` from the unwrap as it's not wrapped in an object.

Part of zaproxy/zap-api-python#114.