### PR TITLE
Update base image and Java of main Docker images

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2024-01-10
+- Change stable image to use `debian:bookworm-slim` instead of `bullseye-slim`, it will now start using Java 17.
+- Change bare image to use `eclipse-temurin:17-jre-alpine` instead of `11-jre-alpine`.
+
 ### 2024-12-10
 - Updated to use Webswing 24.2.2.
 

--- a/docker/Dockerfile-bare
+++ b/docker/Dockerfile-bare
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1
 # This dockerfile builds the zap bare release
-FROM --platform=linux/amd64 debian:bullseye-slim AS builder
+FROM --platform=linux/amd64 debian:bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
 	wget \
 	curl \
-	openjdk-11-jdk \
+	openjdk-17-jdk \
 	xmlstarlet \
 	unzip && \
 	rm -rf /var/lib/apt/lists/*
@@ -22,7 +22,7 @@ RUN ./zap.sh -cmd -silent -addonupdate
 # Copy them to installation directory
 RUN cp /root/.ZAP/plugin/*.zap plugin/ || :
 
-FROM eclipse-temurin:11-jre-alpine AS final
+FROM eclipse-temurin:17-jre-alpine AS final
 LABEL maintainer="psiinon@gmail.com"
 
 RUN apk add --no-cache bash curl 

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1
 # This dockerfile builds the zap stable release
-FROM --platform=linux/amd64 debian:bullseye-slim AS builder
+FROM --platform=linux/amd64 debian:bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
 	wget \
 	curl \
-	openjdk-11-jdk \
+	openjdk-17-jdk \
 	xmlstarlet \
 	unzip && \
 	rm -rf /var/lib/apt/lists/*
@@ -34,7 +34,7 @@ RUN --mount=type=secret,id=webswing_url \
 	# Remove Webswing bundled examples
 	rm -Rf webswing/apps/
 
-FROM debian:bullseye-slim AS final
+FROM debian:bookworm-slim AS final
 LABEL maintainer="psiinon@gmail.com"
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -44,7 +44,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	automake \
 	autoconf \
 	gcc g++ \
-	openjdk-11-jdk \
+	openjdk-17-jdk \
 	wget \
 	curl \
 	xmlstarlet \
@@ -60,7 +60,15 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	x11vnc && \
 	rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --no-cache-dir --upgrade awscli pip zaproxy pyyaml urllib3
+RUN pip3 install \
+	--break-system-packages \
+	--no-cache-dir \
+	--upgrade \
+	awscli \
+	pip \
+	zaproxy \
+	pyyaml \
+	urllib3
 
 RUN useradd -u 1000 -d /home/zap -m -s /bin/bash zap
 RUN echo zap:zap | chpasswd
@@ -79,7 +87,7 @@ COPY --link --from=builder --chown=1000:1000 /zap .
 COPY --link --from=builder --chown=1000:1000 /zap/webswing /zap/webswing
 
 ARG TARGETARCH
-ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-$TARGETARCH
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-$TARGETARCH
 ENV PATH=$JAVA_HOME/bin:/zap/:$PATH
 ENV ZAP_PATH=/zap/zap.sh
 


### PR DESCRIPTION
Use `debian:bookworm-slim`/`eclipse-temurin:17-jre-alpine` and Java 17 in stable and bare.

Part of #8211.