### PR TITLE
fix: make zap.sh respect $JAVA_HOME on Linux

### DIFF
--- a/zap/src/main/dist/zap.sh
+++ b/zap/src/main/dist/zap.sh
@@ -30,6 +30,11 @@ if [ "$OS" = "Darwin" ]; then
   fi
 fi
 
+# On Linux, respect JAVA_HOME if it exists in the environment
+if [ "$OS" = "Linux" ] && [ -n "$JAVA_HOME" ]; then
+  PATH="$JAVA_HOME/bin:$PATH"
+fi
+
 # Extract and check the Java version
 JAVA_OUTPUT=$(java -version 2>&1)
 


### PR DESCRIPTION
Pretty self-explanatory. Makes packaging easier for distros where multiple Java environments can be installed at the same time, such as Arch Linux.

Scoped this check to Linux-only, as I don't know if this will negatively affect Mac OS or BSD systems.