### PR TITLE
Deprecate context menu method no longer needed

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemContextInclude.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/popup/PopupMenuItemContextInclude.java
@@ -91,10 +91,21 @@ public class PopupMenuItemContextInclude extends PopupMenuItemSiteNodeContainer 
         this.subMenus.add(piicm);
     }
 
+    /**
+     * @deprecated (2.16.0) Override {@link #createPopupIncludeInContextMenu(int)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "2.16.0")
     protected ExtensionPopupMenuItem createPopupIncludeInContextMenu() {
         return new PopupMenuItemIncludeInContext();
     }
 
+    /**
+     * Called when creating the "New Context" menu item.
+     *
+     * @param weight the weight that the menu item should have.
+     * @return the menu item that creates a new context.
+     * @since 2.15.0
+     */
     protected ExtensionPopupMenuItem createPopupIncludeInContextMenu(int weight) {
         return new PopupMenuItemIncludeInContext(weight);
     }


### PR DESCRIPTION
Deprecate and recommend the use of the method that uses weights.

From zaproxy/zap-extensions#6008.