### PR TITLE
Remove stats passive scan rule

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -55,7 +55,6 @@ import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.extension.AddOnInstallationStatusListener;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
-import org.zaproxy.zap.extension.pscan.scanner.StatsPassiveScanner;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.extension.script.ScriptType;
 import org.zaproxy.zap.view.ScanStatus;
@@ -310,20 +309,6 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
 
             // Read from the configs
             scannerList.setAutoTagScanners(getPassiveScanParam().getAutoTagScanners());
-
-            // Load the  'switchable' plugins
-            List<PluginPassiveScanner> listTest =
-                    List.of(new RegexAutoTagScanner(), new StatsPassiveScanner());
-            listTest.forEach(e -> e.setStatus(AddOn.Status.release));
-
-            for (PluginPassiveScanner scanner : listTest) {
-                if (scanner instanceof RegexAutoTagScanner) {
-                    continue;
-                }
-                if (!addPluginPassiveScannerImpl(scanner)) {
-                    LOGGER.error("Failed to install pscanrule: {}", scanner.getName());
-                }
-            }
         }
         return scannerList;
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/StatsPassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/StatsPassiveScanner.java
@@ -32,6 +32,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.model.SessionStructure;
 import org.zaproxy.zap.utils.Stats;
 
+@Deprecated(since = "2.16.0", forRemoval = true)
 public class StatsPassiveScanner extends PluginPassiveScanner {
 
     public static final String CODE_STATS_PREFIX = "stats.code.";

--- a/zap/src/test/java/org/zaproxy/zap/extension/pscan/scanner/StatsPassiveScannerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/pscan/scanner/StatsPassiveScannerUnitTest.java
@@ -36,6 +36,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.utils.Stats;
 import org.zaproxy.zap.utils.StatsListener;
 
+@Deprecated
+@SuppressWarnings("removal")
 class StatsPassiveScannerUnitTest {
     private StatsListener listener;
     private PluginPassiveScanner scanner;


### PR DESCRIPTION
Let the `pscan` add-on have the scan rule.

Part of #7959.

---
Depends on zaproxy/zap-extensions#5555.