### PR TITLE
Fix snap build, round 2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,7 +40,6 @@ parts:
     override-build: |
       cp /etc/ssl/certs/java/cacerts $SNAPCRAFT_PART_INSTALL/usr/lib/jvm/java-17-openjdk-$SNAPCRAFT_TARGET_ARCH/lib/security/cacerts
       cp /etc/ssl/certs/java/cacerts $SNAPCRAFT_PART_INSTALL/etc/ssl/certs/java/cacerts
-      rm $SNAPCRAFT_PART_INSTALL/usr/lib/jvm/java-11-openjdk-$SNAPCRAFT_TARGET_ARCH/lib/security/blacklisted.certs
   desktop-glib-only:
     build-packages:
       - libglib2.0-dev


### PR DESCRIPTION
No longer attempt to remove the file as it's not present when building in CI.