### PR TITLE
Add cryptographic verification and reference pinning for all external downloads

### DIFF
--- a/docker/Dockerfile-bare
+++ b/docker/Dockerfile-bare
@@ -12,11 +12,6 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 
 WORKDIR /zap
 
-# Old insecure version of code
-#RUN wget -qO- https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml | xmlstarlet sel -t -v //url |grep -i Linux | wget --content-disposition -i - -O - | tar zxv && \
-#	mv ZAP*/* . && \
-#	rm -R ZAP*
-
 # Pinned URL and checksum for the stable release
 ARG ZAP_LINUX_URL
 ARG ZAP_LINUX_SHA256
@@ -27,12 +22,6 @@ RUN wget -O zap-linux.tgz "$ZAP_LINUX_URL" && \
     tar zxvf zap-linux.tgz && \
     mv ZAP*/* . && \
     rm -R ZAP* zap-linux.tgz
-
-#Build command looks like:
-# docker build \
-#  --build-arg ZAP_LINUX_URL=https://example.com/path/to/ZAP_2.16.0_Linux.tar.gz \
-#  --build-arg ZAP_LINUX_SHA256=your_real_checksum_here \
-#  -f Dockerfile-bare .
 
 # Update add-ons
 RUN ./zap.sh -cmd -silent -addonupdate

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -15,12 +15,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 
 WORKDIR /zap-src
 
-#Old insecure version of code
 # Pull the ZAP repo and build ZAP with weekly add-ons that utilizes a specific git ref
-#RUN git clone --depth 1 https://github.com/zaproxy/zaproxy.git && \
-#	cd zaproxy && \
-#	ZAP_WEEKLY_ADDONS_NO_TEST=true ./gradlew :zap:prepareDistWeekly
-
 # Example pinned tag that needs to be changed
 ARG ZAPROXY_REF=refs/tags/v2.16.0  
 
@@ -37,18 +32,7 @@ WORKDIR /zap
 ENV WEBSWING_VERSION=24.2.2
 ARG WEBSWING_SHA256
 
-# Old insecure version of code
-#RUN --mount=type=secret,id=webswing_url \
-#	if [ -s /run/secrets/webswing_url ] ; \
-#	then curl -s -L  "$(cat /run/secrets/webswing_url)-${WEBSWING_VERSION}-distribution.zip" > webswing.zip; \
-#	else curl -s -L  "https://dev.webswing.org/files/public/webswing-examples-eval-${WEBSWING_VERSION}-distribution.zip" > webswing.zip; fi && \
-#	unzip webswing.zip && \
-#	rm webswing.zip && \
-#	mv webswing-* webswing && \
-	# Remove Webswing bundled examples
-#	rm -Rf webswing/apps/
-
-# At build time you’ll pass --build-arg WEBSWING_SHA256={ZAP_LINUX_SHA256}. This addresses problem of downloadding and then unzipping with no verification as shown in previous commented-out code
+# At build time you’ll pass --build-arg WEBSWING_SHA256={ZAP_LINUX_SHA256}. 
 RUN --mount=type=secret,id=webswing_url \
     if [ -s /run/secrets/webswing_url ] ; \
     then curl -s -L "$(cat /run/secrets/webswing_url)-${WEBSWING_VERSION}-distribution.zip" -o webswing.zip; \

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -16,24 +16,12 @@ WORKDIR /zap
 ARG ZAP_LINUX_URL
 ARG ZAP_LINUX_SHA256
 
-# Old insecure code
-# RUN wget -qO- https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml | xmlstarlet sel -t -v //url |grep -i Linux | wget --content-disposition -i - -O - | tar zxv && \
-#	mv ZAP*/* . && \
-#	rm -R ZAP*
-
 # Securely download ZAP by pinning the tarball URL and verifying its SHA-256 checksum before extraction, preventing tampered or untrusted binaries.
 RUN wget -O zap-linux.tgz "$ZAP_LINUX_URL" && \
     echo "${ZAP_LINUX_SHA256}  zap-linux.tgz" | sha256sum -c - && \
     tar zxvf zap-linux.tgz && \
     mv ZAP*/* . && \
     rm -R ZAP* zap-linux.tgz
-
-# on build-time, pass command looking like:
-#	RUN wget -O zap-linux.tgz "$ZAP_LINUX_URL" && \
-#    echo "${ZAP_LINUX_SHA256}  zap-linux.tgz" | sha256sum -c - && \
-#    tar zxvf zap-linux.tgz && \
-#    mv ZAP*/* . && \
-#    rm -R ZAP* zap-linux.tgz
 
 # Update add-ons
 RUN ./zap.sh -cmd -silent -addonupdate
