### PR TITLE
Update Commons BeanUtils

### DIFF
--- a/LEGALNOTICE.md
+++ b/LEGALNOTICE.md
@@ -31,7 +31,7 @@ and subject to their respective licenses.
 
 | Library                             | License                   |
 |-------------------------------------|---------------------------|
-| commons-beanutils-1.10.1.jar        | Apache 2.0                |
+| commons-beanutils-1.11.0.jar        | Apache 2.0                |
 | commons-codec-1.18.0.jar            | Apache 2.0                |
 | commons-collections-3.2.2.jar       | Apache 2.0                |
 | commons-configuration-1.10.jar      | Apache 2.0                |

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -89,7 +89,7 @@ tasks.withType<JavaCompile>().configureEach {
 dependencies {
     api("com.fifesoft:rsyntaxtextarea:3.6.0")
     api("com.github.zafarkhaja:java-semver:0.10.2")
-    api("commons-beanutils:commons-beanutils:1.10.1")
+    implementation("commons-beanutils:commons-beanutils:1.11.0")
     api("commons-codec:commons-codec:1.18.0")
     api("commons-collections:commons-collections:3.2.2")
     api("commons-configuration:commons-configuration:1.10")


### PR DESCRIPTION
Update to latest version to address CVE, even if they don't impact the codebase.
Also, make it an implementation dependency to discourage/prevent its use by add-ons and allow to remove it in a follow up version along with `json-lib` #7798.