### PR TITLE
Use dev add-on from source in integration tests

### DIFF
--- a/docker/Dockerfile-tests
+++ b/docker/Dockerfile-tests
@@ -1,5 +1,22 @@
 # syntax=docker/dockerfile:1
 # This dockerfile builds a ZAP docker image used for integration tests
+FROM --platform=linux/amd64 debian:bookworm-slim AS builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -q -y --fix-missing \
+	openjdk-17-jdk \
+	git && \
+	rm -rf /var/lib/apt/lists/* && \
+	mkdir /zap-src
+
+WORKDIR /zap-src
+
+# Build required add-ons
+RUN git clone --depth 1 https://github.com/zaproxy/zap-extensions.git && \
+	cd zap-extensions && \
+	./gradlew :aO:dev:cZAO --into /zap-src/zap/plugin/
+
 FROM ghcr.io/zaproxy/zaproxy:nightly
 LABEL maintainer="psiinon@gmail.com"
 
@@ -7,6 +24,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 #Change to the zap user so things get done as the right person (apart from copy)
 USER zap
+
+COPY --link --from=builder --chown=1000:1000 /zap-src/zap/plugin/* /home/zap/.ZAP_D/plugin/
 
 COPY --link --chown=1000:1000 integration_tests /zap/wrk/
 

--- a/docker/integration_tests/af_plan_tests.sh
+++ b/docker/integration_tests/af_plan_tests.sh
@@ -13,9 +13,6 @@ cd /zap/wrk/configs/plans/
 export JIGSAW_USER="guest"
 export JIGSAW_PWORD="guest"
 
-# Install dev add-on
-/zap/zap.sh -cmd -addoninstall dev
-
 summary="\nSummary:\n"
 
 for file in *.yaml


### PR DESCRIPTION
Build the add-on instead of using the one from the marketplace to allow to use new test cases without releasing a new version.