### PR TITLE
Actions: remove Bluesky alerts

### DIFF
--- a/.github/workflows/check-zap-errors.yml
+++ b/.github/workflows/check-zap-errors.yml
@@ -23,13 +23,6 @@ jobs:
           # Pulls Nightly from GHCR
           docker run --rm -v $(pwd)/.github/workflows/conf:/zap/wrk/:rw -t ghcr.io/zaproxy/zaproxy:nightly zap.sh -addonupdate -addoninstallall -dev -cmd -autorun /zap/wrk/af-check-errors.yml
         continue-on-error: true
-      - name: "Send messages on failures"
-        uses: myConsciousness/bluesky-post@96827d0a9604cb228b11b3095f6961196efba4a0 # v5
-        if: ${{ ! cancelled() && ( steps.check-stable.outcome != 'success' || steps.check-nightly.outcome != 'success' ) }}
-        with:
-          text: "Hey @psiinon.bsky.social - looks like the overnight ZAP Check failed 😟 https://github.com/zaproxy/zaproxy/actions/runs/${{ github.run_id }}"  
-          identifier: ${{ secrets.BLUESKY_ZAPBOT_IDENTIFIER }}
-          password: ${{ secrets.BLUESKY_ZAPBOT_PASSWORD }}
       - name: "Fail if necessary"
         if: steps.check-stable.outcome != 'success' || steps.check-nightly.outcome != 'success'
         run: exit 1

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -66,15 +66,3 @@ jobs:
         name: Run baseline tests
         if: ${{ ! cancelled() }}
         run: docker run --rm -t ghcr.io/zaproxy/zaproxy-tests wrk/baseline_tests.sh
-      - name: "Send messages on failures"
-        uses: myConsciousness/bluesky-post@96827d0a9604cb228b11b3095f6961196efba4a0 # v5
-        if: |
-          ! cancelled() && ( 
-            steps.test-install.outcome != 'success' || 
-            steps.test-python.outcome != 'success' ||
-            steps.test-af-context.outcome != 'success' ||
-            steps.test-af-plan.outcome != 'success')
-        with:
-          text: "Hey @psiinon.bsky.social - looks like the ZAP Integration Tests failed 😟 https://github.com/zaproxy/zaproxy/actions/runs/${{ github.run_id }}"  
-          identifier: ${{ secrets.BLUESKY_ZAPBOT_IDENTIFIER }}
-          password: ${{ secrets.BLUESKY_ZAPBOT_PASSWORD }}


### PR DESCRIPTION
The failures are now posted to a Slack channel, which all of the Core team can see