### PR TITLE
Correct label in a Structural Modifier dialogue

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/view/ContextStructurePanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ContextStructurePanel.java
@@ -402,7 +402,7 @@ public class ContextStructurePanel extends AbstractContextPropertiesPanel {
                 }
                 name = ddn.getName();
                 ro = true;
-                this.addReadOnlyField(FIELD_NAME, getModVal(type), false);
+                this.addReadOnlyField(FIELD_TYPE, getModVal(type), false);
             } else {
                 this.addComboField(
                         FIELD_TYPE,


### PR DESCRIPTION
Use Type instead of Name for the type field.