### PR TITLE
Deprecate/disable core passive scanner

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/AntiCsrfDetectScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/anticsrf/AntiCsrfDetectScanner.java
@@ -23,7 +23,7 @@ import java.util.List;
 import net.htmlparser.jericho.Source;
 import org.apache.commons.httpclient.URIException;
 import org.parosproxy.paros.network.HttpMessage;
-import org.zaproxy.zap.extension.pscan.PassiveScanTaskHelper;
+import org.zaproxy.zap.extension.pscan.PassiveScanActions;
 import org.zaproxy.zap.extension.pscan.PassiveScanner;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.model.SessionStructure;
@@ -44,15 +44,15 @@ public class AntiCsrfDetectScanner implements PassiveScanner {
     public static final String ACSRF_STATS_PREFIX = "stats.acsrf.";
 
     private final ExtensionAntiCSRF extAntiCSRF;
-    private PassiveScanTaskHelper helper;
+    private PassiveScanActions actions;
 
     public AntiCsrfDetectScanner(ExtensionAntiCSRF extAntiCSRF) {
         this.extAntiCSRF = extAntiCSRF;
     }
 
     @Override
-    public void setTaskHelper(PassiveScanTaskHelper helper) {
-        this.helper = helper;
+    public void setPassiveScanActions(PassiveScanActions actions) {
+        this.actions = actions;
     }
 
     @Override
@@ -65,8 +65,8 @@ public class AntiCsrfDetectScanner implements PassiveScanner {
         List<AntiCsrfToken> list = extAntiCSRF.getTokensFromResponse(msg, source);
         for (AntiCsrfToken token : list) {
             if (this.registerToken(msg.getHistoryRef().getHistoryType())) {
-                if (helper != null) {
-                    helper.addHistoryTag(msg.getHistoryRef(), ExtensionAntiCSRF.TAG);
+                if (actions != null) {
+                    actions.addHistoryTag(msg.getHistoryRef(), ExtensionAntiCSRF.TAG);
                 }
                 extAntiCSRF.registerAntiCsrfToken(token);
             }

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveController.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveController.java
@@ -1,0 +1,28 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscan;
+
+/** <strong>Note:</strong> Not part of the public API. */
+public interface PassiveController {
+
+    int getRecordsToScan();
+
+    void clearQueue();
+}

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanAPI.java
@@ -114,9 +114,6 @@ public class PassiveScanAPI extends ApiImplementor {
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
         switch (name) {
             case ACTION_SET_ENABLED:
-                boolean enabled = getParam(params, PARAM_ENABLED, false);
-
-                extension.setPassiveScanEnabled(enabled);
                 break;
             case ACTION_SET_SCAN_ONLY_IN_SCOPE:
                 extension

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanActions.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanActions.java
@@ -1,0 +1,31 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2024 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscan;
+
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.model.HistoryReference;
+
+/** <strong>Note:</strong> Not part of the public API. */
+public interface PassiveScanActions {
+
+    void addHistoryTag(HistoryReference historyRef, String tag);
+
+    void raiseAlert(HistoryReference historyRef, Alert alert);
+}

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanController.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanController.java
@@ -43,6 +43,7 @@ import org.zaproxy.zap.view.ScanStatus;
  * @since 2.12.0
  */
 @SuppressWarnings("removal")
+@Deprecated(forRemoval = true, since = "2.16.0")
 public class PassiveScanController extends Thread implements ProxyListener {
 
     private static final Logger LOGGER = LogManager.getLogger(PassiveScanController.class);

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanData.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanData.java
@@ -58,7 +58,7 @@ public class PassiveScanData {
     private List<User> userList = null;
     private Map<CustomPage.Type, Boolean> customPageMap;
 
-    PassiveScanData(HttpMessage msg) {
+    public PassiveScanData(HttpMessage msg) {
         this.message = msg;
         this.context = getContext(message);
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanTask.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanTask.java
@@ -37,6 +37,8 @@ import org.zaproxy.zap.utils.Stats;
  *
  * @since 2.12.0
  */
+@SuppressWarnings("removal")
+@Deprecated(forRemoval = true, since = "2.16.0")
 public class PassiveScanTask implements Runnable {
 
     /** I think this should be a thread which runs just one scan rule against one history record */
@@ -44,7 +46,6 @@ public class PassiveScanTask implements Runnable {
 
     private PassiveScanTaskHelper helper;
 
-    @SuppressWarnings("deprecation")
     private PassiveScanThread psThread;
 
     private int maxBodySize;
@@ -56,7 +57,6 @@ public class PassiveScanTask implements Runnable {
 
     private static final Logger LOGGER = LogManager.getLogger(PassiveScanTask.class);
 
-    @SuppressWarnings("deprecation")
     public PassiveScanTask(HistoryReference hr, PassiveScanTaskHelper helper) {
         this.href = hr;
         this.helper = helper;

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanTaskHelper.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanTaskHelper.java
@@ -40,6 +40,7 @@ import org.zaproxy.zap.extension.alert.ExtensionAlert;
  * @since 2.12.0
  */
 @SuppressWarnings("removal")
+@Deprecated(forRemoval = true, since = "2.16.0")
 public class PassiveScanTaskHelper {
 
     private static final Logger LOGGER = LogManager.getLogger(PassiveScanTaskHelper.class);

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanThread.java
@@ -27,7 +27,8 @@ import org.parosproxy.paros.model.HistoryReference;
 /**
  * @deprecated (2.12.0) Use {@link org.zaproxy.zap.extension.pscan.PassiveScanController} instead.
  */
-@Deprecated
+@SuppressWarnings("removal")
+@Deprecated(forRemoval = true, since = "2.12.0")
 public class PassiveScanThread extends Thread {
 
     public static final int PROXY_LISTENER_ORDER = ProxyListenerLog.PROXY_LISTENER_ORDER + 1;

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanner.java
@@ -29,7 +29,10 @@ public interface PassiveScanner {
 
     default void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {}
 
-    @SuppressWarnings("deprecation")
+    default void setPassiveScanActions(PassiveScanActions actions) {}
+
+    @SuppressWarnings("removal")
+    @Deprecated(forRemoval = true, since = "2.12.0")
     default void setParent(PassiveScanThread parent) {}
 
     String getName();
@@ -67,8 +70,12 @@ public interface PassiveScanner {
 
     boolean appliesToHistoryType(int historyType);
 
+    @SuppressWarnings("removal")
+    @Deprecated(forRemoval = true, since = "2.16.0")
     default void setTaskHelper(PassiveScanTaskHelper helper) {}
 
+    @SuppressWarnings("removal")
+    @Deprecated(forRemoval = true, since = "2.16.0")
     default PassiveScanTaskHelper getTaskHelper() {
         return null;
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
@@ -95,17 +95,6 @@ public abstract class PluginPassiveScanner extends Enableable
     }
 
     /**
-     * <strong>Note:</strong> This method should no longer need to be overridden, the functionality
-     * provided by the {@code parent} can be obtained directly with {@link #newAlert()} and {@link
-     * #addHistoryTag(String)}.
-     */
-    @Override
-    @SuppressWarnings("deprecation")
-    public void setParent(PassiveScanThread parent) {
-        // Nothing to do.
-    }
-
-    /**
      * Sets the current configuration of the passive scanner.
      *
      * @param config the configuration of the scanner
@@ -386,16 +375,12 @@ public abstract class PluginPassiveScanner extends Enableable
         return passiveScanData;
     }
 
-    private PassiveScanTaskHelper taskHelper;
+    private PassiveScanActions actions;
 
+    /** <strong>Note:</strong> Not part of the public API. */
     @Override
-    public void setTaskHelper(PassiveScanTaskHelper helper) {
-        this.taskHelper = helper;
-    }
-
-    @Override
-    public PassiveScanTaskHelper getTaskHelper() {
-        return this.taskHelper;
+    public void setPassiveScanActions(PassiveScanActions actions) {
+        this.actions = actions;
     }
 
     /**
@@ -417,7 +402,7 @@ public abstract class PluginPassiveScanner extends Enableable
      * @since 2.12.0
      */
     protected void addHistoryTag(String tag) {
-        this.taskHelper.addHistoryTag(passiveScanData.getMessage().getHistoryRef(), tag);
+        this.actions.addHistoryTag(passiveScanData.getMessage().getHistoryRef(), tag);
     }
 
     /**
@@ -676,7 +661,7 @@ public abstract class PluginPassiveScanner extends Enableable
 
         /** Raises the alert with specified data. */
         public void raise() {
-            plugin.taskHelper.raiseAlert(message.getHistoryRef(), build());
+            plugin.actions.raiseAlert(message.getHistoryRef(), build());
             Stats.incCounter("stats.pscan." + plugin.getPluginId() + ".alerts");
         }
     }

--- a/zap/src/test/java/org/zaproxy/zap/extension/pscan/PluginPassiveScannerUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/pscan/PluginPassiveScannerUnitTest.java
@@ -494,10 +494,10 @@ class PluginPassiveScannerUnitTest {
     }
 
     @Test
-    void shouldCallTaskHelperWithTagAdded() {
+    void shouldCallActionsWithTagAdded() {
         // Given
         String tag = "tag";
-        PassiveScanTaskHelper taskHelper = mock(PassiveScanTaskHelper.class);
+        PassiveScanActions actions = mock(PassiveScanActions.class);
         TestPluginPassiveScanner scanner = new TestPluginPassiveScanner();
         HttpMessage msg = mock(HttpMessage.class);
         HistoryReference href = mock(HistoryReference.class);
@@ -505,11 +505,11 @@ class PluginPassiveScannerUnitTest {
         PassiveScanData passiveScanData = mock(PassiveScanData.class);
         when(passiveScanData.getMessage()).thenReturn(msg);
         scanner.setHelper(passiveScanData);
-        scanner.setTaskHelper(taskHelper);
+        scanner.setPassiveScanActions(actions);
         // When
         scanner.addHistoryTag(tag);
         // Then
-        verify(taskHelper).addHistoryTag(href, tag);
+        verify(actions).addHistoryTag(href, tag);
     }
 
     private static class TestPluginPassiveScanner extends PluginPassiveScanner {


### PR DESCRIPTION
No longer add/use the passive scanner as it will be done by the `pscan` add-on.
The extension itself is not yet deprecated as it's still in use by other core extensions.

Part of #7959.

---
WIP pending the changes in the add-on.