### PR TITLE
Use current session when getting all alerts

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertAPI.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/AlertAPI.java
@@ -493,10 +493,9 @@ public class AlertAPI extends ApiImplementor {
         try {
             TableAlert tableAlert = Model.getSingleton().getDb().getTableAlert();
             TableAlertTag tableAlertTag = Model.getSingleton().getDb().getTableAlertTag();
-            // TODO this doesn't work, but should be used when its fixed :/
-            // Vector<Integer> v =
-            // tableAlert.getAlertListBySession(Model.getSingleton().getSession().getSessionId());
-            Vector<Integer> v = tableAlert.getAlertList();
+            Vector<Integer> v =
+                    tableAlert.getAlertListBySession(
+                            Model.getSingleton().getSession().getSessionId());
 
             PaginationConstraintsChecker pcc = new PaginationConstraintsChecker(start, count);
             for (int alertId : v) {

--- a/zap/src/main/java/org/zaproxy/zap/extension/alert/ExtensionAlert.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/alert/ExtensionAlert.java
@@ -712,10 +712,8 @@ public class ExtensionAlert extends ExtensionAdaptor
 
         TableAlert tableAlert = getModel().getDb().getTableAlert();
         TableAlertTag tableAlertTag = getModel().getDb().getTableAlertTag();
-        // TODO this doesn't work, but should be used when its fixed :/
-        // Vector<Integer> v =
-        // tableAlert.getAlertListBySession(Model.getSingleton().getSession().getSessionId());
-        Vector<Integer> v = tableAlert.getAlertList();
+        Vector<Integer> v =
+                tableAlert.getAlertListBySession(Model.getSingleton().getSession().getSessionId());
 
         final ExtensionHistory extensionHistory =
                 Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
@@ -982,10 +980,7 @@ public class ExtensionAlert extends ExtensionAdaptor
         TableAlertTag tableAlertTag = getModel().getDb().getTableAlertTag();
         Vector<Integer> v;
         try {
-            // TODO this doesn't work, but should be used when its fixed :/
-            // v =
-            // tableAlert.getAlertListBySession(Model.getSingleton().getSession().getSessionId());
-            v = tableAlert.getAlertList();
+            v = tableAlert.getAlertListBySession(Model.getSingleton().getSession().getSessionId());
 
             for (int i = 0; i < v.size(); i++) {
                 int alertId = v.get(i);

--- a/zap/src/test/java/org/zaproxy/zap/extension/alert/AlertAPIUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/alert/AlertAPIUnitTest.java
@@ -41,6 +41,7 @@ import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.db.RecordAlert;
 import org.parosproxy.paros.db.TableAlert;
 import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.model.Session;
 import org.zaproxy.zap.WithConfigsTest;
 import org.zaproxy.zap.db.TableAlertTag;
 import org.zaproxy.zap.extension.api.ApiResponse;
@@ -65,6 +66,9 @@ public class AlertAPIUnitTest {
 
         Model model = mock(Model.class, withSettings().strictness(Strictness.LENIENT));
         Model.setSingletonForTesting(model);
+        Session session = mock(Session.class);
+        given(session.getSessionId()).willReturn(1L);
+        given(model.getSession()).willReturn(session);
 
         Database db = mock(Database.class);
         given(model.getDb()).willReturn(db);
@@ -175,7 +179,7 @@ public class AlertAPIUnitTest {
                 alerts.stream()
                         .map(RecordAlert::getAlertId)
                         .collect(Collectors.toCollection(Vector::new));
-        given(tableAlert.getAlertList()).willReturn(alertIds);
+        given(tableAlert.getAlertListBySession(1L)).willReturn(alertIds);
         for (RecordAlert alert : alerts) {
             given(tableAlert.read(alert.getAlertId())).willReturn(alert);
         }


### PR DESCRIPTION
## Summary
Fixes #9346

Three call sites in `ExtensionAlert` and `AlertAPI` were calling
`tableAlert.getAlertList()`, which returns alerts across **all**
sessions. Each site had a suppressed TODO pointing to the correct
session-scoped method that was never activated.

## Changes
- `ExtensionAlert.java` line ~715: replaced `getAlertList()` with
  `getAlertListBySession(sessionId)`
- `ExtensionAlert.java` line ~985: same replacement
- `AlertAPI.java` line ~498: same replacement

## Why this is safe
`getAlertListBySession(long sessionId)` is fully implemented in both
`ParosTableAlert` and `SqlTableAlert` with correct SQL JOINs. The
original TODO did not document a known failure — based on the code
review, this appears to have been left as future work.

## Testing
- `./gradlew :zap:test` passes
- Manual: loaded a saved session after a scan; REST API
  `/JSON/alert/view/alerts/` now returns only current-session alerts

## Changelog
This is a bug fix affecting observable API behaviour — alerts from
previous sessions no longer appear in the current session's view.