### PR TITLE
Replace full paths in AF itest plans

### DIFF
--- a/docker/integration_tests/configs/plans/auth-ajax-simple.yaml
+++ b/docker/integration_tests/configs/plans/auth-ajax-simple.yaml
@@ -60,7 +60,7 @@ jobs:
     engine: "ECMAScript : Graal.js"
     name: "af-diags.js"
     target: ""
-    source: "/zap/wrk/configs/scripts/standalone/af-diags.js"
+    source: "../scripts/standalone/af-diags.js"
   name: "script"
   type: "script"
 - parameters:

--- a/docker/integration_tests/configs/plans/auth-client-script-ajax-spider.yaml
+++ b/docker/integration_tests/configs/plans/auth-client-script-ajax-spider.yaml
@@ -8,7 +8,7 @@ env:
     authentication:
       method: client
       parameters:
-        script: /zap/wrk/configs/scripts/auth/clientScriptAuth.zst
+        script: ../scripts/auth/clientScriptAuth.zst
         scriptEngine: Mozilla Zest
       verification:
         method: poll

--- a/docker/integration_tests/configs/plans/auth-client-script-client-spider.yaml
+++ b/docker/integration_tests/configs/plans/auth-client-script-client-spider.yaml
@@ -8,7 +8,7 @@ env:
     authentication:
       method: client
       parameters:
-        script: /zap/wrk/configs/scripts/auth/clientScriptAuth.zst
+        script: ../scripts/auth/clientScriptAuth.zst
         scriptEngine: Mozilla Zest
       verification:
         method: poll

--- a/docker/integration_tests/configs/plans/auth-client-script-simple-json-blocking-ui-scroll-fields.yaml
+++ b/docker/integration_tests/configs/plans/auth-client-script-simple-json-blocking-ui-scroll-fields.yaml
@@ -12,7 +12,7 @@ env:
       parameters:
         loginPageUrl: "http://localhost:9091/auth/simple-json-blocking-ui-scroll-fields/"
         loginPageWait: 5
-        script: /zap/wrk/configs/scripts/auth/clientScriptAuthBlockingScrolls.zst
+        script: ../scripts/auth/clientScriptAuthBlockingScrolls.zst
         scriptEngine: Mozilla Zest
       verification:
         method: "autodetect"
@@ -102,7 +102,7 @@ jobs:
     engine: "ECMAScript : Graal.js"
     name: "af-diags.js"
     target: ""
-    source: "/zap/wrk/configs/scripts/standalone/af-diags.js"
+    source: "../scripts/standalone/af-diags.js"
   name: "script"
   type: "script"
 - parameters:

--- a/docker/integration_tests/configs/plans/auth-client-script-simple-json-blocking-ui.yaml
+++ b/docker/integration_tests/configs/plans/auth-client-script-simple-json-blocking-ui.yaml
@@ -12,7 +12,7 @@ env:
       parameters:
         loginPageUrl: "http://localhost:9091/auth/simple-json-blocking-ui/"
         loginPageWait: 5
-        script: /zap/wrk/configs/scripts/auth/clientScriptAuthBlocking.zst
+        script: ../scripts/auth/clientScriptAuthBlocking.zst
         scriptEngine: Mozilla Zest
       verification:
         method: "autodetect"
@@ -102,7 +102,7 @@ jobs:
     engine: "ECMAScript : Graal.js"
     name: "af-diags.js"
     target: ""
-    source: "/zap/wrk/configs/scripts/standalone/af-diags.js"
+    source: "../scripts/standalone/af-diags.js"
   name: "script"
   type: "script"
 - parameters:

--- a/docker/integration_tests/configs/plans/auth-client-simple.yaml
+++ b/docker/integration_tests/configs/plans/auth-client-simple.yaml
@@ -59,7 +59,7 @@ jobs:
     engine: "ECMAScript : Graal.js"
     name: "af-diags.js"
     target: ""
-    source: "/zap/wrk/configs/scripts/standalone/af-diags.js"
+    source: "../scripts/standalone/af-diags.js"
   name: "script"
   type: "script"
 - parameters:

--- a/docker/integration_tests/configs/plans/auth-json-bearer-cookie.yaml
+++ b/docker/integration_tests/configs/plans/auth-json-bearer-cookie.yaml
@@ -101,7 +101,7 @@ jobs:
     engine: "ECMAScript : Graal.js"
     name: "af-diags.js"
     target: ""
-    source: "/zap/wrk/configs/scripts/standalone/af-diags.js"
+    source: "../scripts/standalone/af-diags.js"
   name: "script"
   type: "script"
 - parameters:

--- a/docker/integration_tests/configs/plans/auth-json-bearer-js-cookie.yaml
+++ b/docker/integration_tests/configs/plans/auth-json-bearer-js-cookie.yaml
@@ -101,7 +101,7 @@ jobs:
     engine: "ECMAScript : Graal.js"
     name: "af-diags.js"
     target: ""
-    source: "/zap/wrk/configs/scripts/standalone/af-diags.js"
+    source: "../scripts/standalone/af-diags.js"
   name: "script"
   type: "script"
 - parameters:

--- a/docker/integration_tests/configs/plans/auth-json-bearer.yaml
+++ b/docker/integration_tests/configs/plans/auth-json-bearer.yaml
@@ -101,7 +101,7 @@ jobs:
     engine: "ECMAScript : Graal.js"
     name: "af-diags.js"
     target: ""
-    source: "/zap/wrk/configs/scripts/standalone/af-diags.js"
+    source: "../scripts/standalone/af-diags.js"
   name: "script"
   type: "script"
 - parameters:

