### PR TITLE
Support host override for local OpenAPI spec

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2025-03-25
+- Update ZAP API scan to support host override for local OpenAPI spec.
+
 ### 2025-02-20
 - Added jq to all images except bare.
 

--- a/docker/zap-api-scan.py
+++ b/docker/zap-api-scan.py
@@ -430,22 +430,22 @@ def main(argv):
                 logging.debug('Import OpenAPI URL ' + target_url)
                 res = zap.openapi.import_url(target, host_override)
                 urls = zap.core.urls()
-
-                if host_override:
-                    if urlparse(host_override).scheme:
-                        target = host_override
-                    else:
-                        target = urljoin(target_url, '//' + host_override)
-                    logging.info(
-                        'Using override, new target: {0}'.format(target))
             else:
                 logging.debug('Import OpenAPI File ' + target_file)
-                res = zap.openapi.import_file(target_file)
+                res = zap.openapi.import_file(target_file, host_override)
                 urls = zap.core.urls()
                 if len(urls) > 0:
                     # Choose the first one - will be striping off the path below
                     target = urls[0]
                     logging.debug('Using target from imported file: {0}'.format(target))
+
+            if host_override:
+                if urlparse(host_override).scheme:
+                    target = host_override
+                else:
+                    target = urljoin(target, '//' + host_override)
+                logging.info(
+                    'Using override, new target: {0}'.format(target))
             logging.info('Number of Imported URLs: ' + str(len(urls)))
         elif format == 'soap':
             trigger_hook('importing_soap', target_url, target_file)


### PR DESCRIPTION
The host override can also be useful when handling local spec. I'd say it's not too uncommon to have only the productive system in the spec. If ZAP should run against a staging or development environment system the `-O` option comes in handy.

:hammer_and_pick: with :heart: by [Siemens](https://opensource.siemens.com/)