### PR TITLE
Handle concurrency in proxy scripts

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ProxyListenerScript.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ProxyListenerScript.java
@@ -66,7 +66,11 @@ public class ProxyListenerScript implements ProxyListener {
             ProxyScript script = cachedScript.getScript();
             try {
                 boolean forwardMessage =
-                        request ? script.proxyRequest(msg) : script.proxyResponse(msg);
+                        cachedScript.execute(
+                                () ->
+                                        request
+                                                ? script.proxyRequest(msg)
+                                                : script.proxyResponse(msg));
                 if (!forwardMessage) {
                     return false;
                 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptsCache.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptsCache.java
@@ -232,14 +232,13 @@ public class ScriptsCache<T> {
             this.script = script;
         }
 
-        void execute(Callable<T> action) throws Exception {
+        <R> R execute(Callable<R> action) throws Exception {
             if (isSyncAccess()) {
                 synchronized (this) {
-                    action.call();
+                    return action.call();
                 }
-            } else {
-                action.call();
             }
+            return action.call();
         }
 
         private boolean isSyncAccess() {

--- a/zap/src/test/java/org/zaproxy/zap/extension/script/ProxyListenerScriptUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/script/ProxyListenerScriptUnitTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.withSettings;
 
+import java.util.concurrent.Callable;
 import javax.script.ScriptException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -226,6 +227,12 @@ class ProxyListenerScriptUnitTest extends WithConfigsTest {
         CachedScript<T> cachedScript =
                 mock(CachedScript.class, withSettings().strictness(Strictness.LENIENT));
         given(cachedScript.getScript()).willReturn(script);
+        try {
+            given(cachedScript.execute(any()))
+                    .willAnswer(a -> ((Callable<?>) a.getArgument(0)).call());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
         if (scriptWrapper != null) {
             given(cachedScript.getScriptWrapper()).willReturn(scriptWrapper);
         }


### PR DESCRIPTION
Execute the scripts through the cached script to ensure the sync access of the engine is respected, since the proxy listeners can "now" be called concurrently.

Fix #8631.