### PR TITLE
Fix error importing context with auth script

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/utils/EncodingUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/EncodingUtils.java
@@ -43,10 +43,13 @@ public class EncodingUtils {
 
     public static Map<String, String> stringToMap(String input) {
         Map<String, String> map = new HashMap<>();
+        if (input.isEmpty()) {
+            return map;
+        }
 
         String[] nameValuePairs = input.split("&");
         for (String nameValuePair : nameValuePairs) {
-            String[] nameValue = nameValuePair.split(":");
+            String[] nameValue = nameValuePair.split(":", 2);
             map.put(
                     new String(Base64.decodeBase64(nameValue[0])),
                     nameValue.length > 1 ? new String(Base64.decodeBase64(nameValue[1])) : "");

--- a/zap/src/test/java/org/zaproxy/zap/utils/EncodingUtilsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/EncodingUtilsUnitTest.java
@@ -1,0 +1,69 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2025 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class EncodingUtilsUnitTest {
+
+    @Test
+    void shouldEncodeEmptyMapToEmptyString() {
+        // Given
+        Map<String, String> input = Map.of();
+        // When
+        String result = EncodingUtils.mapToString(input);
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldEncodeEmptyMapEntryToEmptyPairString() {
+        // Given
+        Map<String, String> input = Map.of("", "");
+        // When
+        String result = EncodingUtils.mapToString(input);
+        // Then
+        assertThat(result).isEqualTo(":");
+    }
+
+    @Test
+    void shouldDecodeEmptyStringToEmptyMap() {
+        // Given
+        String input = "";
+        // When
+        Map<String, String> result = EncodingUtils.stringToMap(input);
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldDecodeEmptyPairStringToEmptyMapEntry() {
+        // Given
+        String input = ":";
+        // When
+        Map<String, String> result = EncodingUtils.stringToMap(input);
+        // Then
+        assertThat(result).contains(entry("", ""));
+    }
+}

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -128,6 +128,7 @@ dependencies {
     testCompileOnly("com.google.code.findbugs:findbugs-annotations:3.0.1")
 
     testImplementation("net.bytebuddy:byte-buddy:1.17.4")
+    testImplementation("org.assertj:assertj-core:3.27.6")
     testImplementation("org.hamcrest:hamcrest-core:3.0")
     testImplementation("org.junit.jupiter:junit-jupiter:5.12.1")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")


### PR DESCRIPTION
Correct the conversion from/to map/string to ensure the script parameters are properly exported/imported.

---
e.g.:
```
ERROR org.parosproxy.paros.control.MenuFileControl - Index 0 out of bounds for length 0
java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
	at org.zaproxy.zap.utils.EncodingUtils.stringToMap(EncodingUtils.java:54) ~[main/:?]
	at org.zaproxy.zap.authentication.ScriptBasedAuthenticationMethodType.loadMethod(ScriptBasedAuthenticationMethodType.java:709) ~[main/:?]
	at org.zaproxy.zap.authentication.ScriptBasedAuthenticationMethodType.importData(ScriptBasedAuthenticationMethodType.java:966) ~[main/:?]
	at org.zaproxy.zap.extension.authentication.ExtensionAuthentication.importContextData(ExtensionAuthentication.java:514) ~[main/:?]
	at org.parosproxy.paros.model.Model.importContext(Model.java:576) ~[main/:?]
	at org.parosproxy.paros.model.Session.importContext(Session.java:1634) ~[main/:?]
```