### PR TITLE
Fix Sites tree text visibility after Look & Feel change

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/view/SiteMapTreeCellRenderer.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/SiteMapTreeCellRenderer.java
@@ -27,6 +27,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTree;
+import javax.swing.UIManager;
 import javax.swing.tree.DefaultTreeCellRenderer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -110,6 +111,16 @@ public class SiteMapTreeCellRenderer extends DefaultTreeCellRenderer {
             boolean hasFocus) {
 
         component.removeAll();
+        super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus);
+
+        // Explicitly set foreground and background colors from UIManager to ensure
+        // readability when Look & Feel changes. This ensures colors are always
+        // read from the current LAF rather than relying on cached values.
+        setForeground(
+                UIManager.getColor(sel ? "Tree.selectionForeground" : "Tree.textForeground"));
+        setBackground(
+                UIManager.getColor(sel ? "Tree.selectionBackground" : "Tree.textBackground"));
+
         SiteNode node = null;
         if (value instanceof SiteNode) {
             node = (SiteNode) value;
@@ -123,7 +134,6 @@ public class SiteMapTreeCellRenderer extends DefaultTreeCellRenderer {
             }
 
             setPreferredSize(null); // clears the preferred size, making the node visible
-            super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus);
 
             // folder / file icons with scope 'target' if relevant
             if (node.isRoot()) {


### PR DESCRIPTION
### Summary
Fixes an issue where text in the Sites tree becomes unreadable after switching
the Look & Feel (e.g. Nimbus, Flat Dark).

### Issue
#9107

### Root Cause
The Sites tree cell renderer relied on foreground/background colors cached by
the previous Look & Feel. After dynamically switching the Look & Feel, these
colors were no longer updated, resulting in invisible or low-contrast text.

### Changes
- Updated `SiteMapTreeCellRenderer` to explicitly fetch foreground and background
  colors from `UIManager` during each render.
- Correctly handle both selected and non-selected tree states.
- Removed duplicate renderer initialization to follow Swing best practices.

### Testing
- Built and ran ZAP from source.
- Switched Look & Feel between Nimbus and Flat Dark.
- Verified that text in the Sites tree remains visible and readable in all cases.

### Notes
- Uses standard Swing `UIManager` keys (no hardcoded colors).
- Minimal and localized change with no functional side effects.
