### PR TITLE
For multipart form-data use the non-normalized boundary when extracting

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantMultipartFormParameters.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/VariantMultipartFormParameters.java
@@ -79,7 +79,7 @@ public class VariantMultipartFormParameters implements Variant {
         }
 
         try {
-            parseImpl(msg, contentType);
+            parseImpl(msg, msg.getRequestHeader().getHeader(HttpHeader.CONTENT_TYPE));
         } catch (Exception e) {
             LOGGER.error("An error occurred while parsing multipart content:", e);
         }


### PR DESCRIPTION
- Update logic in the variant
- Add test with boundary that has mixed capitalization

Fixes zaproxy/zaproxy#9208

<details>
<summary>Tested with the Path Traversal scan rule and this quick little Ruby server:</summary>

```ruby
require 'sinatra/base'

class App < Sinatra::Base

  # Simple form for manual testing
  get '/' do
    <<-HTML
    <form action="/submit" method="post" enctype="multipart/form-data">
      <label>Value 1: <input type="text" name="value1"></label><br>
      <label>Value 2: <input type="text" name="value2"></label><br>
      <button type="submit">Send</button>
    </form>
    HTML
  end

  # Endpoint that accepts multipart/form-data and echoes back values
  post '/submit' do
    v1 = params['value1']
    v2 = params['value2']
    "Received:\nvalue1 = #{v1}\nvalue2 = #{v2}\n"
  end

  # Random text generator
  def random_lorem
    [
      "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
      "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
      "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.",
      "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore.",
      "Excepteur sint occaecat cupidatat non proident."
    ].sample
  end

  # Catch ALL unmatched routes (no more 404s)
  not_found do
    status 200
    content_type 'text/plain'
    random_lorem
  end

  run! if app_file == $0
end
```

</details>