### PR TITLE
Allow to lock scan policies

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyAllCategoryPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/PolicyAllCategoryPanel.java
@@ -28,6 +28,7 @@
 // not important).
 // ZAP: 2019/06/01 Normalise line endings.
 // ZAP: 2019/06/05 Normalise format/style.
+// ZAP: 2025/11/17 Support locked policy.
 package org.zaproxy.zap.extension.ascan;
 
 import java.awt.GridBagConstraints;
@@ -44,6 +45,7 @@ import java.util.Locale;
 import javax.swing.DefaultCellEditor;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -75,6 +77,7 @@ public class PolicyAllCategoryPanel extends AbstractParamPanel {
     private static final Logger LOGGER = LogManager.getLogger(PolicyAllCategoryPanel.class);
 
     private ZapTextField policyName = null;
+    private JCheckBox locked;
     private JTable tableTest = null;
     private JScrollPane jScrollPane = null;
     private AllCategoryTableModel allCategoryTableModel = null;
@@ -138,6 +141,30 @@ public class PolicyAllCategoryPanel extends AbstractParamPanel {
         } else {
             this.add(
                     getPolicyName(),
+                    LayoutHelper.getGBC(
+                            1,
+                            row,
+                            2,
+                            1.0D,
+                            0,
+                            GridBagConstraints.HORIZONTAL,
+                            new Insets(2, 2, 2, 2)));
+
+            locked = new JCheckBox();
+            locked.setSelected(policy.isLocked());
+            row++;
+            this.add(
+                    new JLabel(Constant.messages.getString("ascan.policy.locked.label")),
+                    LayoutHelper.getGBC(
+                            0,
+                            row,
+                            1,
+                            0.0D,
+                            0,
+                            GridBagConstraints.HORIZONTAL,
+                            new Insets(2, 2, 2, 2)));
+            this.add(
+                    locked,
                     LayoutHelper.getGBC(
                             1,
                             row,
@@ -549,6 +576,9 @@ public class PolicyAllCategoryPanel extends AbstractParamPanel {
     @Override
     public void saveParam(Object obj) throws Exception {
         this.policy.setName(getPolicyName().getText());
+        if (locked != null) {
+            policy.setLocked(locked.isSelected());
+        }
     }
 
     /**

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanPolicy.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ScanPolicy.java
@@ -39,6 +39,7 @@ public class ScanPolicy {
     private String name;
     private String statsId;
     private boolean readOnly;
+    private boolean locked;
     private PluginFactory pluginFactory = new PluginFactory();
     private AlertThreshold defaultThreshold;
     private AttackStrength defaultStrength;
@@ -57,10 +58,12 @@ public class ScanPolicy {
         name = conf.getString("policy", "");
         statsId = conf.getString("statsId", null);
         readOnly = conf.getBoolean("readonly", false);
+        locked = conf.getBoolean("locked", false);
         if (statsId == null
                 && name.equals(Constant.messages.getString("ascan.policymgr.default.name"))) {
             statsId = "default";
         }
+        pluginFactory.setLocked(locked);
         pluginFactory.loadAllPlugin(conf);
 
         setDefaultThreshold(getAlertThresholdFromConfig());
@@ -85,6 +88,7 @@ public class ScanPolicy {
         policy.defaultThreshold = this.getDefaultThreshold();
         policy.statsId = this.statsId;
         policy.readOnly = this.readOnly;
+        policy.locked = this.locked;
     }
 
     /**
@@ -94,6 +98,7 @@ public class ScanPolicy {
      */
     public void saveTo(Configuration conf) throws ConfigurationException {
         conf.setProperty("policy", getName());
+        conf.setProperty("locked", isLocked());
         conf.setProperty("scanner.level", getDefaultThreshold().name());
         conf.setProperty("scanner.strength", getDefaultStrength().name());
         getPluginFactory().saveTo(conf);
@@ -189,5 +194,30 @@ public class ScanPolicy {
      */
     public boolean isReadOnly() {
         return readOnly;
+    }
+
+    /**
+     * Tells whether or not the policy is locked.
+     *
+     * <p>Locked policies do not allow the use of any other scan rules than the ones defined in
+     * their configuration.
+     *
+     * @return {@code true} if the policy is locked, {@code false} otherwise.
+     * @since 2.17.0
+     */
+    public boolean isLocked() {
+        return locked;
+    }
+
+    /**
+     * Sets whether or not this policy should be locked.
+     *
+     * @param locked {@code true} if the policy should be locked, {@code false} otherwise.
+     * @since 2.17.0
+     * @see #isLocked()
+     */
+    public void setLocked(boolean locked) {
+        this.locked = locked;
+        pluginFactory.setLocked(locked);
     }
 }

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -539,6 +539,7 @@ ascan.policy.level.low = Low
 ascan.policy.level.medium = Medium
 ascan.policy.level.off = OFF
 ascan.policy.load.error = Failed to load policy file, see log for detail
+ascan.policy.locked.label = Locked:
 ascan.policy.name.default = Default Policy
 ascan.policy.name.label = Policy:
 ascan.policy.namedialog.name.label = New Policy Name:

--- a/zap/src/test/java/org/zaproxy/zap/extension/ascan/ScanPolicyUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/ascan/ScanPolicyUnitTest.java
@@ -25,6 +25,8 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.core.scanner.Plugin;
 import org.zaproxy.zap.WithConfigsTest;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
@@ -119,5 +121,54 @@ class ScanPolicyUnitTest extends WithConfigsTest {
         ScanPolicy scanPolicy = new ScanPolicy(conf);
         // Then
         assertThat(scanPolicy.getDefaultStrength(), is(equalTo(Plugin.AttackStrength.MEDIUM)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldLoadLockedStateFromConfig(boolean locked) throws Exception {
+        // Given
+        ZapXmlConfiguration conf = new ZapXmlConfiguration();
+        conf.setProperty("locked", locked);
+        // When
+        ScanPolicy scanPolicy = new ScanPolicy(conf);
+        // Then
+        assertThat(scanPolicy.isLocked(), is(equalTo(locked)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetPluginFactoryLockedStateFromConfig(boolean locked) throws Exception {
+        // Given
+        ZapXmlConfiguration conf = new ZapXmlConfiguration();
+        conf.setProperty("locked", locked);
+        // When
+        ScanPolicy scanPolicy = new ScanPolicy(conf);
+        // Then
+        assertThat(scanPolicy.getPluginFactory().isLocked(), is(equalTo(locked)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetLockedState(boolean locked) {
+        // Given
+        ScanPolicy scanPolicy = new ScanPolicy();
+        // When
+        scanPolicy.setLocked(locked);
+        // Then
+        assertThat(scanPolicy.isLocked(), is(equalTo(locked)));
+        assertThat(scanPolicy.getPluginFactory().isLocked(), is(equalTo(locked)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSaveLockedState(boolean locked) throws Exception {
+        // Given
+        ZapXmlConfiguration conf = new ZapXmlConfiguration();
+        ScanPolicy scanPolicy = new ScanPolicy();
+        scanPolicy.setLocked(locked);
+        // When
+        scanPolicy.saveTo(conf);
+        // Then
+        assertThat(conf.getBoolean("locked"), is(equalTo(locked)));
     }
 }


### PR DESCRIPTION
Prevent the usage of scan rules that are not defined in the policy file while allowing to override the default alert threshold.