### PR TITLE
Stop publishing to `softwaresecurityproject`

### DIFF
--- a/.github/workflows/release-live-docker.yml
+++ b/.github/workflows/release-live-docker.yml
@@ -47,7 +47,6 @@ jobs:
           provenance: false
           tags: |
             ghcr.io/zaproxy/zaproxy:nightly
-            softwaresecurityproject/zap-nightly:latest
             zaproxy/zap-nightly:latest
           secrets: |
             webswing_url=${{ secrets.WEBSWING_URL }}

--- a/.github/workflows/release-main-docker.yml
+++ b/.github/workflows/release-main-docker.yml
@@ -55,9 +55,6 @@ jobs:
             ghcr.io/zaproxy/zaproxy:${{ env.REL_VERSION }}
             ghcr.io/zaproxy/zaproxy:stable
             ghcr.io/zaproxy/zaproxy:latest
-            softwaresecurityproject/zap-stable:${{ env.REL_DATE_SHORT }}
-            softwaresecurityproject/zap-stable:${{ env.REL_VERSION }}
-            softwaresecurityproject/zap-stable:latest
             zaproxy/zap-stable:${{ env.REL_DATE_SHORT }}
             zaproxy/zap-stable:${{ env.REL_VERSION }}
             zaproxy/zap-stable:latest
@@ -80,9 +77,6 @@ jobs:
             ghcr.io/zaproxy/zaproxy:${{ env.REL_DATE_SHORT }}-bare
             ghcr.io/zaproxy/zaproxy:${{ env.REL_VERSION }}-bare
             ghcr.io/zaproxy/zaproxy:bare
-            softwaresecurityproject/zap-bare:${{ env.REL_DATE_SHORT }}
-            softwaresecurityproject/zap-bare:${{ env.REL_VERSION }}
-            softwaresecurityproject/zap-bare:latest
             zaproxy/zap-bare:${{ env.REL_DATE_SHORT }}
             zaproxy/zap-bare:${{ env.REL_VERSION }}
             zaproxy/zap-bare:latest

--- a/.github/workflows/release-weekly-docker.yml
+++ b/.github/workflows/release-weekly-docker.yml
@@ -50,8 +50,6 @@ jobs:
           tags: |
             ghcr.io/zaproxy/zaproxy:${{ env.REL_DATE_SHORT }}-weekly
             ghcr.io/zaproxy/zaproxy:weekly
-            softwaresecurityproject/zap-weekly:${{ env.REL_DATE_SHORT }}
-            softwaresecurityproject/zap-weekly:latest
             zaproxy/zap-weekly:${{ env.REL_DATE_SHORT }}
             zaproxy/zap-weekly:latest
           secrets: |

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2025-01-16
+- Stop publishing images under the `softwaresecurityproject` Docker Hub org, superseded by `zaproxy`, which should be used instead.
+
 ### 2024-01-10
 - Change stable image to use `debian:bookworm-slim` instead of `bullseye-slim`, it will now start using Java 17.
 - Change bare image to use `eclipse-temurin:17-jre-alpine` instead of `11-jre-alpine`.


### PR DESCRIPTION
The `zaproxy` org should be used instead.