### PR TITLE
Prevent engine close in Check For ZAP Errors

### DIFF
--- a/.github/workflows/conf/af-check-errors.yml
+++ b/.github/workflows/conf/af-check-errors.yml
@@ -33,6 +33,8 @@ jobs:
           }
         }
         System.setErr(ps)
+        // Eval to errors (a global var) to prevent the engine from being closed.
+        errors
   - type: script
     parameters:
       action: "run"


### PR DESCRIPTION
Purposefully leak the script to allow the internal function to be used throughout the plan.

Related to #9230, the engines are now closed when the script or its results are no longer in use to prevent leaks.