### PR TITLE
Do not persist temp ascan msgs when headless

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/ScannerParam.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/ScannerParam.java
@@ -348,7 +348,7 @@ public class ScannerParam extends AbstractParam {
         persistTemporaryMessages =
                 getBoolean(
                         PERSIST_TEMPORARY_MESSAGES,
-                        ZAP.getProcessType() != ZAP.ProcessType.cmdline);
+                        ZAP.getProcessType() == ZAP.ProcessType.desktop);
     }
 
     private void migrateOldOptions() {


### PR DESCRIPTION
Change from command line to daemon as well, since it benefits more users with reduced disk/DB space requirements.