### PR TITLE
Reduce classloading in Docker HTTP Sender scripts

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2025-12-11
+- Update `Alert_on_HTTP_Response_Code_Errors.js` and `Alert_on_Unexpected_Content_Types.js` to reduce classloading (Issue 9187).
+
 ### 2025-11-21
 - Updated `Alert_on_HTTP_Response_Code_Errors.js` to work with GraalVM JavaScript engine.
 

--- a/docker/scripts/scripts/httpsender/Alert_on_HTTP_Response_Code_Errors.js
+++ b/docker/scripts/scripts/httpsender/Alert_on_HTTP_Response_Code_Errors.js
@@ -2,7 +2,14 @@
 // By default it will raise 'Info' level alerts for Client Errors (4xx) (apart from 404s) and 'Low' Level alerts for Server Errors (5xx)
 // But it can be easily changed.
 
-var Pattern = Java.type("java.util.regex.Pattern")
+const Integer = Java.type("java.lang.Integer")
+const Pattern = Java.type("java.util.regex.Pattern")
+
+const Alert = Java.type("org.parosproxy.paros.core.scanner.Alert")
+const ExtensionAlert = Java.type("org.zaproxy.zap.extension.alert.ExtensionAlert")
+const HistoryReference = Java.type("org.parosproxy.paros.model.HistoryReference")
+
+const extensionAlert = control.getExtensionLoader().getExtension(ExtensionAlert.NAME)
 
 pluginid = 100000	// https://github.com/zaproxy/zaproxy/blob/main/docs/scanners.md
 
@@ -16,7 +23,6 @@ function responseReceived(msg, initiator, helper) {
 		return
 	}
 
-	var extensionAlert = control.getExtensionLoader().getExtension(org.zaproxy.zap.extension.alert.ExtensionAlert.NAME)
 	if (extensionAlert != null) {
 		var code = msg.getResponseHeader().getStatusCode()
 		if (code < 400 || code >= 600) {
@@ -30,10 +36,9 @@ function responseReceived(msg, initiator, helper) {
 				title = "A Server Error response code was returned by the server"
 			}
 			// CONFIDENCE_HIGH = 3 (we can be pretty sure we're right)
-			var alert = new org.parosproxy.paros.core.scanner.Alert(pluginid, risk, 3, title)
+			var alert = new Alert(pluginid, risk, 3, title)
 			var ref = msg.getHistoryRef()
-			if (ref != null && org.parosproxy.paros.model.HistoryReference.getTemporaryTypes().contains(
-						java.lang.Integer.valueOf(ref.getHistoryType()))) {
+			if (ref != null && HistoryReference.getTemporaryTypes().contains(Integer.valueOf(ref.getHistoryType()))) {
 				// Dont use temporary types as they will get deleted
 				ref = null
 			}
@@ -69,7 +74,7 @@ function responseReceived(msg, initiator, helper) {
 						type = 15 // User - fallback
 						break
 				}
-				ref = new org.parosproxy.paros.model.HistoryReference(model.getSession(), type, msg)
+				ref = new HistoryReference(model.getSession(), type, msg)
 			}
 			alert.setMessage(msg)
 			alert.setUri(msg.getRequestHeader().getURI().toString())

--- a/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
+++ b/docker/scripts/scripts/httpsender/Alert_on_Unexpected_Content_Types.js
@@ -2,11 +2,16 @@
 // By default it will raise 'Low' level alerts for content types that are not expected to be returned by APIs.
 // But it can be easily changed.
 
-var Pattern = Java.type("java.util.regex.Pattern")
+const Integer = Java.type("java.lang.Integer")
+const Pattern = Java.type("java.util.regex.Pattern")
+
+const Alert = Java.type("org.parosproxy.paros.core.scanner.Alert")
+const ExtensionAlert = Java.type("org.zaproxy.zap.extension.alert.ExtensionAlert")
+const HistoryReference = Java.type("org.parosproxy.paros.model.HistoryReference")
+
+const extensionAlert = control.getExtensionLoader().getExtension(ExtensionAlert.NAME)
 
 var pluginid = 100001	// https://github.com/zaproxy/zaproxy/blob/main/docs/scanners.md
-
-var extensionAlert = control.getExtensionLoader().getExtension(org.zaproxy.zap.extension.alert.ExtensionAlert.NAME)
 
 var expectedTypes = [
 		"application/octet-stream",
@@ -37,10 +42,9 @@ function responseReceived(msg, initiator, helper) {
 				var risk = 1	// Low
 				var title = "Unexpected Content-Type was returned"
 				// CONFIDENCE_HIGH = 3 (we can be pretty sure we're right)
-				var alert = new org.parosproxy.paros.core.scanner.Alert(pluginid, risk, 3, title)
+				var alert = new Alert(pluginid, risk, 3, title)
 				var ref = msg.getHistoryRef()
-				if (ref != null && org.parosproxy.paros.model.HistoryReference.getTemporaryTypes().contains(
-							java.lang.Integer.valueOf(ref.getHistoryType()))) {
+				if (ref != null && HistoryReference.getTemporaryTypes().contains(Integer.valueOf(ref.getHistoryType()))) {
 					// Dont use temporary types as they will get deleted
 					ref = null
 				}
@@ -76,7 +80,7 @@ function responseReceived(msg, initiator, helper) {
 							type = 15 // User - fallback
 							break
 					}
-					ref = new org.parosproxy.paros.model.HistoryReference(model.getSession(), type, msg)
+					ref = new HistoryReference(model.getSession(), type, msg)
 				}
 				alert.setMessage(msg)
 				alert.setUri(msg.getRequestHeader().getURI().toString())


### PR DESCRIPTION
Load the Java types once during the script initialization instead of in the body of the functions which would cause performance issues.

Part of #9187.