### PR TITLE
Fix Docker httpsender script

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2025-11-21
+- Updated `Alert_on_HTTP_Response_Code_Errors.js` to work with GraalVM JavaScript engine.
+
 ### 2025-11-03
 - Set statsId and readonly for scan policies.
 

--- a/docker/scripts/scripts/httpsender/Alert_on_HTTP_Response_Code_Errors.js
+++ b/docker/scripts/scripts/httpsender/Alert_on_HTTP_Response_Code_Errors.js
@@ -76,9 +76,7 @@ function responseReceived(msg, initiator, helper) {
 			alert.setDescription("A response code of " + code + " was returned by the server.\n" +
 				"This may indicate that the application is failing to handle unexpected input correctly.\n" +
 				"Raised by the 'Alert on HTTP Response Code Error' script");
-			// Use a regex to extract the evidence from the response header
-			var regex = new RegExp("^HTTP.*" + code)
-			alert.setEvidence(msg.getResponseHeader().toString().match(regex))
+			alert.setEvidence(code.toString())
 			alert.setCweId(388)	// CWE CATEGORY: Error Handling
 			alert.setWascId(20)	// WASC  Improper Input Handling
 			extensionAlert.alertFound(alert , ref)


### PR DESCRIPTION
Fixes an issue in the Alert_on_HTTP_Response_Code_Errors.js included in the zap-api-scan.py script.

When .setEvidence is called to record the status code returned by the target server the return value from a regexp match was used. This returns an array of strings which raises an error as the function expects a string.

The status code is already extracted from the message earlier in the script, so that value is used instead of parsing it from the header.

This resolves #9139.