### PR TITLE
Set the tag when updating the main release

### DIFF
--- a/buildSrc/src/main/java/org/zaproxy/zap/tasks/UploadAssetsGitHubRelease.java
+++ b/buildSrc/src/main/java/org/zaproxy/zap/tasks/UploadAssetsGitHubRelease.java
@@ -130,7 +130,7 @@ public abstract class UploadAssetsGitHubRelease extends DefaultTask {
         String releaseBody = release.getBody();
         if (addChecksums.get()) {
             releaseBody = updateChecksumsTable(releaseBody);
-            release.update().body(releaseBody).update();
+            release.update().body(releaseBody).tag(tagName).update();
         }
 
         for (Asset asset : assets) {


### PR DESCRIPTION
Attempt to keep the tag when updating the main release with the macOS binaries.