### PR TITLE
Ensure published alert has history ID

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Alert.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Alert.java
@@ -855,6 +855,16 @@ public class Alert implements Comparable<Alert> {
     }
 
     /**
+     * Sets the ID of the {@code HistoryReference} of the alert.
+     *
+     * @param historyId the history ID.
+     * @since 2.16.0
+     */
+    public void setHistoryId(int historyId) {
+        this.historyId = historyId;
+    }
+
+    /**
      * Gets the ID of the {@code HistoryReference} of the alert.
      *
      * @return the history ID, or 0 if not defined.

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -527,6 +527,7 @@ public class ExtensionAlert extends ExtensionAdaptor
 
         int alertId = recordAlert.getAlertId();
         alert.setAlertId(alertId);
+        alert.setHistoryId(recordAlert.getHistoryId());
 
         TableAlertTag tableAlertTag = getModel().getDb().getTableAlertTag();
         for (Map.Entry<String, String> e : alert.getTags().entrySet()) {


### PR DESCRIPTION
Set the ID after persisting the alert as the alert used is not read from the DB and thus it will not have it.

Issue introduced in #8667.