### PR TITLE
fix: re-enable TLS 1.3 on proxy server socket (Java 11 workaround stale)

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/network/SSLConnector.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/SSLConnector.java
@@ -127,9 +127,7 @@ public class SSLConnector
         SECURITY_PROTOCOL_TLS_V1,
         SECURITY_PROTOCOL_TLS_V1_1,
         SECURITY_PROTOCOL_TLS_V1_2,
-        // Disable TLS 1.3 by default as it currently fails with Java 11
-        // TODO re-enable (or just use DEFAULT_ENABLED_PROTOCOLS) when Java 11 works with TLS 1.3
-        // SECURITY_PROTOCOL_TLS_V1_3
+        SECURITY_PROTOCOL_TLS_V1_3
     };
 
     private static final String[] FAIL_SAFE_DEFAULT_ENABLED_PROTOCOLS = {SECURITY_PROTOCOL_TLS_V1};


### PR DESCRIPTION
## Summary

Re-enables TLS 1.3 in `DEFAULT_SERVER_ENABLED_PROTOCOLS` in `SSLConnector.java`.

## Context

In 2019, TLS 1.3 was disabled on ZAP's proxy server socket with the comment
"fails with Java 11" (added in commit context from 2019/02/26). ZAP now
requires Java 17 minimum (moving to Java 21 per #9258). TLS 1.3 has been
stable in Java since 11.0.3.

The client-side array `DEFAULT_ENABLED_PROTOCOLS` already includes TLS 1.3.
This asymmetry means browsers connecting to ZAP's proxy are silently
downgraded from TLS 1.3 to TLS 1.2 on every connection — even when the
browser negotiates TLS 1.3 by default (Chrome 70+, Firefox 63+, Safari 12.1+).

## Change

- Uncommented `SECURITY_PROTOCOL_TLS_V1_3` in `DEFAULT_SERVER_ENABLED_PROTOCOLS`
- Removed the stale TODO and the Java 11 explanation comment

## Testing

Built and confirmed `compileJava` passes. No existing tests cover this
class — a follow-up test PR is planned.