### PR TITLE
Remove passive scan status label

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -43,7 +43,6 @@ import org.parosproxy.paros.extension.history.ProxyListenerLog;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpMessage;
-import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
 import org.zaproxy.zap.extension.script.ExtensionScript;
@@ -67,7 +66,6 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
     private boolean passiveScanEnabled;
     private PassiveScanParam passiveScanParam;
     private static final List<Class<? extends Extension>> DEPENDENCIES;
-    private ScanStatus scanStatus = null;
 
     static {
         List<Class<? extends Extension>> dep = new ArrayList<>(1);
@@ -101,10 +99,6 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
             extensionHook.getHookView().addOptionPanel(getPassiveScannerOptionsPanel());
             extensionHook.getHookView().addOptionPanel(getOptionsPassiveScan());
             extensionHook.getHookView().addOptionPanel(getPolicyPanel());
-            getView()
-                    .getMainFrame()
-                    .getMainFooterPanel()
-                    .addFooterToolbarRightLabel(getScanStatus().getCountLabel());
         }
 
         ExtensionScript extScript =
@@ -427,7 +421,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
                             extensionLoader.getExtension(ExtensionHistory.class),
                             extensionLoader.getExtension(ExtensionAlert.class),
                             getPassiveScanParam(),
-                            hasView() ? getScanStatus() : null);
+                            null);
             psc.setSession(Model.getSingleton().getSession());
             psc.start();
         }
@@ -612,16 +606,9 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
         }
     }
 
+    @Deprecated(forRemoval = true, since = "2.16.0")
     protected ScanStatus getScanStatus() {
-        if (scanStatus == null) {
-            scanStatus =
-                    new ScanStatus(
-                            new ImageIcon(
-                                    ExtensionPassiveScan.class.getResource(
-                                            "/resource/icon/16/pscan.png")),
-                            Constant.messages.getString("pscan.footer.label"));
-        }
-        return scanStatus;
+        return null;
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanController.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanController.java
@@ -50,7 +50,6 @@ public class PassiveScanController extends Thread implements ProxyListener {
     private PassiveScanParam pscanOptions;
     private PassiveScanTaskHelper helper;
     private Session session;
-    private ScanStatus scanStatus;
 
     private ThreadPoolExecutor executor;
 
@@ -69,7 +68,6 @@ public class PassiveScanController extends Thread implements ProxyListener {
         setName("ZAP-PassiveScanController");
         this.extHist = extHistory;
         this.pscanOptions = passiveScanParam;
-        this.scanStatus = scanStatus;
 
         helper = new PassiveScanTaskHelper(extPscan, extAlert, passiveScanParam);
 
@@ -136,9 +134,6 @@ public class PassiveScanController extends Thread implements ProxyListener {
                 }
                 int recordsToScan = this.getRecordsToScan();
                 Stats.setHighwaterMark("stats.pscan.recordsToScan", recordsToScan);
-                if (scanStatus != null) {
-                    scanStatus.setScanCount(recordsToScan);
-                }
 
             } catch (Exception e) {
                 if (shutDown) {

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -2335,7 +2335,6 @@ pscan.api.view.recordsToScan = The number of records the passive scanner still h
 pscan.api.view.scanOnlyInScope = Tells whether or not the passive scan should be performed only on messages that are in scope.
 pscan.api.view.scanners = Lists all passive scan rules with their ID, name, enabled state, and alert threshold.
 pscan.desc = Passive scanner
-pscan.footer.label = Passive Scan Queue
 pscan.name = Passive Scan Extension
 pscan.options.dialog.scanner.add.button.confirm = Add
 pscan.options.dialog.scanner.add.title = Add Passive Scan Tag Rule


### PR DESCRIPTION
Let the `pscan` add-on manage the scan status label.

Part of #7959.

---
Depends on zaproxy/zap-extensions#5560.