### PR TITLE
Downgrade base image to core22 to restore compatibility with Ubuntu 22.04

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
   while you are developing and testing your applications.
   Its also a great tool for experienced pentesters to use for manual security testing.
 
-base: core24
+base: core22
 grade: stable
 confinement: classic
 


### PR DESCRIPTION
Fixes #8850 

What is the wanted behavior regarding versioning? As far as I'm informed, you can just leave the old `2.16.1` version which creates a new revision in snapcraft.
Alternatively, we could create a new release like `2.16.1+snap2` to show the change clearer.