### PR TITLE
Docker: Update weekly image to debian:trixie and JDK 21

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2026-02-26
+- Updated weekly image to debian:trixie and JDK 21
+
 ### 2026-02-25
 - Updated live image to debian:trixie and JDK 21
 

--- a/docker/Dockerfile-weekly
+++ b/docker/Dockerfile-weekly
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # This dockerfile builds the zap weekly release
-FROM --platform=linux/amd64 debian:bookworm-slim AS builder
+FROM --platform=linux/amd64 debian:trixie-slim AS builder
 RUN apt-get update && apt-get install -q -y --fix-missing \
 	wget \
 	curl \
@@ -21,7 +21,7 @@ RUN --mount=type=secret,id=webswing_url \
 	# Remove Webswing bundled examples
 	rm -Rf webswing/apps/
 
-FROM debian:bookworm-slim AS final
+FROM debian:trixie-slim AS final
 LABEL maintainer="psiinon@gmail.com"
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
 	automake \
 	autoconf \
 	gcc g++ \
-	openjdk-17-jdk \
+	openjdk-21-jdk \
 	wget \
 	curl \
 	xmlstarlet \
@@ -51,7 +51,7 @@ RUN apt-get update && apt-get install -q -y --fix-missing \
     mkdir /zap  && \
     chown zap:zap /zap
 
-RUN pip3 install --break-system-packages --no-cache-dir --upgrade awscli pip zaproxy pyyaml requests urllib3 
+RUN pip install --break-system-packages --no-cache-dir --upgrade awscli zaproxy pyyaml requests urllib3 
 
 WORKDIR /zap
 
@@ -67,7 +67,7 @@ RUN curl -s https://raw.githubusercontent.com/zaproxy/zap-admin/master/ZapVersio
 	rm -R ZAP*
 
 ARG TARGETARCH
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-$TARGETARCH
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-$TARGETARCH
 ENV PATH=$JAVA_HOME/bin:/zap/:$PATH
 ENV ZAP_PATH=/zap/zap.sh
 


### PR DESCRIPTION
Part of https://github.com/zaproxy/zaproxy/issues/9258