### PR TITLE
Remove passive scan rules on soft uninstall

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -709,6 +709,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
                     loadScanRules(statusUpdate.getAddOn());
                     break;
 
+                case SOFT_UNINSTALL:
                 case UNINSTALL:
                     AddOn addOn = statusUpdate.getAddOn();
 


### PR DESCRIPTION
The scan rules need to be removed also when the add-on is soft uninstalled as the classes themselves and the ones they reference will no longer be usable (classloader is closed).

Fix #8533.