### PR TITLE
Update engine name in integration tests

### DIFF
--- a/docker/integration_tests/configs/plans/contexts/session-script.context
+++ b/docker/integration_tests/configs/plans/contexts/session-script.context
@@ -67,7 +67,7 @@
             <type>2</type>
             <script>
                 <name>session-mgmt-script.js</name>
-                <params>YWFh:QUFB&amp;Y2Nj:Q0ND&amp;YmJi:QkJC&amp;ZGRk:RERE&amp;c2NyaXB0RW5naW5l:T3JhY2xlIE5hc2hvcm4=&amp;c2NyaXB0:L3phcC93cmsvY29uZmlncy9zY3JpcHRzL3Nlc3Npb24vc2Vzc2lvbi1tZ210LXNjcmlwdC5qcw==</params>
+                <params>YWFh:QUFB&amp;Y2Nj:Q0ND&amp;YmJi:QkJC&amp;ZGRk:RERE&amp;c2NyaXB0RW5naW5l:R3JhYWwuanM=&amp;c2NyaXB0:L3phcC93cmsvY29uZmlncy9zY3JpcHRzL3Nlc3Npb24vc2Vzc2lvbi1tZ210LXNjcmlwdC5qcw==</params>
             </script>
         </session>
         <authorization>


### PR DESCRIPTION
Use Graal.js instead of Oracle Nashorn, per Java 17 move in Nightly Docker image (#8212).