### PR TITLE
Fix quit after user cancel in macOS

### DIFF
--- a/zap/gradle/japicmp.yaml
+++ b/zap/gradle/japicmp.yaml
@@ -21,3 +21,5 @@ methodExcludes:
  - "org.parosproxy.paros.model.OptionsParam#getCertificateParam()"
  - "org.parosproxy.paros.model.OptionsParam#getExperimentalFeaturesParam()"
  - "org.parosproxy.paros.model.OptionsParam#setCertificateParam(org.parosproxy.paros.extension.option.OptionsParamCertificate)"
+ - "org.parosproxy.paros.control.Control#exit(boolean,java.io.File)"
+ - "org.parosproxy.paros.control.MenuFileControl#exit()"

--- a/zap/src/main/java/org/parosproxy/paros/control/Control.java
+++ b/zap/src/main/java/org/parosproxy/paros/control/Control.java
@@ -232,7 +232,10 @@ public class Control extends AbstractControl implements SessionListener {
         }
     }
 
-    public void exit(boolean noPrompt, final File openOnExit) {
+    /**
+     * @return {@code true} if shutdown was started, {@code false} if the user cancelled a prompt
+     */
+    public boolean exit(boolean noPrompt, final File openOnExit) {
         boolean isNewState = model.getSession().isNewState();
         int rootCount = 0;
         if (!Constant.isLowMemoryOptionSet()) {
@@ -282,7 +285,7 @@ public class Control extends AbstractControl implements SessionListener {
 
             if (message != null
                     && view.showConfirmDialog(new ZapHtmlLabel(message)) != JOptionPane.OK_OPTION) {
-                return;
+                return false;
             }
         }
 
@@ -335,6 +338,7 @@ public class Control extends AbstractControl implements SessionListener {
         } else {
             t.start();
         }
+        return true;
     }
 
     /**

--- a/zap/src/main/java/org/parosproxy/paros/control/MenuFileControl.java
+++ b/zap/src/main/java/org/parosproxy/paros/control/MenuFileControl.java
@@ -110,8 +110,8 @@ public class MenuFileControl implements SessionListener {
         this.control = control;
     }
 
-    public void exit() {
-        control.exit(false, null);
+    public boolean exit() {
+        return control.exit(false, null);
     }
 
     public void newSession(boolean isPromptNewSession) throws ClassNotFoundException, Exception {

--- a/zap/src/main/java/org/zaproxy/zap/OsXGui.java
+++ b/zap/src/main/java/org/zaproxy/zap/OsXGui.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap;
 import java.awt.Desktop;
 import java.awt.Image;
 import java.awt.Toolkit;
+import java.awt.desktop.QuitResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.control.Control;
@@ -64,7 +65,7 @@ class OsXGui {
         Desktop desktop = Desktop.getDesktop();
         desktop.setAboutHandler(ae -> showAboutDialog());
         desktop.setPreferencesHandler(pe -> showOptionsDialog());
-        desktop.setQuitHandler((qe, qr) -> exitZap());
+        desktop.setQuitHandler((qe, qr) -> exitZap(qr));
     }
 
     private static Image createIcon() {
@@ -81,7 +82,9 @@ class OsXGui {
         Control.getSingleton().getMenuToolsControl().options();
     }
 
-    private static void exitZap() {
-        Control.getSingleton().getMenuFileControl().exit();
+    private static void exitZap(QuitResponse quitResponse) {
+        if (!Control.getSingleton().getMenuFileControl().exit()) {
+            quitResponse.cancelQuit();
+        }
     }
 }


### PR DESCRIPTION
On macOS if there was unsaved data in a session and the user Quit but then canceled, the next time they quit nothing happened. It now behaves as expected.