### PR TITLE
Bugfix/alert view alert counts by risk xml response fix #8814

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertAPI.java
@@ -766,6 +766,9 @@ public class AlertAPI extends ApiImplementor {
 
     @SuppressWarnings("unchecked")
     private static class CustomApiResponseSet<T> extends ApiResponseSet<T> {
+
+        private Map<String, T> values = null;
+
         public CustomApiResponseSet(String name, Map<String, T> values) {
             super(name, values);
         }
@@ -773,7 +776,7 @@ public class AlertAPI extends ApiImplementor {
         @Override
         public void toXML(Document doc, Element parent) {
             parent.setAttribute("type", "set");
-            for (Map.Entry<String, T> val : getValues().entrySet()) {
+            for (Map.Entry<String, T> val : values.entrySet()) {
                 Element el = doc.createElement(val.getKey());
                 if ("tags".equals(val.getKey())) {
                     el.setAttribute("type", "list");
@@ -790,7 +793,8 @@ public class AlertAPI extends ApiImplementor {
                         Element elValue = doc.createElement("value");
                         elValue.appendChild(
                                 doc.createTextNode(
-                                        XMLStringUtil.escapeControlChrs(tag.getValue())));
+                                        XMLStringUtil.escapeControlChrs(
+                                                tag.getValue())));
                         elTag.appendChild(elValue);
 
                         el.appendChild(elTag);

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ApiResponseSet.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ApiResponseSet.java
@@ -60,12 +60,13 @@ public class ApiResponseSet<T> extends ApiResponse {
         return jo;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void toXML(Document doc, Element parent) {
         parent.setAttribute("type", "set");
-
         for (Entry<String, T> val : values.entrySet()) {
-            Element el = doc.createElement(val.getKey());
+            String sanitizedKey = val.getKey().replace(" ", "-");
+            Element el = doc.createElement(sanitizedKey);
             String textValue = val.getValue() == null ? "" : val.getValue().toString();
             Text text = doc.createTextNode(XMLStringUtil.escapeControlChrs(textValue));
             el.appendChild(text);

--- a/zap/src/main/java/org/zaproxy/zap/extension/api/ApiResponseSet.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/ApiResponseSet.java
@@ -60,7 +60,6 @@ public class ApiResponseSet<T> extends ApiResponse {
         return jo;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public void toXML(Document doc, Element parent) {
         parent.setAttribute("type", "set");


### PR DESCRIPTION
### **Title**:
Fix: XML Response Handling in `alertCountsByRisk` API (#8814)

### **Description**:
This pull request resolves the issue encountered when attempting to retrieve an XML response from the `alertCountsByRisk` API endpoint. The bug was caused by special characters, specifically spaces in the key names (`False Positive`), which were causing XML generation to fail.

### **Issue**:
When the API returned XML for the `alertCountsByRisk` endpoint, an `internal_error` was encountered. Upon debugging, it was found that the space in the key name `False Positive` was causing the failure.

### **Solution**:
To fix the issue, I sanitized the key names by replacing spaces with hyphens (`-`) to ensure they were properly formatted for XML. This resolved the issue, and XML responses are now correctly generated.

### **Changes Made**:
- In the `org/zaproxy/zap/extension/api/ApiResponseSet.java` file, I added the following change to sanitize the keys:
  ```java
  String sanitizedKey = val.getKey().replace(" ", "-");
  

https://github.com/user-attachments/assets/2f98aeee-e95e-4a34-9631-3919307aae86

