### PR TITLE
Make Alert_on_Unexpected_Content_Types.js more forgiving

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2024-06-19
+- Alert_on_Unexpected_Content_Types.js > Now handles JSON, YAML, and XML related types more generically (Issue 8522).
+
 ### 2024-06-06
 - Updated to use Webswing 24.
 

--- a/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
+++ b/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
@@ -9,24 +9,11 @@ var pluginid = 100001	// https://github.com/zaproxy/zaproxy/blob/main/docs/scann
 var extensionAlert = control.getExtensionLoader().getExtension(org.zaproxy.zap.extension.alert.ExtensionAlert.NAME)
 
 var expectedTypes = [
-		"application/hal+json",
-		"application/health+json",
-		"application/json",
 		"application/octet-stream",
-		"application/problem+json",
-		"application/problem+xml",
-		"application/soap+xml",
-		"application/vnd.api+json",
-		"application/xml",
-		"application/x-ndjson",
-		"application/x-yaml",
-		"application/yaml",
-		"text/x-json",
-		"text/json",
-		"text/yaml",
-		"text/plain",
-		"text/xml"
+		"text/plain"
 	]
+
+var expectedTypeGroups = ["json", "yaml", "xml"]
 
 function sendingRequest(msg, initiator, helper) {
 	// Nothing to do
@@ -44,7 +31,7 @@ function responseReceived(msg, initiator, helper) {
 			if (ctype.indexOf(";") > 0) {
 				ctype = ctype.substring(0, ctype.indexOf(";"))
 			}
-			if (expectedTypes.indexOf(ctype) < 0) {
+			if (!msg.getResponseHeader().hasContentType(expectedTypeGroups) && expectedTypes.indexOf(ctype) < 0) {
 				// Another rule will complain if theres no type
 		
 				var risk = 1	// Low

--- a/zap/src/test/java/org/parosproxy/paros/network/HttpHeaderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/network/HttpHeaderUnitTest.java
@@ -1,0 +1,54 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.network;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class HttpHeaderUnitTest {
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "application/taxii+json",
+                "application/vnd.api+json",
+                "text/json",
+                "application/yaml",
+                "application/x-yaml",
+                "text/yaml",
+                "application/xml",
+                "application/problem+xml",
+                "text/xml"
+            })
+    void shouldIdentifyContentTypes(String type) {
+        // Given
+        HttpResponseHeader header = new HttpResponseHeader();
+        header.setHeader(HttpHeader.CONTENT_TYPE, type);
+        String[] acceptedTypes = {"json", "xml", "yaml"};
+        // When
+        boolean hasType = header.hasContentType(acceptedTypes);
+        // Then
+        assertThat(hasType, is(equalTo(true)));
+    }
+}


### PR DESCRIPTION
- CHANGELOG > Added change note.
- Alert_on_Enexpected_Content_Type.js > Leverage "HttpHeader.hasContentType" to be more forgiving.
- HttpHeaderUnitTest > Add test to ensure behavior is as expected and that vargs will accept an array.

Fixes zaproxy/zaproxy#8522