### PR TITLE
Deprecate and disable pscan API

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ApiGeneratorUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ApiGeneratorUtils.java
@@ -34,7 +34,6 @@ import org.zaproxy.zap.extension.brk.BreakAPI;
 import org.zaproxy.zap.extension.forceduser.ForcedUserAPI;
 import org.zaproxy.zap.extension.httpsessions.HttpSessionsAPI;
 import org.zaproxy.zap.extension.params.ParamsAPI;
-import org.zaproxy.zap.extension.pscan.PassiveScanAPI;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigAPI;
 import org.zaproxy.zap.extension.search.SearchAPI;
 import org.zaproxy.zap.extension.sessions.SessionManagementAPI;
@@ -66,7 +65,6 @@ public class ApiGeneratorUtils {
         api.addApiOptions(new AntiCsrfParam());
         imps.add(api);
 
-        imps.add(new PassiveScanAPI(null));
         imps.add(new SearchAPI(null));
 
         api = new AutoUpdateAPI(null);

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -135,8 +135,6 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
                             createScriptIcon(),
                             true));
         }
-
-        extensionHook.addApiImplementor(new PassiveScanAPI(this));
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanAPI.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.extension.api.ApiResponseSet;
 import org.zaproxy.zap.extension.api.ApiView;
 import org.zaproxy.zap.utils.ApiUtils;
 
+@Deprecated(since = "2.16.0", forRemoval = true)
 public class PassiveScanAPI extends ApiImplementor {
 
     private static final Logger LOGGER = LogManager.getLogger(PassiveScanAPI.class);

--- a/zap/src/main/weekly-add-ons.json
+++ b/zap/src/main/weekly-add-ons.json
@@ -31,6 +31,7 @@
       ":addOns:openapi",
       ":addOns:postman",
       ":addOns:plugnhack",
+      ":addOns:pscan",
       ":addOns:pscanrules",
       ":addOns:pscanrulesBeta",
       ":addOns:quickstart",


### PR DESCRIPTION
The API will be provided by the add-on.
Add `pscan` to the weekly add-ons.

Part of zaproxy/zaproxy#7959.