### PR TITLE
Update Java version in start script automatically

### DIFF
--- a/buildSrc/src/main/kotlin/org/zaproxy/zap/distributions.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/zaproxy/zap/distributions.gradle.kts
@@ -68,12 +68,14 @@ val bundledAddOns: Any = provider {
     }
 }
 
+fun startScriptTokenMap(zapJar: String) = mapOf("zapJar" to zapJar, "javaVersion" to (extra["zapJavaVersion"] as JavaVersion).majorVersion)
+
 val distFiles by tasks.registering(Sync::class) {
     destinationDir = layout.buildDirectory.dir("distFiles").get().asFile
     from(jarWithBom)
     from(distDir) {
         filesMatching(listOf("zap.bat", "zap.sh")) {
-            filter<ReplaceTokens>("tokens" to mapOf("zapJar" to jarWithBom.get().archiveFileName.get()))
+            filter<ReplaceTokens>("tokens" to startScriptTokenMap(jarWithBom.get().archiveFileName.get()))
         }
         exclude("README.weekly")
         exclude("plugin/*.zap")
@@ -315,7 +317,7 @@ val distDaily by tasks.registering(Zip::class) {
         into(rootDir)
         include(startScripts)
         filesMatching(startScripts) {
-            filter<ReplaceTokens>("tokens" to mapOf("zapJar" to jarDaily.get().archiveFileName.get()))
+            filter<ReplaceTokens>("tokens" to startScriptTokenMap(jarDaily.get().archiveFileName.get()))
         }
     }
     from(File(distDir, "plugin")) {
@@ -374,7 +376,7 @@ val prepareDistWeekly by tasks.registering(Sync::class) {
     from(distDir) {
         include(startScripts)
         filesMatching(startScripts) {
-            filter<ReplaceTokens>("tokens" to mapOf("zapJar" to jarDaily.get().archiveFileName.get()))
+            filter<ReplaceTokens>("tokens" to startScriptTokenMap(jarDaily.get().archiveFileName.get()))
         }
     }
     from(weeklyAddOnsDir) {

--- a/zap/src/main/dist/zap.sh
+++ b/zap/src/main/dist/zap.sh
@@ -47,10 +47,10 @@ JAVA_VERSION=$(java -version 2>&1 | awk -F\" '/version/ { print $2 }')
 JAVA_MAJOR_VERSION=${JAVA_VERSION%%[.|-]*}
 JAVA_MINOR_VERSION=$(echo $JAVA_VERSION | awk -F\. '{ print $2 }')
 
-if [ ${JAVA_MAJOR_VERSION:-0} -ge 11 ]; then
+if [ ${JAVA_MAJOR_VERSION:-0} -ge @javaVersion@ ]; then
   echo "Found Java version $JAVA_VERSION"
 else
-  echo "Exiting: ZAP requires a minimum of Java 11 to run, found $JAVA_VERSION"
+  echo "Exiting: ZAP requires a minimum of Java @javaVersion@ to run, found $JAVA_VERSION"
   exit 1
 fi
 


### PR DESCRIPTION
Change the build to use the compile Java version as the minimum Java version required in the zap.sh script instead of hardcoded value.