### PR TITLE
Allow Site Tree refresh in any mode

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/siterefresh/PopupMenuSitesRefresh.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/siterefresh/PopupMenuSitesRefresh.java
@@ -63,4 +63,9 @@ public class PopupMenuSitesRefresh extends ExtensionPopupMenuItem {
     public int getWeight() {
         return MenuWeights.MENU_SITE_REFRESH_WEIGHT;
     }
+
+    @Override
+    public boolean isSafe() {
+        return true;
+    }
 }


### PR DESCRIPTION
Mark the Refresh Sites Tree popup menu safe.

Found this accidentally the other day, when working on the GUI/Theme issue.