### PR TITLE
ITests: Add Client Script Auth tests for Ajax and Client Spiders

### DIFF
--- a/docker/integration_tests/configs/plans/auth-client-script-ajax-spider.yaml
+++ b/docker/integration_tests/configs/plans/auth-client-script-ajax-spider.yaml
@@ -1,0 +1,43 @@
+env:
+  contexts:
+  - name: RecordedAuthTest
+    urls:
+    - http://localhost:9091/auth/simple-json-cookie
+    includePaths:
+    - http://localhost:9091/auth/simple-json-cookie.*
+    authentication:
+      method: client
+      parameters:
+        script: /zap/wrk/configs/scripts/auth/RecordedTestAuth.zst
+        scriptEngine: Mozilla Zest
+      verification:
+        method: poll
+        loggedInRegex: \Q 200 OK\E
+        loggedOutRegex: \Q 403 Forbidden\E
+        pollFrequency: 60
+        pollUnits: seconds
+        pollUrl: http://localhost:9091/auth/simple-json-cookie/user
+        pollPostData: ""
+    sessionManagement:
+      method: headers
+      parameters:
+        Cookie: "sid={%cookie:sid%}; _random=blahblah"
+    technology: {}
+    structure: {}
+    users:
+    - name: test
+      credentials:
+        Username: test@test.com
+        Password: password123
+  parameters: {}
+- type: spiderAjax
+  parameters:
+    context: RecordedAuthTest
+    user: test
+    browserId: firefox-headless
+  tests:
+  - name: spiderAjax/url
+    type: url
+    onFail: INFO
+    url: http://localhost:9091/auth/simple-json-cookie/s3cr3t.html
+    operator: and

--- a/docker/integration_tests/configs/plans/auth-client-script-client-spider.yml
+++ b/docker/integration_tests/configs/plans/auth-client-script-client-spider.yml
@@ -1,0 +1,46 @@
+env:
+  contexts:
+  - name: RecordedAuthTest
+    urls:
+    - http://localhost:9091/auth/simple-json-cookie
+    includePaths:
+    - http://localhost:9091/auth/simple-json-cookie.*
+    authentication:
+      method: client
+      parameters:
+        script: /zap/wrk/configs/scripts/auth/RecordedTestAuth.zst
+        scriptEngine: Mozilla Zest
+      verification:
+        method: poll
+        loggedInRegex: \Q 200 OK\E
+        loggedOutRegex: \Q 403 Forbidden\E
+        pollFrequency: 60
+        pollUnits: seconds
+        pollUrl: http://localhost:9091/auth/simple-json-cookie/user
+        pollPostData: ""
+    sessionManagement:
+      method: headers
+      parameters:
+        Cookie: "sid={%cookie:sid%}; _random=blahblah"
+    technology: {}
+    structure: {}
+    users:
+    - name: test
+      credentials:
+        Username: test@test.com
+        Password: password123
+  parameters: {}
+jobs:
+- type: spiderClient
+  parameters:
+    context: RecordedAuthTest
+    user: test
+    maxDuration: 0
+    maxChildren: 0
+    browserId: firefox-headless
+  tests:
+  - name: spiderClient/url
+    type: url
+    onFail: INFO
+    url: http://localhost:9091/auth/simple-json-cookie/s3cr3t.html
+    operator: and

--- a/docker/integration_tests/configs/scripts/auth/clientScriptAuth.zst
+++ b/docker/integration_tests/configs/scripts/auth/clientScriptAuth.zst
@@ -1,0 +1,65 @@
+{
+  "about": "This is a Zest script. For more details about Zest visit https://github.com/zaproxy/zest/",
+  "zestVersion": "0.8",
+  "title": "RecordedTestAuth",
+  "description": "",
+  "prefix": "",
+  "type": "StandAlone",
+  "parameters": {
+    "tokenStart": "{{",
+    "tokenEnd": "}}",
+    "tokens": {},
+    "elementType": "ZestVariables"
+  },
+  "statements": [
+    {
+      "windowHandle": "windowHandle1",
+      "browserType": "firefox",
+      "url": "http://localhost:9091/auth/simple-json-cookie/",
+      "capabilities": "",
+      "headless": false,
+      "profilePath": "",
+      "index": 1,
+      "enabled": true,
+      "elementType": "ZestClientLaunch"
+    },
+    {
+      "windowHandle": "windowHandle1",
+      "type": "id",
+      "element": "user",
+      "index": 2,
+      "enabled": true,
+      "elementType": "ZestClientElementClick"
+    },
+    {
+      "value": "test@test.com",
+      "windowHandle": "windowHandle1",
+      "type": "id",
+      "element": "user",
+      "index": 3,
+      "enabled": true,
+      "elementType": "ZestClientElementSendKeys"
+    },
+    {
+      "value": "password123",
+      "windowHandle": "windowHandle1",
+      "type": "id",
+      "element": "password",
+      "index": 4,
+      "enabled": true,
+      "elementType": "ZestClientElementSendKeys"
+    },
+    {
+      "windowHandle": "windowHandle1",
+      "type": "id",
+      "element": "login",
+      "index": 5,
+      "enabled": true,
+      "elementType": "ZestClientElementClick"
+    }
+  ],
+  "authentication": [],
+  "index": 0,
+  "enabled": true,
+  "elementType": "ZestScript"
+}


### PR DESCRIPTION
Add AF plans and supporting auth script for integration tests which exercise Client Script Auth with the Ajax and Client spiders.