### PR TITLE
Do not warn when Nashorn not found

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -176,9 +176,6 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
         ScriptEngine se = mgr.getEngineByName("ECMAScript");
         if (se != null) {
             this.registerScriptEngineWrapper(new JavascriptEngineWrapper(se.getFactory()));
-        } else {
-            LOGGER.warn(
-                    "No default JavaScript/ECMAScript engine found, some scripts might no longer work.");
         }
     }
 


### PR DESCRIPTION
It is expected that Nashorn will no longer be available and Graal.js is now included by default.