### PR TITLE
Fix alert editing through the GUI

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Alert.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Alert.java
@@ -603,6 +603,7 @@ public class Alert implements Comparable<Alert> {
      */
     public Alert newInstance() {
         Alert item = new Alert(this.pluginId);
+        item.setHistoryId(historyId);
         item.setRiskConfidence(this.risk, this.confidence);
         item.setName(this.name);
         item.setDetail(

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertViewPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertViewPanel.java
@@ -789,6 +789,7 @@ public class AlertViewPanel extends AbstractPanel {
             alert.setInputVector(originalAlert.getInputVector());
         }
 
+        int historyId = 0;
         String uri = null;
         HttpMessage msg = null;
         if (httpMessage != null) {
@@ -796,12 +797,14 @@ public class AlertViewPanel extends AbstractPanel {
             msg = httpMessage;
         } else if (historyRef != null) {
             try {
+                historyId = historyRef.getHistoryId();
                 uri = historyRef.getURI().toString();
                 msg = historyRef.getHttpMessage();
             } catch (Exception e) {
                 LOGGER.error(e.getMessage(), e);
             }
         } else if (originalAlert != null) {
+            historyId = originalAlert.getHistoryId();
             uri = originalAlert.getUri();
             msg = originalAlert.getMessage();
         }
@@ -817,6 +820,7 @@ public class AlertViewPanel extends AbstractPanel {
                 alertEditCweId.getValue(),
                 alertEditWascId.getValue(),
                 msg);
+        alert.setHistoryId(historyId);
         alert.setTags(getAlertTags());
         return alert;
     }

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/AlertUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/AlertUnitTest.java
@@ -275,4 +275,16 @@ class AlertUnitTest {
         assertThat(tags.containsKey(cwe2Key), is(equalTo(true)));
         assertThat(tags.get(cwe2Key), is(equalTo(cwe2Url)));
     }
+
+    @Test
+    void shouldHaveSameHistoryIdAsOldInstance() {
+        // Given
+        int historyId = 123;
+        Alert alert = new Alert(1);
+        alert.setHistoryId(historyId);
+        // When
+        Alert newAlert = alert.newInstance();
+        // Then
+        assertThat(newAlert.getHistoryId(), is(equalTo(historyId)));
+    }
 }


### PR DESCRIPTION
Keep track of the original history ID when the alert is copied.