### PR TITLE
Fix exception when printing null to error stream

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/ZAP.java
+++ b/zap/src/main/java/org/zaproxy/zap/ZAP.java
@@ -119,7 +119,7 @@ public class ZAP {
                                 .equals(x)) {
                             return;
                         }
-                        if (x.startsWith("Multiplexing LAF")) {
+                        if (x != null && x.startsWith("Multiplexing LAF")) {
                             return;
                         }
                         super.println(x);


### PR DESCRIPTION
Add null check to prevent a NullPointerException when checking the message being printed.