### PR TITLE
Add configurable maximum authentication retry limit

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/authentication/AuthenticationMethod.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/AuthenticationMethod.java
@@ -77,6 +77,8 @@ public abstract class AuthenticationMethod {
 
     public static final int DEFAULT_POLL_FREQUENCY = 60;
 
+    public static final int DEFAULT_MAX_AUTH_RETRIES = 0;
+
     public static enum AuthCheckingStrategy {
         EACH_RESP,
         EACH_REQ,
@@ -102,6 +104,8 @@ public abstract class AuthenticationMethod {
 
     private AuthPollFrequencyUnits pollFrequencyUnits = AuthPollFrequencyUnits.REQUESTS;
 
+    private int maxAuthRetries = DEFAULT_MAX_AUTH_RETRIES;
+
     /**
      * Checks if the authentication method is fully configured.
      *
@@ -123,6 +127,7 @@ public abstract class AuthenticationMethod {
         method.pollHeaders = this.pollHeaders;
         method.pollFrequency = this.pollFrequency;
         method.pollFrequencyUnits = this.pollFrequencyUnits;
+        method.maxAuthRetries = this.maxAuthRetries;
         method.loggedInIndicatorPattern = this.loggedInIndicatorPattern;
         method.loggedOutIndicatorPattern = this.loggedOutIndicatorPattern;
         return method;
@@ -547,6 +552,14 @@ public abstract class AuthenticationMethod {
         this.pollFrequencyUnits = pollFrequencyUnits;
     }
 
+    public int getMaxAuthRetries() {
+        return maxAuthRetries;
+    }
+
+    public void setMaxAuthRetries(int maxAuthRetries) {
+        this.maxAuthRetries = maxAuthRetries;
+    }
+
     /**
      * Checks if another method is of the same type.
      *
@@ -603,6 +616,9 @@ public abstract class AuthenticationMethod {
             return false;
         }
         if (!this.pollFrequencyUnits.equals(other.pollFrequencyUnits)) {
+            return false;
+        }
+        if (this.maxAuthRetries != other.maxAuthRetries) {
             return false;
         }
         return true;

--- a/zap/src/main/java/org/zaproxy/zap/users/AuthenticationState.java
+++ b/zap/src/main/java/org/zaproxy/zap/users/AuthenticationState.java
@@ -29,6 +29,8 @@ public class AuthenticationState {
 
     private int requestsSincePoll = 0;
 
+    private int failedAuthAttempts = 0;
+
     private int lastAuthRequestHistoryId;
 
     public String lastAuthFailure;
@@ -79,6 +81,18 @@ public class AuthenticationState {
 
     public void incRequestsSincePoll() {
         this.requestsSincePoll += 1;
+    }
+
+    public int getFailedAuthAttempts() {
+        return failedAuthAttempts;
+    }
+
+    public void setFailedAuthAttempts(int failedAuthAttempts) {
+        this.failedAuthAttempts = failedAuthAttempts;
+    }
+
+    public void incFailedAuthAttempts() {
+        this.failedAuthAttempts++;
     }
 
     public int getLastAuthRequestHistoryId() {

--- a/zap/src/main/java/org/zaproxy/zap/users/User.java
+++ b/zap/src/main/java/org/zaproxy/zap/users/User.java
@@ -167,11 +167,28 @@ public class User extends Enableable {
         // Make sure there are no simultaneous authentications for the same user
         synchronized (this) {
             if (this.requiresAuthentication()) {
-                this.authenticate();
-                if (this.requiresAuthentication()) {
-                    LOGGER.info("Authentication failed for user: {}", name);
+                int maxRetries = getContext().getAuthenticationMethod().getMaxAuthRetries();
+                // 0 means unlimited retries (default, backward compatible)
+                if (maxRetries > 0
+                        && this.authenticationState.getFailedAuthAttempts() >= maxRetries) {
+                    LOGGER.debug(
+                            "Skipping authentication for user: {} (max retries {} reached)",
+                            name,
+                            maxRetries);
                     return;
                 }
+                this.authenticate();
+                if (this.requiresAuthentication()) {
+                    this.authenticationState.incFailedAuthAttempts();
+                    LOGGER.info(
+                            "Authentication failed for user: {} (attempt {}/{})",
+                            name,
+                            this.authenticationState.getFailedAuthAttempts(),
+                            maxRetries > 0 ? String.valueOf(maxRetries) : "unlimited");
+                    return;
+                }
+                // Reset the counter on successful authentication
+                this.authenticationState.setFailedAuthAttempts(0);
             }
         }
         processMessageToMatchAuthenticatedSession(message);

--- a/zap/src/test/java/org/zaproxy/zap/users/UserUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/users/UserUnitTest.java
@@ -202,6 +202,7 @@ class UserUnitTest {
     void shouldAuthenticateWhenRequired() {
         // Given
         User user = spy(new User(CONTEXT_ID, USER_NAME));
+        doReturn(mockedContext).when(user).getContext();
         // When
         doReturn(true).when(user).requiresAuthentication();
         doNothing().when(user).authenticate();
@@ -231,5 +232,69 @@ class UserUnitTest {
         user.authenticate();
         // Then
         assertFalse(user.requiresAuthentication());
+    }
+
+    @Test
+    void processMessageToMatchUser_MaxRetriesZero_RetriesIndefinitely() {
+        // Given - maxAuthRetries=0 means unlimited (backward compat)
+        User user = spy(new User(CONTEXT_ID, USER_NAME));
+        doReturn(mockedContext).when(user).getContext();
+        // Auth always fails: requiresAuthentication always returns true, authenticate does nothing
+        doReturn(true).when(user).requiresAuthentication();
+        doNothing().when(user).authenticate();
+        when(mockedAuthenticationMethod.getMaxAuthRetries()).thenReturn(0);
+        // When - call multiple times, should never stop trying
+        for (int i = 0; i < 10; i++) {
+            user.processMessageToMatchUser(Mockito.mock(HttpMessage.class));
+        }
+        // Then - authenticate was called every time (not blocked)
+        verify(user, Mockito.times(10)).authenticate();
+    }
+
+    @Test
+    void processMessageToMatchUser_MaxRetriesSet_StopsAfterLimit() {
+        // Given - maxAuthRetries=3
+        User user = spy(new User(CONTEXT_ID, USER_NAME));
+        doReturn(mockedContext).when(user).getContext();
+        doReturn(true).when(user).requiresAuthentication();
+        doNothing().when(user).authenticate();
+        when(mockedAuthenticationMethod.getMaxAuthRetries()).thenReturn(3);
+        // When - call 5 times
+        for (int i = 0; i < 5; i++) {
+            user.processMessageToMatchUser(Mockito.mock(HttpMessage.class));
+        }
+        // Then - authenticate was called only 3 times (stopped after limit)
+        verify(user, Mockito.times(3)).authenticate();
+    }
+
+    @Test
+    void processMessageToMatchUser_AuthSucceedsAfterFailures_ResetsCounter() {
+        // Given - maxAuthRetries=3
+        User user = spy(new User(CONTEXT_ID, USER_NAME));
+        doReturn(mockedContext).when(user).getContext();
+        doNothing().when(user).authenticate();
+        when(mockedAuthenticationMethod.getMaxAuthRetries()).thenReturn(3);
+        // First 2 calls fail, 3rd succeeds, then next 2 fail
+        doReturn(true) // call 1: requires auth
+                .doReturn(true) // call 1: still requires after authenticate (fail)
+                .doReturn(true) // call 2: requires auth
+                .doReturn(true) // call 2: still requires after authenticate (fail)
+                .doReturn(true) // call 3: requires auth
+                .doReturn(false) // call 3: no longer requires after authenticate (success!)
+                .doReturn(true) // call 4: requires auth (re-auth needed)
+                .doReturn(true) // call 4: still requires after authenticate (fail)
+                .doReturn(true) // call 5: requires auth
+                .doReturn(true) // call 5: still requires after authenticate (fail)
+                .when(user)
+                .requiresAuthentication();
+        // When
+        for (int i = 0; i < 5; i++) {
+            user.processMessageToMatchUser(Mockito.mock(HttpMessage.class));
+        }
+        // Then - authenticate called 5 times total (2 fail + 1 success + 2 fail)
+        // Counter reset after success, so calls 4 and 5 still go through
+        verify(user, Mockito.times(5)).authenticate();
+        // Final failed count is 2 (reset after success, then 2 more failures)
+        assertEquals(2, user.getAuthenticationState().getFailedAuthAttempts());
     }
 }


### PR DESCRIPTION
# Add configurable maximum authentication retry limit

## Summary

When browser-based authentication fails (e.g. wrong credentials, ambiguous login form, page load timeout), `User.processMessageToMatchUser()` retries authentication indefinitely on every HTTP request. There is no maximum retry count and the spider's `maxDuration` does not cover authentication time, so scans can run for extended periods producing zero useful results.

This PR adds a `maxAuthRetries` setting to `AuthenticationMethod` that limits consecutive authentication retry attempts. The default is 0 (unlimited), preserving current behaviour for all existing users.

## How it works

- `maxAuthRetries = 0` (default): unlimited retries, exactly today's behaviour
- `maxAuthRetries > 0`: after N consecutive failures, authentication is skipped and the spider continues unauthenticated
- The counter resets to 0 on successful authentication, so transient failures don't permanently lock out a user

## Configuration

This setting is intended to be configured through the Automation Framework YAML (wired in a companion PR to `zap-extensions`). Users will add `maxAuthRetries` inside the `parameters` block of their authentication configuration:

```yaml
contexts:
  - name: "myContext"
    urls:
      - "https://example.com"
    authentication:
      method: "browser"
      parameters:
        loginPageUrl: "https://example.com"
        browserId: "chrome-headless"
        loginPageWait: 15
        maxAuthRetries: 5
      verification:
        method: "autodetect"
```

The setting applies to all authentication methods (browser, form, json, script, client, http). When not specified, the default is 0 (unlimited) — no change in behaviour.

Programmatic access is also available via the new getter/setter on `AuthenticationMethod`:

```java
context.getAuthenticationMethod().setMaxAuthRetries(5);
```

## Changes

| File | Change |
|------|--------|
| `AuthenticationState.java` | Add `failedAuthAttempts` counter with getter, setter, and increment (follows `requestsSincePoll` pattern) |
| `AuthenticationMethod.java` | Add `maxAuthRetries` field (default 0), getter, setter. Update `clone()` and `equals()` (follows `pollFrequency` pattern) |
| `User.java` | Check `maxAuthRetries` limit before calling `authenticate()` in `processMessageToMatchUser()`. Increment counter on failure, reset on success |
| `UserUnitTest.java` | 3 new tests: backward compat (0 = unlimited), limit enforcement, counter reset after success. Fix existing `shouldAuthenticateWhenRequired` test to mock context |

## Backward compatibility

No impact on existing users. The default value of 0 means unlimited retries, which is identical to current behaviour. The setting must be explicitly configured to take effect.

## Companion PR

A follow-up PR to [zap-extensions](https://github.com/zaproxy/zap-extensions) will wire this into the Automation Framework YAML as a `maxAuthRetries` parameter in `AuthenticationData.java`. That PR depends on this one being merged first.

## Testing

- All existing tests pass unchanged (the `shouldAuthenticateWhenRequired` fix is required because the new code path calls `getContext()` which the test did not previously mock)
- 3 new test cases cover:
  - `processMessageToMatchUser_MaxRetriesZero_RetriesIndefinitely` — backward compat
  - `processMessageToMatchUser_MaxRetriesSet_StopsAfterLimit` — limit enforcement
  - `processMessageToMatchUser_AuthSucceedsAfterFailures_ResetsCounter` — counter reset
