### PR TITLE
Add temp history ID for Client Spider

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/model/HistoryReference.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/HistoryReference.java
@@ -294,6 +294,15 @@ public class HistoryReference {
      */
     public static final int TYPE_CLIENT_SPIDER = 24;
 
+    /**
+     * A temporary HTTP message of the Client Spider.
+     *
+     * <p>A message that was not allowed to be sent.
+     *
+     * @since 2.16.0
+     */
+    public static final int TYPE_CLIENT_SPIDER_TEMPORARY = 25;
+
     private static java.text.DecimalFormat decimalFormat = new java.text.DecimalFormat("##0.###");
     private static TableHistory staticTableHistory = null;
     // ZAP: Support for multiple tags
@@ -311,6 +320,7 @@ public class HistoryReference {
         defaultHistoryTypes.add(HistoryReference.TYPE_SPIDER_AJAX_TEMPORARY);
         defaultHistoryTypes.add(HistoryReference.TYPE_SPIDER_TEMPORARY);
         defaultHistoryTypes.add(HistoryReference.TYPE_FUZZER_TEMPORARY);
+        defaultHistoryTypes.add(HistoryReference.TYPE_CLIENT_SPIDER_TEMPORARY);
         DEFAULT_TEMPORARY_HISTORY_TYPES = Collections.unmodifiableSet(defaultHistoryTypes);
 
         TEMPORARY_HISTORY_TYPES.addAll(DEFAULT_TEMPORARY_HISTORY_TYPES);

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -315,6 +315,8 @@ public class ExtensionAlert extends ExtensionAdaptor
                 return HistoryReference.TYPE_SPIDER;
             case HistoryReference.TYPE_FUZZER_TEMPORARY:
                 return HistoryReference.TYPE_FUZZER;
+            case HistoryReference.TYPE_CLIENT_SPIDER_TEMPORARY:
+                return HistoryReference.TYPE_CLIENT_SPIDER;
             default:
                 return HistoryReference.TYPE_SCANNER;
         }


### PR DESCRIPTION
Allow to keep temporary state for the Client Spider.