### PR TITLE
docker: Update stable, bare, and tests images to debian:trixie-slim

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2026-05-28
+- Updated stable, bare, and tests images to use `debian:trixie-slim` instead of `bookworm-slim` ahead of Debian bookworm EOL on 2026-06-10 (Issue 9310).
+
 ### 2026-05-08
 - Fixed bug in baseline scan which could result in a python error when running the packaged scan without a mapped drive.
 

--- a/docker/Dockerfile-bare
+++ b/docker/Dockerfile-bare
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # This dockerfile builds the zap bare release
-FROM --platform=linux/amd64 debian:bookworm-slim AS builder
+FROM --platform=linux/amd64 debian:trixie-slim AS builder
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
 	wget \

--- a/docker/Dockerfile-stable
+++ b/docker/Dockerfile-stable
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # This dockerfile builds the zap stable release
-FROM --platform=linux/amd64 debian:bookworm-slim AS builder
+FROM --platform=linux/amd64 debian:trixie-slim AS builder
 
 RUN apt-get update && apt-get install -q -y --fix-missing \
 	wget \
@@ -34,7 +34,7 @@ RUN --mount=type=secret,id=webswing_url \
 	# Remove Webswing bundled examples
 	rm -Rf webswing/apps/
 
-FROM debian:bookworm-slim AS final
+FROM debian:trixie-slim AS final
 LABEL maintainer="psiinon@gmail.com"
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/docker/Dockerfile-tests
+++ b/docker/Dockerfile-tests
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # This dockerfile builds a ZAP docker image used for integration tests
-FROM --platform=linux/amd64 debian:bookworm-slim AS builder
+FROM --platform=linux/amd64 debian:trixie-slim AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Summary

Debian bookworm reaches end-of-life on 2026-06-10. After that date the base image stops receiving security updates, so the Docker images built on top of it become a CVE liability for any pipeline pulling them.

This PR updates the three remaining bookworm-based images stable, bare, and tests to `debian:trixie-slim`. The live and weekly images were already migrated in February 2026 (see `docker/CHANGELOG.md`), so this brings the full image set onto a currently supported OS.

## Changes

- `docker/Dockerfile-stable`: builder and final stages bumped from `debian:bookworm-slim` to `debian:trixie-slim`.
- `docker/Dockerfile-bare`: builder stage bumped to `debian:trixie-slim`. Final stage uses `eclipse-temurin:17-jre-alpine` and is unaffected by the bookworm EOL.
- `docker/Dockerfile-tests`: builder stage bumped to `debian:trixie-slim`. Final stage uses `ghcr.io/zaproxy/zaproxy:nightly`, which is rebuilt from the already-trixie weekly image.
- `docker/CHANGELOG.md`: entry added.

## Design notes

The JDK is intentionally left at `openjdk-17-jdk` for the stable image. The package is still maintained in trixie, and keeping it on 17 aligns with ZAP's default compile target (`JavaVersion.VERSION_17` in `zap/zap.gradle.kts`), so the runtime stays predictable for the latest stable release. Happy to bump to `openjdk-21-jdk` in a follow-up if symmetry with live/weekly is preferred.

## Test plan

- `docker build -f docker/Dockerfile-stable .` succeeds — all apt packages resolve in trixie.
- Resulting container starts ZAP cleanly and the HEALTHCHECK passes.
- `docker build -f docker/Dockerfile-bare .` succeeds.
-  `docker build -f docker/Dockerfile-tests .` succeeds.
