### PR TITLE
Deprecate `HarUtils`

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/CoreAPI.java
@@ -85,9 +85,9 @@ import org.zaproxy.zap.network.DomainMatcher;
 import org.zaproxy.zap.network.HttpRedirectionValidator;
 import org.zaproxy.zap.network.HttpRequestConfig;
 import org.zaproxy.zap.utils.ApiUtils;
-import org.zaproxy.zap.utils.HarUtils;
 import org.zaproxy.zap.utils.ZapSupportUtils;
 
+@SuppressWarnings("removal")
 public class CoreAPI extends ApiImplementor implements SessionListener {
 
     private static final Logger LOGGER = LogManager.getLogger(CoreAPI.class);
@@ -1426,10 +1426,10 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                         getRecordHistory(tableHistory, getParam(params, PARAM_ID, -1));
                 addHarEntry(entries, recordHistory);
 
-                HarLog harLog = HarUtils.createZapHarLog();
+                HarLog harLog = org.zaproxy.zap.utils.HarUtils.createZapHarLog();
                 harLog.setEntries(entries);
 
-                responseBody = HarUtils.harLogToByteArray(harLog);
+                responseBody = org.zaproxy.zap.utils.HarUtils.harLogToByteArray(harLog);
             } catch (ApiException e) {
                 throw e;
             } catch (Exception e) {
@@ -1466,10 +1466,10 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                             rh -> addHarEntry(entries, rh));
                 }
 
-                HarLog harLog = HarUtils.createZapHarLog();
+                HarLog harLog = org.zaproxy.zap.utils.HarUtils.createZapHarLog();
                 harLog.setEntries(entries);
 
-                responseBody = HarUtils.harLogToByteArray(harLog);
+                responseBody = org.zaproxy.zap.utils.HarUtils.harLogToByteArray(harLog);
             } catch (ApiException e) {
                 throw e;
             } catch (Exception e) {
@@ -1491,7 +1491,9 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
             byte[] responseBody = {};
             HttpMessage request = null;
             try {
-                request = HarUtils.createHttpMessage(params.getString(PARAM_REQUEST));
+                request =
+                        org.zaproxy.zap.utils.HarUtils.createHttpMessage(
+                                params.getString(PARAM_REQUEST));
             } catch (IOException e) {
                 throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_REQUEST, e);
             }
@@ -1509,16 +1511,16 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
                                 httpMessage -> {
                                     HistoryReference hRef = httpMessage.getHistoryRef();
                                     entries.addEntry(
-                                            HarUtils.createHarEntry(
+                                            org.zaproxy.zap.utils.HarUtils.createHarEntry(
                                                     hRef.getHistoryId(),
                                                     hRef.getHistoryType(),
                                                     httpMessage));
                                 });
 
-                        HarLog harLog = HarUtils.createZapHarLog();
+                        HarLog harLog = org.zaproxy.zap.utils.HarUtils.createZapHarLog();
                         harLog.setEntries(entries);
 
-                        responseBody = HarUtils.harLogToByteArray(harLog);
+                        responseBody = org.zaproxy.zap.utils.HarUtils.harLogToByteArray(harLog);
                     } catch (ApiException e) {
                         throw e;
                     } catch (Exception e) {
@@ -1643,7 +1645,7 @@ public class CoreAPI extends ApiImplementor implements SessionListener {
      */
     private static void addHarEntry(HarEntries entries, RecordHistory recordHistory) {
         entries.addEntry(
-                HarUtils.createHarEntry(
+                org.zaproxy.zap.utils.HarUtils.createHarEntry(
                         recordHistory.getHistoryId(),
                         recordHistory.getHistoryType(),
                         recordHistory.getHttpMessage()));

--- a/zap/src/main/java/org/zaproxy/zap/extension/search/SearchAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/search/SearchAPI.java
@@ -47,7 +47,6 @@ import org.zaproxy.zap.extension.api.ApiResponseConversionUtils;
 import org.zaproxy.zap.extension.api.ApiResponseList;
 import org.zaproxy.zap.extension.api.ApiResponseSet;
 import org.zaproxy.zap.extension.api.ApiView;
-import org.zaproxy.zap.utils.HarUtils;
 
 public class SearchAPI extends ApiImplementor {
 
@@ -275,6 +274,7 @@ public class SearchAPI extends ApiImplementor {
     }
 
     @Override
+    @SuppressWarnings("removal")
     public HttpMessage handleApiOther(HttpMessage msg, String name, JSONObject params)
             throws ApiException {
         byte responseBody[] = {};
@@ -313,17 +313,17 @@ public class SearchAPI extends ApiImplementor {
                     searchType,
                     rh -> {
                         HarEntry entry =
-                                HarUtils.createHarEntry(
+                                org.zaproxy.zap.utils.HarUtils.createHarEntry(
                                         rh.getHistoryId(),
                                         rh.getHistoryType(),
                                         rh.getHttpMessage());
                         entries.addEntry(entry);
                     });
 
-            HarLog harLog = HarUtils.createZapHarLog();
+            HarLog harLog = org.zaproxy.zap.utils.HarUtils.createZapHarLog();
             harLog.setEntries(entries);
 
-            responseBody = HarUtils.harLogToByteArray(harLog);
+            responseBody = org.zaproxy.zap.utils.HarUtils.harLogToByteArray(harLog);
 
         } catch (Exception e) {
             LOGGER.error(e.getMessage(), e);

--- a/zap/src/main/java/org/zaproxy/zap/utils/HarUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/HarUtils.java
@@ -67,7 +67,9 @@ import org.zaproxy.zap.network.HttpRequestBody;
  * @see <a href="http://www.softwareishard.com/blog/har-12-spec/">HTTP Archive 1.2</a>
  * @since 2.3.0
  * @see HttpMessage
+ * @deprecated (2.16.0) Use/rely on exim add-on.
  */
+@Deprecated(forRemoval = true, since = "2.16.0")
 public final class HarUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(HarUtils.class);


### PR DESCRIPTION
Discourage the use of `HarUtils` by 3rd-party add-ons.
Suppress removal warns on the core code still using it, some deprecated and superseded functionality already.