### PR TITLE
Change title case of two popup labels

### DIFF
--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -624,7 +624,7 @@ ascan.toolbar.newalerts.label = New Alerts:
 ascan.toolbar.progress.label = Progress:
 ascan.toolbar.progress.select = --Select Scan--
 ascan.toolbar.requests.label = Num Requests:
-ascan.url.popup = Active Scan single URL
+ascan.url.popup = Active Scan Single URL
 
 attack.site.popup = Attack
 
@@ -1714,7 +1714,7 @@ history.scan.warning = Error getting History.
 history.scope.button.selected = Show all URLs
 history.scope.button.unselected = Show only URLs in Scope
 history.showinhistory.popup = Show in History Tab
-history.showresponse.popup = Show response in Browser
+history.showresponse.popup = Show Response in Browser
 history.tags.popup = Manage History Tags...
 
 http.panel.component.all.tooltip = Combined Display for Header and Body


### PR DESCRIPTION
Touches #2000.

Two popup labels in the core `Messages.properties` had a stray lowercase content word that breaks the Chicago title-caps style ZAP follows ([dev rules](https://www.zaproxy.org/docs/developer/dev-rules-and-guidelines/#style-guidelines), [reference](https://capitalizemytitle.com/#Chicago)). Their sibling popups in the same panels are already properly cased, which makes these two stand out:

```
ascan.site.popup     = Active Scan Site
ascan.subtree.popup  = Active Scan Subtree
ascan.url.popup      = Active Scan single URL          ← fixed → ...Single URL

history.showinhistory.popup = Show in History Tab
history.showresponse.popup  = Show response in Browser  ← fixed → Show Response in Browser
```

In `Show Response in Browser`, `in` stays lowercase because Chicago keeps short prepositions (≤ 4 letters) lowercase except in initial position.

Per the tracker issue's note that this is intended to be tackled bit by bit, I'm scoping this PR to those two strings. Translations live on CrowdIn, so only the canonical `Messages.properties` is touched.

## Verification

`grep`'d both keys to confirm no other UI surface uses the same string raw, and that the panel siblings (`ascan.site.popup`, `ascan.subtree.popup`, `history.showinhistory.popup`) already follow the same convention. Diff is `+2 / -2` lines, single file.
