### PR TITLE
Correct all active scan resumption through the API

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/ascan/ExtensionActiveScan.java
@@ -736,7 +736,7 @@ public class ExtensionActiveScan extends ExtensionAdaptor
 
     @Override
     public void resumeAllScans() {
-        ascanController.removeAllScans();
+        ascanController.resumeAllScans();
         if (hasView()) {
             // Update the UI in case this was initiated from the API
             this.getActiveScanPanel().updateScannerUI();


### PR DESCRIPTION
## Summary
Fix `ExtensionActiveScan.resumeAllScans()` to delegate to `ascanController.resumeAllScans()` instead of `ascanController.removeAllScans()`.

## Problem
`resumeAllScans` was unintentionally removing all active scans instead of resuming paused ones.

## Root Cause
Wrong controller method call in `ExtensionActiveScan` (remove vs resume).

## Impact
- Restores expected behavior for "resume all scans".
- Prevents accidental stop/removal of active scan entries when resume-all is triggered (for example via API flows).

## Additional Context
According to `git blame`, this incorrect call has been present since 2019.
