### PR TITLE
Remove unused resource messages

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/stdmenus/ExtensionStdMenus.java
@@ -71,8 +71,6 @@ public class ExtensionStdMenus extends ExtensionAdaptor implements ClipboardOwne
     private PopupContextTreeMenu popupContextTreeMenuDelete = null;
     private PopupContextTreeMenu popupContextTreeMenuExport;
 
-    // Still being developed
-    // private PopupMenuShowResponseInBrowser popupMenuShowResponseInBrowser = null;
     private static final Logger LOGGER = LogManager.getLogger(ExtensionStdMenus.class);
 
     public ExtensionStdMenus() {

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -609,8 +609,6 @@ ascan.scripts.interface.active.error = The provided Active Rules script ({0}) do
 ascan.scripts.skip.reason = no scripts enabled
 ascan.scripts.type.active = Active Rules
 ascan.scripts.type.active.desc = Active Rules scripts run when you run the Active Scanner.\n\nYou must enable them before they will be used.\n\n
-ascan.site.popup = Active Scan Site
-ascan.subtree.popup = Active Scan Subtree
 ascan.toolbar.ascans.label = Current Scans:
 ascan.toolbar.button.clear = Clean Completed Scans
 ascan.toolbar.button.new = New Scan
@@ -624,7 +622,6 @@ ascan.toolbar.newalerts.label = New Alerts:
 ascan.toolbar.progress.label = Progress:
 ascan.toolbar.progress.select = --Select Scan--
 ascan.toolbar.requests.label = Num Requests:
-ascan.url.popup = Active Scan single URL
 
 attack.site.popup = Attack
 
@@ -1714,7 +1711,6 @@ history.scan.warning = Error getting History.
 history.scope.button.selected = Show all URLs
 history.scope.button.unselected = Show only URLs in Scope
 history.showinhistory.popup = Show in History Tab
-history.showresponse.popup = Show response in Browser
 history.tags.popup = Manage History Tags...
 
 http.panel.component.all.tooltip = Combined Display for Header and Body


### PR DESCRIPTION
The message `history.showresponse.popup` was added in b8dc3501d51a7e4a05e120b34d2fea178c61f765 but not actually used, likely related to commented code, which is being removed as well.

The message `ascan.url.popup` stopped being referenced in c3de0fe0ff759807ca5a84fbcb6353813c6ae958 as the several context menus were replaced with the custom scan dialogue.
Remove additional active scan related context menu messages that stopped being referenced in the same commit.