### PR TITLE
Alerts unit test: Remove spurious println

### DIFF
--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/AlertUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/AlertUnitTest.java
@@ -289,7 +289,6 @@ class AlertUnitTest {
         // Then
         Map<String, String> tags = alert.getTags();
         assertThat(tagCount, is(equalTo(1)));
-        System.out.println(tags);
         assertThat(tags.containsKey(cwe2Key), is(equalTo(true)));
         assertThat(tags.get(cwe2Key), is(equalTo(cwe2Url)));
     }


### PR DESCRIPTION
I seem to have left a println in on a previous PR, this cleans it up.

Sorry about that.