@@ -43,16 +31,6 @@ RUN cp /root/.ZAP/plugin/*.zap plugin/ || :
 # Setup Webswing
 ENV WEBSWING_VERSION=24.2.2
 ARG WEBSWING_SHA256
-
-#RUN --mount=type=secret,id=webswing_url \
-#	if [ -s /run/secrets/webswing_url ] ; \
-#	then curl -s -L  "$(cat /run/secrets/webswing_url)-${WEBSWING_VERSION}-distribution.zip" > webswing.zip; \
-#	else curl -s -L  "https://dev.webswing.org/files/public/webswing-examples-eval-${WEBSWING_VERSION}-distribution.zip" > webswing.zip; fi && \
-#	unzip webswing.zip && \
-#	rm webswing.zip && \
-#	mv webswing-* webswing && \
-	# Remove Webswing bundled examples
-#	rm -Rf webswing/apps/
 
 # At build time you’ll pass --build-arg WEBSWING_SHA256={ZAP_LINUX_SHA256}. This addresses problem of downloadding and then unzipping with no verification as shown in previous commented-out code
 RUN --mount=type=secret,id=webswing_url \

--- a/docker/Dockerfile-tests
+++ b/docker/Dockerfile-tests
@@ -12,11 +12,6 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 
 WORKDIR /zap-src
 
-# Old insecure version of code 
-# RUN git clone --depth 1 https://github.com/zaproxy/zap-extensions.git && \
-#	cd zap-extensions && \
-#	./gradlew :aO:dev:cZAO --into /zap-src/zap/plugin/
-
 # This could be a commit hash
 ARG ZAP_EXTENSIONS_REF=refs/tags/vX.Y.Z  
 

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -13,17 +13,6 @@ WORKDIR /zap
 ENV WEBSWING_VERSION=24.2.2
 ARG WEBSWING_SHA256
 
-# Old insecure version of code
-#RUN --mount=type=secret,id=webswing_url \
-#	if [ -s /run/secrets/webswing_url ] ; \
-#	then curl -s -L  "$(cat /run/secrets/webswing_url)-${WEBSWING_VERSION}-distribution.zip" > webswing.zip; \
-#	else curl -s -L  "https://dev.webswing.org/files/public/webswing-examples-eval-${WEBSWING_VERSION}-distribution.zip" > webswing.zip; fi && \
-#	unzip webswing.zip && \
-#	rm webswing.zip && \
-#	mv webswing-* webswing && \
-	# Remove Webswing bundled examples
-#	rm -Rf webswing/apps/
-
 # Securely download Webswing by verifying the archive's SHA-256 checksum before extraction, preventing untrusted or tampered downloads
 RUN --mount=type=secret,id=webswing_url \
     if [ -s /run/secrets/webswing_url ] ; \
@@ -75,12 +64,6 @@ RUN mkdir /home/zap/.vnc
 
 ARG ZAP_WEEKLY_URL
 ARG ZAP_WEEKLY_SHA256
-
-#RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersions.xml | xmlstarlet sel -t -v //url |grep -i weekly | wget --content-disposition -i - && \
-#	unzip *.zip && \
-#	rm *.zip && \
-#	cp -R ZAP*/* . &&  \
-#	rm -R ZAP*
 
 RUN wget -O zap-weekly.zip "$ZAP_WEEKLY_URL" && \
     echo "${ZAP_WEEKLY_SHA256}  zap-weekly.zip" | sha256sum -c - && \


### PR DESCRIPTION
### Summary ###
This PR remediates multiple insecure download patterns across the ZAP Dockerfiles, where external artifacts (Webswing ZIPs, ZAP tarballs, and GitHub source trees) were retrieved without any authenticity or integrity verification.

