### PR TITLE
Reduce attack surface by removing unused build tools, compilers, and unnecessary utilities from final images

### DIFF
--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -39,44 +39,31 @@ LABEL maintainer="psiinon@gmail.com"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# The older version of this command installed a bunch of uneccesary packages, build tools, libraries, etc, broadening attack surface for unused services or libraries
 RUN apt-get update && apt-get install -q -y --fix-missing \
-	make \
-	ant \
-	automake \
-	autoconf \
-	gcc g++ \
-	openjdk-17-jdk \
-	wget \
+	openjdk-17-jre \
 	curl \
-	xmlstarlet \
-	unzip \
-	jq \
-	git \
-	openbox \
-	xterm \
-	net-tools \
 	python3-pip \
 	python-is-python3 \
 	firefox-esr \
-	vim \
 	xvfb \
-	x11vnc && \
+	x11vnc \
+	openbox \
+	xterm && \
 	rm -rf /var/lib/apt/lists/*  && \
-	useradd -u 1000 -d /home/zap -m -s /bin/bash zap && \
-	echo zap:zap | chpasswd && \
+	# Create zap user with locked password (no hardcoded credentials)
+	useradd -u 1000 -d /home/zap -m -s /bin/bash -p '!' zap && \
 	mkdir /zap  && \
 	chown zap:zap /zap
 
+# The older version of this command installed a bunch of uneccesary aws tools, correlates to Computer Security best practices of not allowing unused services to run and bloat operations
 RUN pip3 install \
 	--break-system-packages \
 	--no-cache-dir \
 	--upgrade \
-	awscli \
 	pip \
 	zaproxy \
-	pyyaml \
-	requests \
-	urllib3
+	pyyaml
 
 #Change to the zap user so things get done as the right person (apart from copy)
 USER zap

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -40,36 +40,24 @@ LABEL maintainer="psiinon@gmail.com"
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
-	make \
-	automake \
-	autoconf \
-	gcc g++ \
-	openjdk-17-jdk \
-	wget \
+	openjdk-17-jre \
 	curl \
-	xmlstarlet \
-	unzip \
-	jq \
-	git \
-	openbox \
-	xterm \
-	net-tools \
 	python3-pip \
 	python-is-python3 \
 	firefox-esr \
 	xvfb \
-	x11vnc && \
+	x11vnc \
+	openbox \
+	xterm && \
 	rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install \
 	--break-system-packages \
 	--no-cache-dir \
 	--upgrade \
-	awscli \
 	pip \
 	zaproxy \
 	pyyaml \
-	urllib3
 
 RUN useradd -u 1000 -d /home/zap -m -s /bin/bash zap
 RUN echo zap:zap | chpasswd

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -25,33 +25,23 @@ FROM debian:bookworm-slim AS final
 LABEL maintainer="psiinon@gmail.com"
 
 ARG DEBIAN_FRONTEND=noninteractive
+# Install only runtime dependencies for weekly ZAP
 RUN apt-get update && apt-get install -q -y --fix-missing \
-	make \
-	automake \
-	autoconf \
-	gcc g++ \
-	openjdk-17-jdk \
-	wget \
-	curl \
-	xmlstarlet \
-	unzip \
-	jq \
-	git \
-	openbox \
-	xterm \
-	net-tools \
-	python3-pip \
-	python-is-python3 \
-	firefox-esr \
-	xvfb \
-	x11vnc && \
-	rm -rf /var/lib/apt/lists/* && \
-    useradd -u 1000 -d /home/zap -m -s /bin/bash zap && \
-    echo zap:zap | chpasswd && \
-    mkdir /zap  && \
-    chown zap:zap /zap
+    openjdk-17-jre \
+    curl \
+    python3-pip \
+    python-is-python3 \
+    firefox-esr \
+    xvfb \
+    x11vnc \
+    openbox \
+    xterm && \
+    rm -rf /var/lib/apt/lists/* && \
+    # Create zap user without hardcoded password
+    useradd -u 1000 -d /home/zap -m -s /bin/bash -p '!' zap && \
+    mkdir /zap && chown zap:zap /zap
 
-RUN pip3 install --break-system-packages --no-cache-dir --upgrade awscli pip zaproxy pyyaml requests urllib3 
+RUN pip3 install --break-system-packages --no-cache-dir --upgrade pip zaproxy pyyaml 
 
 WORKDIR /zap
 


### PR DESCRIPTION
## Summary ##
This PR removes numerous unneeded packages, compilers, build tooling, and debugging utilities from the final stages of the ZAP Dockerfiles. These tools were required only during the build process, but were previously included in the final runtime images, significantly increasing the attack surface. This change aligns the images with OWASP-recommended and Computer Security-best-practices minimalism, reduces exposure to vulnerabilities, and ensures that the container runtime environment contains only software essential for operating ZAP.

## Fault/Vulnerability ##
The original Dockerfiles installed many powerful or unnecessary tools in the final runtime layers, including:
#### Build & Compilation Tooling ####
1. `make`, `automake`, `autoconf`
2. `gcc`, `g++`
3. `ant`
4. `git`

#### File & System Utilities Not Required at Runtime ####
1. `unzip`, `jq`,  `xmlstarlet`
2. `net-tools (ifconfig, netstat)`
3. `vim`
4. `wget` (runtime

#### Development JDK instead of Runtime JRE ####
Uneccesarily installed `openjdk-17-jdk` in production layers

Although these tools themselves face low vulnerabilities, the practice of installing significant software like the ones listed above introduce several issues:

#### Expanded Attack Surface (CVE Scopre)
The more packages installed, the more potential vulnerabilities exist within the image.
Compilers and scripting tools are especially dangerous if an attacker gains shell access.

#### Facilitation of Post-Exploitation ####
Tools like `gcc`, `g++`, and `git` enable compiling payloads, fetching malicious repos, and building exploit frameworks

## OWASP and Best Practice Violations ##
[OWASP Attack Surface Analysis Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Attack_Surface_Analysis_Cheat_Sheet.html#:~:text=Interfaces%20with%20other%20applications/systems) - Remove interfaces with other applications, systems, or packages
[Create minimal images](https://aws.amazon.com/blogs/containers/building-better-container-images/#:~:text=Make%20use%20of%20multi%2Dstage%20builds)

## Changes Made ##
This PR applies the following modifications across the `live`, `stable`, and `weekly` images.
#### Remove build tooling from final stages ####
All of the following were removed wherever not strictly needed at runtime:
1. `gcc`, `g++`
2. `make`, `automake`, `autoconf`
3. `ant`
4. `git`
5. `jq`, `xmlstartlet`, `unzip`
6. `net-tools`
7. `vim`
8. These tools noe exist only in the builder stages
#### Replaced JDK with JRE ####
Where runtime Java was required, switched `openjdk-17-jdk` → `openjdk-17-jre`. This removes uneccesary compilations tools, header files, and debugging components. 
#### Cleaned up runtime package lists ####
After analysis using `grep` to search for instances where tools were used in the codebase, only the following are required:
1. `openjdk-17-jre`
2. `python3`, `python3-pip`, `python3-venv`
3. `firefox-esr`, `xvfb`, `x11vnc`, `openbos`, `xterm`
4. `curl`

## How the Fix Works ##
By removing unnecessary utilities from the final image layers:
1. Attackers have fewer tools available during exploitation.
2. CVEs associated with compilers, linkers, and system utilities no longer apply.
3. The Trusted Computing Base (TCB) is minimized, reducing audit complexity.
4. Final images become smaller, easier to cache, faster to scan, and safer.
Builder stages still contain the tools required for compilation, but Docker guarantees that builder-stage layers never appear in the final runtime image.

## Security Impact ##
#### Significant Reduction in CVE Exposure ####
Removing development packages commonly eliminates hundreds of potential vulnerabilities from the final image.
#### Eliminates Tools Used in Real Attack Chains ####
Most container breakout and lateral movement guides rely on:
1. curl / wget
2. gcc
3. git
4. netstat / ifconfig
5. unzip / tar
This PR strips nearly all of these, except when required.
#### Reduces the blast radius if ZAP is compromised ####
With fewer binaries available:
1. Malware cannot be compiled
2. Exploit frameworks cannot be cloned
3. Attackers cannot scan networks or inspect interfaces
4. Shell escapes become substantially less powerful