### PR TITLE
Make zap.sh respect $JAVA_HOME on Linux

### DIFF
--- a/zap/src/main/dist/zap.sh
+++ b/zap/src/main/dist/zap.sh
@@ -28,6 +28,9 @@ if [ "$OS" = "Darwin" ]; then
     PATH="$JAVA_PATH:$PATH"
     popd > /dev/null
   fi
+elif [ "$OS" = "Linux" ] && [ -n "$JAVA_HOME" ]; then
+  # On Linux, respect JAVA_HOME if it exists in the environment
+  PATH="$JAVA_HOME/bin:$PATH"
 fi
 
 # Extract and check the Java version


### PR DESCRIPTION
Pretty self-explanatory. Makes packaging easier for distros where multiple Java environments can be installed at the same time, such as Arch Linux.

Scoped this check to Linux-only, as I don't know if this will negatively affect Mac OS or BSD systems.