### PR TITLE
Update build dependencies

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,15 +24,15 @@ tasks.withType<JavaCompile>().configureEach {
 dependencies {
     implementation("com.github.javaparser:javaparser-core:3.15.21")
     implementation("com.github.zafarkhaja:java-semver:0.9.0")
-    implementation("commons-codec:commons-codec:1.12")
+    implementation("commons-codec:commons-codec:1.17.1")
     implementation("commons-configuration:commons-configuration:1.10")
     implementation("commons-collections:commons-collections:3.2.2")
     implementation("commons-io:commons-io:2.13.0")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.1")
-    val jgitVersion = "6.7.0.202309050840-r"
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.2")
+    val jgitVersion = "7.1.0.202411261347-r"
     implementation("org.eclipse.jgit:org.eclipse.jgit:$jgitVersion")
     implementation("org.eclipse.jgit:org.eclipse.jgit.archive:$jgitVersion")
-    implementation("org.kohsuke:github-api:1.95")
+    implementation("org.kohsuke:github-api:1.326")
     // Include annotations used by the above library to avoid compiler warnings.
     compileOnly("com.google.code.findbugs:findbugs-annotations:3.0.1")
     compileOnly("com.infradna.tool:bridge-method-annotation:1.18") {

--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/CreatePullRequest.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/CreatePullRequest.java
@@ -140,7 +140,7 @@ public abstract class CreatePullRequest extends DefaultTask {
                             .head(ghUser.getName() + ":" + getBranchName().get())
                             .state(GHIssueState.OPEN)
                             .list()
-                            .asList();
+                            .toList();
             String description =
                     getPullRequestDescription().getOrElse(getCommitDescription().get());
             if (pulls.isEmpty()) {


### PR DESCRIPTION
Update build dependencies to work with the targeted Java version, which should restore the upload of the macOS dist.