### PR TITLE
Refactor Python dependency installation to remove --break-system-packages and move all Python tooling into isolated virtual environments (PEP 668 compliance)

### DIFF
--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -68,23 +68,6 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	mkdir /zap  && \
 	chown zap:zap /zap
 
-# The old RUN command's use of "--break-system-packages" forces pip to overwrite or bypass the distro-managed Python packages under /usr/lib/python3*/site-packages.
-# This defeats the distro’s protection against conflicting versions, 
-#	can break system tools that rely on the OS’s Python libs,
-#	makes patching & CVE management harder (packages no longer tracked by apt),
-#	Violates the Docker/OWASP guidance to avoid modifying system Python and to prefer isolated environments such as the Python best-practice of using virtualenvs.
-#	In general, this Violates the Docker/OWASP guidance to avoid modifying system Python and to prefer isolated environments (virtualenvs).
-#RUN pip3 install \
-#	--break-system-packages \
-#	--no-cache-dir \
-#	--upgrade \
-#	awscli \
-#	pip \
-#	zaproxy \
-#	pyyaml \
-#	requests \
-#	urllib3
-
 # Create dedicated virtualenv for ZAP Python tooling
 RUN python3 -m venv /opt/zap-venv && \
     /opt/zap-venv/bin/pip install --no-cache-dir --upgrade \

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -62,17 +62,6 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	x11vnc && \
 	rm -rf /var/lib/apt/lists/*
 
-# Same issues as in Dockerfile-live 
-#RUN pip3 install \
-#	--break-system-packages \
-#	--no-cache-dir \
-#	--upgrade \
-#	awscli \
-#	pip \
-#	zaproxy \
-#	pyyaml \
-#	urllib3
-
 # Create dedicated virtualenv for ZAP Python tooling
 RUN python3 -m venv /opt/zap-venv && \
     /opt/zap-venv/bin/pip install --no-cache-dir --upgrade \

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -52,9 +52,6 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
     mkdir /zap  && \
     chown zap:zap /zap
 
-# Same issue as Dockerfile-live
-#RUN pip3 install --break-system-packages --no-cache-dir --upgrade awscli pip zaproxy pyyaml requests urllib3 
-
 USER zap
 RUN python3 -m venv /home/zap/zap-venv && \
     /home/zap/zap-venv/bin/pip install --no-cache-dir --upgrade \


### PR DESCRIPTION
## Summary
This PR removes the insecure and non-reproducible pattern of installing Python packages globally using pip3 --break-system-packages and replaces it with:
1. a dedicated Python virtual environment (venv)
2. isolated, reproducible pip installations
3. clean separation of system Python vs. ZAP Python tooling

This significantly improves supply-chain security, prevents package conflicts, and aligns with modern Python and container best practices.
## Fault/Vulnerability
Across multiple Dockerfiles (live, stable, and weekly), ZAP images previously installed Python tooling like this:
```shell
RUN pip3 install \
    --break-system-packages \
    --no-cache-dir \
    --upgrade \
    awscli pip zaproxy pyyaml requests urllib3
```
This bypasses distro protections by Debian Bookworm. Debian Bookworm implements PEP 668 and marks Python as externally managed. Usage of the flag `--break-system-packages` overrides this protection, allowing pip to overwrite system libraries under `/usr/lib/python3*/site-packages` and `/usr/local/lib/python3*/dist-packages`, which inhibits the guarantees of dependency isolation, Python security patches, package managers, and fails to containerize the environment and instead makes it OS-wide. 
## Violations
[Marking Python base environments](https://peps.python.org/pep-0668/#:~:text=A%20distro%20Python%20when%20used%20inside%20a%20virtual%20environment%20(either%20from%20venv%20or%20virtualenv).)
## Changes Made
For `Dockerfile-stable`, `Dockerfile-weekly`, and `Dockerfile-live`, all instances of 
```shell
RUN pip3 install --break-system-packages --no-cache-dir --upgrade \
    awscli pip zaproxy pyyaml urllib3
```
have been replaced with
```shell
RUN python3 -m venv /opt/zap-venv && \
    /opt/zap-venv/bin/pip install --no-cache-dir --upgrade \
        pip \
        zaproxy \
        pyyaml && \
    chown -R zap:zap /opt/zap-venv

ENV PATH=/opt/zap-venv/bin:$PATH
```
## How the Fix Works
This fix avoids conflicts between `apt` and `pip`, eliminates OS-wide Python package sprawl, and is compliant with Python PEP 668 best practices. 
## Security Impact
Significant improvements include stopping pip from overwriting OS-managed packages, preventing dependency confusion and corruption, and reducing CVE footprint of system Python