### PR TITLE
Unit test added for session serialization/deserialization

### DIFF
--- a/zap/src/test/java/org/parosproxy/paros/model/SessionPersistenceTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/model/SessionPersistenceTest.java
@@ -1,0 +1,43 @@
+package org.parosproxy.paros.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class SessionPersistenceTest{
+  
+  @Test
+  void shouldPersistCoreFieldsAcrossSaveAndOpen() throws Exception{
+
+    //create tmp directory
+    Path tmpDir = Files.createTempDirectory("zap-test");
+    File sessionFile = tempDir.resolve("unit-test.session").toFile();
+
+    //create original session
+    Session original = new Session();
+    original.setSessionName("unit-test-session");
+    original.setSessionDesc("unit-test-decription");
+
+    //save session
+    original.save(sessionFile.getAbsolutePath());
+
+    //opens session in new instance 
+    Session restored = new Session();
+    restored.open(sessionFile.getAbsolutePath());
+
+    //Assertions
+    assertNotNull(restored);
+    assertEquals(original.getSessionName(), restored.getSessionName());
+    assertEquals(original.getSessionDesc(), restored.getSessionDesc());
+    assertEquals(original.getSessionID(), restored.getSessionId());
+
+    //delete file 
+    sessionFile.delete();
+    tmpDir.toFile().delete();
+  }
+}


### PR DESCRIPTION
Closes p1/630p1

Summary:
-Added a unit test for save/open persistence 
-Verifies core fields like sessions Name, Description, and Id 
-Uses a temporary file to avoid altercations 

How to run:
./gradlew test --tests SessionPersistenceTest

Evidence:
-Tests fails if session fields are lost
-Protects against regressions in sessions