### PR TITLE
Reserve IDs for Passive Community Scripts

### DIFF
--- a/docs/scanners.md
+++ b/docs/scanners.md
@@ -257,6 +257,9 @@ Scan rules:
 100031  DNS Email Spoofing [Script]
 100032  WordPress Username Enumeration [Script]
 100033  Server Side Template Injection [Script]
+100034  Information Disclosure - Google API Key [Script]
+100035  Information Disclosure - Java Stack Trace [Script]
+100035  Information Disclosure - Amazon S3 Bucket URL [Script]
 
 110000  Websocket Passive Scan scripts
 110001  Application Error Disclosure [Script]


### PR DESCRIPTION
Reserve IDs for the following passive scripts in the zaproxy/community-scripts repo:

- passive/google_api_keys_finder.js
- passive/JavaDisclosure.js
- passive/s3.js