### PR TITLE
Add Sites tree right-click 'Get Info' menu item (#3738)

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/control/CoreFunctionality.java
+++ b/zap/src/main/java/org/zaproxy/zap/control/CoreFunctionality.java
@@ -118,6 +118,7 @@ public final class CoreFunctionality {
             extensions.add(new org.zaproxy.zap.extension.script.ExtensionScript());
             extensions.add(new org.zaproxy.zap.extension.search.ExtensionSearch());
             extensions.add(new org.zaproxy.zap.extension.sessions.ExtensionSessionManagement());
+            extensions.add(new org.zaproxy.zap.extension.siteinfo.ExtensionSiteInfo());
             extensions.add(new org.zaproxy.zap.extension.siterefresh.ExtensionSitesRefresh());
             extensions.add(new org.zaproxy.zap.extension.stats.ExtensionStats());
             extensions.add(new org.zaproxy.zap.extension.stdmenus.ExtensionStdMenus());

--- a/zap/src/main/java/org/zaproxy/zap/extension/siteinfo/ExtensionSiteInfo.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/siteinfo/ExtensionSiteInfo.java
@@ -1,0 +1,73 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.siteinfo;
+
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+
+/** Adds the right-click "Get Info" menu item to the Sites tree (issue #3738). */
+public class ExtensionSiteInfo extends ExtensionAdaptor {
+
+    private static final String NAME = "ExtensionSiteInfo";
+
+    private PopupMenuSiteGetInfo popupMenuSiteGetInfo;
+
+    public ExtensionSiteInfo() {
+        super(NAME);
+        this.setOrder(1001);
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        super.hook(extensionHook);
+        if (getView() != null) {
+            extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuSiteGetInfo());
+        }
+    }
+
+    private PopupMenuSiteGetInfo getPopupMenuSiteGetInfo() {
+        if (popupMenuSiteGetInfo == null) {
+            popupMenuSiteGetInfo = new PopupMenuSiteGetInfo();
+        }
+        return popupMenuSiteGetInfo;
+    }
+
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString("siteinfo.name");
+    }
+
+    @Override
+    public String getAuthor() {
+        return Constant.ZAP_TEAM;
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("siteinfo.desc");
+    }
+
+    /** No database tables used, so all supported. */
+    @Override
+    public boolean supportsDb(String type) {
+        return true;
+    }
+}

