### PR TITLE
Disable and deprecate `ExtensionLog4j`

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/control/CoreFunctionality.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/CoreFunctionality.java
@@ -112,7 +112,6 @@ public final class CoreFunctionality {
                             .ExtensionHttpPanelSyntaxHighlightTextView());
             extensions.add(new org.zaproxy.zap.extension.httpsessions.ExtensionHttpSessions());
             extensions.add(new org.zaproxy.zap.extension.keyboard.ExtensionKeyboard());
-            extensions.add(new org.zaproxy.zap.extension.log4j.ExtensionLog4j());
             extensions.add(new org.zaproxy.zap.extension.params.ExtensionParams());
             extensions.add(new org.zaproxy.zap.extension.pscan.ExtensionPassiveScan());
             extensions.add(new org.zaproxy.zap.extension.ruleconfig.ExtensionRuleConfig());

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/AttackModeScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/AttackModeScanner.java
@@ -44,7 +44,6 @@ import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.eventBus.Event;
 import org.zaproxy.zap.eventBus.EventConsumer;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
-import org.zaproxy.zap.extension.log4j.ExtensionLog4j;
 import org.zaproxy.zap.extension.ruleconfig.ExtensionRuleConfig;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.model.Context;
@@ -74,7 +73,7 @@ public class AttackModeScanner implements EventConsumer {
             scanStatus =
                     new ScanStatus(
                             new ImageIcon(
-                                    ExtensionLog4j.class.getResource(
+                                    AttackModeScanner.class.getResource(
                                             "/resource/icon/fugue/target.png")),
                             Constant.messages.getString("ascan.attack.icon.title"));
         }

--- a/zap/src/main/java/org/zaproxy/zap/extension/log4j/ExtensionLog4j.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/log4j/ExtensionLog4j.java
@@ -48,6 +48,7 @@ import org.zaproxy.zap.view.ZapMenuItem;
  *
  * @author Psiinon
  */
+@Deprecated(forRemoval = true, since = "2.16.0")
 public class ExtensionLog4j extends ExtensionAdaptor {
 
     private static final String NAME = "ExtensionLog4j";

--- a/zap/src/test/java/org/zaproxy/zap/extension/log4j/ExtensionLog4jUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/log4j/ExtensionLog4jUnitTest.java
@@ -36,9 +36,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.zaproxy.zap.extension.log4j.ExtensionLog4j.ErrorAppender;
 
 /** Unit test for {@link ExtensionLog4j}. */
+@Deprecated
+@SuppressWarnings("removal")
 class ExtensionLog4jUnitTest {
 
     /** Unit test for {@link ErrorAppender}. */
@@ -47,12 +48,14 @@ class ExtensionLog4jUnitTest {
         private Logger logger;
         private List<String> logEvents;
 
-        private ErrorAppender errorAppender;
+        private org.zaproxy.zap.extension.log4j.ExtensionLog4j.ErrorAppender errorAppender;
 
         @BeforeEach
         void setup() {
             logEvents = new ArrayList<>();
-            errorAppender = new ErrorAppender(logEvents::add);
+            errorAppender =
+                    new org.zaproxy.zap.extension.log4j.ExtensionLog4j.ErrorAppender(
+                            logEvents::add);
 
             LoggerContext context = LoggerContext.getContext();
             LoggerConfig rootLoggerconfig = context.getConfiguration().getRootLogger();


### PR DESCRIPTION
Let the functionality be provided by the `dev` add-on.

---
Depends on zaproxy/zap-extensions#5566.