### PR TITLE
Skip unwrap of `alertCountsByRisk`

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/api/PythonAPIGenerator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/api/PythonAPIGenerator.java
@@ -68,6 +68,8 @@ public class PythonAPIGenerator extends AbstractAPIGenerator {
 
     private static final Map<String, Set<String>> NON_WRAPPED_API_ELEMENTS =
             Map.of(
+                    "alert",
+                    Set.of("alertCountsByRisk"),
                     "automation",
                     Set.of("planProgress"),
                     "stats",


### PR DESCRIPTION
Exclude `alert/alertCountsByRisk` from the unwrap as it's not wrapped in an object.

Part of #9314.