--- a/zap/src/main/java/org/zaproxy/zap/extension/siteinfo/PopupMenuSiteGetInfo.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/siteinfo/PopupMenuSiteGetInfo.java
@@ -1,0 +1,133 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.siteinfo;
+
+import java.awt.Component;
+import java.text.DateFormat;
+import java.util.Date;
+import javax.swing.JOptionPane;
+import javax.swing.JTree;
+import javax.swing.tree.TreePath;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
+import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.model.SiteNode;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.view.popup.MenuWeights;
+
+/**
+ * Right-click "Get Info" item for the Sites tree, as requested in
+ * https://github.com/zaproxy/zaproxy/issues/3738. Shows a small modal dialog summarising the
+ * subtree rooted at the selected node: number of nodes, the most recent history reference, and the
+ * scanner / source that recorded it.
+ */
+public class PopupMenuSiteGetInfo extends ExtensionPopupMenuItem {
+
+    private static final long serialVersionUID = 1L;
+
+    public PopupMenuSiteGetInfo() {
+        super(Constant.messages.getString("siteinfo.popup"));
+
+        this.addActionListener(e -> showInfoDialog());
+    }
+
+    private void showInfoDialog() {
+        JTree tree = View.getSingleton().getSiteTreePanel().getTreeSite();
+        TreePath selection = tree.getSelectionPath();
+        if (selection == null) {
+            return;
+        }
+        SiteNode node = (SiteNode) selection.getLastPathComponent();
+        SiteInfoCalculator.Stats stats = SiteInfoCalculator.compute(node);
+
+        StringBuilder body = new StringBuilder();
+        body.append(
+                Constant.messages.getString("siteinfo.dialog.subtreeNodes", stats.getNodeCount()));
+        body.append('\n');
+        if (stats.hasNewestHistoryRef()) {
+            body.append(
+                    Constant.messages.getString(
+                            "siteinfo.dialog.lastNodeAdded",
+                            DateFormat.getDateTimeInstance()
+                                    .format(new Date(stats.getNewestHistoryRefTimeMillis()))));
+            body.append('\n');
+            body.append(
+                    Constant.messages.getString(
+                            "siteinfo.dialog.howFound",
+                            describeHistoryType(stats.getNewestHistoryRefType())));
+        } else {
+            body.append(Constant.messages.getString("siteinfo.dialog.noHistory"));
+        }
+
+        JOptionPane.showMessageDialog(
+                View.getSingleton().getMainFrame(),
+                body.toString(),
+                Constant.messages.getString("siteinfo.dialog.title", node.getNodeName()),
+                JOptionPane.INFORMATION_MESSAGE);
+    }
+
+    /** Map {@code HistoryReference.TYPE_*} to a short display string. Visible for testing. */
+    static String describeHistoryType(int type) {
+        switch (type) {
+            case HistoryReference.TYPE_PROXIED:
+                return Constant.messages.getString("siteinfo.type.proxied");
+            case HistoryReference.TYPE_ZAP_USER:
+                return Constant.messages.getString("siteinfo.type.user");
+            case HistoryReference.TYPE_SPIDER:
+                return Constant.messages.getString("siteinfo.type.spider");
+            case HistoryReference.TYPE_SPIDER_AJAX:
+                return Constant.messages.getString("siteinfo.type.spiderAjax");
+            case HistoryReference.TYPE_SCANNER:
+                return Constant.messages.getString("siteinfo.type.scanner");
+            case HistoryReference.TYPE_FUZZER:
+                return Constant.messages.getString("siteinfo.type.fuzzer");
+            case HistoryReference.TYPE_BRUTE_FORCE:
+                return Constant.messages.getString("siteinfo.type.bruteForce");
+            case HistoryReference.TYPE_CALLBACK:
+                return Constant.messages.getString("siteinfo.type.callback");
+            case HistoryReference.TYPE_OAST:
+                return Constant.messages.getString("siteinfo.type.oast");
+            default:
+                return Constant.messages.getString("siteinfo.type.other", type);
+        }
+    }
+
+    @Override
+    public boolean isEnableForComponent(Component invoker) {
+        if (invoker instanceof JTree) {
+            JTree tree = (JTree) invoker;
+            if ("treeSite".equals(tree.getName())) {
+                this.setEnabled(true);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public int getWeight() {
+        return MenuWeights.MENU_SITE_GET_INFO_WEIGHT;
+    }
+
+    @Override
+    public boolean isSafe() {
+        return true;
+    }
+}

--- a/zap/src/main/java/org/zaproxy/zap/extension/siteinfo/SiteInfoCalculator.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/siteinfo/SiteInfoCalculator.java
@@ -1,0 +1,115 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.siteinfo;
+
+import java.util.Enumeration;
+import javax.swing.tree.TreeNode;
+import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.model.SiteNode;
+
+/**
+ * Walks a {@link SiteNode} subtree and gathers descriptive statistics: number of nodes, the most
+ * recently added {@link HistoryReference} timestamp, and the {@link HistoryReference} type that
+ * produced it.
+ *
+ * <p>The calculator is split out from the popup menu so it can be exercised by a unit test without
+ * a Swing or database fixture.
+ */
+public final class SiteInfoCalculator {
+
+    /** Result snapshot for a subtree walk. */
+    public static final class Stats {
+        private final int nodeCount;
+        private final long newestHistoryRefTimeMillis;
+        private final int newestHistoryRefType;
+
+        public Stats(int nodeCount, long newestHistoryRefTimeMillis, int newestHistoryRefType) {
+            this.nodeCount = nodeCount;
+            this.newestHistoryRefTimeMillis = newestHistoryRefTimeMillis;
+            this.newestHistoryRefType = newestHistoryRefType;
+        }
+
+        /** Total number of {@link SiteNode} nodes in the subtree, including the root. */
+        public int getNodeCount() {
+            return nodeCount;
+        }
+
+        /**
+         * Time the newest {@link HistoryReference} in the subtree was sent, in milliseconds since
+         * epoch. Returns {@code 0} when the subtree has no history references at all.
+         */
+        public long getNewestHistoryRefTimeMillis() {
+            return newestHistoryRefTimeMillis;
+        }
+
+        /**
+         * Returns {@code true} if the walk found at least one {@link HistoryReference} in the
+         * subtree.
+         */
+        public boolean hasNewestHistoryRef() {
+            return newestHistoryRefTimeMillis > 0;
+        }
+
+        /**
+         * History type ({@code HistoryReference.TYPE_*}) of the newest {@link HistoryReference} in
+         * the subtree. Only meaningful when {@link #hasNewestHistoryRef()} returns {@code true}.
+         */
+        public int getNewestHistoryRefType() {
+            return newestHistoryRefType;
+        }
+    }
+
+    private SiteInfoCalculator() {}
+
+    /**
+     * Walk {@code root} (depth-first, pre-order) and collect descriptive stats for the whole
+     * subtree. The {@code root} node itself is included in the count.
+     */
+    public static Stats compute(SiteNode root) {
+        if (root == null) {
+            return new Stats(0, 0, 0);
+        }
+
+        int count = 0;
+        long newestTime = 0;
+        int newestType = 0;
+
+        Enumeration<TreeNode> nodes = root.depthFirstEnumeration();
+        while (nodes.hasMoreElements()) {
+            TreeNode tn = nodes.nextElement();
+            if (!(tn instanceof SiteNode)) {
+                continue;
+            }
+            count++;
+            SiteNode node = (SiteNode) tn;
+            HistoryReference href = node.getHistoryReference();
+            if (href == null) {
+                continue;
+            }
+            long t = href.getTimeSentMillis();
+            if (t > newestTime) {
+                newestTime = t;
+                newestType = href.getHistoryType();
+            }
+        }
+
+        return new Stats(count, newestTime, newestType);
+    }
+}

--- a/zap/src/main/java/org/zaproxy/zap/view/popup/MenuWeights.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/popup/MenuWeights.java
@@ -89,6 +89,7 @@ public class MenuWeights {
     public static final int MENU_SYNTAX_WEIGHT = 60;
     public static final int MENU_VIEW_WEIGHT = 40;
     public static final int MENU_SITE_REFRESH_WEIGHT = 20;
+    public static final int MENU_SITE_GET_INFO_WEIGHT = 25;
 
     // Contexts menu
     public static final int MENU_CONTEXT_ACTIVE_WEIGHT = 11680;

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -2694,6 +2694,25 @@ sessionmanagement.panel.label.noConfigPanel = <html><i>This method is fully conf
 sessionmanagement.panel.label.typeSelect = Currently selected Session Management method for the Context: 
 sessionmanagement.panel.title = Session Management
 
+siteinfo.desc = Adds the right-click "Get Info" menu item to the Sites tree.
+siteinfo.dialog.howFound = Newest node was found via: {0}
+siteinfo.dialog.lastNodeAdded = Last node added: {0}
+siteinfo.dialog.noHistory = No history references in this part of the tree yet.
+siteinfo.dialog.subtreeNodes = Nodes in subtree: {0}
+siteinfo.dialog.title = Sites tree info: {0}
+siteinfo.name = Sites Tree Get Info Extension
+siteinfo.popup = Get Info...
+siteinfo.type.bruteForce = Forced Browse
+siteinfo.type.callback = Callback
+siteinfo.type.fuzzer = Fuzzer
+siteinfo.type.oast = OAST
+siteinfo.type.other = Other (type {0})
+siteinfo.type.proxied = Proxied / Manual
+siteinfo.type.scanner = Active Scanner
+siteinfo.type.spider = Spider
+siteinfo.type.spiderAjax = AJAX Spider
+siteinfo.type.user = ZAP user
+
 siterefresh.desc = Adds menu item to refresh the Sites tree
 siterefresh.name = Refresh Sites Tree Extension
 siterefresh.popop = Refresh Sites Tree

--- a/zap/src/test/java/org/zaproxy/zap/extension/siteinfo/SiteInfoCalculatorUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/siteinfo/SiteInfoCalculatorUnitTest.java
@@ -1,0 +1,130 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.siteinfo;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
+import javax.swing.tree.TreeNode;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.model.SiteNode;
+
+/** Unit test for {@link SiteInfoCalculator}. */
+class SiteInfoCalculatorUnitTest {
+
+    @Test
+    void shouldReturnEmptyStatsForNullRoot() {
+        SiteInfoCalculator.Stats stats = SiteInfoCalculator.compute(null);
+
+        assertThat(stats.getNodeCount(), is(equalTo(0)));
+        assertThat(stats.hasNewestHistoryRef(), is(false));
+    }
+
+    @Test
+    void shouldCountSubtreeNodesIncludingRoot() {
+        SiteNode root = nodeWithHistoryReference(100);
+        SiteNode child1 = nodeWithHistoryReference(200);
+        SiteNode child2 = nodeWithHistoryReference(300);
+        wireSubtree(root, List.of(root, child1, child2));
+
+        SiteInfoCalculator.Stats stats = SiteInfoCalculator.compute(root);
+
+        assertThat(stats.getNodeCount(), is(equalTo(3)));
+    }
+
+    @Test
+    void shouldPickNewestHistoryReferenceTimeAcrossSubtree() {
+        SiteNode root = nodeWithHistoryReference(100);
+        SiteNode child1 = nodeWithHistoryReference(500);
+        SiteNode child2 = nodeWithHistoryReference(300);
+        wireSubtree(root, List.of(root, child1, child2));
+
+        SiteInfoCalculator.Stats stats = SiteInfoCalculator.compute(root);
+
+        assertThat(stats.hasNewestHistoryRef(), is(true));
+        assertThat(stats.getNewestHistoryRefTimeMillis(), is(equalTo(500L)));
+        assertThat(stats.getNewestHistoryRefType(), is(equalTo(HistoryReference.TYPE_SPIDER)));
+    }
+
+    @Test
+    void shouldHandleNodesWithoutHistoryReferences() {
+        SiteNode root = nodeWithHistoryReference(100);
+        SiteNode child = mock(SiteNode.class);
+        given(child.getHistoryReference()).willReturn(null);
+        wireSubtree(root, List.of(root, child));
+
+        SiteInfoCalculator.Stats stats = SiteInfoCalculator.compute(root);
+
+        assertThat(stats.getNodeCount(), is(equalTo(2)));
+        assertThat(stats.hasNewestHistoryRef(), is(true));
+        assertThat(stats.getNewestHistoryRefTimeMillis(), is(equalTo(100L)));
+    }
+
+    @Test
+    void shouldReportNoHistoryWhenSubtreeHasNone() {
+        SiteNode root = mock(SiteNode.class);
+        given(root.getHistoryReference()).willReturn(null);
+        wireSubtree(root, List.of(root));
+
+        SiteInfoCalculator.Stats stats = SiteInfoCalculator.compute(root);
+
+        assertThat(stats.getNodeCount(), is(equalTo(1)));
+        assertThat(stats.hasNewestHistoryRef(), is(false));
+    }
+
+    private static SiteNode nodeWithHistoryReference(long timeSentMillis) {
+        SiteNode node = mock(SiteNode.class);
+        HistoryReference href = mock(HistoryReference.class);
+        given(href.getTimeSentMillis()).willReturn(timeSentMillis);
+        given(href.getHistoryType()).willReturn(HistoryReference.TYPE_SPIDER);
+        given(node.getHistoryReference()).willReturn(href);
+        return node;
+    }
+
+    /**
+     * Stub {@code root.depthFirstEnumeration()} to walk the supplied nodes in order. Mockito cannot
+     * generate an enumeration directly, so this helper does it by hand.
+     */
+    private static void wireSubtree(SiteNode root, List<? extends TreeNode> nodes) {
+        given(root.depthFirstEnumeration()).willReturn(asEnumeration(nodes));
+    }
+
+    private static Enumeration<TreeNode> asEnumeration(List<? extends TreeNode> nodes) {
+        Iterator<? extends TreeNode> it = nodes.iterator();
+        return new Enumeration<TreeNode>() {
+            @Override
+            public boolean hasMoreElements() {
+                return it.hasNext();
+            }
+
+            @Override
+            public TreeNode nextElement() {
+                return it.next();
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
 
@kingthorin (issue author) suggested a right-click \"Get Info\" item on the Sites tree that surfaces:

- number of nodes in the subtree
- last time a node was added
- how the newest node was found (Spider / AJAX Spider / Proxied / etc.)

This PR adds that. A new `ExtensionSiteInfo` contributes a `Get Info...` entry next to the existing `Refresh Sites Tree` item; selecting it pops up a `JOptionPane` with the three metrics.

The issue explicitly says the info \"should be calculated when requested, as precalculating it for every node in the tree every time the tree is updated would be wasteful\" — so the implementation walks the subtree only on demand and doesn't introduce any per-update bookkeeping.

## Implementation

- `org.zaproxy.zap.extension.siteinfo.SiteInfoCalculator` — pure helper that walks a `SiteNode.depthFirstEnumeration()` and returns a `Stats` snapshot (`nodeCount`, `newestHistoryRefTimeMillis`, `newestHistoryRefType`). Easy to unit-test.
- `PopupMenuSiteGetInfo` — `ExtensionPopupMenuItem` that's enabled when the invoker is the Sites tree (`treeSite`). It runs the calculator, formats the timestamp via `DateFormat.getDateTimeInstance()` (locale-aware), and translates the history type code into a localised label.
- `ExtensionSiteInfo` — registers the popup item, mirroring the structure of the existing `ExtensionSitesRefresh`.
- `MenuWeights.MENU_SITE_GET_INFO_WEIGHT = 25` — places the new item just above `MENU_SITE_REFRESH_WEIGHT = 20` in the bottom section of the menu.
- Wiring: added to `CoreFunctionality.java` next to `ExtensionSitesRefresh`.

## Tests

`SiteInfoCalculatorUnitTest` covers the helper end-to-end:

- empty / null root returns empty stats
- subtree node count includes the root
- newest timestamp + type are picked across the whole subtree (not just the root's)
- nodes without a `HistoryReference` are counted but skipped for the timestamp
- subtrees with no history references at all report \"no history\"

```
$ ./gradlew :zap:test --tests \"*SiteInfoCalculator*\"
BUILD SUCCESSFUL
5 tests, 0 failures
```

`./gradlew :zap:spotlessJavaCheck` and `:zap:compileJava` are clean. Spotless was applied to the new files.

## i18n

10 new keys under the `siteinfo.*` namespace in `Messages.properties` (description, popup label, dialog title and body strings, and one label per `HistoryReference.TYPE_*` value). Localised translations can follow in `Messages_*.properties` once the strings are stable.

## Test plan

- [x] Unit tests pass (`SiteInfoCalculatorUnitTest`).
- [x] `:zap:compileJava` clean.
- [x] `:zap:spotlessJavaCheck` clean.
- [ ] Manual UI smoke: right-click on Sites tree node → \"Get Info...\" → dialog shows expected counts and timestamp.