### PR TITLE
Add constants for Client Spider

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/model/HistoryReference.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/HistoryReference.java
@@ -287,6 +287,13 @@ public class HistoryReference {
      */
     public static final int TYPE_PARAM_DIGGER = 23;
 
+    /**
+     * An HTTP message sent by the Client Spider.
+     *
+     * @since 2.16.0
+     */
+    public static final int TYPE_CLIENT_SPIDER = 24;
+
     private static java.text.DecimalFormat decimalFormat = new java.text.DecimalFormat("##0.###");
     private static TableHistory staticTableHistory = null;
     // ZAP: Support for multiple tags

--- a/zap/src/main/java/org/parosproxy/paros/model/Session.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/Session.java
@@ -410,7 +410,8 @@ public class Session {
                                 HistoryReference.TYPE_SPIDER,
                                 HistoryReference.TYPE_BRUTE_FORCE,
                                 HistoryReference.TYPE_SPIDER_AJAX,
-                                HistoryReference.TYPE_SCANNER);
+                                HistoryReference.TYPE_SCANNER,
+                                HistoryReference.TYPE_CLIENT_SPIDER);
 
         for (int i = 0; i < list.size(); i++) {
             // ZAP: Removed unnecessary cast.

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java
@@ -150,6 +150,13 @@ public class HttpSender {
     public static final int OAST_INITIATOR = 16;
     public static final int PARAM_DIGGER_INITIATOR = 17;
 
+    /**
+     * The ID for the Client Spider.
+     *
+     * @since 2.16.0
+     */
+    public static final int CLIENT_SPIDER_INITIATOR = 18;
+
     private static final HttpRequestConfig NO_REDIRECTS = HttpRequestConfig.builder().build();
     private static final HttpRequestConfig FOLLOW_REDIRECTS =
             HttpRequestConfig.builder().setFollowRedirects(true).build();

--- a/zap/src/main/java/org/zaproxy/zap/extension/compare/ExtensionCompare.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/compare/ExtensionCompare.java
@@ -170,7 +170,8 @@ public class ExtensionCompare extends ExtensionAdaptor
                         HistoryReference.TYPE_PROXIED,
                         HistoryReference.TYPE_ZAP_USER,
                         HistoryReference.TYPE_SPIDER,
-                        HistoryReference.TYPE_SPIDER_AJAX);
+                        HistoryReference.TYPE_SPIDER_AJAX,
+                        HistoryReference.TYPE_CLIENT_SPIDER);
 
         for (Integer hId : hIds) {
             RecordHistory recH = th.read(hId);

--- a/zap/src/main/java/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/pscan/PluginPassiveScanner.java
@@ -72,8 +72,11 @@ public abstract class PluginPassiveScanner extends Enableable
 
     private static final Integer[] DEFAULT_HISTORY_TYPES =
             new Integer[] {
-                HistoryReference.TYPE_PROXIED, HistoryReference.TYPE_ZAP_USER,
-                HistoryReference.TYPE_SPIDER, HistoryReference.TYPE_SPIDER_AJAX
+                HistoryReference.TYPE_PROXIED,
+                HistoryReference.TYPE_ZAP_USER,
+                HistoryReference.TYPE_SPIDER,
+                HistoryReference.TYPE_SPIDER_AJAX,
+                HistoryReference.TYPE_CLIENT_SPIDER
             };
 
     private static final Set<Integer> DEFAULT_HISTORY_TYPES_SET =

--- a/zap/src/main/java/org/zaproxy/zap/extension/search/SearchThread.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/search/SearchThread.java
@@ -210,7 +210,8 @@ public class SearchThread extends Thread {
                                     HistoryReference.TYPE_ZAP_USER,
                                     HistoryReference.TYPE_SPIDER,
                                     HistoryReference.TYPE_SPIDER_AJAX,
-                                    HistoryReference.TYPE_AUTHENTICATION);
+                                    HistoryReference.TYPE_AUTHENTICATION,
+                                    HistoryReference.TYPE_CLIENT_SPIDER);
             int last = list.size();
             int currentRecordId = 0;
             for (int index = 0; index < last; index++) {


### PR DESCRIPTION
Add HTTP Sender initiator and history reference constants.
Update codebase to make use of the messages sent by the client spider (i.e. passive scanning, session, search).