### PR TITLE
Itests: New baseline result + bluesky warning

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -43,18 +43,22 @@ jobs:
             index:org.opencontainers.image.licenses=Apache-2.0
       - 
         name: Run install tests
+        id: "test-install"
         if: ${{ ! cancelled() }}
         run: docker run --rm -t ghcr.io/zaproxy/zaproxy-tests wrk/install_tests.sh
       - 
         name: Run python tests
+        id: "test-python"
         if: ${{ ! cancelled() }}
         run: docker run --rm -t ghcr.io/zaproxy/zaproxy-tests wrk/python_tests.sh
       - 
         name: Automation Framework context tests
+        id: "test-af-context"
         if: ${{ ! cancelled() }}
         run: docker run --rm -t ghcr.io/zaproxy/zaproxy-tests wrk/af_context_tests.sh
       - 
         name: Automation Framework plan tests
+        id: "test-af-plan"
         if: ${{ ! cancelled() }}
         run: docker run --rm -t ghcr.io/zaproxy/zaproxy-tests wrk/af_plan_tests.sh
       -
@@ -62,3 +66,16 @@ jobs:
         name: Run baseline tests
         if: ${{ ! cancelled() }}
         run: docker run --rm -t ghcr.io/zaproxy/zaproxy-tests wrk/baseline_tests.sh
+      - name: "Send messages on failures"
+        uses: myConsciousness/bluesky-post@96827d0a9604cb228b11b3095f6961196efba4a0 # v5
+        if: |
+          ${{ ! cancelled() && ( 
+            steps.test-install.outcome != 'success' || 
+            steps.test-python.outcome != 'success' ||
+            steps.test-af-context.outcome != 'success' ||
+            steps.test-af-plan.outcome != 'success'
+          ) }}
+        with:
+          text: "Hey @psiinon.bsky.social - looks like the ZAP Integration Tests failed 😟 https://github.com/zaproxy/zaproxy/actions/runs/${{ github.run_id }}"  
+          identifier: ${{ secrets.BLUESKY_ZAPBOT_IDENTIFIER }}
+          password: ${{ secrets.BLUESKY_ZAPBOT_PASSWORD }}

--- a/docker/integration_tests/results/baseline1-2.out
+++ b/docker/integration_tests/results/baseline1-2.out
@@ -1,0 +1,12 @@
+Using the Automation Framework
+WARN-NEW: Re-examine Cache-control Directives [10015] x X 
+WARN-NEW: X-Content-Type-Options Header Missing [10021] x X 
+WARN-NEW: Strict-Transport-Security Header Not Set [10035] x X 
+WARN-NEW: Content Security Policy (CSP) Header Not Set [10038] x X 
+WARN-NEW: Storable and Cacheable Content [10049] x X 
+WARN-NEW: Retrieved from Cache [10050] x X 
+WARN-NEW: CSP: Wildcard Directive [10055] x X 
+WARN-NEW: Permissions Policy Header Not Set [10063] x X 
+WARN-NEW: Cross-Domain Misconfiguration [10098] x X 
+WARN-NEW: Insufficient Site Isolation Against Spectre Vulnerability [90004] x X 
+FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 10	WARN-INPROG: 0	INFO: 0	IGNORE: 0	PASS: 56


### PR DESCRIPTION
Baseline 1 tests failed
https://github.com/zaproxy/zaproxy/actions/runs/12970235911 

It would be good to investigate why we arent getting the "Missing Anti-clickjacking Header" (timing issue?) but until then..
