### PR TITLE
Do not prompt when out of space and headless

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/control/Control.java
+++ b/zap/src/main/java/org/parosproxy/paros/control/Control.java
@@ -411,6 +411,10 @@ public class Control extends AbstractControl implements SessionListener {
         control = new Control(model, null);
     }
 
+    public static void setSingletonForTesting(Control control) {
+        Control.control = control;
+    }
+
     /**
      * Initialises the {@code Control} singleton with the given data.
      *

--- a/zap/src/main/java/org/zaproxy/zap/utils/ErrorUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/ErrorUtils.java
@@ -110,7 +110,7 @@ public final class ErrorUtils {
                     logAndStderr("Shutting down ZAP due to space issues...");
                     Control control = Control.getSingleton();
                     control.setExitStatus(2, errorMsg);
-                    control.exit(false, null);
+                    control.exit(true, null);
                 }
             }
 

--- a/zap/src/test/java/org/zaproxy/zap/utils/ErrorUtilsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/ErrorUtilsUnitTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
 
 public class ErrorUtilsUnitTest {
 
@@ -66,6 +67,20 @@ public class ErrorUtilsUnitTest {
         // When / Then
         assertThat(ErrorUtils.handleDiskSpaceException(e), is(equalTo(true)));
         assertThat(ErrorUtils.getOutOfDiskSpaceHandler().isOutOfSpace(), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldExitWhenExitOnOutOfSpaceEnabled() {
+        // Given
+        Control control = mock();
+        Control.setSingletonForTesting(control);
+        Exception e = new Exception("Test", new Exception("Data File size limit is reached"));
+        ErrorUtils.getOutOfDiskSpaceHandler().setExitOnOutOfSpace(true);
+        // When
+        ErrorUtils.handleDiskSpaceException(e);
+        // Then
+        verify(control).setExitStatus(2, null);
+        verify(control).exit(true, null);
     }
 
     @Test


### PR DESCRIPTION
Disable the prompt since the GUI is not enabled.

Part of #9212.