### PR TITLE
Tweak JavaDoc packages

### DIFF
--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -217,6 +217,7 @@ tasks.named<Javadoc>("javadoc") {
     title = "Zed Attack Proxy"
     source =
         sourceSets["main"].allJava.matching {
+            include("ch/**")
             include("org/parosproxy/**")
             include("org/zaproxy/**")
         }


### PR DESCRIPTION
Include `ch` package as they are referenced by other core classes.