### PR TITLE
Reduce EDT accesses in headless

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -680,22 +680,7 @@ public class ExtensionAlert extends ExtensionAdaptor
 
     @Override
     public void sessionChanged(final Session session) {
-        if (EventQueue.isDispatchThread()) {
-            sessionChangedEventHandler(session);
-
-        } else {
-            try {
-                EventQueue.invokeAndWait(
-                        new Runnable() {
-                            @Override
-                            public void run() {
-                                sessionChangedEventHandler(session);
-                            }
-                        });
-            } catch (Exception e) {
-                LOGGER.error(e.getMessage(), e);
-            }
-        }
+        ThreadUtils.invokeAndWaitHandled(() -> sessionChangedEventHandler(session));
     }
 
     private void sessionChangedEventHandler(Session session) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -20,10 +20,8 @@
 package org.zaproxy.zap.extension.ascan;
 
 import java.awt.Dimension;
-import java.awt.EventQueue;
 import java.awt.event.KeyEvent;
 import java.io.File;
-import java.lang.reflect.InvocationTargetException;
 import java.security.InvalidParameterException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -60,6 +58,7 @@ import org.zaproxy.zap.model.StructuralSiteNode;
 import org.zaproxy.zap.model.Target;
 import org.zaproxy.zap.users.User;
 import org.zaproxy.zap.utils.Stats;
+import org.zaproxy.zap.utils.ThreadUtils;
 import org.zaproxy.zap.view.ZapMenuItem;
 
 public class ExtensionActiveScan extends ExtensionAdaptor
@@ -423,23 +422,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor
 
     @Override
     public void sessionChanged(final Session session) {
-        if (EventQueue.isDispatchThread()) {
-            sessionChangedEventHandler(session);
-
-        } else {
-            try {
-                EventQueue.invokeAndWait(
-                        new Runnable() {
-                            @Override
-                            public void run() {
-                                sessionChangedEventHandler(session);
-                            }
-                        });
-
-            } catch (InterruptedException | InvocationTargetException e) {
-                LOGGER.error(e.getMessage(), e);
-            }
-        }
+        ThreadUtils.invokeAndWaitHandled(() -> sessionChangedEventHandler(session));
     }
 
     private void sessionChangedEventHandler(Session session) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/brk/ExtensionBreak.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/brk/ExtensionBreak.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.brk;
 
 import java.awt.Component;
-import java.awt.EventQueue;
 import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -55,6 +54,7 @@ import org.zaproxy.zap.extension.brk.impl.http.HttpBreakpointsUiManagerInterface
 import org.zaproxy.zap.extension.brk.impl.http.ProxyListenerBreak;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
 import org.zaproxy.zap.extension.httppanel.Message;
+import org.zaproxy.zap.utils.ThreadUtils;
 import org.zaproxy.zap.view.ZapMenuItem;
 
 public class ExtensionBreak extends ExtensionAdaptor
@@ -548,21 +548,11 @@ public class ExtensionBreak extends ExtensionAdaptor
 
     @Override
     public void sessionAboutToChange(final Session session) {
-        if (EventQueue.isDispatchThread()) {
-            sessionAboutToChange();
-        } else {
-            try {
-                EventQueue.invokeAndWait(
-                        new Runnable() {
-                            @Override
-                            public void run() {
-                                sessionAboutToChange();
-                            }
-                        });
-            } catch (Exception e) {
-                LOGGER.error(e.getMessage(), e);
-            }
+        if (!hasView()) {
+            return;
         }
+
+        ThreadUtils.invokeAndWaitHandled(() -> breakpointManagementInterface.reset());
     }
 
     @Override
@@ -571,13 +561,6 @@ public class ExtensionBreak extends ExtensionAdaptor
             return;
         }
         breakpointManagementInterface.init();
-    }
-
-    private void sessionAboutToChange() {
-        if (getView() == null) {
-            return;
-        }
-        breakpointManagementInterface.reset();
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/params/ExtensionParams.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/params/ExtensionParams.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.params;
 
-import java.awt.EventQueue;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -197,22 +196,7 @@ public class ExtensionParams extends ExtensionAdaptor
 
     @Override
     public void sessionChanged(final Session session) {
-        if (EventQueue.isDispatchThread()) {
-            sessionChangedEventHandler(session);
-
-        } else {
-            try {
-                EventQueue.invokeAndWait(
-                        new Runnable() {
-                            @Override
-                            public void run() {
-                                sessionChangedEventHandler(session);
-                            }
-                        });
-            } catch (Exception e) {
-                LOGGER.error(e.getMessage(), e);
-            }
-        }
+        ThreadUtils.invokeAndWaitHandled(() -> sessionChangedEventHandler(session));
     }
 
     /**


### PR DESCRIPTION
Use the utility class to execute in the EDT when needed, which prevents the EDT from being spawn when in headless mode.