### PR TITLE
Fix parsing of root JSON number

### DIFF
--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantJSONQueryUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/VariantJSONQueryUnitTest.java
@@ -419,6 +419,31 @@ class VariantJSONQueryUnitTest {
         assertThat(message.getRequestBody().toString(), is("\"injection\""));
     }
 
+    @Test
+    void shouldExtractPrimitiveNumbers() throws HttpMalformedHeaderException {
+        // Given
+        VariantJSONQuery variantJSONQuery = new VariantJSONQuery();
+        variantJSONQuery.setMessage(getMessageWithBody("12345"));
+        // When
+        List<NameValuePair> parameters = variantJSONQuery.getParamList();
+        // Then
+        assertThat(parameters.size(), is(equalTo(1)));
+        assertThat(parameters.get(0).getValue(), is("12345"));
+    }
+
+    @Test
+    void shouldReplacePrimitiveNumbers() throws HttpMalformedHeaderException {
+        // Given
+        VariantJSONQuery variantJSONQuery = new VariantJSONQuery();
+        HttpMessage message = getMessageWithBody("12345");
+        variantJSONQuery.setMessage(message);
+        // When
+        List<NameValuePair> parameters = variantJSONQuery.getParamList();
+        variantJSONQuery.setParameter(message, parameters.get(0), "", "injection");
+        // Then
+        assertThat(message.getRequestBody().toString(), is("\"injection\""));
+    }
+
     private static HttpMessage getMessageWithBody(String body) throws HttpMalformedHeaderException {
         return new HttpMessage(
                 new HttpRequestHeader(


### PR DESCRIPTION
Finish the parsing if the root element is a number instead of throwing an exception.

---
e.g.
```
WARN  VariantJSONQuery - Failed to parse the request body for url https://www.example.org : Reached EOF while reading number
java.lang.IllegalArgumentException: Reached EOF while reading number
	at org.parosproxy.paros.core.scanner.JsonParamParser.parseValue(JsonParamParser.java:237)
	at org.parosproxy.paros.core.scanner.JsonParamParser.parseObject(JsonParamParser.java:185)
	at org.parosproxy.paros.core.scanner.JsonParamParser.getParameters(JsonParamParser.java:87)
	at org.parosproxy.paros.core.scanner.VariantJSONQuery.parseContent(VariantJSONQuery.java:85)
	at org.parosproxy.paros.core.scanner.VariantAbstractRPCQuery.setRequestContent(VariantAbstractRPCQuery.java:152)
	at org.parosproxy.paros.core.scanner.VariantAbstractRPCQuery.setMessage(VariantAbstractRPCQuery.java:60)
	at org.parosproxy.paros.core.scanner.AbstractAppParamPlugin.scan(AbstractAppParamPlugin.java:95)
	at org.parosproxy.paros.core.scanner.AbstractPlugin.run(AbstractPlugin.java:402)
	at java.base/java.lang.Thread.run(Unknown Source)
```