--- a/docker/integration_tests/configs/plans/auth-json-diff-cookies.yaml
+++ b/docker/integration_tests/configs/plans/auth-json-diff-cookies.yaml
@@ -80,7 +80,7 @@ jobs:
     engine: "ECMAScript : Graal.js"
     name: "af-diags.js"
     target: ""
-    source: "/zap/wrk/configs/scripts/standalone/af-diags.js"
+    source: "../scripts/standalone/af-diags.js"
   name: "script"
   type: "script"
 - parameters:

--- a/docker/integration_tests/configs/plans/auth-non-std-json-bearer.yaml
+++ b/docker/integration_tests/configs/plans/auth-non-std-json-bearer.yaml
@@ -91,7 +91,7 @@ jobs:
     engine: "ECMAScript : Graal.js"
     name: "af-diags.js"
     target: ""
-    source: "/zap/wrk/configs/scripts/standalone/af-diags.js"
+    source: "../scripts/standalone/af-diags.js"
   name: "script"
   type: "script"
 - parameters:

--- a/docker/integration_tests/configs/plans/auth-password-added-json.yaml
+++ b/docker/integration_tests/configs/plans/auth-password-added-json.yaml
@@ -101,7 +101,7 @@ jobs:
     engine: "ECMAScript : Graal.js"
     name: "af-diags.js"
     target: ""
-    source: "/zap/wrk/configs/scripts/standalone/af-diags.js"
+    source: "../scripts/standalone/af-diags.js"
   name: "script"
   type: "script"
 - parameters:

--- a/docker/integration_tests/configs/plans/auth-password-hidden-json.yaml
+++ b/docker/integration_tests/configs/plans/auth-password-hidden-json.yaml
@@ -101,7 +101,7 @@ jobs:
     engine: "ECMAScript : Graal.js"
     name: "af-diags.js"
     target: ""
-    source: "/zap/wrk/configs/scripts/standalone/af-diags.js"
+    source: "../scripts/standalone/af-diags.js"
   name: "script"
   type: "script"
 - parameters:

--- a/docker/integration_tests/configs/plans/auth-password-new-json.yaml
+++ b/docker/integration_tests/configs/plans/auth-password-new-json.yaml
@@ -100,7 +100,7 @@ jobs:
     engine: "ECMAScript : Graal.js"
     name: "af-diags.js"
     target: ""
-    source: "/zap/wrk/configs/scripts/standalone/af-diags.js"
+    source: "../scripts/standalone/af-diags.js"
   name: "script"
   type: "script"
 - parameters:

--- a/docker/integration_tests/configs/plans/auth-simple-json-shadow-dom.yaml
+++ b/docker/integration_tests/configs/plans/auth-simple-json-shadow-dom.yaml
@@ -101,7 +101,7 @@ jobs:
     engine: "ECMAScript : Graal.js"
     name: "af-diags.js"
     target: ""
-    source: "/zap/wrk/configs/scripts/standalone/af-diags.js"
+    source: "../scripts/standalone/af-diags.js"
   name: "script"
   type: "script"
 - parameters:

--- a/docker/integration_tests/configs/plans/auth-simple-json.yaml
+++ b/docker/integration_tests/configs/plans/auth-simple-json.yaml
@@ -101,7 +101,7 @@ jobs:
     engine: "ECMAScript : Graal.js"
     name: "af-diags.js"
     target: ""
-    source: "/zap/wrk/configs/scripts/standalone/af-diags.js"
+    source: "../scripts/standalone/af-diags.js"
   name: "script"
   type: "script"
 - parameters:

--- a/docker/integration_tests/configs/plans/jigsaw-basic-user.yaml
+++ b/docker/integration_tests/configs/plans/jigsaw-basic-user.yaml
@@ -94,7 +94,7 @@ jobs:
     engine: "ECMAScript : Graal.js"
     name: "af-diags.js"
     target: ""
-    source: "/zap/wrk/configs/scripts/standalone/af-diags.js"
+    source: "../scripts/standalone/af-diags.js"
   name: "script"
   type: "script"
 - parameters:

--- a/docker/integration_tests/configs/plans/petstore-openapi.yaml
+++ b/docker/integration_tests/configs/plans/petstore-openapi.yaml
@@ -45,7 +45,7 @@ jobs:
     engine: "ECMAScript : Graal.js"
     name: "af-diags.js"
     target: ""
-    source: "/zap/wrk/configs/scripts/standalone/af-diags.js"
+    source: "../scripts/standalone/af-diags.js"
   name: "script"
   type: "script"
 - parameters:

--- a/docker/integration_tests/configs/plans/seq-simple.yaml
+++ b/docker/integration_tests/configs/plans/seq-simple.yaml
@@ -17,7 +17,7 @@ jobs:
 - type: sequence-import
   parameters:
     name: seq-simple
-    path: /zap/wrk/configs/plans/data/seq-simple.har 
+    path: data/seq-simple.har
     assertCode: true
     assertLength: 10
 - type: sequence-activeScan

--- a/docker/integration_tests/configs/plans/testfire-form-user.yaml
+++ b/docker/integration_tests/configs/plans/testfire-form-user.yaml
@@ -58,7 +58,7 @@ jobs:
     engine: "ECMAScript : Graal.js"
     name: "af-diags.js"
     target: ""
-    source: "/zap/wrk/configs/scripts/standalone/af-diags.js"
+    source: "../scripts/standalone/af-diags.js"
   name: "script"
   type: "script"
 - parameters:


### PR DESCRIPTION
Allow to use the plans without running in a test container.