### PR TITLE
Always call System.exit in cmd-line mode to prevent hang

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/ZAP.java
+++ b/zap/src/main/java/org/zaproxy/zap/ZAP.java
@@ -98,9 +98,7 @@ public class ZAP {
         ZapBootstrap bootstrap = createZapBootstrap(cmdLine);
         try {
             int rc = bootstrap.start();
-            if (rc != 0) {
-                System.exit(rc);
-            }
+            System.exit(rc);
 
         } catch (final Exception e) {
             LOGGER.fatal(e.getMessage(), e);


### PR DESCRIPTION
## Summary

In command-line mode (e.g., automation framework plans), ZAP.main() only called System.exit() for non-zero return codes. On success (
c == 0), main() simply returned, relying on the JVM to exit naturally when all non-daemon threads terminate.

This caused ZAP to hang indefinitely when non-daemon threads survived the shutdown sequence.

## Root Cause

Multiple non-daemon thread pools remain alive after Control.shutdown() returns:

| Thread Pool | Factory | Daemon? |
|---|---|---|
| ZAP-IO (Netty NioEventLoopGroup) | DefaultThreadFactory('ZAP-IO') | No |
| ZAP-IO-EventExecutor | DefaultThreadFactory('ZAP-IO-EventExecutor') | No |
| ZAP-IO-Server (cached pool) | DefaultThreadFactory('ZAP-IO-Server') | No |
| Crawljax worker threads | CoreModule.CrawlerThreadFactory | Explicitly No |

A race condition between the AjaxSpider cleanup (which runs in the \ZAP-AjaxSpiderAuto\ thread's \inally\ block _after_ setting \
unning=false\) and \ExtensionNetwork.destroy()\ (which shuts down the shared \NioEventLoopGroup\) further exacerbates the issue, producing the repeating \BaseServer - An error occurred while initializing the channel\ log errors reported in the issue.

## Fix

Call \System.exit(rc)\ unconditionally in \ZAP.main()\, matching the existing behavior of both GUI mode (\Control.exit()\  \System.exit(exitStatus)\) and daemon mode (\CoreAPI\  \System.exit()\).

This is a minimal, safe 3-line change (remove the \if (rc != 0)\ guard).
