### PR TITLE
Do not warn on empty encoded HTTP bodies

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/network/AbstractStreamHttpEncoding.java
+++ b/zap/src/main/java/org/zaproxy/zap/network/AbstractStreamHttpEncoding.java
@@ -29,6 +29,8 @@ abstract class AbstractStreamHttpEncoding implements HttpEncoding {
 
     private static final int BUFFER_SIZE = 2048;
 
+    private static final byte[] EMPTY = {};
+
     private final OutputStreamSupplier outputStreamSupplier;
     private final InputStreamSupplier inputStreamSupplier;
 
@@ -49,6 +51,10 @@ abstract class AbstractStreamHttpEncoding implements HttpEncoding {
 
     @Override
     public byte[] decode(byte[] content) throws IOException {
+        if (content.length == 0) {
+            return EMPTY;
+        }
+
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (ByteArrayInputStream bais = new ByteArrayInputStream(content);
                 InputStream is = inputStreamSupplier.get(bais)) {

--- a/zap/src/test/java/org/zaproxy/zap/network/HttpEncodingDeflateUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/network/HttpEncodingDeflateUnitTest.java
@@ -37,6 +37,9 @@ class HttpEncodingDeflateUnitTest {
     private static final byte[] CONTENT = "Content 123 ABC".getBytes(StandardCharsets.UTF_8);
     private static final byte[] CONTENT_ENCODED = deflate(CONTENT);
 
+    private static final byte[] EMPTY_CONTENT = {};
+    private static final byte[] EMPTY_CONTENT_ENCODED = deflate(EMPTY_CONTENT);
+
     private HttpEncodingDeflate encoding = HttpEncodingDeflate.getSingleton();
 
     @Test
@@ -53,6 +56,30 @@ class HttpEncodingDeflateUnitTest {
         byte[] decodedContent = encoding.decode(CONTENT_ENCODED);
         // Then
         assertThat(decodedContent, is(equalTo(CONTENT)));
+    }
+
+    @Test
+    void shouldEncodeEmptyContent() throws IOException {
+        // Given / When
+        byte[] encodedContent = encoding.encode(EMPTY_CONTENT);
+        // Then
+        assertThat(encodedContent, is(equalTo(EMPTY_CONTENT_ENCODED)));
+    }
+
+    @Test
+    void shouldDecodeEmptyContent() throws IOException {
+        // Given / When
+        byte[] decodedContent = encoding.decode(EMPTY_CONTENT_ENCODED);
+        // Then
+        assertThat(decodedContent, is(equalTo(EMPTY_CONTENT)));
+    }
+
+    @Test
+    void shouldSkipDecodePlainEmptyContent() throws IOException {
+        // Given / When
+        byte[] decodedContent = encoding.decode(EMPTY_CONTENT);
+        // Then
+        assertThat(decodedContent, is(equalTo(EMPTY_CONTENT)));
     }
 
     @Test

--- a/zap/src/test/java/org/zaproxy/zap/network/HttpEncodingGzipUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/network/HttpEncodingGzipUnitTest.java
@@ -37,6 +37,9 @@ class HttpEncodingGzipUnitTest {
     private static final byte[] CONTENT = "Content 123 ABC".getBytes(StandardCharsets.UTF_8);
     private static final byte[] CONTENT_ENCODED = gzip(CONTENT);
 
+    private static final byte[] EMPTY_CONTENT = {};
+    private static final byte[] EMPTY_CONTENT_ENCODED = gzip(EMPTY_CONTENT);
+
     private HttpEncodingGzip encoding = HttpEncodingGzip.getSingleton();
 
     @Test
@@ -53,6 +56,30 @@ class HttpEncodingGzipUnitTest {
         byte[] decodedContent = encoding.decode(CONTENT_ENCODED);
         // Then
         assertThat(decodedContent, is(equalTo(CONTENT)));
+    }
+
+    @Test
+    void shouldEncodeEmptyContent() throws IOException {
+        // Given / When
+        byte[] encodedContent = encoding.encode(EMPTY_CONTENT);
+        // Then
+        assertThat(encodedContent, is(equalTo(EMPTY_CONTENT_ENCODED)));
+    }
+
+    @Test
+    void shouldDecodeEmptyContent() throws IOException {
+        // Given / When
+        byte[] decodedContent = encoding.decode(EMPTY_CONTENT_ENCODED);
+        // Then
+        assertThat(decodedContent, is(equalTo(EMPTY_CONTENT)));
+    }
+
+    @Test
+    void shouldSkipDecodePlainEmptyContent() throws IOException {
+        // Given / When
+        byte[] decodedContent = encoding.decode(EMPTY_CONTENT);
+        // Then
+        assertThat(decodedContent, is(equalTo(EMPTY_CONTENT)));
     }
 
     @Test


### PR DESCRIPTION
Do not attempt to decode if empty and thus prevent the warn of EOFException.

---
e.g.: `WARN  org.parosproxy.paros.network.HttpBody - An error occurred while decoding the body: null`