### PR TITLE
Add statistic for Active Scan alert refs

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/HostProcess.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/HostProcess.java
@@ -924,7 +924,7 @@ public class HostProcess implements Runnable {
 
         PluginStats pluginStats = mapPluginStats.get(alert.getPluginId());
         if (pluginStats != null) {
-            pluginStats.incAlertCount();
+            pluginStats.incAlertCount(alert.getAlertRef());
 
             int maxAlertsPerRule = scannerParam.getMaxAlertsPerRule();
             if (maxAlertsPerRule > 0 && pluginStats.getAlertCount() >= maxAlertsPerRule) {

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/PluginStats.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/PluginStats.java
@@ -35,6 +35,7 @@ public class PluginStats {
     private long totalTime;
     private int messageCount;
     private int alertCount;
+    private String alertKeyBase;
     private int progress;
     private boolean skipped;
     private String skippedReason;
@@ -47,6 +48,7 @@ public class PluginStats {
     PluginStats(Plugin plugin) {
         this.pluginName = plugin.getDisplayName();
         this.pluginId = plugin.getId();
+        this.alertKeyBase = Scanner.ASCAN_RULE_PREFIX + this.pluginId + Scanner.ALERTS_POSTFIX;
     }
 
     /**
@@ -164,9 +166,12 @@ public class PluginStats {
      *
      * <p>Should be called when the plugin notifies that an alert was found.
      */
-    void incAlertCount() {
+    void incAlertCount(String alertRef) {
         alertCount++;
-        Stats.incCounter(Scanner.ASCAN_RULE_PREFIX + this.pluginId + Scanner.ALERTS_POSTFIX);
+        Stats.incCounter(alertKeyBase);
+        if (!alertRef.equals(Integer.toString(this.pluginId))) {
+            Stats.incCounter(alertKeyBase + "." + alertRef);
+        }
     }
 
     /**


### PR DESCRIPTION
When incrementing alert stats per rule (plugin) also increment an individual stat by alert ref (if the alert ref is not the same as the plugin id).

Remove the related pscan stat handling, it will be re-implemented in the pscan add-on.