### Fault / Vulnerability ###
The original Dockerfiles performed actions such as:
```shell
curl -L <url> > file.zip
wget <url> | tar zxv
git clone --depth 1 ...
```
with no checksum verification and no commit pinning.

This presents multiple supply-chain risks:
1. MITM attacks could substitute malicious binaries or modified source archives.
2. Compromised hosting servers could deliver trojanized artifacts.
3. Unpinned git clones fetch the latest commit from the remote repository, enabling:
    a. Accidental breakage
    b. Targeted injection of malicious commits
    c.  Non-reproducible builds

### OWASP Violations ###
This behavior violates several OWASP guidelines:
1. [OWASP CI/CD Security Cheat Sheet](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse) - Software must only be installed after authenticity and integrity checks.
2. [OWASP Supply Chain Security Guidelines](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-09-Improper-Artifact-Integrity-Validation) - All downloaded artifacts must be cryptographically verified.
3. [OWASP Harden Build Tools](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html#:~:text=identified%20build%20tools.-,Harden%20Build%20Tools,-%C2%B6) - Builds must be deterministic and pinned to known versions.

### Changes Made ###
1. Added mandatory SHA-256 verification for:
    a. Webswing ZIP downloads
    b. ZAP stable tarballs
2. Added ARGs for checksums to enforce explicit verification
3. Added pinned Git references (refs/tags/vX.Y.Z) before build execution
4. Removed unsafe “pipe-to-shell” or “pipe-to-tar” patterns
5. Replaced floating URLs with checksum-validated downloads provided as build-time parameters

### How the Fix Works ###
By validating downloaded artifacts against known cryptographic digests, and by checking out exact commit references:
1. Every download now has a known-good fingerprint
2. Builds become deterministic
3. ZAP Docker images can no longer silently drift due to upstream changes
4. Supply-chain attack surface is minimized greatly

### Security Impact ###
1. This PR substantially hardens the entire build pipeline:
2. Prevents arbitrary code execution via tampered ZIPs/tarballs
3. Eliminates trust on first use (TOFU) patterns
4. Ensures CI/CD creates reproducible, verifiable images
5. Significantly improves defense against:
    a. Dependency poisoning
    b. Repository compromise
    c. MITM interference
    d. Malicious injects into cloned repos

### Usage ###
Build _live_ image:
``` shell
docker build \
  -f Dockerfile-live \
  -t zap-live-secure \
  --secret id=webswing_url,src=webswing_url.txt \
  --build-arg WEBSWING_VERSION=24.2.2 \
  --build-arg WEBSWING_SHA256="<expected_sha256_here>" \
  --build-arg ZAPROXY_REF="refs/tags/v2.16.0" \
  .
```

Build _stable_ image:
```shell
docker build \
  -f Dockerfile-stable \
  -t zap-stable-secure \
  --build-arg ZAP_LINUX_URL="https://example.com/ZAP_2.16.0_Linux.tar.gz" \
  --build-arg ZAP_LINUX_SHA256="<sha256_of_tarball>" \
  --build-arg WEBSWING_VERSION=24.2.2 \
  --build-arg WEBSWING_SHA256="<sha256_of_webswing_zip>" \
  --secret id=webswing_url,src=webswing_url.txt \
  .
```

Build _weekly_ image:
```shell
docker build \
  -f Dockerfile-weekly \
  -t zap-weekly-secure \
  --build-arg WEBSWING_VERSION=24.2.2 \
  --build-arg WEBSWING_SHA256="<sha256_here>" \
  --secret id=webswing_url,src=webswing_url.txt \
  .
```

Build _bare_ image:
```shell
docker build \
  -f Dockerfile-bare \
  -t zap-bare-secure \
  --build-arg ZAP_LINUX_URL="https://example.com/ZAP_linux.tgz" \
  --build-arg ZAP_LINUX_SHA256="<sha256_here>" \
  .
``` 

Build _tests_ image:
```shell
docker build \
  -f Dockerfile-tests \
  -t zap-tests-secure \
  --build-arg ZAPROXY_REF="refs/tags/v2.16.0" \
  .
```