### PR TITLE
Fix auth type isTypeForMethod implementations

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/FormBasedAuthenticationMethodType.java
@@ -177,7 +177,7 @@ public class FormBasedAuthenticationMethodType extends PostBasedAuthenticationMe
 
     @Override
     public boolean isTypeForMethod(AuthenticationMethod method) {
-        return method instanceof FormBasedAuthenticationMethod;
+        return method != null && FormBasedAuthenticationMethod.class.equals(method.getClass());
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/authentication/HttpAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/HttpAuthenticationMethodType.java
@@ -312,7 +312,7 @@ public class HttpAuthenticationMethodType extends AuthenticationMethodType {
 
     @Override
     public boolean isTypeForMethod(AuthenticationMethod method) {
-        return (method instanceof HttpAuthenticationMethod);
+        return method != null && HttpAuthenticationMethod.class.equals(method.getClass());
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/authentication/JsonBasedAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/JsonBasedAuthenticationMethodType.java
@@ -180,7 +180,7 @@ public class JsonBasedAuthenticationMethodType extends PostBasedAuthenticationMe
 
     @Override
     public boolean isTypeForMethod(AuthenticationMethod method) {
-        return method instanceof JsonBasedAuthenticationMethod;
+        return method != null && JsonBasedAuthenticationMethod.class.equals(method.getClass());
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/authentication/ManualAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/ManualAuthenticationMethodType.java
@@ -355,7 +355,7 @@ public class ManualAuthenticationMethodType extends AuthenticationMethodType {
 
     @Override
     public boolean isTypeForMethod(AuthenticationMethod method) {
-        return (method instanceof ManualAuthenticationMethod);
+        return method != null && ManualAuthenticationMethod.class.equals(method.getClass());
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/ScriptBasedAuthenticationMethodType.java
@@ -636,7 +636,7 @@ public class ScriptBasedAuthenticationMethodType extends AuthenticationMethodTyp
 
     @Override
     public boolean isTypeForMethod(AuthenticationMethod method) {
-        return (method instanceof ScriptBasedAuthenticationMethod);
+        return method != null && ScriptBasedAuthenticationMethod.class.equals(method.getClass());
     }
 
     @Override


### PR DESCRIPTION
Using `instanceof` means that the methods can match auth method types that extend the current class.
This makes it impossible to select the extended auth method.