### PR TITLE
Adjust Alert compareTo and equals for case sensitive URI comparison

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Alert.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Alert.java
@@ -70,6 +70,7 @@
 // ZAP: 2023/11/14 When setting CWE also add a CWE alert tag with an appropriate URL.
 // ZAP: 2025/10/01 Added support for nodeName.
 // ZAP: 2025/10/16 Added support for systemic alerts.
+// ZAP: 2025/10/30 Adjust compateTo and equals handling of nodeName and uri (now case sensitive)
 package org.parosproxy.paros.core.scanner;
 
 import java.net.URL;
@@ -488,9 +489,9 @@ public class Alert implements Comparable<Alert> {
         }
 
         if (StringUtils.isNotBlank(nodeName) && StringUtils.isNotBlank(alert2.nodeName)) {
-            result = nodeName.compareToIgnoreCase(alert2.nodeName);
+            result = nodeName.compareTo(alert2.nodeName);
         } else {
-            result = uri.compareToIgnoreCase(alert2.uri);
+            result = uri.compareTo(alert2.uri);
         }
         if (result != 0) {
             return result;
@@ -570,7 +571,7 @@ public class Alert implements Comparable<Alert> {
             if (!nodeName.equals(item.nodeName)) {
                 return false;
             }
-        } else if (!uri.equalsIgnoreCase(item.uri)) {
+        } else if (!uri.equals(item.uri)) {
             return false;
         }
         if (!param.equalsIgnoreCase(item.param)) {

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/AlertUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/AlertUnitTest.java
@@ -22,6 +22,7 @@ package org.parosproxy.paros.core.scanner;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -151,6 +152,36 @@ class AlertUnitTest {
     }
 
     @Test
+    void shouldNotEqualIfAlertUriDifferentCapitalization() {
+        // Given
+        Alert alertA = new Alert(1);
+        Alert alertB = new Alert(1);
+        // When
+        alertA.setAlertId(0);
+        alertB.setAlertId(1);
+        alertA.setUri("https://example.com/SCRIPT?q=a");
+        alertB.setUri("https://example.com/script?q=a");
+        boolean equals = alertA.equals(alertB);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldNotEqualIfAlertNodeNameDifferentCapitalization() {
+        // Given
+        Alert alertA = new Alert(1);
+        Alert alertB = new Alert(1);
+        // When
+        alertA.setAlertId(0);
+        alertB.setAlertId(1);
+        alertA.setNodeName("https://example.com/SCRIPT (q)");
+        alertB.setNodeName("https://example.com/script (q)");
+        boolean equals = alertA.equals(alertB);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
     void shouldNotCompareIfAlertRefDifferent() {
         // Given
         Alert alertA = new Alert(1);
@@ -163,6 +194,36 @@ class AlertUnitTest {
         int cmp = alertA.compareTo(alertB);
         // Then
         assertThat(cmp, is(equalTo(-1)));
+    }
+
+    @Test
+    void shouldCompareDissimilarIfAlertNodeNameDifferentByCapitalization() {
+        // Given
+        Alert alertA = new Alert(1);
+        Alert alertB = new Alert(1);
+        // When
+        alertA.setAlertId(0);
+        alertB.setAlertId(1);
+        alertA.setNodeName("https://example.com/SCRIPT (q)");
+        alertB.setNodeName("https://example.com/script (q)");
+        int cmp = alertA.compareTo(alertB);
+        // Then
+        assertThat(cmp, is(lessThan(0)));
+    }
+
+    @Test
+    void shouldCompareDissimilarIfAlertUriDifferentByCapitalization() {
+        // Given
+        Alert alertA = new Alert(1);
+        Alert alertB = new Alert(1);
+        // When
+        alertA.setAlertId(0);
+        alertB.setAlertId(1);
+        alertA.setUri("https://example.com/SCRIPT?q=a");
+        alertB.setUri("https://example.com/script?q=a");
+        int cmp = alertA.compareTo(alertB);
+        // Then
+        assertThat(cmp, is(lessThan(0)));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/extension/alert/AlertSetUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/alert/AlertSetUnitTest.java
@@ -157,20 +157,20 @@ public class AlertSetUnitTest {
                 getAlert(
                         0,
                         "Test Alert",
-                        "https://www.example.com/(test)",
+                        "https://www.example.com/ (test)",
                         "https://www.example.com/?test=1");
         Alert a2 =
                 getAlert(
                         1,
                         "Test Alert",
-                        "https://www.example.com/(test)",
+                        "https://www.example.com/ (test)",
                         "https://www.example.com/?test=2");
         Alert a3 =
                 getAlert(
                         2,
                         "Test Alert",
-                        "https://www.example.com/(x)",
-                        "https://www.example.com/?test=2");
+                        "https://www.example.com/ (x)",
+                        "https://www.example.com/?x=2");
 
         // When
         alertSet.add(a1);


### PR DESCRIPTION
Follow-up to zaproxy/zaproxy#9067

I've manually confirm that with these changes we do once again get two results for the firing range rXSS in question.