### PR TITLE
Provide DB details and notify close

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/db/AbstractDatabase.java
+++ b/zap/src/main/java/org/parosproxy/paros/db/AbstractDatabase.java
@@ -74,7 +74,16 @@ public abstract class AbstractDatabase implements Database {
 
     @Override
     public void removeDatabaseListener(DatabaseListener listener) {
+        notifyClosing(listener);
         databaseListeners.remove(listener);
+    }
+
+    private void notifyClosing(DatabaseListener listener) {
+        try {
+            listener.closing(getDatabaseServer());
+        } catch (Exception e) {
+            getLogger().error(e.getMessage(), e);
+        }
     }
 
     @Override
@@ -89,6 +98,9 @@ public abstract class AbstractDatabase implements Database {
      */
     @Override
     public void close(boolean compact, boolean cleanup) {
+        for (DatabaseListener listener : databaseListeners) {
+            notifyClosing(listener);
+        }
         removeDatabaseListeners();
     }
 

--- a/zap/src/main/java/org/parosproxy/paros/db/DatabaseListener.java
+++ b/zap/src/main/java/org/parosproxy/paros/db/DatabaseListener.java
@@ -29,4 +29,11 @@ public interface DatabaseListener {
 
     void databaseOpen(DatabaseServer dbServer)
             throws DatabaseException, DatabaseUnsupportedException;
+
+    /**
+     * Called when the database is in process of closing, or when the listener is removed.
+     *
+     * @since 2.16.1
+     */
+    default void closing(DatabaseServer db) throws DatabaseException {}
 }

--- a/zap/src/main/java/org/parosproxy/paros/db/DatabaseServer.java
+++ b/zap/src/main/java/org/parosproxy/paros/db/DatabaseServer.java
@@ -26,4 +26,29 @@ package org.parosproxy.paros.db;
  *
  * @author psiinon
  */
-public interface DatabaseServer {}
+public interface DatabaseServer {
+
+    /**
+     * Gets the URL used to connect to the DB.
+     *
+     * @return the URL, never {@code null}.
+     * @since 2.16.1
+     */
+    String getUrl();
+
+    /**
+     * Gets the user name used to connect to the DB.
+     *
+     * @return the user name, never {@code null}.
+     * @since 2.16.1
+     */
+    String getUser();
+
+    /**
+     * Gets the password of the user.
+     *
+     * @return the password, might be {@code null}.
+     * @since 2.16.1
+     */
+    String getPassword();
+}

--- a/zap/src/main/java/org/parosproxy/paros/db/paros/ParosDatabaseServer.java
+++ b/zap/src/main/java/org/parosproxy/paros/db/paros/ParosDatabaseServer.java
@@ -75,6 +75,21 @@ public class ParosDatabaseServer implements DatabaseServer {
         start(dbname);
     }
 
+    @Override
+    public String getUrl() {
+        return mUrl;
+    }
+
+    @Override
+    public String getUser() {
+        return mUser;
+    }
+
+    @Override
+    public String getPassword() {
+        return mPassword;
+    }
+
     private void start(String dbname) throws ClassNotFoundException, Exception {
         // hsqldb only accept '/' as path;
         dbname = dbname.replaceAll("\\\\", "/");

--- a/zap/src/main/java/org/zaproxy/zap/db/sql/SqlDatabaseServer.java
+++ b/zap/src/main/java/org/zaproxy/zap/db/sql/SqlDatabaseServer.java
@@ -43,6 +43,21 @@ public class SqlDatabaseServer implements DatabaseServer {
         start(dbname);
     }
 
+    @Override
+    public String getUrl() {
+        return dbUrl;
+    }
+
+    @Override
+    public String getUser() {
+        return dbUser;
+    }
+
+    @Override
+    public String getPassword() {
+        return dbPassword;
+    }
+
     private void start(String dbname) throws ClassNotFoundException, Exception {
         this.setDbUrl(DbSQL.getSingleton().getDbUrl());
         this.setDbUser(DbSQL.getSingleton().getDbUser());


### PR DESCRIPTION
Allow the add-ons to know the URL/user of the DB to allow to connect to it more easily by other means (e.g. Flyway, JDO).
Notify when the database is being closed to allow resources to be cleaned up.