### PR TITLE
Itests: fix error check dir path

### DIFF
--- a/.github/workflows/check-zap-errors.yml
+++ b/.github/workflows/check-zap-errors.yml
@@ -10,4 +10,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check For Errors"
-        run: docker run --rm -v .github/workflows/conf:/zap/wrk/:rw -t zaproxy/zap-stable:latest zap.sh -addonupdate -cmd -autorun /zap/wrk/check-zap-errors.yaml
+        run: docker run --rm -v $(pwd)/.github/workflows/conf:/zap/wrk/:rw -t zaproxy/zap-stable:latest zap.sh -addonupdate -cmd -autorun /zap/wrk/check-zap-errors.yaml


### PR DESCRIPTION
Hope it will work this time..

Last time it failed with:

docker: Error response from daemon: create .github/workflows/conf: ".github/workflows/conf" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.