### PR TITLE
Docker: Update live image to debian:trixie and JDK 21

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2026-02-25
+- Updated live image to debian:trixie and JDK 21
+
 ### 2026-02-09
 - Added support for the delay job in the baseline
 

--- a/docker/Dockerfile-live
+++ b/docker/Dockerfile-live
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1
 # This dockerfile builds a 'live' zap docker image using the latest files in the repos
-FROM --platform=linux/amd64 debian:bookworm-slim AS builder
+FROM --platform=linux/amd64 debian:trixie-slim AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
-	openjdk-17-jdk \
+	openjdk-21-jdk \
 	wget \
 	curl \
 	unzip \
@@ -34,7 +34,7 @@ RUN --mount=type=secret,id=webswing_url \
 	# Remove Webswing bundled examples
 	rm -Rf webswing/apps/
 
-FROM debian:bookworm-slim AS final
+FROM debian:trixie-slim AS final
 LABEL maintainer="psiinon@gmail.com"
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -45,7 +45,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	automake \
 	autoconf \
 	gcc g++ \
-	openjdk-17-jdk \
+	openjdk-21-jdk \
 	wget \
 	curl \
 	xmlstarlet \
@@ -67,12 +67,11 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	mkdir /zap  && \
 	chown zap:zap /zap
 
-RUN pip3 install \
+RUN pip install \
 	--break-system-packages \
 	--no-cache-dir \
 	--upgrade \
 	awscli \
-	pip \
 	zaproxy \
 	pyyaml \
 	requests \
@@ -84,7 +83,7 @@ USER zap
 RUN mkdir /home/zap/.vnc
 
 ARG TARGETARCH
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-$TARGETARCH
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-$TARGETARCH
 ENV PATH=$JAVA_HOME/bin:/zap/:$PATH
 
 ENV ZAP_PATH=/zap/zap.sh


### PR DESCRIPTION
Part of https://github.com/zaproxy/zaproxy/issues/9258