### PR TITLE
Deprecate/remove passive scan related options

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/DialogAddAutoTagScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/DialogAddAutoTagScanner.java
@@ -30,11 +30,11 @@ import javax.swing.JPanel;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import org.parosproxy.paros.Constant;
-import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
-@SuppressWarnings("serial")
+@SuppressWarnings({"removal", "serial"})
+@Deprecated(forRemoval = true, since = "2.16.0")
 class DialogAddAutoTagScanner extends AbstractFormDialog {
 
     private static final long serialVersionUID = -5209887319253495735L;
@@ -92,8 +92,8 @@ class DialogAddAutoTagScanner extends AbstractFormDialog {
     private ZapTextField responseBodyRegexTextField;
     private JCheckBox enabledCheckBox;
 
-    protected RegexAutoTagScanner scanner;
-    private List<RegexAutoTagScanner> scanners;
+    protected org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner scanner;
+    private List<org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner> scanners;
 
     private ConfirmButtonValidatorDocListener confirmButtonValidatorDocListener;
 
@@ -219,7 +219,7 @@ class DialogAddAutoTagScanner extends AbstractFormDialog {
     }
 
     protected boolean validateName(String name) {
-        for (RegexAutoTagScanner s : scanners) {
+        for (org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner s : scanners) {
             if (name.equals(s.getName())) {
                 JOptionPane.showMessageDialog(
                         this,
@@ -248,9 +248,9 @@ class DialogAddAutoTagScanner extends AbstractFormDialog {
     @Override
     protected void performAction() {
         scanner =
-                new RegexAutoTagScanner(
+                new org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner(
                         getNameTextField().getText(),
-                        RegexAutoTagScanner.TYPE.TAG,
+                        org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner.TYPE.TAG,
                         getConfigurationTextField().getText());
         scanner.setRequestHeaderRegex(getRequestHeaderRegexTextField().getText());
         scanner.setRequestUrlRegex(getRequestUrlRegexTextField().getText());
@@ -280,7 +280,7 @@ class DialogAddAutoTagScanner extends AbstractFormDialog {
         getResponseBodyRegexTextField().discardAllEdits();
     }
 
-    public RegexAutoTagScanner getScanner() {
+    public org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner getScanner() {
         return scanner;
     }
 
@@ -356,7 +356,8 @@ class DialogAddAutoTagScanner extends AbstractFormDialog {
         return enabledCheckBox;
     }
 
-    public void setScanners(List<RegexAutoTagScanner> scanners) {
+    public void setScanners(
+            List<org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner> scanners) {
         this.scanners = scanners;
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/DialogModifyAutoTagScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/DialogModifyAutoTagScanner.java
@@ -21,8 +21,9 @@ package org.zaproxy.zap.extension.pscan;
 
 import java.awt.Dialog;
 import org.parosproxy.paros.Constant;
-import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
 
+@SuppressWarnings("removal")
+@Deprecated(forRemoval = true, since = "2.16.0")
 class DialogModifyAutoTagScanner extends DialogAddAutoTagScanner {
 
     private static final long serialVersionUID = 6536266615593275432L;
@@ -42,7 +43,7 @@ class DialogModifyAutoTagScanner extends DialogAddAutoTagScanner {
         return CONFIRM_BUTTON_LABEL;
     }
 
-    public void setApp(RegexAutoTagScanner app) {
+    public void setApp(org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner app) {
         this.scanner = app;
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/ExtensionPassiveScan.java
@@ -23,9 +23,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.FileConfiguration;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.control.Control.Mode;
@@ -43,9 +40,9 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
-import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
 import org.zaproxy.zap.view.ScanStatus;
 
+@SuppressWarnings("removal")
 public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionChangedListener {
 
     public static final String NAME = "ExtensionPassiveScan";
@@ -57,14 +54,51 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
     // the HttpMessage.
     public static final int PROXY_LISTENER_ORDER = ProxyListenerLog.PROXY_LISTENER_ORDER + 1;
 
-    private static final Logger LOGGER = LogManager.getLogger(ExtensionPassiveScan.class);
-    private PassiveScannerList scannerList;
-    private OptionsPassiveScan optionsPassiveScan = null;
-    private PolicyPassiveScanPanel policyPanel = null;
+    private static final PassiveScanRuleManager NOOP_PASSIVE_SCAN_RULE_MANAGER =
+            new PassiveScanRuleManager() {
+
+                @Override
+                public boolean add(PassiveScanner scanRule) {
+                    // Nothing to do.
+                    return false;
+                }
+
+                @Override
+                public PassiveScanner getScanRule(int id) {
+                    // Nothing to do.
+                    return null;
+                }
+
+                @Override
+                public List<PassiveScanner> getScanRules() {
+                    // Nothing to do.
+                    return null;
+                }
+
+                @Override
+                public List<PluginPassiveScanner> getPluginScanRules() {
+                    // Nothing to do.
+                    return null;
+                }
+
+                @Override
+                public boolean remove(PassiveScanner scanRule) {
+                    // Nothing to do.
+                    return false;
+                }
+
+                @Override
+                public boolean remove(String className) {
+                    // Nothing to do.
+                    return false;
+                }
+            };
+
     private PassiveScanController psc = null;
     private boolean passiveScanEnabled;
-    private PassiveScanParam passiveScanParam;
     private static final List<Class<? extends Extension>> DEPENDENCIES;
+
+    private PassiveScanRuleManager scanRuleManager = NOOP_PASSIVE_SCAN_RULE_MANAGER;
 
     static {
         List<Class<? extends Extension>> dep = new ArrayList<>(1);
@@ -72,8 +106,6 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
 
         DEPENDENCIES = Collections.unmodifiableList(dep);
     }
-
-    private PassiveScannerOptionsPanel passiveScannerOptionsPanel;
 
     public ExtensionPassiveScan() {
         super();
@@ -90,20 +122,12 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
     public void hook(ExtensionHook extensionHook) {
         super.hook(extensionHook);
 
-        extensionHook.addOptionsParamSet(getPassiveScanParam());
-
         extensionHook.addProxyListener(new PassiveScanProxyListener());
         extensionHook.addSessionListener(this);
-        if (getView() != null) {
-            extensionHook.getHookView().addOptionPanel(getPassiveScannerOptionsPanel());
-            extensionHook.getHookView().addOptionPanel(getOptionsPassiveScan());
-            extensionHook.getHookView().addOptionPanel(getPolicyPanel());
-        }
     }
 
     @Override
     public void optionsLoaded() {
-        getPassiveScannerList().setAutoTagScanners(getPassiveScanParam().getAutoTagScanners());
         // Start passive scanning
         passiveScanEnabled = true;
         getPassiveScanController();
@@ -122,16 +146,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
     }
 
     public boolean removePassiveScanner(String className) {
-
-        PassiveScanner scanner = getPassiveScannerList().removeScanner(className);
-
-        if (scanner != null && hasView() && scanner instanceof PluginPassiveScanner) {
-            getPolicyPanel()
-                    .getPassiveScanTableModel()
-                    .removeScanner((PluginPassiveScanner) scanner);
-        }
-
-        return scanner != null;
+        return scanRuleManager.remove(className);
     }
 
     /**
@@ -152,14 +167,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
      * @see PassiveScanner
      */
     public boolean addPassiveScanner(PassiveScanner passiveScanner) {
-        if (passiveScanner == null) {
-            throw new IllegalArgumentException("Parameter passiveScanner must not be null.");
-        }
-
-        if (passiveScanner instanceof PluginPassiveScanner) {
-            return addPluginPassiveScannerImpl((PluginPassiveScanner) passiveScanner);
-        }
-        return addPassiveScannerImpl(passiveScanner);
+        return scanRuleManager.add(passiveScanner);
     }
 
     /**
@@ -193,10 +201,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
      * @see PluginPassiveScanner
      */
     public boolean addPluginPassiveScanner(PluginPassiveScanner pluginPassiveScanner) {
-        if (pluginPassiveScanner == null) {
-            throw new IllegalArgumentException("Parameter pluginPassiveScanner must not be null.");
-        }
-        return addPluginPassiveScannerImpl(pluginPassiveScanner);
+        return scanRuleManager.add(pluginPassiveScanner);
     }
 
     /**
@@ -211,68 +216,28 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
      * @see PluginPassiveScanner
      */
     public boolean removePluginPassiveScanner(PluginPassiveScanner pluginPassiveScanner) {
-        if (pluginPassiveScanner == null) {
-            throw new IllegalArgumentException("Parameter pluginPassiveScanner must not be null.");
-        }
-        return removePassiveScanner(pluginPassiveScanner.getClass().getName());
+        return scanRuleManager.remove(pluginPassiveScanner);
     }
 
-    private boolean addPassiveScannerImpl(PassiveScanner passiveScanner) {
-        return getPassiveScannerList().add(passiveScanner);
+    /** <strong>Note:</strong> Not part of the public API. */
+    public void setPassiveScanRuleManager(PassiveScanRuleManager scanRuleManager) {
+        if (scanRuleManager == null) {
+            this.scanRuleManager = NOOP_PASSIVE_SCAN_RULE_MANAGER;
+        } else {
+            this.scanRuleManager = scanRuleManager;
+        }
     }
 
-    private boolean addPluginPassiveScannerImpl(PluginPassiveScanner scanner) {
-        if (scanner instanceof RegexAutoTagScanner) {
-            return false;
-        }
-
-        boolean added = false;
-        try {
-            FileConfiguration config = this.getModel().getOptionsParam().getConfig();
-            scanner.setConfig(config);
-
-            added = addPassiveScannerImpl(scanner);
-
-            if (added) {
-                if (hasView()) {
-                    getPolicyPanel().getPassiveScanTableModel().addScanner(scanner);
-                }
-                LOGGER.info("Loaded passive scan rule: {}", scanner.getName());
-            }
-            if (scanner.getPluginId() == -1) {
-                LOGGER.error(
-                        "The passive scan rule \"{}\" [{}] does not have a defined ID.",
-                        scanner.getName(),
-                        scanner.getClass().getCanonicalName());
-            }
-
-        } catch (Exception e) {
-            LOGGER.error("Failed to load passive scan rule {}", scanner.getName(), e);
-        }
-
-        return added;
+    protected PassiveScanRuleManager getScanRuleManager() {
+        return scanRuleManager;
     }
 
     protected PassiveScannerList getPassiveScannerList() {
-        if (scannerList == null) {
-            scannerList = new PassiveScannerList();
-
-            // Read from the configs
-            scannerList.setAutoTagScanners(getPassiveScanParam().getAutoTagScanners());
-        }
-        return scannerList;
+        return new PassiveScannerList();
     }
 
     public List<PluginPassiveScanner> getPluginPassiveScanners() {
-        List<PluginPassiveScanner> pluginPassiveScanners = new ArrayList<>();
-        for (PassiveScanner scanner : getPassiveScannerList().list()) {
-            if ((scanner instanceof PluginPassiveScanner)
-                    && !(scanner instanceof RegexAutoTagScanner)) {
-                pluginPassiveScanners.add((PluginPassiveScanner) scanner);
-            }
-        }
-
-        return pluginPassiveScanners;
+        return scanRuleManager.getPluginScanRules();
     }
 
     /**
@@ -379,10 +344,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
     }
 
     protected PolicyPassiveScanPanel getPolicyPanel() {
-        if (policyPanel == null) {
-            policyPanel = new PolicyPassiveScanPanel();
-        }
-        return policyPanel;
+        return new PolicyPassiveScanPanel();
     }
 
     public int getRecordsToScan() {
@@ -400,7 +362,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
                             this,
                             extensionLoader.getExtension(ExtensionHistory.class),
                             extensionLoader.getExtension(ExtensionAlert.class),
-                            getPassiveScanParam(),
+                            null,
                             null);
             psc.setSession(Model.getSingleton().getSession());
             psc.start();
@@ -422,24 +384,7 @@ public class ExtensionPassiveScan extends ExtensionAdaptor implements SessionCha
     }
 
     PassiveScanParam getPassiveScanParam() {
-        if (passiveScanParam == null) {
-            passiveScanParam = new PassiveScanParam();
-        }
-        return passiveScanParam;
-    }
-
-    private PassiveScannerOptionsPanel getPassiveScannerOptionsPanel() {
-        if (passiveScannerOptionsPanel == null) {
-            passiveScannerOptionsPanel = new PassiveScannerOptionsPanel(this, Constant.messages);
-        }
-        return passiveScannerOptionsPanel;
-    }
-
-    private OptionsPassiveScan getOptionsPassiveScan() {
-        if (optionsPassiveScan == null) {
-            optionsPassiveScan = new OptionsPassiveScan(this.getPassiveScannerList());
-        }
-        return optionsPassiveScan;
+        return getModel().getOptionsParam().getParamSet(PassiveScanParam.class);
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/OptionsPassiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/OptionsPassiveScan.java
@@ -28,11 +28,11 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.view.AbstractParamPanel;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
 import org.zaproxy.zap.utils.ZapHtmlLabel;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTablePanel;
 
-@SuppressWarnings("serial")
+@SuppressWarnings({"removal", "serial"})
+@Deprecated(forRemoval = true, since = "2.16.0")
 public class OptionsPassiveScan extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;
@@ -104,7 +104,8 @@ public class OptionsPassiveScan extends AbstractParamPanel {
     }
 
     private static class ScannersMultipleOptionsPanel
-            extends AbstractMultipleOptionsTablePanel<RegexAutoTagScanner> {
+            extends AbstractMultipleOptionsTablePanel<
+                    org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner> {
 
         private static final long serialVersionUID = 8762085355395403532L;
 
@@ -136,7 +137,7 @@ public class OptionsPassiveScan extends AbstractParamPanel {
         }
 
         @Override
-        public RegexAutoTagScanner showAddDialogue() {
+        public org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner showAddDialogue() {
             if (addDialog == null) {
                 addDialog = new DialogAddAutoTagScanner(View.getSingleton().getOptionsDialog(null));
                 addDialog.pack();
@@ -144,14 +145,16 @@ public class OptionsPassiveScan extends AbstractParamPanel {
             addDialog.setScanners(model.getElements());
             addDialog.setVisible(true);
 
-            RegexAutoTagScanner app = addDialog.getScanner();
+            org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner app =
+                    addDialog.getScanner();
             addDialog.clear();
 
             return app;
         }
 
         @Override
-        public RegexAutoTagScanner showModifyDialogue(RegexAutoTagScanner e) {
+        public org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner showModifyDialogue(
+                org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner e) {
             if (modifyDialog == null) {
                 modifyDialog =
                         new DialogModifyAutoTagScanner(View.getSingleton().getOptionsDialog(null));
@@ -161,7 +164,8 @@ public class OptionsPassiveScan extends AbstractParamPanel {
             modifyDialog.setApp(e);
             modifyDialog.setVisible(true);
 
-            RegexAutoTagScanner app = modifyDialog.getScanner();
+            org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner app =
+                    modifyDialog.getScanner();
             modifyDialog.clear();
 
             if (!app.equals(e)) {
@@ -172,7 +176,8 @@ public class OptionsPassiveScan extends AbstractParamPanel {
         }
 
         @Override
-        public boolean showRemoveDialogue(RegexAutoTagScanner e) {
+        public boolean showRemoveDialogue(
+                org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner e) {
             JCheckBox removeWithoutConfirmationCheckBox =
                     new JCheckBox(REMOVE_DIALOG_CHECKBOX_LABEL);
             Object[] messages = {REMOVE_DIALOG_TEXT, " ", removeWithoutConfirmationCheckBox};

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/OptionsPassiveScanTableModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/OptionsPassiveScanTableModel.java
@@ -22,12 +22,13 @@ package org.zaproxy.zap.extension.pscan;
 import java.util.ArrayList;
 import java.util.List;
 import org.parosproxy.paros.Constant;
-import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
-@SuppressWarnings("serial")
+@SuppressWarnings({"removal", "serial"})
+@Deprecated(forRemoval = true, since = "2.16.0")
 public class OptionsPassiveScanTableModel
-        extends AbstractMultipleOptionsTableModel<RegexAutoTagScanner> {
+        extends AbstractMultipleOptionsTableModel<
+                org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner> {
 
     private static final long serialVersionUID = 1L;
 
@@ -39,7 +40,8 @@ public class OptionsPassiveScanTableModel
 
     private static final int COLUMN_COUNT = COLUMN_NAMES.length;
 
-    private List<RegexAutoTagScanner> defns = new ArrayList<>(5);
+    private List<org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner> defns =
+            new ArrayList<>(5);
 
     public OptionsPassiveScanTableModel() {
         super();
@@ -48,18 +50,19 @@ public class OptionsPassiveScanTableModel
     /**
      * @param defns
      */
-    public void setScanDefns(List<RegexAutoTagScanner> defns) {
+    public void setScanDefns(
+            List<org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner> defns) {
         this.defns = new ArrayList<>(defns.size());
 
-        for (RegexAutoTagScanner def : defns) {
-            this.defns.add(new RegexAutoTagScanner(def));
+        for (org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner def : defns) {
+            this.defns.add(new org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner(def));
         }
 
         fireTableDataChanged();
     }
 
     @Override
-    public List<RegexAutoTagScanner> getElements() {
+    public List<org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner> getElements() {
         return defns;
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanAPI.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.extension.api.ApiResponseSet;
 import org.zaproxy.zap.extension.api.ApiView;
 import org.zaproxy.zap.utils.ApiUtils;
 
+@SuppressWarnings("removal")
 @Deprecated(since = "2.16.0", forRemoval = true)
 public class PassiveScanAPI extends ApiImplementor {
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanController.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanController.java
@@ -42,12 +42,12 @@ import org.zaproxy.zap.view.ScanStatus;
  *
  * @since 2.12.0
  */
+@SuppressWarnings("removal")
 public class PassiveScanController extends Thread implements ProxyListener {
 
     private static final Logger LOGGER = LogManager.getLogger(PassiveScanController.class);
 
     private ExtensionHistory extHist;
-    private PassiveScanParam pscanOptions;
     private PassiveScanTaskHelper helper;
     private Session session;
 
@@ -67,9 +67,8 @@ public class PassiveScanController extends Thread implements ProxyListener {
             ScanStatus scanStatus) {
         setName("ZAP-PassiveScanController");
         this.extHist = extHistory;
-        this.pscanOptions = passiveScanParam;
 
-        helper = new PassiveScanTaskHelper(extPscan, extAlert, passiveScanParam);
+        helper = new PassiveScanTaskHelper(extPscan, extAlert, null);
 
         // Get the last id - in case we've just opened an existing session
         currentId = this.getLastHistoryId();
@@ -124,7 +123,8 @@ public class PassiveScanController extends Thread implements ProxyListener {
                 }
 
                 if (href != null
-                        && (!pscanOptions.isScanOnlyInScope() || session.isInScope(href))) {
+                        && (!getPassiveScanParam().isScanOnlyInScope()
+                                || session.isInScope(href))) {
                     LOGGER.debug(
                             "Submitting request to executor: {} id {} type {}",
                             href.getURI(),
@@ -149,9 +149,13 @@ public class PassiveScanController extends Thread implements ProxyListener {
         }
     }
 
+    private PassiveScanParam getPassiveScanParam() {
+        return extHist.getModel().getOptionsParam().getParamSet(PassiveScanParam.class);
+    }
+
     private ThreadPoolExecutor getExecutor() {
         if (this.executor == null || this.executor.isShutdown()) {
-            int threads = pscanOptions.getPassiveScanThreads();
+            int threads = getPassiveScanParam().getPassiveScanThreads();
             LOGGER.debug("Creating new executor with {} threads", threads);
 
             this.executor =

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanParam.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanParam.java
@@ -29,8 +29,9 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.common.AbstractParam;
 import org.parosproxy.paros.model.HistoryReference;
 import org.zaproxy.zap.extension.api.ZapApiIgnore;
-import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
 
+@SuppressWarnings("removal")
+@Deprecated(forRemoval = true, since = "2.16.0")
 public class PassiveScanParam extends AbstractParam {
 
     private static final Logger LOGGER = LogManager.getLogger(PassiveScanParam.class);
@@ -62,7 +63,8 @@ public class PassiveScanParam extends AbstractParam {
 
     @Deprecated public static final int PASSIVE_SCAN_DEFAULT_THREADS = 4;
 
-    private List<RegexAutoTagScanner> autoTagScanners = new ArrayList<>(0);
+    private List<org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner> autoTagScanners =
+            new ArrayList<>(0);
 
     private boolean confirmRemoveAutoTagScanner = true;
 
@@ -108,12 +110,14 @@ public class PassiveScanParam extends AbstractParam {
                 if (!"".equals(name) && !tempListNames.contains(name)) {
                     tempListNames.add(name);
 
-                    RegexAutoTagScanner app =
-                            new RegexAutoTagScanner(
+                    org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner app =
+                            new org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner(
                                     sub.getString(AUTO_TAG_SCANNER_NAME_KEY),
                                     getEnum(
                                             AUTO_TAG_SCANNER_TYPE_KEY,
-                                            RegexAutoTagScanner.TYPE.TAG),
+                                            org.zaproxy.zap.extension.pscan.scanner
+                                                    .RegexAutoTagScanner.TYPE
+                                                    .TAG),
                                     sub.getString(AUTO_TAG_SCANNER_CONFIG_KEY),
                                     sub.getString(AUTO_TAG_SCANNER_REQ_URL_REGEX_KEY),
                                     sub.getString(AUTO_TAG_SCANNER_REQ_HEAD_REGEX_KEY),
@@ -143,14 +147,15 @@ public class PassiveScanParam extends AbstractParam {
         this.maxBodySizeInBytesToScan = this.getInt(MAX_BODY_SIZE_IN_BYTES, 0);
     }
 
-    public void setAutoTagScanners(List<RegexAutoTagScanner> scanners) {
+    public void setAutoTagScanners(
+            List<org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner> scanners) {
         this.autoTagScanners = scanners;
 
         ((HierarchicalConfiguration) getConfig()).clearTree(ALL_AUTO_TAG_SCANNERS_KEY);
 
         for (int i = 0, size = scanners.size(); i < size; ++i) {
             String elementBaseKey = ALL_AUTO_TAG_SCANNERS_KEY + "(" + i + ").";
-            RegexAutoTagScanner scanner = scanners.get(i);
+            org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner scanner = scanners.get(i);
 
             getConfig().setProperty(elementBaseKey + AUTO_TAG_SCANNER_NAME_KEY, scanner.getName());
             getConfig()
@@ -181,7 +186,7 @@ public class PassiveScanParam extends AbstractParam {
         }
     }
 
-    public List<RegexAutoTagScanner> getAutoTagScanners() {
+    public List<org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner> getAutoTagScanners() {
         return autoTagScanners;
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanRuleManager.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanRuleManager.java
@@ -1,0 +1,38 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscan;
+
+import java.util.List;
+
+/** <strong>Note:</strong> Not part of the public API. */
+public interface PassiveScanRuleManager {
+
+    boolean add(PassiveScanner scanRule);
+
+    PassiveScanner getScanRule(int id);
+
+    List<PassiveScanner> getScanRules();
+
+    List<PluginPassiveScanner> getPluginScanRules();
+
+    boolean remove(PassiveScanner scanRule);
+
+    boolean remove(String className);
+}

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanTask.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanTask.java
@@ -106,7 +106,7 @@ public class PassiveScanTask implements Runnable {
             Source src = new Source(msg.getResponseBody().toString());
             PassiveScanData passiveScanData = new PassiveScanData(msg);
 
-            for (PassiveScanner scanner : helper.getPassiveScannerList().list()) {
+            for (PassiveScanner scanner : helper.getPassiveScanRuleManager().getScanRules()) {
                 currentScanner = scanner;
                 try {
                     if (shutdown) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScannerList.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScannerList.java
@@ -26,8 +26,9 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
 
+@SuppressWarnings("removal")
+@Deprecated(forRemoval = true, since = "2.16.0")
 public class PassiveScannerList {
 
     private static final Logger LOGGER = LogManager.getLogger(PassiveScannerList.class);
@@ -53,12 +54,13 @@ public class PassiveScannerList {
         return this.passiveScanners;
     }
 
-    public void setAutoTagScanners(List<RegexAutoTagScanner> autoTagScanners) {
+    public void setAutoTagScanners(
+            List<org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner> autoTagScanners) {
         List<PassiveScanner> tempScanners =
                 new ArrayList<>(passiveScanners.size() + autoTagScanners.size());
 
         for (PassiveScanner scanner : passiveScanners) {
-            if (scanner instanceof RegexAutoTagScanner) {
+            if (scanner instanceof org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner) {
                 this.scannerNames.remove(scanner.getName());
             } else {
                 tempScanners.add(scanner);

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScannerOptionsPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScannerOptionsPanel.java
@@ -43,6 +43,8 @@ import org.zaproxy.zap.view.LayoutHelper;
  *
  * @since 2.6.0
  */
+@SuppressWarnings("removal")
+@Deprecated(forRemoval = true, since = "2.16.0")
 class PassiveScannerOptionsPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
@@ -46,7 +46,7 @@ public abstract class PluginPassiveScanner extends Enableable
      * The (base) configuration key used to saved the configurations of a passive scanner, ID, alert
      * threshold and enabled state.
      */
-    private static final String PSCANS_KEY = PassiveScanParam.PASSIVE_SCANS_BASE_KEY + ".pscanner";
+    private static final String PSCANS_KEY = "pscans.pscanner";
 
     /** The configuration key used to save/load the ID of a passive scanner. */
     private static final String ID_KEY = "id";

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PolicyPassiveScanPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PolicyPassiveScanPanel.java
@@ -47,6 +47,7 @@ import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.panels.TableFilterPanel;
 
+@Deprecated(forRemoval = true, since = "2.16.0")
 public class PolicyPassiveScanPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/RegexAutoTagScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/scanner/RegexAutoTagScanner.java
@@ -29,6 +29,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.model.SessionStructure;
 import org.zaproxy.zap.utils.Stats;
 
+@Deprecated(forRemoval = true, since = "2.16.0")
 public class RegexAutoTagScanner extends PluginPassiveScanner {
 
     public static final String TAG_STATS_PREFIX = "stats.tag.";

--- a/zap/src/test/java/org/zaproxy/zap/extension/pscan/PassiveScanParamUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/pscan/PassiveScanParamUnitTest.java
@@ -35,6 +35,7 @@ import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 /** Unit test for {@link PassiveScanParam}. */
+@SuppressWarnings("removal")
 class PassiveScanParamUnitTest {
 
     private PassiveScanParam param;

--- a/zap/src/test/java/org/zaproxy/zap/extension/pscan/PassiveScannerListUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/pscan/PassiveScannerListUnitTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
 
 /** Unit test for {@link PassiveScannerList}. */
+@SuppressWarnings("removal")
 class PassiveScannerListUnitTest {
 
     private PassiveScannerList psl;

--- a/zap/src/test/java/org/zaproxy/zap/extension/pscan/scanner/DefaultRegexAutoTagScannerTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/pscan/scanner/DefaultRegexAutoTagScannerTest.java
@@ -50,6 +50,7 @@ import org.zaproxy.zap.utils.StatsListener;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 @Timeout(6)
+@SuppressWarnings("removal")
 class DefaultRegexAutoTagScannerTest {
 
     private static final String BASE_STRING = "lorem ipsum < type= href= ";

--- a/zap/src/test/java/org/zaproxy/zap/extension/pscan/scanner/RegexAutoTagScannerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/pscan/scanner/RegexAutoTagScannerUnitTest.java
@@ -37,6 +37,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.utils.Stats;
 import org.zaproxy.zap.utils.StatsListener;
 
+@SuppressWarnings("removal")
 class RegexAutoTagScannerUnitTest {
 
     private static final String BODY =


### PR DESCRIPTION
No longer hook the options and UI that manage the passive scanner related options, as it will be done by the `pscan` add-on. Also, let the add-on manage the scan rules themselves.

Part of #7959.

---
WIP pending changes in the add-on.