### PR TITLE
Normalize credential params and usage in AF plans

### DIFF
--- a/docker/integration_tests/configs/plans/auth-client-script-ajax-spider.yaml
+++ b/docker/integration_tests/configs/plans/auth-client-script-ajax-spider.yaml
@@ -27,8 +27,8 @@ env:
     users:
     - name: test
       credentials:
-        Username: test@test.com
-        Password: password123
+        username: test@test.com
+        password: password123
   parameters: {}
 jobs:
 - type: spiderAjax

--- a/docker/integration_tests/configs/plans/auth-client-script-client-spider.yaml
+++ b/docker/integration_tests/configs/plans/auth-client-script-client-spider.yaml
@@ -27,8 +27,8 @@ env:
     users:
     - name: test
       credentials:
-        Username: test@test.com
-        Password: password123
+        username: test@test.com
+        password: password123
   parameters: {}
 jobs:
 - type: spiderClient

--- a/docker/integration_tests/configs/scripts/auth/clientScriptAuth.zst
+++ b/docker/integration_tests/configs/scripts/auth/clientScriptAuth.zst
@@ -32,7 +32,7 @@
       "elementType": "ZestClientElementClick"
     },
     {
-      "value": "test@test.com",
+      "value": "{{username}}",
       "windowHandle": "windowHandle1",
       "type": "id",
       "element": "user",
@@ -41,7 +41,7 @@
       "elementType": "ZestClientElementSendKeys"
     },
     {
-      "value": "password123",
+      "value": "{{password}}",
       "windowHandle": "windowHandle1",
       "type": "id",
       "element": "password",

--- a/docker/integration_tests/configs/scripts/auth/clientScriptAuthBlocking.zst
+++ b/docker/integration_tests/configs/scripts/auth/clientScriptAuthBlocking.zst
@@ -56,7 +56,7 @@
       "elementType": "ZestClientElementScrollTo"
     },
     {
-      "value": "test@test.com",
+      "value": "{{username}}",
       "windowHandle": "windowHandle1",
       "type": "id",
       "element": "user",
@@ -75,7 +75,7 @@
       "elementType": "ZestClientElementScrollTo"
     },
     {
-      "value": "password123",
+      "value": "{{password}}",
       "windowHandle": "windowHandle1",
       "type": "id",
       "element": "password",

--- a/docker/integration_tests/configs/scripts/auth/clientScriptAuthBlockingScrolls.zst
+++ b/docker/integration_tests/configs/scripts/auth/clientScriptAuthBlockingScrolls.zst
@@ -56,7 +56,7 @@
       "elementType": "ZestClientElementScrollTo"
     },
     {
-      "value": "test@test.com",
+      "value": "{{username}}",
       "windowHandle": "windowHandle1",
       "type": "id",
       "element": "user",
@@ -75,7 +75,7 @@
       "elementType": "ZestClientElementScrollTo"
     },
     {
-      "value": "password123",
+      "value": "{{password}}",
       "windowHandle": "windowHandle1",
       "type": "id",
       "element": "password",


### PR DESCRIPTION
Use lowercase parameter names instead of capitalized.
Use variables in the scripts instead of hardcoded credentials.

Related to zaproxy/zap-extensions#6822.