### PR TITLE
Correct `StructuralNodeModifier` key check

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/model/StructuralNodeModifier.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/StructuralNodeModifier.java
@@ -69,7 +69,7 @@ public class StructuralNodeModifier extends Enableable implements Cloneable {
         JSONObject json = JSONObject.fromObject(config);
         this.name = json.getString(CONFIG_NAME);
         this.type = Type.valueOf(json.getString(CONFIG_TYPE));
-        if (json.containsKey(CONFIG_TYPE)) {
+        if (json.containsKey(CONFIG_PATTERN)) {
             pattern = Pattern.compile(json.getString(CONFIG_PATTERN));
         }
     }

--- a/zap/src/test/java/org/zaproxy/zap/model/StructuralNodeModifierUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/model/StructuralNodeModifierUnitTest.java
@@ -1,0 +1,43 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit test for {@link StructuralNodeModifier}. */
+class StructuralNodeModifierUnitTest {
+
+    @Test
+    void shouldCreateFromStringWithoutPattern() {
+        // Given
+        var data = "{\"name\":\"name\", \"type\":\"StructuralParameter\"}";
+        // When
+        var snm = new StructuralNodeModifier(data);
+        // Then
+        assertThat(snm.getName(), is(equalTo("name")));
+        assertThat(snm.getType(), is(equalTo(StructuralNodeModifier.Type.StructuralParameter)));
+        assertThat(snm.getPattern(), is(nullValue()));
+    }
+}


### PR DESCRIPTION
Use name of the field pattern instead of type when checking for the presence of pattern field.