### PR TITLE
Improve support for FreeBSD

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/Constant.java
+++ b/zap/src/main/java/org/parosproxy/paros/Constant.java
@@ -1465,7 +1465,7 @@ public final class Constant {
 
     // Determine Linux Operating System
     // ZAP: Changed to final.
-    private static final Pattern patternLinux = 
+    private static final Pattern patternLinux =
             Pattern.compile("linux|freebsd", Pattern.CASE_INSENSITIVE);
 
     public static boolean isLinux() {


### PR DESCRIPTION
This patch fixes issues that occur when users try to change certain configurations, such as Selenium settings, on FreeBSD. Without it, the AJAX spider does not work correctly. In most cases, Linux routines can be used similarly on FreeBSD. I have added an isFreeBSD() function to be used when specific handling for FreeBSD is necessary.