### PR TITLE
Fix GUI exceptions while updating add-ons

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/view/HttpPanelManager.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/HttpPanelManager.java
@@ -327,7 +327,7 @@ public class HttpPanelManager {
             componentViews.remove(viewFactoryName);
 
             if (componentViews.isEmpty()) {
-                this.views.put(componentName, null);
+                this.views.remove(componentName);
             }
         }
 
@@ -376,7 +376,7 @@ public class HttpPanelManager {
             componentDefaultViews.remove(viewFactoryName);
 
             if (componentDefaultViews.isEmpty()) {
-                this.defaultViews.put(componentName, null);
+                this.defaultViews.remove(componentName);
             }
         }
 


### PR DESCRIPTION
Remove the empty entries in the `HttpPanelManager` instead of setting them to null as they would be accessed later leading to NPEs.