### PR TITLE
Unpin chalk binary in live Docker workflow

### DIFF
--- a/.github/workflows/release-live-docker.yml
+++ b/.github/workflows/release-live-docker.yml
@@ -14,7 +14,6 @@ jobs:
       - name: Set up Chalk
         uses: crashappsec/setup-chalk-action@main
         with:
-          version: 0.4.14
           password: ${{ secrets.CHALK_PASSWORD }}
           public_key: ${{ secrets.CHALK_PUBLIC_KEY }}
           private_key: ${{ secrets.CHALK_PRIVATE_KEY }}


### PR DESCRIPTION
The latest version should have the expected build times again.