### PR TITLE
Sensitive Masking for data in Zap for custom bug bounty programs

### DIFF
--- a/SensitiveDataMasking(README).md
+++ b/SensitiveDataMasking(README).md
@@ -2,6 +2,7 @@
 
 This document summarizes the code changes made in this branch/PR compared to the ZAP upstream baseline you started from.
 
+Masking is disabled by default and needs to be enabled in Tools -> Options -> Sensitive data (tab in left of window pane of options menu) 
 ## 1. Added new parameter class for storing masking settings
 
 **File**: `zaproxy/zap/src/main/java/org/zaproxy/zap/extension/sensitive/OptionsParamSensitiveData.java`  

--- a/SensitiveDataMasking(README).md
+++ b/SensitiveDataMasking(README).md
@@ -1,0 +1,100 @@
+# Sensitive Data Masking – Summary of Code Changes
+
+This document summarizes the code changes made in this branch/PR compared to the ZAP upstream baseline you started from.
+
+## 1. Added new parameter class for storing masking settings
+
+**File**: `zaproxy/zap/src/main/java/org/zaproxy/zap/extension/sensitive/OptionsParamSensitiveData.java`  
+**Intention**: Introduce configurable options for masking sensitive HTTP data (enable/disable, mask value, and sensitive key patterns).  
+**Changes**:
+- Added a new `AbstractParam` implementation with configuration keys:
+  - `sensitiveData.masking.enabled`
+  - `sensitiveData.mask.value`
+  - `sensitiveData.keys`
+- Added defaults for common sensitive keys (for example `password`, `token`, `authorization`, `cookie`).
+- Normalized/deduplicated configured keys (preserving order).
+- Implemented defensive parsing if configuration is not available.
+**Feature added**: ZAP can persist and retrieve sensitive-data masking preferences from configuration.
+
+## 2. Added core masking utilities (values, header lines, and header blocks)
+
+**File**: `zaproxy/zap/src/main/java/org/zaproxy/zap/extension/sensitive/SensitiveDataUtils.java`  
+**Intention**: Centralize masking logic so UI/components can reuse it consistently.  
+**Changes**:
+- Implemented `maskIfSensitive(key, value, options)` (case-insensitive key matching).
+- Added `maskHeaderLineIfSensitive("Header: value", options)` to mask only the value portion.
+- Added `maskHeaderBlockIfSensitive(block, options)` to mask multi-line header blocks.
+- Preserved the original line separator style (`\r\n`, `\n`, or `\r`) when rewriting header blocks.
+- Added Log4j2 `INFO` logging when masking is applied.
+**Feature added**: A reusable API to mask sensitive values across different UI display contexts.
+
+## 3. Added an extension to register the options param set and the Options panel
+
+**File**: `zaproxy/zap/src/main/java/org/zaproxy/zap/extension/sensitive/ExtensionSensitiveData.java`  
+**Intention**: Register the sensitive-data options as a proper ZAP extension and expose a UI panel in Options.  
+**Changes**:
+- Created `ExtensionSensitiveData` (extends `ExtensionAdaptor`).
+- Registered the param set via `extensionHook.addOptionsParamSet(optionsParam)`.
+- Added an options panel via `extensionHook.getHookView().addOptionPanel(...)` when `hasView()` is true.
+**Feature added**: The feature becomes a first-class “extension-style” options param set and UI panel.
+
+## 4. Added a UI Options panel to configure masking
+
+**File**: `zaproxy/zap/src/main/java/org/zaproxy/zap/extension/sensitive/OptionsSensitiveDataPanel.java`  
+**Intention**: Provide GUI controls to enable/disable masking, set a mask value, and edit sensitive keys.  
+**Changes**:
+- New `AbstractParamPanel` named “Sensitive Data”.
+- Checkbox: “Enable masking”.
+- Text field: mask value.
+- Text area: sensitive keys (one per line).
+- Loads/saves values via `OptionsParam.getParamSet(OptionsParamSensitiveData.class)`.
+**Feature added**: Users can configure masking from **Tools → Options → Sensitive Data**.
+
+## 5. Registered the new extension in core built-in extensions
+
+**File**: `zaproxy/zap/src/main/java/org/zaproxy/zap/control/CoreFunctionality.java`  
+**Intention**: Ensure the new core extension loads automatically in the standard ZAP build.  
+**Changes**:
+- Added `new org.zaproxy.zap.extension.sensitive.ExtensionSensitiveData()` to the built-in extensions list.
+**Feature added**: The Sensitive Data extension loads by default (core build), enabling the Options panel and param set registration.
+
+## 6. Integrated masking into request header display models (UI request panel text)
+
+**Files**:
+- `zaproxy/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestHeaderStringHttpPanelViewModel.java`
+- `zaproxy/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModel.java`
+- `zaproxy/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/largerequest/LargeRequestStringHttpPanelViewModel.java`
+
+**Intention**: Ensure masked data appears in the Request panel header text views when masking is enabled.  
+**Changes**:
+- In `getData()`, retrieves the sensitive options via:
+  - `Model.getSingleton().getOptionsParam().getParamSet(OptionsParamSensitiveData.class)`
+- Masks the rendered header text via:
+  - `SensitiveDataUtils.maskHeaderBlockIfSensitive(header, sensitiveDataOptions)`
+**Feature added**: Sensitive header values are masked in request header displays (when masking is enabled).
+
+## 7. Added unit tests for masking utilities
+
+**File**: `zaproxy/zap/src/test/java/org/zaproxy/zap/extension/sensitive/SensitiveDataUtilsUnitTest.java`  
+**Intention**: Validate masking behavior and prevent regressions.  
+**Changes**:
+- Added tests covering:
+  - masking enabled/disabled behavior
+  - custom mask value behavior
+  - masking a single header line
+  - masking a multi-line header block
+**Feature added**: Automated verification that masking logic behaves as expected.
+
+
+### PR Updates / New Additions Compared to Previous PR
+
+1.  **Architecture shift**: moved from `OptionsParam`-owned param to proper extension-based param set.
+
+2.  **Extension registration**: `ExtensionSensitiveData` now registers the param set and UI panel via `ExtensionHook`.
+
+3.  **UI integration**: HTTP panels updated to retrieve param via `optionsParam.getParamSet(...)` instead of global OptionsParam.
+
+4.  **Verified functionality**: compiles cleanly and unit tests pass. Masking is disabled by default, but the user can enable it in **Tools -> Options -> Sensitive Data**.
+
+
+

