### PR TITLE
Retain and expose source message ID of alerts

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java
@@ -120,6 +120,7 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
 
     private HostProcess parent = null;
     private HttpMessage msg = null;
+    private int sourceMessageId = 0;
     private boolean enabled = true;
     private final Logger logger = LogManager.getLogger(getClass());
     private Configuration config = null;
@@ -166,8 +167,17 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
     @Override
     public void init(HttpMessage msg, HostProcess parent) {
         this.msg = msg.cloneAll();
+        sourceMessageId = getId(msg.getHistoryRef());
         this.parent = parent;
         init();
+    }
+
+    private static int getId(HistoryReference historyReference) {
+        return historyReference != null ? historyReference.getHistoryId() : 0;
+    }
+
+    int getSourceMessageId() {
+        return sourceMessageId;
     }
 
     /**
@@ -1434,6 +1444,7 @@ public abstract class AbstractPlugin implements Plugin, Comparable<Object> {
             setCweId(plugin.getCweId());
             setWascId(plugin.getWascId());
             setTags(plugin.getAlertTags());
+            setSourceHistoryId(plugin.getSourceMessageId());
         }
 
         @Override

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Alert.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Alert.java
@@ -198,6 +198,7 @@ public class Alert implements Comparable<Alert> {
     private static final String CWE_URL_BASE = "https://cwe.mitre.org/data/definitions/";
 
     private int alertId = -1; // ZAP: Changed default alertId
+    private int historyId;
     private int pluginId = -1;
     private String name = "";
     private int risk = RISK_INFO;
@@ -250,6 +251,7 @@ public class Alert implements Comparable<Alert> {
                 recordAlert.getConfidence(),
                 recordAlert.getAlert());
 
+        historyId = recordAlert.getHistoryId();
         HistoryReference hRef = null;
         try {
             hRef = new HistoryReference(recordAlert.getHistoryId());
@@ -282,6 +284,7 @@ public class Alert implements Comparable<Alert> {
                 null);
         setInputVector(recordAlert.getInputVector());
         setHistoryRef(ref);
+        setSourceHistoryId(recordAlert.getSourceHistoryId());
         String alertRef = recordAlert.getAlertRef();
         if (alertRef != null) {
             this.setAlertRef(alertRef);
@@ -849,6 +852,16 @@ public class Alert implements Comparable<Alert> {
             sb.append("  <evidence>").append(replaceEntity(evidence)).append("</evidence>\r\n");
         }
         return sb.toString();
+    }
+
+    /**
+     * Gets the ID of the {@code HistoryReference} of the alert.
+     *
+     * @return the history ID, or 0 if not defined.
+     * @since 2.16.0
+     */
+    public int getHistoryId() {
+        return historyId;
     }
 
     public int getSourceHistoryId() {

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertAPI.java
@@ -540,11 +540,8 @@ public class AlertAPI extends ApiImplementor {
         map.put("wascid", String.valueOf(alert.getWascId()));
         map.put("sourceid", String.valueOf(alert.getSource().getId()));
         map.put("solution", alert.getSolution());
-        map.put(
-                "messageId",
-                (alert.getHistoryRef() != null)
-                        ? String.valueOf(alert.getHistoryRef().getHistoryId())
-                        : "");
+        map.put("messageId", String.valueOf(alert.getHistoryId()));
+        map.put("sourceMessageId", alert.getSourceHistoryId());
         map.put("tags", alert.getTags());
         return new CustomApiResponseSet<>("alert", map);
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertEventPublisher.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertEventPublisher.java
@@ -42,6 +42,16 @@ public class AlertEventPublisher implements EventPublisher {
      */
     public static final String HISTORY_REFERENCE_ID = "historyId";
 
+    /**
+     * Indicates the {@code HistoryReference} ID of the source of the alert.
+     *
+     * <p>The field is available in the events {@link #ALERT_ADDED_EVENT}, {@link
+     * #ALERT_CHANGED_EVENT} and {@link #ALERT_REMOVED_EVENT}.
+     *
+     * @since 2.16.0
+     */
+    public static final String SOURCE_HISTORY_REFERENCE_ID = "sourceHistoryId";
+
     public static final String NAME = "name";
     public static final String PLUGIN_ID = "pluginId";
     public static final String URI = "uri";

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/AbstractPluginUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/AbstractPluginUnitTest.java
@@ -51,6 +51,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
@@ -1317,6 +1318,24 @@ class AbstractPluginUnitTest extends PluginTestUtils {
         assertThat(alert.getCweId(), is(equalTo(cweId)));
         assertThat(alert.getWascId(), is(equalTo(wascId)));
         assertThat(alert.getMessage(), is(sameInstance(alertMessage)));
+    }
+
+    @Test
+    void shouldRaiseAlertWithHistorySourceWithNewAlert() {
+        // Given
+        AbstractPlugin plugin = createDefaultPlugin();
+        HostProcess hostProcess = mock(HostProcess.class);
+        HttpMessage message = createAlertMessage();
+        HistoryReference href = mock(HistoryReference.class);
+        given(message.getHistoryRef()).willReturn(href);
+        int sourceHistoryId = 42;
+        given(href.getHistoryId()).willReturn(sourceHistoryId);
+        // When
+        plugin.init(message, hostProcess);
+        plugin.newAlert().setUri("uri").setMessage(message).raise();
+        // Then
+        Alert alert = getRaisedAlert(hostProcess);
+        assertThat(alert.getSourceHistoryId(), is(equalTo(sourceHistoryId)));
     }
 
     @Test

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/AlertUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/AlertUnitTest.java
@@ -23,6 +23,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,8 +32,49 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.core.scanner.Alert.Builder;
+import org.parosproxy.paros.db.RecordAlert;
 
 class AlertUnitTest {
+
+    @Test
+    void shouldHaveNoHistoryIdByDefault() {
+        // Given / When
+        Alert alert = new Alert(1);
+        // Then
+        assertThat(alert.getHistoryId(), is(equalTo(0)));
+    }
+
+    @Test
+    void shouldHaveHistoryIdFromRecordAlert() {
+        // Given
+        RecordAlert recordAlert = mock(RecordAlert.class);
+        int historyId = 42;
+        given(recordAlert.getHistoryId()).willReturn(historyId);
+        // When
+        Alert alert = new Alert(recordAlert);
+        // Then
+        assertThat(alert.getHistoryId(), is(equalTo(historyId)));
+    }
+
+    @Test
+    void shouldHaveNoSourceHistoryIdByDefault() {
+        // Given / When
+        Alert alert = new Alert(1);
+        // Then
+        assertThat(alert.getSourceHistoryId(), is(equalTo(0)));
+    }
+
+    @Test
+    void shouldHaveSourceHistoryIdFromRecordAlert() {
+        // Given
+        RecordAlert recordAlert = mock(RecordAlert.class);
+        int sourceHistoryId = 42;
+        given(recordAlert.getSourceHistoryId()).willReturn(sourceHistoryId);
+        // When
+        Alert alert = new Alert(recordAlert);
+        // Then
+        assertThat(alert.getSourceHistoryId(), is(equalTo(sourceHistoryId)));
+    }
 
     @Test
     void shouldDefaultAlertRefToPluginId() {

--- a/zap/src/test/java/org/zaproxy/zap/extension/alert/AlertAPIUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/alert/AlertAPIUnitTest.java
@@ -1,0 +1,122 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.alert;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import net.sf.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.quality.Strictness;
+import org.parosproxy.paros.db.Database;
+import org.parosproxy.paros.db.RecordAlert;
+import org.parosproxy.paros.db.TableAlert;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.WithConfigsTest;
+import org.zaproxy.zap.db.TableAlertTag;
+import org.zaproxy.zap.extension.api.ApiResponse;
+import org.zaproxy.zap.extension.api.ApiResponseElement;
+
+/** Unit test for {@link AlertAPI}. */
+public class AlertAPIUnitTest {
+
+    private TableAlert tableAlert;
+    private TableAlertTag tableAlertTag;
+    private ExtensionAlert extensionAlert;
+
+    private AlertAPI api;
+
+    @BeforeEach
+    void setUp() {
+        WithConfigsTest.setUpConstantMessages();
+
+        extensionAlert = mock(ExtensionAlert.class);
+
+        Model model = mock(Model.class, withSettings().strictness(Strictness.LENIENT));
+        Model.setSingletonForTesting(model);
+
+        Database db = mock(Database.class);
+        given(model.getDb()).willReturn(db);
+        tableAlert = mock(TableAlert.class);
+        given(db.getTableAlert()).willReturn(tableAlert);
+        tableAlertTag = mock(TableAlertTag.class);
+        given(db.getTableAlertTag()).willReturn(tableAlertTag);
+
+        api = new AlertAPI(extensionAlert);
+    }
+
+    @Test
+    void shouldHavePrefix() throws Exception {
+        // Given / When
+        String prefix = api.getPrefix();
+        // Then
+        assertThat(prefix, is(equalTo("alert")));
+    }
+
+    @Test
+    void shouldReturnAlertData() throws Exception {
+        // Given
+        String name = "alert";
+        JSONObject params = new JSONObject();
+        int alertId = 1;
+        params.put("id", alertId);
+        RecordAlert recordAlert = mock(RecordAlert.class);
+        given(recordAlert.getAlert()).willReturn("name");
+
+        given(recordAlert.getAlertId()).willReturn(alertId);
+        given(recordAlert.getPluginId()).willReturn(1234);
+        given(recordAlert.getAlert()).willReturn("Alert Name");
+        given(recordAlert.getRisk()).willReturn(1);
+        given(recordAlert.getConfidence()).willReturn(2);
+        given(recordAlert.getDescription()).willReturn("Alert Description");
+        given(recordAlert.getUri()).willReturn("uri");
+        given(recordAlert.getParam()).willReturn("param");
+        given(recordAlert.getAttack()).willReturn("attack");
+        given(recordAlert.getOtherInfo()).willReturn("other info");
+        given(recordAlert.getSolution()).willReturn("solution");
+        given(recordAlert.getReference()).willReturn("reference");
+        given(recordAlert.getHistoryId()).willReturn(123);
+        given(recordAlert.getSourceHistoryId()).willReturn(1234);
+        given(recordAlert.getEvidence()).willReturn("evidence");
+        given(recordAlert.getInputVector()).willReturn("input Vector");
+        given(recordAlert.getCweId()).willReturn(10);
+        given(recordAlert.getWascId()).willReturn(11);
+        given(recordAlert.getSourceId()).willReturn(2);
+        given(recordAlert.getAlertRef()).willReturn("1234-1");
+
+        given(tableAlert.read(alertId)).willReturn(recordAlert);
+        // When
+        ApiResponse response = api.handleApiView(name, params);
+        // Then
+        assertThat(response.getName(), is(equalTo(name)));
+        assertThat(response, is(instanceOf(ApiResponseElement.class)));
+        assertThat(
+                response.toJSON().toString(),
+                is(
+                        equalTo(
+                                "{\"alert\":{\"sourceid\":\"2\",\"other\":\"other info\",\"method\":\"\",\"evidence\":\"evidence\",\"pluginId\":\"1234\",\"cweid\":\"10\",\"confidence\":\"Medium\",\"sourceMessageId\":1234,\"wascid\":\"11\",\"description\":\"Alert Description\",\"messageId\":\"123\",\"inputVector\":\"input Vector\",\"url\":\"uri\",\"tags\":{},\"reference\":\"reference\",\"solution\":\"solution\",\"alert\":\"Alert Name\",\"param\":\"param\",\"attack\":\"attack\",\"name\":\"Alert Name\",\"risk\":\"Low\",\"id\":\"1\",\"alertRef\":\"1234-1\"}}")));
+    }
+}


### PR DESCRIPTION
Allow the user to know the ID of the source message that caused the alert, as opposed to the ID of the message that has the alert (e.g. evidence) which might not always be the same (e.g. active scans).