### PR TITLE
Add auth integration test which requires scrolls

### DIFF
--- a/docker/integration_tests/configs/plans/auth-client-script-simple-json-blocking-ui-scroll-fields.yaml
+++ b/docker/integration_tests/configs/plans/auth-client-script-simple-json-blocking-ui-scroll-fields.yaml
@@ -1,0 +1,113 @@
+---
+env:
+  contexts:
+  - name: "simple-json"
+    urls:
+    - "http://localhost:9091/auth/simple-json-blocking-ui-scroll-fields"
+    includePaths:
+    - "http://localhost:9091/auth/simple-json-blocking-ui-scroll-fields.*"
+    excludePaths: []
+    authentication:
+      method: "client"
+      parameters:
+        loginPageUrl: "http://localhost:9091/auth/simple-json-blocking-ui-scroll-fields/"
+        loginPageWait: 5
+        script: /zap/wrk/configs/scripts/auth/clientScriptAuthBlockingScrolls.zst
+        scriptEngine: Mozilla Zest
+      verification:
+        method: "autodetect"
+    sessionManagement:
+      method: "autodetect"
+      parameters: {}
+    technology:
+      exclude: []
+    users:
+    - name: "test"
+      credentials:
+        username: "test@test.com"
+        password: "password123"
+  parameters:
+    failOnError: true
+    failOnWarning: false
+    continueOnFailure: true
+    progressToStdout: true
+  vars: {}
+jobs:
+- parameters:
+    maxAlertsPerRule: 0
+    scanOnlyInScope: true
+    maxBodySizeInBytesToScan: 0
+    enableTags: false
+    disableAllRules: true
+  rules:
+  - id: 10111
+    name: "Authentication Request Identified"
+    threshold: "medium"
+  - id: 10112
+    name: "Session Management Response Identified"
+    threshold: "medium"
+  - id: 10113
+    name: "Verification Request Identified"
+    threshold: "medium"
+  name: "passiveScan-config"
+  type: "passiveScan-config"
+- parameters:
+    user: "test"
+  requests:
+  - url: "http://localhost:9091/auth/simple-json-blocking-ui-scroll-fields/user"
+    name: ""
+    method: ""
+    httpVersion: ""
+    headers: []
+    data: ""
+  name: "requestor"
+  type: "requestor"
+  tests:
+  - type: "stats"
+    statistic: "stats.auth.success"
+    site: "http://localhost:9091"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.state.loggedin"
+    site: "http://localhost:9091"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.sessiontoken.accesstoken"
+    site: "http://localhost:9091"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.configure.session.header"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.configure.verification"
+    operator: ">="
+    value: 1
+    onFail: "error"
+  - type: "stats"
+    statistic: "stats.auth.detect.auth.json"
+    operator: ">="
+    value: 1
+    onFail: "error"
+- parameters:
+    action: "add"
+    type: "standalone"
+    engine: "ECMAScript : Graal.js"
+    name: "af-diags.js"
+    target: ""
+    source: "/zap/wrk/configs/scripts/standalone/af-diags.js"
+  name: "script"
+  type: "script"
+- parameters:
+    action: "run"
+    type: "standalone"
+    name: "af-diags.js"
+  name: "script"
+  type: "script"

--- a/docker/integration_tests/configs/scripts/auth/clientScriptAuthBlockingScrolls.zst
+++ b/docker/integration_tests/configs/scripts/auth/clientScriptAuthBlockingScrolls.zst
@@ -1,0 +1,110 @@
+{
+  "about": "This is a Zest script. For more details about Zest visit https://github.com/zaproxy/zest/",
+  "zestVersion": "0.3",
+  "title": "test.zst",
+  "description": "",
+  "prefix": "",
+  "type": "Authentication",
+  "parameters": {
+    "tokenStart": "{{",
+    "tokenEnd": "}}",
+    "tokens": {},
+    "elementType": "ZestVariables"
+  },
+  "statements": [
+    {
+      "index": 1,
+      "enabled": true,
+      "elementType": "ZestComment",
+      "comment": "Recorded by ZAP by Checkmarx Browser Extension 0.0.13 on Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:138.0) Gecko/20100101 Firefox/138.0"
+    },
+    {
+      "windowHandle": "windowHandle1",
+      "browserType": "firefox",
+      "url": "http://localhost:9091/auth/simple-json-blocking-ui-scroll-fields/",
+      "capabilities": "",
+      "headless": true,
+      "index": 2,
+      "enabled": true,
+      "elementType": "ZestClientLaunch"
+    },
+    {
+      "windowHandle": "windowHandle1",
+      "type": "id",
+      "element": "user",
+      "index": 3,
+      "waitForMsec": 5000,
+      "enabled": true,
+      "elementType": "ZestClientElementScrollTo"
+    },
+    {
+      "windowHandle": "windowHandle1",
+      "type": "id",
+      "element": "user",
+      "index": 4,
+      "waitForMsec": 5000,
+      "enabled": true,
+      "elementType": "ZestClientElementClick"
+    },
+    {
+      "windowHandle": "windowHandle1",
+      "type": "id",
+      "element": "user",
+      "index": 5,
+      "waitForMsec": 5000,
+      "enabled": true,
+      "elementType": "ZestClientElementScrollTo"
+    },
+    {
+      "value": "test@test.com",
+      "windowHandle": "windowHandle1",
+      "type": "id",
+      "element": "user",
+      "index": 6,
+      "waitForMsec": 5000,
+      "enabled": true,
+      "elementType": "ZestClientElementSendKeys"
+    },
+    {
+      "windowHandle": "windowHandle1",
+      "type": "id",
+      "element": "password",
+      "index": 7,
+      "waitForMsec": 5000,
+      "enabled": true,
+      "elementType": "ZestClientElementScrollTo"
+    },
+    {
+      "value": "password123",
+      "windowHandle": "windowHandle1",
+      "type": "id",
+      "element": "password",
+      "index": 8,
+      "waitForMsec": 5000,
+      "enabled": true,
+      "elementType": "ZestClientElementSendKeys"
+    },
+    {
+      "windowHandle": "windowHandle1",
+      "type": "id",
+      "element": "login",
+      "index": 9,
+      "waitForMsec": 5000,
+      "enabled": true,
+      "elementType": "ZestClientElementScrollTo"
+    },
+    {
+      "windowHandle": "windowHandle1",
+      "type": "id",
+      "element": "login",
+      "index": 10,
+      "waitForMsec": 5000,
+      "enabled": true,
+      "elementType": "ZestClientElementClick"
+    }
+  ],
+  "authentication": [],
+  "index": 0,
+  "enabled": true,
+  "elementType": "ZestScript"
+}


### PR DESCRIPTION
Add an auth test that requires scrolling to all the fields while having a blocking header.

---
Requires zaproxy/zap-extensions#6453.