### PR TITLE
Remove hardcoded default passwords and transition Dockerfiles to secure, non-persistent authentication patterns

### DIFF
--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -62,8 +62,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	xvfb \
 	x11vnc && \
 	rm -rf /var/lib/apt/lists/*  && \
-	useradd -u 1000 -d /home/zap -m -s /bin/bash zap && \
-	echo zap:zap | chpasswd && \
+	useradd -u 1000 -d /home/zap -m -s /bin/bash -p '!' zap && \
 	mkdir /zap  && \
 	chown zap:zap /zap
 

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -71,9 +71,8 @@ RUN pip3 install \
 	pyyaml \
 	urllib3
 
-RUN useradd -u 1000 -d /home/zap -m -s /bin/bash zap
-RUN echo zap:zap | chpasswd
-RUN mkdir /zap && chown zap:zap /zap
+RUN useradd -u 1000 -d /home/zap -m -s /bin/bash -p '!' zap && \
+ mkdir /zap && chown zap:zap /zap
 
 WORKDIR /zap
 

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -46,8 +46,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	xvfb \
 	x11vnc && \
 	rm -rf /var/lib/apt/lists/* && \
-    useradd -u 1000 -d /home/zap -m -s /bin/bash zap && \
-    echo zap:zap | chpasswd && \
+    useradd -u 1000 -d /home/zap -m -s /bin/bash -p '!' zap && \
     mkdir /zap  && \
     chown zap:zap /zap
 


### PR DESCRIPTION
## Summary ##
This PR removes all occurrences of hardcoded passwords (e.g., `echo zap:zap | chpasswd`) in the ZAP Dockerfiles and replaces them with secure alternatives that do not embed credentials into container layers. Across multiple Dockerfiles (`live`, `stable`, `weekly`), default credentials were being written directly into the image, exposing users to predictable authentication states and enabling trivial container compromise.

## Fault/Vulnerability ##
Previously, Dockerfiles contained blocks equivalent to:
```shell
echo zap:zap | chpasswd
```
or
```shell
useradd -u 1000 -d /home/zap -m -s /bin/bash zap
echo zap:zap | chpasswd
```
This creates the following vulnerabilities:
#### 1. Predictable, universally known credentials ####
Every container instance starts with:
    a. Username: zap
    b. Password: zap
Any user with access to the container, logs, or image registry already knows these credentials.

#### 2. Credential persistence baked into image layers ####
Hardcoding credentials means:
    a. They are stored permanently in the Docker layer
    b. They are recoverable via image introspection (docker history, dive)
    c. They cannot be rotated without building a new image

#### 3. Violates least privilege & impersonation protections #### 
A threat actor obtaining interactive access (via exec, breakout, or misconfiguration) would immediately authenticate as the container’s default user.

#### 4. Prevents integration with modern runtime authentication models ####
Hardcoded passwords conflict with:
    a. orchestrators using ephemeral users
    b. rootless containers
    c. Kubernetes PSP/SCC best practices

## OWASP Violations ##
This practice violates several OWASP guidelines:

[OWASP Secretes Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html#:~:text=3.2.1-,As%20part%20of%20your%20CI/CD%20tooling,-%C2%B6) - Avoid embedding passwords, API keys, or credentials directly into image layers.

## Changes Made ##
This PR applies the following remediations:

1. Removed all hardcoded password assignments from every Dockerfile:
`echo zap:zap | chpasswd`

2. Replaced user creation with secure, locked-password invocation:
`useradd -u 1000 -d /home/zap -m -s /bin/bash -p '!' zap`
`-p '!'` sets an invalid password hash, effectively disabling password login.

3. Ensured the container environment remains functional by:
    a. Preserving correct UID, GID, home directory, and shell
    b. Ensuring zap can still be used as the runtime user
    c. Avoiding any authentication vector that relies on password logins

4. Prepared the image to integrate cleanly with:
    a. SSH-less orchestrated environments (Docker, Kubernetes, Podman)
    b. Rootless container execution
    c. Runtime-scoped secret injection if ever needed (docker run -e, docker secrets, Kubernetes Secrets)

## How the Fix Works ##
The `zap` user is still created normally, but the password field is replaced with a locked entry. This means that no credential material is stored in the image. If authentication is ever needed, which is rare in containerized workflows, credentials can be supplied at runtime, not at build-time. Therefore, Attackers cannot authenticate with a predictable default credential, and Image layers no longer contain sensitive information.

## Security Impact ##
This PR improves security in several ways:

#### 1. Removes a trivial but high-impact vulnerability ####
Default credentials are among the top causes of container compromises.
#### 2. Eliminates secret leakage in build artifacts ####
Hardcoded passwords are impossible to safely manage or revoke.
#### 3. Aligns with enterprise and OWASP security standards ####
This enables the images to meet:
1. OWASP Docker Security
2. CIS Docker Benchmark
3. Kubernetes Security Guidelines
4. Supply-chain security frameworks (SLSA / NIST SSDF)
#### 4. Enables future runtime-hardening ####
Locked-password users are compatible with:
1. `/home/zap/.ZAP_D` tmpfs mounting
2. Seccomp/apparmor confinement
3. Non-login shells
4. Rootless operation