### PR TITLE
Include more info when logging DB max size limits

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/db/paros/ParosTableHistory.java
+++ b/zap/src/main/java/org/parosproxy/paros/db/paros/ParosTableHistory.java
@@ -459,14 +459,22 @@ public class ParosTableHistory extends ParosAbstractTable implements TableHistor
                     "The actual Request Body length "
                             + reqBody.length
                             + " is greater than the configured request body length "
-                            + this.configuredrequestbodysize);
+                            + this.configuredrequestbodysize
+                            + " for "
+                            + method
+                            + " "
+                            + uri);
         }
         if (resBody.length > this.configuredresponsebodysize) {
             throw new SQLException(
                     "The actual Response Body length "
                             + resBody.length
                             + " is greater than the configured response body length "
-                            + this.configuredresponsebodysize);
+                            + this.configuredresponsebodysize
+                            + " for "
+                            + method
+                            + " "
+                            + uri);
         }
 
         psInsert.setLong(1, sessionId);

--- a/zap/src/main/java/org/zaproxy/zap/db/sql/SqlTableHistory.java
+++ b/zap/src/main/java/org/zaproxy/zap/db/sql/SqlTableHistory.java
@@ -280,14 +280,22 @@ public class SqlTableHistory extends SqlAbstractTable implements TableHistory {
                     "The actual Request Body length "
                             + reqBody.length
                             + " is greater than the configured request body length "
-                            + this.configuredrequestbodysize);
+                            + this.configuredrequestbodysize
+                            + " for "
+                            + method
+                            + " "
+                            + uri);
         }
         if (resBody.length > this.configuredresponsebodysize) {
             throw new DatabaseException(
                     "The actual Response Body length "
                             + resBody.length
                             + " is greater than the configured response body length "
-                            + this.configuredresponsebodysize);
+                            + this.configuredresponsebodysize
+                            + " for "
+                            + method
+                            + " "
+                            + uri);
         }
 
         SqlPreparedStatementWrapper psInsert = null;


### PR DESCRIPTION
Include the method and URI of the message that is over the limits.

---
e.g.:
```
The actual Response Body length 1256 is greater than the configured response body length 1 for GET http://example.org/robots.txt
```