### PR TITLE
Notify script node changes in the correct thread

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptTreeModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ScriptTreeModel.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.swing.tree.DefaultTreeModel;
+import org.zaproxy.zap.utils.ThreadUtils;
 
 /**
  * A {@link javax.swing.tree.TreeModel TreeModel} of (user created) scripts and script templates.
@@ -175,7 +176,7 @@ public class ScriptTreeModel extends DefaultTreeModel {
     public void nodeStructureChanged(ScriptWrapper script) {
         ScriptNode node = this.getNodeForScript(script);
         if (node != null) {
-            this.nodeStructureChanged(node);
+            ThreadUtils.invokeAndWaitHandled(() -> nodeStructureChanged(node));
         }
     }
 


### PR DESCRIPTION
Notify the changes in the EDT to prevent concurrency issues.

---
From ZAP User Group: https://groups.google.com/g/zaproxy-users/c/-WOC5xDNuA4/m/SP1BMlnVAAAJ
```
ERROR BaseHttpSender - Error while notifying listener org.zaproxy.zap.extension.script.HttpSenderScriptListener cause: Cannot invoke "javax.swing.tree.VariableHeightLayoutCache$TreeStateNode.getIndex(javax.swing.tree.TreeNode)" because "parent" is null
java.lang.NullPointerException: Cannot invoke "javax.swing.tree.VariableHeightLayoutCache$TreeStateNode.getIndex(javax.swing.tree.TreeNode)" because "parent" is null
	at javax.swing.tree.VariableHeightLayoutCache.treeStructureChanged(VariableHeightLayoutCache.java:641) ~[?:?]
	at javax.swing.plaf.basic.BasicTreeUI$Handler.treeStructureChanged(BasicTreeUI.java:4404) ~[?:?]
	at javax.swing.tree.DefaultTreeModel.fireTreeStructureChanged(DefaultTreeModel.java:616) ~[?:?]
	at javax.swing.tree.DefaultTreeModel.nodeStructureChanged(DefaultTreeModel.java:400) ~[?:?]
	at org.zaproxy.zap.extension.script.ScriptTreeModel.nodeStructureChanged(ScriptTreeModel.java:178) ~[zap-2.15.0.jar:2.15.0]
	at org.zaproxy.zap.extension.script.ExtensionScript.setEnabled(ExtensionScript.java:1867) ~[zap-2.15.0.jar:2.15.0]
	at org.zaproxy.zap.extension.script.ExtensionScript.handleScriptException(ExtensionScript.java:1603) ~[zap-2.15.0.jar:2.15.0]
	at org.zaproxy.zap.extension.script.ExtensionScript.handleScriptException(ExtensionScript.java:1573) ~[zap-2.15.0.jar:2.15.0]
	at org.zaproxy.zap.extension.script.ScriptsCache.lambda$execute$3(ScriptsCache.java:131) ~[zap-2.15.0.jar:2.15.0]
	at java.util.ArrayList.forEach(ArrayList.java:1596) ~[?:?]
	at java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1116) ~[?:?]
	at org.zaproxy.zap.extension.script.ScriptsCache.execute(ScriptsCache.java:122) ~[zap-2.15.0.jar:2.15.0]
	at org.zaproxy.zap.extension.script.HttpSenderScriptListener.onHttpRequestSend(HttpSenderScriptListener.java:55) ~[zap-2.15.0.jar:2.15.0]
	at org.zaproxy.addon.network.internal.client.BaseHttpSender.notifyRequestListeners(BaseHttpSender.java:175) ~[?:?]
	at org.zaproxy.addon.network.internal.client.BaseHttpSender.sendNoRedirections(BaseHttpSender.java:348) ~[?:?]
	at org.zaproxy.addon.network.internal.client.BaseHttpSender.send(BaseHttpSender.java:307) ~[?:?]
	at org.zaproxy.addon.network.internal.client.BaseHttpSender.sendAndReceive(BaseHttpSender.java:278) ~[?:?]
	at org.zaproxy.addon.network.internal.client.BaseHttpSender.sendAndReceive(BaseHttpSender.java:234) ~[?:?]
	at org.parosproxy.paros.network.HttpSender.sendImpl(HttpSender.java:529) ~[zap-2.15.0.jar:2.15.0]
	at org.parosproxy.paros.network.HttpSender.sendAndReceive(HttpSender.java:349) ~[zap-2.15.0.jar:2.15.0]
	at org.zaproxy.addon.spider.SpiderTask.fetchResource(SpiderTask.java:435) ~[?:?]
	at org.zaproxy.addon.spider.SpiderTask.runImpl(SpiderTask.java:185) ~[?:?]
	at org.zaproxy.addon.spider.SpiderTask.run(SpiderTask.java:157) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.lang.Thread.run(Thread.java:1583) [?:?]
2024-12-09 12:58:00,460 [ZAP-SpiderThreadPool-5-thread-3] ERROR BaseHttpSender - Error while notifying listener org.zaproxy.zap.extension.script.HttpSenderScriptListener cause: 0 >= 0
java.lang.ArrayIndexOutOfBoundsException: 0 >= 0
	at java.util.Vector.elementAt(Vector.java:466) ~[?:?]
	at javax.swing.tree.DefaultMutableTreeNode.getChildAt(DefaultMutableTreeNode.java:258) ~[?:?]
	at javax.swing.tree.DefaultMutableTreeNode.remove(DefaultMutableTreeNode.java:218) ~[?:?]
	at javax.swing.tree.VariableHeightLayoutCache$TreeStateNode.remove(VariableHeightLayoutCache.java:1062) ~[?:?]
	at javax.swing.tree.DefaultMutableTreeNode.remove(DefaultMutableTreeNode.java:396) ~[?:?]
	at javax.swing.tree.DefaultMutableTreeNode.removeFromParent(DefaultMutableTreeNode.java:376) ~[?:?]
	at javax.swing.tree.VariableHeightLayoutCache.treeStructureChanged(VariableHeightLayoutCache.java:647) ~[?:?]
	at javax.swing.plaf.basic.BasicTreeUI$Handler.treeStructureChanged(BasicTreeUI.java:4404) ~[?:?]
	at javax.swing.tree.DefaultTreeModel.fireTreeStructureChanged(DefaultTreeModel.java:616) ~[?:?]
	at javax.swing.tree.DefaultTreeModel.nodeStructureChanged(DefaultTreeModel.java:400) ~[?:?]
	at org.zaproxy.zap.extension.script.ScriptTreeModel.nodeStructureChanged(ScriptTreeModel.java:178) ~[zap-2.15.0.jar:2.15.0]
	at org.zaproxy.zap.extension.script.ExtensionScript.setEnabled(ExtensionScript.java:1867) ~[zap-2.15.0.jar:2.15.0]
	at org.zaproxy.zap.extension.script.ExtensionScript.handleScriptException(ExtensionScript.java:1603) ~[zap-2.15.0.jar:2.15.0]
	at org.zaproxy.zap.extension.script.ExtensionScript.handleScriptException(ExtensionScript.java:1573) ~[zap-2.15.0.jar:2.15.0]
	at org.zaproxy.zap.extension.script.ScriptsCache.lambda$execute$3(ScriptsCache.java:131) ~[zap-2.15.0.jar:2.15.0]
	at java.util.ArrayList.forEach(ArrayList.java:1596) ~[?:?]
	at java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1116) ~[?:?]
	at org.zaproxy.zap.extension.script.ScriptsCache.execute(ScriptsCache.java:122) ~[zap-2.15.0.jar:2.15.0]
	at org.zaproxy.zap.extension.script.HttpSenderScriptListener.onHttpRequestSend(HttpSenderScriptListener.java:55) ~[zap-2.15.0.jar:2.15.0]
	at org.zaproxy.addon.network.internal.client.BaseHttpSender.notifyRequestListeners(BaseHttpSender.java:175) ~[?:?]
	at org.zaproxy.addon.network.internal.client.BaseHttpSender.sendNoRedirections(BaseHttpSender.java:348) ~[?:?]
	at org.zaproxy.addon.network.internal.client.BaseHttpSender.send(BaseHttpSender.java:307) ~[?:?]
	at org.zaproxy.addon.network.internal.client.BaseHttpSender.sendAndReceive(BaseHttpSender.java:278) ~[?:?]
	at org.zaproxy.addon.network.internal.client.BaseHttpSender.sendAndReceive(BaseHttpSender.java:234) ~[?:?]
	at org.parosproxy.paros.network.HttpSender.sendImpl(HttpSender.java:529) ~[zap-2.15.0.jar:2.15.0]
	at org.parosproxy.paros.network.HttpSender.sendAndReceive(HttpSender.java:349) ~[zap-2.15.0.jar:2.15.0]
	at org.zaproxy.addon.spider.SpiderTask.fetchResource(SpiderTask.java:435) ~[?:?]
	at org.zaproxy.addon.spider.SpiderTask.runImpl(SpiderTask.java:185) ~[?:?]
	at org.zaproxy.addon.spider.SpiderTask.run(SpiderTask.java:157) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.lang.Thread.run(Thread.java:1583) [?:?]
```

This might not fix all exceptions since there are still accesses to the GUI that are not done in the correct thread but should reduce them.