### PR TITLE
Remove Nashorn warning suppression

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/ZAP.java
+++ b/zap/src/main/java/org/zaproxy/zap/ZAP.java
@@ -113,12 +113,6 @@ public class ZAP {
 
                     @Override
                     public void println(String x) {
-                        // Suppress Nashorn removal warnings, too verbose (a warn each time is
-                        // used).
-                        if ("Warning: Nashorn engine is planned to be removed from a future JDK release"
-                                .equals(x)) {
-                            return;
-                        }
                         if (x != null && x.startsWith("Multiplexing LAF")) {
                             return;
                         }


### PR DESCRIPTION
The engine is no longer used/included in ZAP's targeted Java versions.