--- a/SensitiveDataMasking(README).md
+++ b/SensitiveDataMasking(README).md
@@ -1,6 +1,6 @@
 # Sensitive Data Masking – Summary of Code Changes
 
-This document summarizes the code changes made in this branch/PR compared to the ZAP upstream baseline you started from.
+This document summarizes the code changes made in this branch/PR compared to the ZAP upstream baseline I started from.
 
 Masking is disabled by default and needs to be enabled in Tools -> Options -> Sensitive data (tab in left of window pane of options menu) 
 ## 1. Added new parameter class for storing masking settings

--- a/zap/src/main/java/org/parosproxy/paros/model/OptionsParam.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/OptionsParam.java
@@ -66,6 +66,7 @@ import org.zaproxy.zap.extension.anticsrf.AntiCsrfParam;
 import org.zaproxy.zap.extension.api.OptionsParamApi;
 import org.zaproxy.zap.extension.autoupdate.OptionsParamCheckForUpdates;
 import org.zaproxy.zap.extension.ext.ExtensionParam;
+import org.zaproxy.zap.extension.sensitive.OptionsParamSensitiveData;
 
 public class OptionsParam extends AbstractParam {
 
@@ -102,6 +103,7 @@ public class OptionsParam extends AbstractParam {
     /** The database configurations. */
     // ZAP: Added the instance variable.
     private DatabaseParam databaseParam = new DatabaseParam();
+    private OptionsParamSensitiveData sensitiveDataParam = new OptionsParamSensitiveData();
 
     private ExtensionParam extensionParam = new ExtensionParam();
 
@@ -199,6 +201,7 @@ public class OptionsParam extends AbstractParam {
         getApiParam().load(getConfig());
         getDatabaseParam().load(getConfig());
         getExtensionParam().load(getConfig());
+        getSensitiveDataParam().load(getConfig());
 
         String userDir = null;
         try {
@@ -306,5 +309,14 @@ public class OptionsParam extends AbstractParam {
      */
     public ExtensionParam getExtensionParam() {
         return extensionParam;
+    }
+
+    /**
+     * Gets the sensitive data configurations.
+     *
+     * @return the sensitive data configurations - $$$666
+     */
+    public OptionsParamSensitiveData getSensitiveDataParam() {
+        return sensitiveDataParam;
     }
 }

--- a/zap/src/main/java/org/parosproxy/paros/model/OptionsParam.java
+++ b/zap/src/main/java/org/parosproxy/paros/model/OptionsParam.java
@@ -66,7 +66,6 @@ import org.zaproxy.zap.extension.anticsrf.AntiCsrfParam;
 import org.zaproxy.zap.extension.api.OptionsParamApi;
 import org.zaproxy.zap.extension.autoupdate.OptionsParamCheckForUpdates;
 import org.zaproxy.zap.extension.ext.ExtensionParam;
-import org.zaproxy.zap.extension.sensitive.OptionsParamSensitiveData;
 
 public class OptionsParam extends AbstractParam {
 
@@ -103,7 +102,6 @@ public class OptionsParam extends AbstractParam {
     /** The database configurations. */
     // ZAP: Added the instance variable.
     private DatabaseParam databaseParam = new DatabaseParam();
-    private OptionsParamSensitiveData sensitiveDataParam = new OptionsParamSensitiveData();
 
     private ExtensionParam extensionParam = new ExtensionParam();
 
@@ -201,7 +199,6 @@ public class OptionsParam extends AbstractParam {
         getApiParam().load(getConfig());
         getDatabaseParam().load(getConfig());
         getExtensionParam().load(getConfig());
-        getSensitiveDataParam().load(getConfig());
 
         String userDir = null;
         try {
@@ -309,14 +306,5 @@ public class OptionsParam extends AbstractParam {
      */
     public ExtensionParam getExtensionParam() {
         return extensionParam;
-    }
-
-    /**
-     * Gets the sensitive data configurations.
-     *
-     * @return the sensitive data configurations - $$$666
-     */
-    public OptionsParamSensitiveData getSensitiveDataParam() {
-        return sensitiveDataParam;
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/control/CoreFunctionality.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/CoreFunctionality.java
@@ -117,6 +117,7 @@ public final class CoreFunctionality {
             extensions.add(new org.zaproxy.zap.extension.ruleconfig.ExtensionRuleConfig());
             extensions.add(new org.zaproxy.zap.extension.script.ExtensionScript());
             extensions.add(new org.zaproxy.zap.extension.search.ExtensionSearch());
+            extensions.add(new org.zaproxy.zap.extension.sensitive.ExtensionSensitiveData());
             extensions.add(new org.zaproxy.zap.extension.sessions.ExtensionSessionManagement());
             extensions.add(new org.zaproxy.zap.extension.siterefresh.ExtensionSitesRefresh());
             extensions.add(new org.zaproxy.zap.extension.stats.ExtensionStats());

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestHeaderStringHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestHeaderStringHttpPanelViewModel.java
@@ -22,12 +22,14 @@ package org.zaproxy.zap.extension.httppanel.view.impl.models.http.request;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.model.OptionsParam;
 import org.zaproxy.zap.extension.sensitive.SensitiveDataUtils;
 import org.zaproxy.zap.extension.httppanel.InvalidMessageDataException;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.AbstractHttpStringHttpPanelViewModel;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.extension.sensitive.OptionsParamSensitiveData;
 
 public class RequestHeaderStringHttpPanelViewModel extends AbstractHttpStringHttpPanelViewModel {
 
@@ -42,8 +44,10 @@ public class RequestHeaderStringHttpPanelViewModel extends AbstractHttpStringHtt
 
         String header =
                 httpMessage.getRequestHeader().toString().replaceAll(HttpHeader.CRLF, HttpHeader.LF);
-        return SensitiveDataUtils.maskHeaderBlockIfSensitive(
-                header, Model.getSingleton().getOptionsParam().getSensitiveDataParam());
+        OptionsParam optionsParam = Model.getSingleton().getOptionsParam();
+        OptionsParamSensitiveData sensitiveDataOptions =
+                optionsParam.getParamSet(OptionsParamSensitiveData.class);
+        return SensitiveDataUtils.maskHeaderBlockIfSensitive(header, sensitiveDataOptions);
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestHeaderStringHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestHeaderStringHttpPanelViewModel.java
@@ -22,8 +22,10 @@ package org.zaproxy.zap.extension.httppanel.view.impl.models.http.request;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.zaproxy.zap.extension.sensitive.SensitiveDataUtils;
 import org.zaproxy.zap.extension.httppanel.InvalidMessageDataException;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.AbstractHttpStringHttpPanelViewModel;
 
@@ -38,7 +40,10 @@ public class RequestHeaderStringHttpPanelViewModel extends AbstractHttpStringHtt
             return "";
         }
 
-        return httpMessage.getRequestHeader().toString().replaceAll(HttpHeader.CRLF, HttpHeader.LF);
+        String header =
+                httpMessage.getRequestHeader().toString().replaceAll(HttpHeader.CRLF, HttpHeader.LF);
+        return SensitiveDataUtils.maskHeaderBlockIfSensitive(
+                header, Model.getSingleton().getOptionsParam().getSensitiveDataParam());
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModel.java
@@ -22,12 +22,14 @@ package org.zaproxy.zap.extension.httppanel.view.impl.models.http.request;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.model.OptionsParam;
 import org.zaproxy.zap.extension.sensitive.SensitiveDataUtils;
 import org.zaproxy.zap.extension.httppanel.InvalidMessageDataException;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.AbstractHttpStringHttpPanelViewModel;
+import org.zaproxy.zap.extension.sensitive.OptionsParamSensitiveData;
 
 public class RequestStringHttpPanelViewModel extends AbstractHttpStringHttpPanelViewModel {
 
@@ -42,9 +44,10 @@ public class RequestStringHttpPanelViewModel extends AbstractHttpStringHttpPanel
 
         String header =
                 httpMessage.getRequestHeader().toString().replaceAll(HttpHeader.CRLF, HttpHeader.LF);
-        String maskedHeader =
-                SensitiveDataUtils.maskHeaderBlockIfSensitive(
-                        header, Model.getSingleton().getOptionsParam().getSensitiveDataParam());
+        OptionsParam optionsParam = Model.getSingleton().getOptionsParam();
+        OptionsParamSensitiveData sensitiveDataOptions =
+                optionsParam.getParamSet(OptionsParamSensitiveData.class);
+        String maskedHeader = SensitiveDataUtils.maskHeaderBlockIfSensitive(header, sensitiveDataOptions);
         return maskedHeader + httpMessage.getRequestBody().toString();
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModel.java
@@ -22,8 +22,10 @@ package org.zaproxy.zap.extension.httppanel.view.impl.models.http.request;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.zaproxy.zap.extension.sensitive.SensitiveDataUtils;
 import org.zaproxy.zap.extension.httppanel.InvalidMessageDataException;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.AbstractHttpStringHttpPanelViewModel;
 
@@ -38,8 +40,12 @@ public class RequestStringHttpPanelViewModel extends AbstractHttpStringHttpPanel
             return "";
         }
 
-        return httpMessage.getRequestHeader().toString().replaceAll(HttpHeader.CRLF, HttpHeader.LF)
-                + httpMessage.getRequestBody().toString();
+        String header =
+                httpMessage.getRequestHeader().toString().replaceAll(HttpHeader.CRLF, HttpHeader.LF);
+        String maskedHeader =
+                SensitiveDataUtils.maskHeaderBlockIfSensitive(
+                        header, Model.getSingleton().getOptionsParam().getSensitiveDataParam());
+        return maskedHeader + httpMessage.getRequestBody().toString();
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModel.java
@@ -48,7 +48,9 @@ public class RequestStringHttpPanelViewModel extends AbstractHttpStringHttpPanel
         OptionsParamSensitiveData sensitiveDataOptions =
                 optionsParam.getParamSet(OptionsParamSensitiveData.class);
         String maskedHeader = SensitiveDataUtils.maskHeaderBlockIfSensitive(header, sensitiveDataOptions);
-        return maskedHeader + httpMessage.getRequestBody().toString();
+        String maskedBody =
+                SensitiveDataUtils.maskBodyIfJson(httpMessage.getRequestBody().toString(), sensitiveDataOptions);
+        return maskedHeader + maskedBody;
     }
 
     @Override

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/largerequest/LargeRequestStringHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/largerequest/LargeRequestStringHttpPanelViewModel.java
@@ -20,8 +20,10 @@
 package org.zaproxy.zap.extension.httppanel.view.largerequest;
 
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpHeader;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.request.RequestStringHttpPanelViewModel;
+import org.zaproxy.zap.extension.sensitive.SensitiveDataUtils;
 
 /**
  * @deprecated (2.12.0) No longer in use.
@@ -35,7 +37,12 @@ public class LargeRequestStringHttpPanelViewModel extends RequestStringHttpPanel
             return "";
         }
 
-        return httpMessage.getRequestHeader().toString().replaceAll(HttpHeader.CRLF, HttpHeader.LF)
+        String header =
+                httpMessage.getRequestHeader().toString().replaceAll(HttpHeader.CRLF, HttpHeader.LF);
+        String maskedHeader =
+                SensitiveDataUtils.maskHeaderBlockIfSensitive(
+                        header, Model.getSingleton().getOptionsParam().getSensitiveDataParam());
+        return maskedHeader
                 + Constant.messages.getString(
                         "http.panel.view.largerequest.all.warning",
                         httpMessage.getRequestBody().length());

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/largerequest/LargeRequestStringHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/largerequest/LargeRequestStringHttpPanelViewModel.java
@@ -21,8 +21,10 @@ package org.zaproxy.zap.extension.httppanel.view.largerequest;
 
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.network.HttpHeader;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.request.RequestStringHttpPanelViewModel;
+import org.zaproxy.zap.extension.sensitive.OptionsParamSensitiveData;
 import org.zaproxy.zap.extension.sensitive.SensitiveDataUtils;
 
 /**
@@ -39,9 +41,10 @@ public class LargeRequestStringHttpPanelViewModel extends RequestStringHttpPanel
 
         String header =
                 httpMessage.getRequestHeader().toString().replaceAll(HttpHeader.CRLF, HttpHeader.LF);
-        String maskedHeader =
-                SensitiveDataUtils.maskHeaderBlockIfSensitive(
-                        header, Model.getSingleton().getOptionsParam().getSensitiveDataParam());
+        OptionsParam optionsParam = Model.getSingleton().getOptionsParam();
+        OptionsParamSensitiveData sensitiveDataOptions =
+                optionsParam.getParamSet(OptionsParamSensitiveData.class);
+        String maskedHeader = SensitiveDataUtils.maskHeaderBlockIfSensitive(header, sensitiveDataOptions);
         return maskedHeader
                 + Constant.messages.getString(
                         "http.panel.view.largerequest.all.warning",

--- a/zap/src/main/java/org/zaproxy/zap/extension/sensitive/ExtensionSensitiveData.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/sensitive/ExtensionSensitiveData.java
@@ -1,0 +1,48 @@
+package org.zaproxy.zap.extension.sensitive;
+
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+
+public class ExtensionSensitiveData extends ExtensionAdaptor {
+
+    public static final String NAME = "ExtensionSensitiveData";
+
+    private OptionsParamSensitiveData optionsParam;
+
+    public ExtensionSensitiveData() {
+        super(NAME);
+    }
+
+    @Override
+    public void init() {
+        super.init();
+        optionsParam = new OptionsParamSensitiveData();
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        super.hook(extensionHook);
+
+        extensionHook.addOptionsParamSet(optionsParam);
+
+        if (hasView()) {
+            extensionHook.getHookView().addOptionPanel(new OptionsSensitiveDataPanel());
+        }
+    }
+
+    @Override
+    public String getUIName() {
+        return "Sensitive Data";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Adds configurable masking for sensitive HTTP data displayed in ZAP.";
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+}
+

--- a/zap/src/main/java/org/zaproxy/zap/extension/sensitive/OptionsParamSensitiveData.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/sensitive/OptionsParamSensitiveData.java
@@ -1,0 +1,137 @@
+package org.zaproxy.zap.extension.sensitive;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.configuration.Configuration;
+import org.parosproxy.paros.common.AbstractParam;
+
+public class OptionsParamSensitiveData extends AbstractParam {
+
+    private static final String SENSITIVE_DATA_BASE_KEY = "sensitiveData";
+    private static final String MASKING_ENABLED_KEY = SENSITIVE_DATA_BASE_KEY + ".masking.enabled";
+    private static final String MASK_VALUE_KEY = SENSITIVE_DATA_BASE_KEY + ".mask.value";
+    private static final String SENSITIVE_KEYS_KEY = SENSITIVE_DATA_BASE_KEY + ".keys";
+
+    private static final String DEFAULT_MASK_VALUE = "****";
+
+    private static final List<String> DEFAULT_SENSITIVE_KEYS =
+            Collections.unmodifiableList(
+                    Arrays.asList(
+                            "password",
+                            "passwd",
+                            "pwd",
+                            "token",
+                            "access_token",
+                            "refresh_token",
+                            "authorization",
+                            "api_key",
+                            "apikey",
+                            "secret",
+                            "session",
+                            "cookie"));
+
+    private boolean maskingEnabled;
+    private String maskValue;
+    private List<String> sensitiveKeys = new ArrayList<>(DEFAULT_SENSITIVE_KEYS);
+
+    @Override
+    protected void parse() {
+        Configuration config = getConfig();
+        if (config == null) {
+            maskingEnabled = false;
+            maskValue = DEFAULT_MASK_VALUE;
+            sensitiveKeys = new ArrayList<>(DEFAULT_SENSITIVE_KEYS);
+            return;
+        }
+
+        maskingEnabled = config.getBoolean(MASKING_ENABLED_KEY, false);
+        maskValue = config.getString(MASK_VALUE_KEY, DEFAULT_MASK_VALUE);
+        sensitiveKeys = readSensitiveKeys(config);
+    }
+
+    public boolean isMaskingEnabled() {
+        return maskingEnabled;
+    }
+
+    public void setMaskingEnabled(boolean maskingEnabled) {
+        this.maskingEnabled = maskingEnabled;
+        setConfigProperty(MASKING_ENABLED_KEY, maskingEnabled);
+    }
+
+    public String getMaskValue() {
+        return maskValue;
+    }
+
+    public void setMaskValue(String maskValue) {
+        this.maskValue = (maskValue == null || maskValue.isEmpty()) ? DEFAULT_MASK_VALUE : maskValue;
+
+        setConfigProperty(MASK_VALUE_KEY, this.maskValue);
+    }
+
+    public List<String> getSensitiveKeys() {
+        return Collections.unmodifiableList(sensitiveKeys);
+    }
+
+    public void setSensitiveKeys(List<String> sensitiveKeys) {
+        if (sensitiveKeys == null || sensitiveKeys.isEmpty()) {
+            this.sensitiveKeys = new ArrayList<>(DEFAULT_SENSITIVE_KEYS);
+        } else {
+            this.sensitiveKeys = normalizeKeys(sensitiveKeys);
+        }
+
+        setConfigProperty(SENSITIVE_KEYS_KEY, this.sensitiveKeys);
+    }
+
+    private static List<String> readSensitiveKeys(Configuration config) {
+        Object property = config.getProperty(SENSITIVE_KEYS_KEY);
+
+        if (property == null) {
+            return new ArrayList<>(DEFAULT_SENSITIVE_KEYS);
+        }
+
+        List<Object> configuredValues = config.getList(SENSITIVE_KEYS_KEY);
+        List<String> keys = new ArrayList<>();
+
+        for (Object value : configuredValues) {
+            if (value != null) {
+                String key = value.toString().trim();
+                if (!key.isEmpty()) {
+                    keys.add(key);
+                }
+            }
+        }
+
+        if (keys.isEmpty()) {
+            return new ArrayList<>(DEFAULT_SENSITIVE_KEYS);
+        }
+
+        return normalizeKeys(keys);
+    }
+
+    private static List<String> normalizeKeys(List<String> keys) {
+        Set<String> normalized = new LinkedHashSet<>();
+
+        for (String key : keys) {
+            if (key != null) {
+                String trimmedKey = key.trim();
+                if (!trimmedKey.isEmpty()) {
+                    normalized.add(trimmedKey);
+                }
+            }
+        }
+
+        return new ArrayList<>(normalized);
+    }
+
+    private void setConfigProperty(String key, Object value) {
+        Configuration config = getConfig();
+
+        if (config != null) {
+            config.setProperty(key, value);
+        }
+    }
+}

--- a/zap/src/main/java/org/zaproxy/zap/extension/sensitive/OptionsParamSensitiveData.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/sensitive/OptionsParamSensitiveData.java
@@ -34,7 +34,7 @@ public class OptionsParamSensitiveData extends AbstractParam {
                             "session",
                             "cookie"));
 
-    private boolean maskingEnabled;
+    private boolean maskingEnabled = true;
     private String maskValue;
     private List<String> sensitiveKeys = new ArrayList<>(DEFAULT_SENSITIVE_KEYS);
 
@@ -48,7 +48,7 @@ public class OptionsParamSensitiveData extends AbstractParam {
             return;
         }
 
-        maskingEnabled = config.getBoolean(MASKING_ENABLED_KEY, false);
+        maskingEnabled = config.getBoolean(MASKING_ENABLED_KEY, true);
         maskValue = config.getString(MASK_VALUE_KEY, DEFAULT_MASK_VALUE);
         sensitiveKeys = readSensitiveKeys(config);
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/sensitive/OptionsSensitiveDataPanel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/sensitive/OptionsSensitiveDataPanel.java
@@ -1,0 +1,89 @@
+package org.zaproxy.zap.extension.sensitive;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import org.parosproxy.paros.model.OptionsParam;
+import org.parosproxy.paros.view.AbstractParamPanel;
+
+public class OptionsSensitiveDataPanel extends AbstractParamPanel {
+
+    private static final long serialVersionUID = 1L;
+
+    private final JCheckBox maskingEnabled = new JCheckBox("Enable masking");
+    private final JTextField maskValue = new JTextField();
+    private final JTextArea keys = new JTextArea(10, 40);
+
+    public OptionsSensitiveDataPanel() {
+        setName("Sensitive Data");
+        setLayout(new GridBagLayout());
+
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.weightx = 1.0;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.anchor = GridBagConstraints.LINE_START;
+
+        add(maskingEnabled, gbc);
+
+        gbc.gridy++;
+        add(new JLabel("Mask value:"), gbc);
+
+        gbc.gridy++;
+        add(maskValue, gbc);
+
+        gbc.gridy++;
+        add(new JLabel("Sensitive keys (one per line):"), gbc);
+
+        gbc.gridy++;
+        gbc.weighty = 1.0;
+        gbc.fill = GridBagConstraints.BOTH;
+        add(new JScrollPane(keys), gbc);
+    }
+
+    @Override
+    public void initParam(Object obj) {
+        OptionsParam optionsParam = (OptionsParam) obj;
+        OptionsParamSensitiveData param = optionsParam.getParamSet(OptionsParamSensitiveData.class);
+        if (param == null) {
+            return;
+        }
+
+        maskingEnabled.setSelected(param.isMaskingEnabled());
+        maskValue.setText(param.getMaskValue());
+        keys.setText(String.join("\n", param.getSensitiveKeys()));
+    }
+
+    @Override
+    public void saveParam(Object obj) throws Exception {
+        OptionsParam optionsParam = (OptionsParam) obj;
+        OptionsParamSensitiveData param = optionsParam.getParamSet(OptionsParamSensitiveData.class);
+        if (param == null) {
+            return;
+        }
+
+        param.setMaskingEnabled(maskingEnabled.isSelected());
+        param.setMaskValue(maskValue.getText());
+
+        List<String> keyList =
+                Arrays.stream(keys.getText().split("\\R"))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.toList());
+        param.setSensitiveKeys(keyList);
+    }
+
+    @Override
+    public String getHelpIndex() {
+        return "ui.dialogs.options.sensitivedata";
+    }
+}
+

--- a/zap/src/main/java/org/zaproxy/zap/extension/sensitive/SensitiveDataUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/sensitive/SensitiveDataUtils.java
@@ -1,8 +1,12 @@
 package org.zaproxy.zap.extension.sensitive;
 
 import java.util.Locale;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public final class SensitiveDataUtils {
+
+    private static final Logger LOGGER = LogManager.getLogger(SensitiveDataUtils.class);
 
     private SensitiveDataUtils() {}
 
@@ -25,7 +29,11 @@ public final class SensitiveDataUtils {
 
             if (normalizedKey.contains(sensitiveKey.toLowerCase(Locale.ROOT))) {
                 String maskValue = sensitiveDataOptions.getMaskValue();
-                return (maskValue == null || maskValue.isEmpty()) ? "****" : maskValue;
+                String finalMask = (maskValue == null || maskValue.isEmpty()) ? "****" : maskValue;
+
+                LOGGER.info("[SensitiveDataMask] key='{}' masked", key);
+
+                return finalMask;
             }
         }
 
@@ -53,6 +61,8 @@ public final class SensitiveDataUtils {
         if (maskedValue.equals(headerValue)) {
             return headerLine;
         }
+
+        LOGGER.info("[SensitiveDataMask] Mask applied to header '{}'", headerName);
 
         return headerLine.substring(0, separatorIndex + 1) + " " + maskedValue;
     }

--- a/zap/src/main/java/org/zaproxy/zap/extension/sensitive/SensitiveDataUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/sensitive/SensitiveDataUtils.java
@@ -1,6 +1,11 @@
 package org.zaproxy.zap.extension.sensitive;
 
 import java.util.Locale;
+import net.sf.json.JSON;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONException;
+import net.sf.json.JSONObject;
+import net.sf.json.JSONSerializer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -90,6 +95,84 @@ public final class SensitiveDataUtils {
         }
 
         return maskedHeaderBlock.toString();
+    }
+
+    public static String maskBodyIfJson(String body, OptionsParamSensitiveData sensitiveDataOptions) {
+        if (body == null
+                || body.isEmpty()
+                || sensitiveDataOptions == null
+                || !sensitiveDataOptions.isMaskingEnabled()) {
+            return body;
+        }
+
+        JSON json;
+        try {
+            json = JSONSerializer.toJSON(body);
+        } catch (JSONException e) {
+            return body;
+        }
+
+        if (json instanceof JSONObject obj) {
+            maskJsonObject(obj, sensitiveDataOptions);
+            return obj.toString();
+        }
+
+        if (json instanceof JSONArray arr) {
+            maskJsonArray(arr, sensitiveDataOptions);
+            return arr.toString();
+        }
+
+        return body;
+    }
+
+    private static void maskJsonObject(
+            JSONObject jsonObject, OptionsParamSensitiveData sensitiveDataOptions) {
+        for (Object k : jsonObject.keySet()) {
+            if (!(k instanceof String key)) {
+                continue;
+            }
+
+            Object value = jsonObject.get(key);
+            if (value instanceof JSONObject childObj) {
+                maskJsonObject(childObj, sensitiveDataOptions);
+                continue;
+            }
+
+            if (value instanceof JSONArray childArr) {
+                maskJsonArray(childArr, sensitiveDataOptions);
+                continue;
+            }
+
+            if (value instanceof String stringValue) {
+                String masked = maskIfSensitive(key, stringValue, sensitiveDataOptions);
+                if (!masked.equals(stringValue)) {
+                    jsonObject.put(key, masked);
+                }
+            } else {
+                for (String sensitiveKey : sensitiveDataOptions.getSensitiveKeys()) {
+                    if (sensitiveKey == null || sensitiveKey.isEmpty()) {
+                        continue;
+                    }
+                    if (key.toLowerCase(Locale.ROOT).contains(sensitiveKey.toLowerCase(Locale.ROOT))) {
+                        String masked =
+                                maskIfSensitive(key, "", sensitiveDataOptions);
+                        jsonObject.put(key, masked);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    private static void maskJsonArray(JSONArray jsonArray, OptionsParamSensitiveData sensitiveDataOptions) {
+        for (int i = 0; i < jsonArray.size(); i++) {
+            Object value = jsonArray.get(i);
+            if (value instanceof JSONObject obj) {
+                maskJsonObject(obj, sensitiveDataOptions);
+            } else if (value instanceof JSONArray arr) {
+                maskJsonArray(arr, sensitiveDataOptions);
+            }
+        }
     }
 
     private static String detectLineSeparator(String text) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/sensitive/SensitiveDataUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/sensitive/SensitiveDataUtils.java
@@ -1,0 +1,97 @@
+package org.zaproxy.zap.extension.sensitive;
+
+import java.util.Locale;
+
+public final class SensitiveDataUtils {
+
+    private SensitiveDataUtils() {}
+
+    public static String maskIfSensitive(
+            String key, String value, OptionsParamSensitiveData sensitiveDataOptions) {
+
+        if (sensitiveDataOptions == null
+                || !sensitiveDataOptions.isMaskingEnabled()
+                || key == null
+                || key.isEmpty()) {
+            return value;
+        }
+
+        String normalizedKey = key.toLowerCase(Locale.ROOT);
+
+        for (String sensitiveKey : sensitiveDataOptions.getSensitiveKeys()) {
+            if (sensitiveKey == null || sensitiveKey.isEmpty()) {
+                continue;
+            }
+
+            if (normalizedKey.contains(sensitiveKey.toLowerCase(Locale.ROOT))) {
+                String maskValue = sensitiveDataOptions.getMaskValue();
+                return (maskValue == null || maskValue.isEmpty()) ? "****" : maskValue;
+            }
+        }
+
+        return value;
+    }
+
+    public static String maskHeaderLineIfSensitive(
+            String headerLine, OptionsParamSensitiveData sensitiveDataOptions) {
+
+        if (headerLine == null || headerLine.isEmpty()) {
+            return headerLine;
+        }
+
+        int separatorIndex = headerLine.indexOf(':');
+
+        if (separatorIndex <= 0) {
+            return headerLine;
+        }
+
+        String headerName = headerLine.substring(0, separatorIndex).trim();
+        String headerValue = headerLine.substring(separatorIndex + 1).trim();
+
+        String maskedValue = maskIfSensitive(headerName, headerValue, sensitiveDataOptions);
+
+        if (maskedValue.equals(headerValue)) {
+            return headerLine;
+        }
+
+        return headerLine.substring(0, separatorIndex + 1) + " " + maskedValue;
+    }
+
+    public static String maskHeaderBlockIfSensitive(
+            String headerBlock, OptionsParamSensitiveData sensitiveDataOptions) {
+
+        if (headerBlock == null
+                || headerBlock.isEmpty()
+                || sensitiveDataOptions == null
+                || !sensitiveDataOptions.isMaskingEnabled()) {
+            return headerBlock;
+        }
+
+        String lineSeparator = detectLineSeparator(headerBlock);
+        String[] lines = headerBlock.split("\\R", -1);
+        StringBuilder maskedHeaderBlock = new StringBuilder(headerBlock.length());
+
+        for (int i = 0; i < lines.length; i++) {
+            maskedHeaderBlock.append(maskHeaderLineIfSensitive(lines[i], sensitiveDataOptions));
+
+            if (i < lines.length - 1) {
+                maskedHeaderBlock.append(lineSeparator);
+            }
+        }
+
+        return maskedHeaderBlock.toString();
+    }
+
+    private static String detectLineSeparator(String text) {
+        if (text.contains("\r\n")) {
+            return "\r\n";
+        }
+        if (text.contains("\n")) {
+            return "\n";
+        }
+        if (text.contains("\r")) {
+            return "\r";
+        }
+        return System.lineSeparator();
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/extension/sensitive/SensitiveDataUtilsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/sensitive/SensitiveDataUtilsUnitTest.java
@@ -1,0 +1,90 @@
+package org.zaproxy.zap.extension.sensitive;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+class SensitiveDataUtilsUnitTest {
+
+    private OptionsParamSensitiveData options;
+
+    @BeforeEach
+    void setUp() {
+        options = new OptionsParamSensitiveData();
+        options.load(new ZapXmlConfiguration());
+    }
+
+    @Test
+    void shouldReturnOriginalValueWhenMaskingIsDisabled() {
+        options.setMaskingEnabled(false);
+
+        String result = SensitiveDataUtils.maskIfSensitive("password", "secret123", options);
+
+        assertThat(result, equalTo("secret123"));
+    }
+
+    @Test
+    void shouldMaskPasswordWhenMaskingIsEnabled() {
+        options.setMaskingEnabled(true);
+
+        String result = SensitiveDataUtils.maskIfSensitive("password", "secret123", options);
+
+        assertThat(result, equalTo("****"));
+    }
+
+    @Test
+    void shouldMaskAuthorizationHeaderWhenMaskingIsEnabled() {
+        options.setMaskingEnabled(true);
+
+        String result =
+                SensitiveDataUtils.maskIfSensitive("Authorization", "Bearer abc.def.ghi", options);
+
+        assertThat(result, equalTo("****"));
+    }
+
+    @Test
+    void shouldReturnOriginalValueForNonSensitiveKey() {
+        options.setMaskingEnabled(true);
+
+        String result = SensitiveDataUtils.maskIfSensitive("username", "alice", options);
+
+        assertThat(result, equalTo("alice"));
+    }
+
+    @Test
+    void shouldUseCustomMaskValue() {
+        options.setMaskingEnabled(true);
+        options.setMaskValue("[REDACTED]");
+
+        String result = SensitiveDataUtils.maskIfSensitive("api_key", "12345", options);
+
+        assertThat(result, equalTo("[REDACTED]"));
+    }
+
+    @Test
+    void shouldMaskSensitiveHeaderLine() {
+        options.setMaskingEnabled(true);
+
+        String result =
+                SensitiveDataUtils.maskHeaderLineIfSensitive(
+                        "Authorization: Bearer abc.def.ghi", options);
+
+        assertThat(result, equalTo("Authorization: ****"));
+    }
+
+    @Test
+    void shouldMaskSensitiveHeaderBlock() {
+        options.setMaskingEnabled(true);
+
+        String result =
+                SensitiveDataUtils.maskHeaderBlockIfSensitive(
+                        "GET / HTTP/1.1\nAuthorization: Bearer abc.def.ghi\nHost: example.com",
+                        options);
+
+        assertThat(result, equalTo("GET / HTTP/1.1\nAuthorization: ****\nHost: example.com"));
+    }
+}
+


### PR DESCRIPTION
# ZAP Sensitive Data Masking – Final README

**Overview**

This PR implements a fully integrated **Sensitive Data Masking** feature in ZAP. It allows sensitive HTTP headers and values (passwords, tokens, API keys, cookies) to be masked in UI panels while preserving scanning, replay, and session functionality. The feature follows the **ZAP extension architecture**, using a dedicated parameter set and an options panel for user configuration.
This is to support custom bug bounty programs where the companies wouldn't like white or blue hats to know the actual sensitive data being leaked during testing with custom zap models like I designed here. 

Masking is **disabled by default** and must be enabled via **Tools → Options → Sensitive Data**.

---

## 1. Added new parameter class for storing masking settings

**File**: `zaproxy/zap/src/main/java/org/zaproxy/zap/extension/sensitive/OptionsParamSensitiveData.java`  
**Intention**: Introduce configurable options for masking sensitive HTTP data (enable/disable, mask value, and sensitive key patterns).  
**Changes**:
- Added a new `AbstractParam` implementation with configuration keys:
  - `sensitiveData.masking.enabled`
  - `sensitiveData.mask.value`
  - `sensitiveData.keys`
- Added defaults for common sensitive keys (e.g., `password`, `token`, `authorization`, `cookie`).
- Normalized/deduplicated configured keys (preserving order).
- Defensive parsing if configuration is missing.
**Feature added**: ZAP can persist and retrieve sensitive-data masking preferences.

---

## 2. Added core masking utilities (values, header lines, and header blocks)

**File**: `zaproxy/zap/src/main/java/org/zaproxy/zap/extension/sensitive/SensitiveDataUtils.java`  
**Intention**: Centralize masking logic so UI/components can reuse it consistently.  
**Changes**:
- Implemented `maskIfSensitive(key, value, options)` (case-insensitive key matching).
- Added `maskHeaderLineIfSensitive(...)` to mask a single line.
- Added `maskHeaderBlockIfSensitive(...)` to mask multi-line headers.
- Preserved original line separator style (`\r\n`, `\n`, or `\r`) when rewriting headers.
- Added Log4j2 `INFO` logging when masking is applied.
**Feature added**: Reusable API to mask sensitive values across all UI contexts.

---

## 3. Added an extension to register the options param set and the Options panel

**File**: `zaproxy/zap/src/main/java/org/zaproxy/zap/extension/sensitive/ExtensionSensitiveData.java`  
**Intention**: Register the sensitive-data options as a proper ZAP extension and expose a UI panel.  
**Changes**:
- Created `ExtensionSensitiveData` extending `ExtensionAdaptor`.
- Registered the param set via `extensionHook.addOptionsParamSet(optionsParam)`.
- Registered options panel via `extensionHook.getHookView().addOptionPanel(...)`.
**Feature added**: Masking becomes a first-class extension-style param set and UI panel.

---

## 4. Added a UI Options panel to configure masking

**File**: `zaproxy/zap/src/main/java/org/zaproxy/zap/extension/sensitive/OptionsSensitiveDataPanel.java`  
**Intention**: Provide GUI controls for masking.  
**Changes**:
- `AbstractParamPanel` named “Sensitive Data”.
- Checkbox: “Enable masking”.
- Text field: mask value.
- Text area: sensitive keys (one per line).
- Loads/saves values via `OptionsParam.getParamSet(OptionsParamSensitiveData.class)`.
**Feature added**: Users can configure masking in **Tools → Options → Sensitive Data**.

---

## 5. Registered the new extension in core built-in extensions

**File**: `zaproxy/zap/src/main/java/org/zaproxy/zap/control/CoreFunctionality.java`  
**Intention**: Ensure the extension loads automatically.  
**Changes**:
- Added `new org.zaproxy.zap.extension.sensitive.ExtensionSensitiveData()` to the built-in extensions list.
**Feature added**: Extension loads with the core ZAP build; options panel and param set registration active.

---

## 6. Integrated masking into request header display models (UI request panel text)

**Files**:
- `RequestHeaderStringHttpPanelViewModel.java`
- `RequestStringHttpPanelViewModel.java`
- `LargeRequestStringHttpPanelViewModel.java`

**Intention**: Mask sensitive data in Request panel header text views.  
**Changes**:
- In `getData()`, retrieves sensitive options:
  ```java
  OptionsParamSensitiveData sensitiveDataOptions =
      optionsParam.getParamSet(OptionsParamSensitiveData.class);