### PR TITLE
Guard against multipart parsing errors

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantMultipartFormParameters.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantMultipartFormParameters.java
@@ -78,6 +78,14 @@ public class VariantMultipartFormParameters implements Variant {
             return;
         }
 
+        try {
+            parseImpl(msg, contentType);
+        } catch (Exception e) {
+            LOGGER.error("An error occurred while parsing multipart content:", e);
+        }
+    }
+
+    private void parseImpl(HttpMessage msg, String contentType) {
         ArrayList<NameValuePair> extractedParameters = new ArrayList<>();
         int position = 0;
         int offset = 0;


### PR DESCRIPTION
Catch exception when parsing the multipart content to not break other parts of the codebase (e.g. Sites tree, parameters extraction).