### PR TITLE
Fix exceptions with auto-detect auth

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/users/DialogAddUser.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/users/DialogAddUser.java
@@ -130,6 +130,9 @@ public class DialogAddUser extends AbstractFormDialog {
 
     @Override
     protected boolean validateFields() {
+        if (credentialsPanel == null) {
+            return true;
+        }
         return credentialsPanel.validateFields();
     }
 
@@ -143,9 +146,10 @@ public class DialogAddUser extends AbstractFormDialog {
                             this.user.getId());
         else this.user = new User(workingContext.getId(), getNameTextField().getText());
         this.user.setEnabled(getEnabledCheckBox().isSelected());
-        // Make sure the credentials panel saves its changes first
-        credentialsPanel.saveCredentials();
-        this.user.setAuthenticationCredentials(credentialsPanel.getCredentials());
+        if (credentialsPanel != null) {
+            credentialsPanel.saveCredentials();
+            this.user.setAuthenticationCredentials(credentialsPanel.getCredentials());
+        }
     }
 
     @Override


### PR DESCRIPTION
Check that the authentication method has credentials to prevent NPEs when managing users.

---
e.g.
```
[AWT-EventQueue-0] ERROR org.zaproxy.zap.ZAP.UncaughtExceptionLogger - Exception in thread "AWT-EventQueue-0"
java.lang.NullPointerException: Cannot invoke "org.zaproxy.zap.authentication.AbstractCredentialsOptionsPanel.validateFields()" because "this.credentialsPanel" is null
	at org.zaproxy.zap.extension.users.DialogAddUser.validateFields(DialogAddUser.java:133)
	at org.zaproxy.zap.view.AbstractFormDialog$4.actionPerformed(AbstractFormDialog.java:173)
```