### PR TITLE
Init alert's history ID in all cases

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Alert.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Alert.java
@@ -251,7 +251,6 @@ public class Alert implements Comparable<Alert> {
                 recordAlert.getConfidence(),
                 recordAlert.getAlert());
 
-        historyId = recordAlert.getHistoryId();
         HistoryReference hRef = null;
         try {
             hRef = new HistoryReference(recordAlert.getHistoryId());
@@ -268,6 +267,7 @@ public class Alert implements Comparable<Alert> {
     }
 
     private void init(RecordAlert recordAlert, HistoryReference ref) {
+        historyId = recordAlert.getHistoryId();
         this.alertId = recordAlert.getAlertId();
         this.source = Source.getSource(recordAlert.getSourceId());
         setDetail(

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/AlertUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/AlertUnitTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.core.scanner.Alert.Builder;
 import org.parosproxy.paros.db.RecordAlert;
+import org.parosproxy.paros.model.HistoryReference;
 
 class AlertUnitTest {
 
@@ -52,6 +53,19 @@ class AlertUnitTest {
         given(recordAlert.getHistoryId()).willReturn(historyId);
         // When
         Alert alert = new Alert(recordAlert);
+        // Then
+        assertThat(alert.getHistoryId(), is(equalTo(historyId)));
+    }
+
+    @Test
+    void shouldHaveHistoryIdFromRecordAlertAndHistoryReference() {
+        // Given
+        RecordAlert recordAlert = mock(RecordAlert.class);
+        HistoryReference historyReference = mock(HistoryReference.class);
+        int historyId = 42;
+        given(recordAlert.getHistoryId()).willReturn(historyId);
+        // When
+        Alert alert = new Alert(recordAlert, historyReference);
         // Then
         assertThat(alert.getHistoryId(), is(equalTo(historyId)));
     }


### PR DESCRIPTION
Initialise the history ID also when creating the `Alert` with the `HistoryReference`.

Fix #8888.