### PR TITLE
Make HarLib an implementation dependency

### DIFF
--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -94,7 +94,7 @@ dependencies {
     api("commons-lang:commons-lang:2.6")
     api("org.apache.commons:commons-lang3:3.14.0")
     api("org.apache.commons:commons-text:1.12.0")
-    api("edu.umass.cs.benchlab:harlib:1.1.3")
+    implementation("edu.umass.cs.benchlab:harlib:1.1.3")
     api("javax.help:javahelp:2.0.05")
     val log4jVersion = "2.23.1"
     api("org.apache.logging.log4j:log4j-api:$log4jVersion")


### PR DESCRIPTION
No longer expose HarLib as it's being superseded by `exim` add-on and the library it uses.