### PR TITLE
Register ZapAction shortcuts

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/extension/history/ExtensionHistory.java
+++ b/zap/src/main/java/org/parosproxy/paros/extension/history/ExtensionHistory.java
@@ -151,6 +151,7 @@ import org.zaproxy.zap.extension.history.PopupMenuJumpTo;
 import org.zaproxy.zap.extension.history.PopupMenuNote;
 import org.zaproxy.zap.extension.history.PopupMenuPurgeHistory;
 import org.zaproxy.zap.extension.history.PopupMenuTag;
+import org.zaproxy.zap.extension.keyboard.ExtensionKeyboard;
 import org.zaproxy.zap.view.popup.MenuWeights;
 import org.zaproxy.zap.view.table.HistoryReferencesTable;
 
@@ -275,6 +276,21 @@ public class ExtensionHistory extends ExtensionAdaptor implements SessionChanged
             extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuPurgeHistory());
 
             ExtensionHelp.enableHelpKey(this.getLogPanel(), "ui.tabs.history");
+        }
+    }
+
+    @Override
+    public void postInit() {
+        super.postInit();
+        if (!hasView()) {
+            return;
+        }
+        ExtensionKeyboard extensionKeyboard =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionKeyboard.class);
+        if (extensionKeyboard != null) {
+            extensionKeyboard.registerGlobalAction(
+                    getPopupMenuJumpTo().getJumpAction(),
+                    ks -> getPopupMenuJumpTo().updateAccelerator(ks));
         }
     }
 

--- a/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuJumpTo.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/history/PopupMenuJumpTo.java
@@ -20,11 +20,10 @@
 package org.zaproxy.zap.extension.history;
 
 import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.util.Collections;
 import java.util.List;
-import javax.swing.AbstractAction;
-import javax.swing.JComponent;
 import javax.swing.JOptionPane;
 import javax.swing.KeyStroke;
 import org.apache.logging.log4j.LogManager;
@@ -32,12 +31,14 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.HistoryReference;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.ZapNumberSpinner;
+import org.zaproxy.zap.view.ZapAction;
 import org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer;
 
 @SuppressWarnings("serial")
 public class PopupMenuJumpTo extends PopupMenuItemHistoryReferenceContainer {
+
+    public static final String IDENTIFIER = "zap.history.jumpto";
 
     private static final Logger LOGGER = LogManager.getLogger(PopupMenuJumpTo.class);
     private static final List<Integer> DISPLAYED_HISTORY_TYPES =
@@ -45,41 +46,32 @@ public class PopupMenuJumpTo extends PopupMenuItemHistoryReferenceContainer {
                     HistoryReference.TYPE_PROXIED,
                     HistoryReference.TYPE_ZAP_USER,
                     HistoryReference.TYPE_PROXY_CONNECT);
-    private static final KeyStroke JUMP_KEY_STROKE =
-            KeyStroke.getKeyStroke(KeyEvent.VK_J, KeyEvent.ALT_DOWN_MASK | KeyEvent.CTRL_DOWN_MASK);
     private static ZapNumberSpinner idSpinner = new ZapNumberSpinner(1, 1, Integer.MAX_VALUE);
 
     private final ExtensionHistory extension;
+    private final JumpToAction jumpAction;
 
     public PopupMenuJumpTo(ExtensionHistory extension) {
         super(Constant.messages.getString("history.jumpto.popup.label"));
 
         this.extension = extension;
+        this.jumpAction = new JumpToAction();
+        updateAccelerator(jumpAction.getAccelerator());
+    }
 
-        String jumpTo = "zap.history.jumpto";
+    public ZapAction getJumpAction() {
+        return jumpAction;
+    }
 
-        View.getSingleton()
-                .getWorkbench()
-                .getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-                .put(JUMP_KEY_STROKE, jumpTo);
-        View.getSingleton()
-                .getWorkbench()
-                .getActionMap()
-                .put(
-                        jumpTo,
-                        new AbstractAction() {
+    public void updateAccelerator(KeyStroke keyStroke) {
+        if (keyStroke != null) {
+            setAccelerator(keyStroke);
+        }
+    }
 
-                            @Override
-                            public void actionPerformed(ActionEvent e) {
-                                jump();
-                            }
-                        });
-        this.setAccelerator(
-                View.getSingleton()
-                        .getMenuShortcutKeyStroke(
-                                JUMP_KEY_STROKE.getKeyCode(),
-                                JUMP_KEY_STROKE.getModifiers(),
-                                false));
+    public static KeyStroke getDefaultAccelerator() {
+        return KeyStroke.getKeyStroke(
+                KeyEvent.VK_J, InputEvent.CTRL_DOWN_MASK | InputEvent.ALT_DOWN_MASK);
     }
 
     @Override
@@ -132,5 +124,20 @@ public class PopupMenuJumpTo extends PopupMenuItemHistoryReferenceContainer {
     @Override
     public boolean isSafe() {
         return true;
+    }
+
+    private class JumpToAction extends ZapAction {
+
+        JumpToAction() {
+            super(
+                    IDENTIFIER,
+                    Constant.messages.getString("history.jumpto.popup.label"),
+                    PopupMenuJumpTo.getDefaultAccelerator());
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            jump();
+        }
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/keyboard/ExtensionKeyboard.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/keyboard/ExtensionKeyboard.java
@@ -21,8 +21,15 @@ package org.zaproxy.zap.extension.keyboard;
 
 import java.awt.Component;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
+import javax.swing.Action;
+import javax.swing.ActionMap;
+import javax.swing.InputMap;
+import javax.swing.JComponent;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.KeyStroke;
@@ -34,7 +41,9 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.view.MainMenuBar;
+import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.DesktopUtils;
+import org.zaproxy.zap.view.ZapAction;
 import org.zaproxy.zap.view.ZapMenuItem;
 
 public class ExtensionKeyboard extends ExtensionAdaptor {
@@ -56,6 +65,8 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
      * @see #getDefaultAccelerator(ZapMenuItem)
      */
     private List<String> menusDupDefaultAccelerator;
+
+    private final Map<String, Consumer<KeyStroke>> acceleratorChangeListeners = new HashMap<>();
 
     public ExtensionKeyboard() {
         super(NAME);
@@ -108,12 +119,119 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
     public void registerMenuItem(ZapMenuItem zme) {
         String identifier = zme.getIdentifier();
         if (identifier != null) {
-            validateDefaultAccelerator(zme);
+            validateDefaultAccelerator(identifier, zme.getDefaultAccelerator());
+            if (isIdentifierWithDuplicatedAccelerator(identifier)
+                    && zme.getDefaultAccelerator() != null
+                    && zme.getDefaultAccelerator().equals(zme.getAccelerator())) {
+                zme.setAccelerator(null);
+            }
             setConfiguredAccelerator(zme);
             this.map.put(identifier, new KeyboardMapping(zme));
         } else {
             LOGGER.warn("ZapMenuItem \"{}\" has a null identifier.", zme.getName());
         }
+    }
+
+    /**
+     * Registers an action and binds it to the given component's {@code InputMap}/{@code ActionMap}.
+     *
+     * @param action the action to register.
+     * @param targetComponent the component to bind the action to.
+     * @param condition the {@code InputMap} condition (e.g. {@link
+     *     JComponent#WHEN_ANCESTOR_OF_FOCUSED_COMPONENT}).
+     * @since 2.18.0
+     */
+    public void registerAction(ZapAction action, JComponent targetComponent, int condition) {
+        registerAction(
+                action,
+                targetComponent,
+                condition,
+                Constant.messages.getString("keyboard.scope.component"));
+    }
+
+    /**
+     * Registers an action and binds it to the given component's {@code InputMap}/{@code ActionMap}.
+     *
+     * @param action the action to register.
+     * @param targetComponent the component to bind the action to.
+     * @param condition the {@code InputMap} condition (e.g. {@link
+     *     JComponent#WHEN_ANCESTOR_OF_FOCUSED_COMPONENT}).
+     * @param scope the scope shown in the keyboard options (e.g. panel name).
+     * @since 2.18.0
+     */
+    public void registerAction(
+            ZapAction action, JComponent targetComponent, int condition, String scope) {
+        registerAction(action, targetComponent, condition, scope, null);
+    }
+
+    /**
+     * Registers an action, binds it to the given component, and optionally notifies {@code
+     * onAcceleratorChange} when the accelerator is set or subsequently changed.
+     *
+     * @param action the action to register.
+     * @param targetComponent the component to bind the action to.
+     * @param condition the {@code InputMap} condition.
+     * @param scope the scope shown in the keyboard options.
+     * @param onAcceleratorChange optional listener; also invoked once with the current accelerator
+     *     after registration.
+     * @return the configured accelerator after registration.
+     * @since 2.18.0
+     */
+    public KeyStroke registerAction(
+            ZapAction action,
+            JComponent targetComponent,
+            int condition,
+            String scope,
+            Consumer<KeyStroke> onAcceleratorChange) {
+        String identifier = action.getIdentifier();
+        validateDefaultAccelerator(identifier, action.getDefaultAccelerator());
+        setConfiguredAccelerator(action);
+        KeyboardMapping mapping = new KeyboardMapping(action, targetComponent, condition, scope);
+        this.map.put(identifier, mapping);
+        bindAction(mapping);
+        return registerAcceleratorChangeListener(action, onAcceleratorChange);
+    }
+
+    /**
+     * Registers an action and binds it globally (to the workbench with {@link
+     * JComponent#WHEN_IN_FOCUSED_WINDOW}).
+     *
+     * @param action the action to register.
+     * @return the configured accelerator after registration.
+     * @since 2.18.0
+     */
+    public KeyStroke registerGlobalAction(ZapAction action) {
+        return registerGlobalAction(action, null);
+    }
+
+    /**
+     * Registers an action globally and optionally notifies {@code onAcceleratorChange} when the
+     * accelerator is set or subsequently changed.
+     *
+     * @param action the action to register.
+     * @param onAcceleratorChange optional listener; also invoked once with the current accelerator
+     *     after registration.
+     * @return the configured accelerator after registration.
+     * @since 2.18.0
+     */
+    public KeyStroke registerGlobalAction(
+            ZapAction action, Consumer<KeyStroke> onAcceleratorChange) {
+        return registerAction(
+                action,
+                View.getSingleton().getWorkbench(),
+                JComponent.WHEN_IN_FOCUSED_WINDOW,
+                Constant.messages.getString("keyboard.scope.global"),
+                onAcceleratorChange);
+    }
+
+    private KeyStroke registerAcceleratorChangeListener(
+            ZapAction action, Consumer<KeyStroke> onAcceleratorChange) {
+        KeyStroke accelerator = action.getAccelerator();
+        if (onAcceleratorChange != null) {
+            acceleratorChangeListeners.put(action.getIdentifier(), onAcceleratorChange);
+            onAcceleratorChange.accept(accelerator);
+        }
+        return accelerator;
     }
 
     /**
@@ -124,13 +242,12 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
      * @param zme the menu item to validate.
      * @see #menusDupDefaultAccelerator
      */
-    private void validateDefaultAccelerator(ZapMenuItem zme) {
-        KeyStroke ks = zme.getDefaultAccelerator();
-        if (ks == null) {
+    private void validateDefaultAccelerator(String identifier, KeyStroke defaultAccelerator) {
+        if (defaultAccelerator == null) {
             return;
         }
 
-        if (isIdentifierWithDuplicatedAccelerator(zme.getIdentifier())) {
+        if (isIdentifierWithDuplicatedAccelerator(identifier)) {
             return;
         }
 
@@ -140,20 +257,17 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
                 continue;
             }
 
-            if (hasSameDefaultAccelerator(km, ks)
-                    && !zme.getIdentifier().equals(km.getIdentifier())) {
+            if (hasSameDefaultAccelerator(km, defaultAccelerator)
+                    && !identifier.equals(km.getIdentifier())) {
                 String msg =
                         String.format(
-                                "Menus %s and %s use the same default accelerator: %s",
-                                zme.getIdentifier(), km.getIdentifier(), ks);
+                                "Shortcuts %s and %s use the same default accelerator: %s",
+                                identifier, km.getIdentifier(), defaultAccelerator);
                 LOGGER.log(Constant.isDevMode() ? Level.ERROR : Level.WARN, msg);
                 if (menusDupDefaultAccelerator == null) {
                     menusDupDefaultAccelerator = new ArrayList<>();
                 }
-                menusDupDefaultAccelerator.add(zme.getIdentifier());
-                if (zme.getDefaultAccelerator().equals(zme.getAccelerator())) {
-                    zme.setAccelerator(null);
-                }
+                menusDupDefaultAccelerator.add(identifier);
             }
         }
     }
@@ -203,19 +317,63 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
     }
 
     private void setConfiguredAccelerator(ZapMenuItem menuItem) {
-        KeyStroke ks = this.getKeyboardParam().getShortcut(menuItem.getIdentifier());
+        setConfiguredAccelerator(menuItem.getIdentifier(), menuItem::setAccelerator);
+    }
+
+    private void setConfiguredAccelerator(ZapAction action) {
+        setConfiguredAccelerator(action.getIdentifier(), action::setAccelerator);
+    }
+
+    private void setConfiguredAccelerator(String identifier, Consumer<KeyStroke> setter) {
+        KeyStroke ks = this.getKeyboardParam().getShortcut(identifier);
         if (ks == null) {
             return;
         }
 
         if (ks.getKeyCode() == 0) {
             // Used to indicate no accelerator should be used
-            LOGGER.debug("Cleaning menu {} accelerator", menuItem.getIdentifier());
+            LOGGER.debug("Cleaning shortcut {} accelerator", identifier);
             ks = null;
         } else {
-            LOGGER.debug("Setting menu {} accelerator to {}", menuItem.getIdentifier(), ks);
+            LOGGER.debug("Setting shortcut {} accelerator to {}", identifier, ks);
         }
-        menuItem.setAccelerator(ks);
+        setter.accept(ks);
+    }
+
+    private void bindAction(KeyboardMapping mapping) {
+        rebindAction(mapping, null, mapping.getKeyStroke());
+    }
+
+    private boolean rebindAction(
+            KeyboardMapping mapping, KeyStroke oldKeyStroke, KeyStroke newKeyStroke) {
+        ZapAction action = mapping.getZapAction();
+        JComponent target = mapping.getTargetComponent();
+        int condition = mapping.getInputMapCondition();
+        String identifier = action.getIdentifier();
+
+        ActionMap actionMap = target.getActionMap();
+        actionMap.put(identifier, action);
+
+        InputMap inputMap = target.getInputMap(condition);
+        if (newKeyStroke != null && newKeyStroke.getKeyCode() != 0) {
+            Object existing = inputMap.get(newKeyStroke);
+            if (existing != null && !identifier.equals(existing)) {
+                LOGGER.warn(
+                        "KeyStroke {} already bound to {} on component {}; not rebinding {}",
+                        newKeyStroke,
+                        existing,
+                        target.getName(),
+                        identifier);
+                return false;
+            }
+        }
+        if (oldKeyStroke != null && oldKeyStroke.getKeyCode() != 0) {
+            inputMap.remove(oldKeyStroke);
+        }
+        if (newKeyStroke != null && newKeyStroke.getKeyCode() != 0) {
+            inputMap.put(newKeyStroke, identifier);
+        }
+        return true;
     }
 
     public List<KeyboardShortcut> getShortcuts() {
@@ -226,9 +384,26 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
         if (hasView()) {
             List<KeyboardShortcut> kss = new ArrayList<>();
             processMainMenuBarMenus(menu -> addAllMenuItems(kss, menu, reset));
+            addAllActions(kss, reset);
             return kss;
         }
         return null;
+    }
+
+    private void addAllActions(List<KeyboardShortcut> kss, boolean reset) {
+        List<KeyboardMapping> actions = new ArrayList<>();
+        for (Object obj : map.values()) {
+            KeyboardMapping km = (KeyboardMapping) obj;
+            if (km.isAction()) {
+                actions.add(km);
+            }
+        }
+        actions.sort(
+                Comparator.comparing(
+                        KeyboardMapping::getName, Comparator.nullsLast(String::compareTo)));
+        for (KeyboardMapping km : actions) {
+            kss.add(actionToShortcut(km, reset));
+        }
     }
 
     private void addAllMenuItems(List<KeyboardShortcut> kss, JMenu menu, boolean reset) {
@@ -263,6 +438,24 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
                 Constant.messages.getString("keyboard.scope.menu"));
     }
 
+    private KeyboardShortcut actionToShortcut(KeyboardMapping mapping, boolean reset) {
+        ZapAction action = mapping.getZapAction();
+        if (reset) {
+            return new KeyboardShortcut(
+                    action.getIdentifier(),
+                    (String) action.getValue(Action.NAME),
+                    getDefaultAccelerator(action),
+                    mapping.getScope());
+        }
+
+        setConfiguredAccelerator(action);
+        return new KeyboardShortcut(
+                action.getIdentifier(),
+                (String) action.getValue(Action.NAME),
+                action.getAccelerator(),
+                mapping.getScope());
+    }
+
     /**
      * Gets the default accelerator of the given menu, taken into account duplicated default
      * accelerators.
@@ -271,10 +464,18 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
      * @return the KeyStroke or {@code null} if duplicated or does not have a default.
      */
     private KeyStroke getDefaultAccelerator(ZapMenuItem menuItem) {
-        if (isIdentifierWithDuplicatedAccelerator(menuItem.getIdentifier())) {
+        return getDefaultAccelerator(menuItem.getIdentifier(), menuItem.getDefaultAccelerator());
+    }
+
+    private KeyStroke getDefaultAccelerator(ZapAction action) {
+        return getDefaultAccelerator(action.getIdentifier(), action.getDefaultAccelerator());
+    }
+
+    private KeyStroke getDefaultAccelerator(String identifier, KeyStroke defaultAccelerator) {
+        if (isIdentifierWithDuplicatedAccelerator(identifier)) {
             return null;
         }
-        return menuItem.getDefaultAccelerator();
+        return defaultAccelerator;
     }
 
     public KeyStroke getShortcut(String identifier) {
@@ -291,8 +492,16 @@ public class ExtensionKeyboard extends ExtensionAdaptor {
             LOGGER.error("No mapping found for keyboard shortcut: {}", identifier);
             return;
         }
+        KeyStroke oldKeyStroke = mapping.getKeyStroke();
+        if (mapping.isAction() && !rebindAction(mapping, oldKeyStroke, ks)) {
+            return;
+        }
         mapping.setKeyStroke(ks);
         this.getKeyboardParam().setShortcut(identifier, ks);
+        Consumer<KeyStroke> listener = acceleratorChangeListeners.get(identifier);
+        if (listener != null) {
+            listener.accept(ks);
+        }
     }
 
     private OptionsKeyboardShortcutPanel getOptionsKeyboardPanel() {

--- a/zap/src/main/java/org/zaproxy/zap/extension/keyboard/KeyboardMapping.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/keyboard/KeyboardMapping.java
@@ -21,71 +21,113 @@ package org.zaproxy.zap.extension.keyboard;
 
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import javax.swing.Action;
+import javax.swing.JComponent;
 import javax.swing.KeyStroke;
 import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.view.ZapAction;
 import org.zaproxy.zap.view.ZapMenuItem;
 
 class KeyboardMapping {
 
     private ZapMenuItem menuItem;
-    private String i18nKey;
+    private ZapAction zapAction;
+    private JComponent targetComponent;
+    private int inputMapCondition = JComponent.WHEN_FOCUSED;
+    private String scope;
 
     public KeyboardMapping() {}
-
-    public KeyboardMapping(String i18nKey) {
-        this.i18nKey = i18nKey;
-    }
 
     public KeyboardMapping(ZapMenuItem menuItem) {
         this.menuItem = menuItem;
     }
 
-    public String getName() {
-        if (this.menuItem != null) {
-            return this.menuItem.getText();
-        }
-        return null;
+    public KeyboardMapping(
+            ZapAction zapAction, JComponent targetComponent, int inputMapCondition, String scope) {
+        this.zapAction = zapAction;
+        this.targetComponent = targetComponent;
+        this.inputMapCondition = inputMapCondition;
+        this.scope = scope;
     }
 
-    public String getIdentifier() {
-        if (this.menuItem != null) {
-            return this.menuItem.getIdentifier();
-        }
-        return this.i18nKey;
+    public boolean isAction() {
+        return zapAction != null;
+    }
+
+    public ZapAction getZapAction() {
+        return zapAction;
+    }
+
+    public JComponent getTargetComponent() {
+        return targetComponent;
+    }
+
+    public int getInputMapCondition() {
+        return inputMapCondition;
     }
 
     public String getScope() {
-        if (this.menuItem != null) {
+        if (scope != null) {
+            return scope;
+        }
+        if (menuItem != null) {
             return Constant.messages.getString("keyboard.scope.menu");
         }
         return "";
     }
 
+    public String getName() {
+        if (menuItem != null) {
+            return menuItem.getText();
+        }
+        if (zapAction != null) {
+            return (String) zapAction.getValue(Action.NAME);
+        }
+        return null;
+    }
+
+    public String getIdentifier() {
+        if (menuItem != null) {
+            return menuItem.getIdentifier();
+        }
+        if (zapAction != null) {
+            return zapAction.getIdentifier();
+        }
+        return null;
+    }
+
     public KeyStroke getKeyStroke() {
-        if (this.menuItem != null) {
-            return this.menuItem.getAccelerator();
+        if (menuItem != null) {
+            return menuItem.getAccelerator();
+        }
+        if (zapAction != null) {
+            return zapAction.getAccelerator();
         }
         return null;
     }
 
     /**
-     * Gets the default accelerator of the menu item.
+     * Gets the default accelerator of the mapping.
      *
      * @return the default accelerator.
      * @since 2.8.0
      */
     public KeyStroke getDefaultKeyStroke() {
-        if (this.menuItem != null) {
-            return this.menuItem.getDefaultAccelerator();
+        if (menuItem != null) {
+            return menuItem.getDefaultAccelerator();
+        }
+        if (zapAction != null) {
+            return zapAction.getDefaultAccelerator();
         }
         return null;
     }
 
     public String getKeyStrokeKeyCodeString() {
-        if (this.menuItem == null || this.menuItem.getAccelerator() == null) {
+        KeyStroke keyStroke = getKeyStroke();
+        if (keyStroke == null) {
             return "";
         }
-        return keyString(this.menuItem.getAccelerator().getKeyCode());
+        return keyString(keyStroke.getKeyCode());
     }
 
     public static String keyString(int keyCode) {
@@ -126,15 +168,20 @@ class KeyboardMapping {
     }
 
     public String getKeyStrokeModifiersString() {
-        if (this.menuItem == null || this.menuItem.getAccelerator() == null) {
+        KeyStroke keyStroke = getKeyStroke();
+        if (keyStroke == null) {
             return "";
         }
-        return modifiersString(this.menuItem.getAccelerator().getModifiers());
+        return modifiersString(keyStroke.getModifiers());
     }
 
     public static String modifiersString(int modifiers) {
         StringBuilder sb = new StringBuilder();
 
+        if ((modifiers & InputEvent.META_DOWN_MASK) > 0) {
+            sb.append(Constant.messages.getString("keyboard.key.command"));
+            sb.append(" ");
+        }
         if ((modifiers & InputEvent.CTRL_DOWN_MASK) > 0) {
             sb.append(Constant.messages.getString("keyboard.key.control"));
             sb.append(" ");
@@ -151,21 +198,27 @@ class KeyboardMapping {
     }
 
     public String getKeyStrokeString() {
-        if (this.menuItem == null || this.menuItem.getAccelerator() == null) {
+        if (getKeyStroke() == null) {
             return "";
         }
         return getKeyStrokeModifiersString() + " " + getKeyStrokeKeyCodeString();
     }
 
     public void setKeyStroke(KeyStroke keyStroke) {
-        if (this.menuItem != null) {
-            this.menuItem.setAccelerator(keyStroke);
+        if (menuItem != null) {
+            menuItem.setAccelerator(keyStroke);
+        } else if (zapAction != null) {
+            zapAction.setAccelerator(keyStroke);
         }
     }
 
     @Override
     public int hashCode() {
-        return 31 * super.hashCode() + ((menuItem == null) ? 0 : menuItem.hashCode());
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((menuItem == null) ? 0 : menuItem.hashCode());
+        result = prime * result + ((zapAction == null) ? 0 : zapAction.hashCode());
+        return result;
     }
 
     @Override
@@ -176,9 +229,6 @@ class KeyboardMapping {
         if (this == obj) {
             return true;
         }
-        if (!super.equals(obj)) {
-            return false;
-        }
         if (getClass() != obj.getClass()) {
             return false;
         }
@@ -188,6 +238,13 @@ class KeyboardMapping {
                 return false;
             }
         } else if (!menuItem.equals(other.menuItem)) {
+            return false;
+        }
+        if (zapAction == null) {
+            if (other.zapAction != null) {
+                return false;
+            }
+        } else if (!zapAction.equals(other.zapAction)) {
             return false;
         }
         return true;

--- a/zap/src/main/java/org/zaproxy/zap/view/ZapAction.java
+++ b/zap/src/main/java/org/zaproxy/zap/view/ZapAction.java
@@ -1,0 +1,131 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.view;
+
+import java.awt.event.ActionEvent;
+import javax.swing.AbstractAction;
+import javax.swing.KeyStroke;
+import org.parosproxy.paros.Constant;
+
+/**
+ * An {@code AbstractAction} that has an identifier, allows to define the default accelerator and
+ * uses internationalised text read from resource files.
+ *
+ * <p>The use of this class is preferred to ad-hoc {@code InputMap}/{@code ActionMap} bindings as it
+ * allows the user to configure its accelerator through the options dialogue. The identifier is used
+ * to save/load its configurations.
+ *
+ * @since 2.18.0
+ */
+@SuppressWarnings("serial")
+public class ZapAction extends AbstractAction {
+
+    private final String identifier;
+    private final KeyStroke defaultAccelerator;
+    private KeyStroke accelerator;
+
+    /**
+     * Constructs a {@code ZapAction} with the given {@code identifier}, {@code name} and default
+     * accelerator (user can override the accelerator through the configurations).
+     *
+     * @param identifier the identifier for the action (used to save/load configurations), should
+     *     not be {@code null}
+     * @param name the name shown in the keyboard options
+     * @param defaultAccelerator the default accelerator for the action, might be {@code null}
+     * @throws NullPointerException if {@code identifier} or {@code name} is {@code null}.
+     */
+    public ZapAction(String identifier, String name, KeyStroke defaultAccelerator) {
+        super(name);
+        if (identifier == null) {
+            throw new NullPointerException("The identifier must not be null.");
+        }
+        if (name == null) {
+            throw new NullPointerException("The name must not be null.");
+        }
+        this.identifier = identifier;
+        this.defaultAccelerator = defaultAccelerator;
+        this.accelerator = defaultAccelerator;
+    }
+
+    /**
+     * Constructs a {@code ZapAction} with the text for the action obtained from the resource files
+     * (e.g. Messages.properties) using as key the parameter {@code i18nKey} and using the given
+     * {@code KeyStroke} as default accelerator (the user can override the accelerator through the
+     * configurations).
+     *
+     * @param i18nKey the key used to read the internationalised text for the action
+     * @param defaultAccelerator the default accelerator for the action, might be {@code null}.
+     * @throws NullPointerException if {@code i18nKey} is {@code null}.
+     */
+    public ZapAction(String i18nKey, KeyStroke defaultAccelerator) {
+        this(i18nKey, Constant.messages.getString(i18nKey), defaultAccelerator);
+    }
+
+    /**
+     * Gets the identifier of the action.
+     *
+     * @return the identifier, never {@code null}.
+     */
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    /**
+     * Gets the accelerator currently set on the action.
+     *
+     * @return the {@code KeyStroke} or {@code null} if none is set.
+     */
+    public KeyStroke getAccelerator() {
+        return accelerator;
+    }
+
+    /**
+     * Sets the accelerator on the action.
+     *
+     * @param keyStroke the {@code KeyStroke} or {@code null} to remove the accelerator.
+     */
+    public void setAccelerator(KeyStroke keyStroke) {
+        this.accelerator = keyStroke;
+    }
+
+    /**
+     * Resets the accelerator to default value (which might be {@code null} thus just removing any
+     * accelerator previously set).
+     *
+     * @see #getDefaultAccelerator()
+     */
+    public void resetAccelerator() {
+        setAccelerator(defaultAccelerator);
+    }
+
+    /**
+     * Gets the default accelerator, defined when the action was constructed.
+     *
+     * @return a {@code KeyStroke} with the default accelerator, might be {@code null}.
+     */
+    public KeyStroke getDefaultAccelerator() {
+        return defaultAccelerator;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        // Subclasses should override.
+    }
+}

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -1888,7 +1888,7 @@ keyboard.api.cheatsheet.table.header.symbols = Symbols
 keyboard.api.cheatsheet.title = ZAP Keyboard Shortcuts
 keyboard.api.other.cheatsheetActionOrder = Lists the keyboard shortcuts sorted by action, optionally, showing actions without shortcut set.
 keyboard.api.other.cheatsheetKeyOrder = Lists the keyboard shortcuts sorted by keyboard shortcut, optionally, showing actions without shortcut set.
-keyboard.desc = Adds support for configurable keyboard shortcuts for all of the ZAP menus.
+keyboard.desc = Adds support for configurable keyboard shortcuts for ZAP menus and actions.
 keyboard.dialog.button.save = Set
 keyboard.dialog.label.action = Action: 
 keyboard.dialog.label.alt = Alt:
@@ -1925,6 +1925,8 @@ keyboard.options.table.header.mods = Modifiers
 keyboard.options.table.header.scope = Scope
 keyboard.options.table.header.shortcut = Shortcut
 keyboard.options.title = Keyboard
+keyboard.scope.component = Component
+keyboard.scope.global = Global
 keyboard.scope.menu = Menu
 
 localProxies.api.action.addAdditionalProxy = Adds an new proxy using the details supplied.

--- a/zap/src/test/java/org/zaproxy/zap/extension/keyboard/ExtensionKeyboardUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/keyboard/ExtensionKeyboardUnitTest.java
@@ -1,0 +1,129 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.keyboard;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.awt.event.KeyEvent;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import javax.swing.KeyStroke;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+import org.zaproxy.zap.view.ZapAction;
+
+/** Unit test for {@link ExtensionKeyboard}. */
+class ExtensionKeyboardUnitTest {
+
+    private static final String IDENTIFIER = "test.action";
+    private static final KeyStroke DEFAULT_ACCELERATOR =
+            KeyStroke.getKeyStroke(KeyEvent.VK_J, KeyEvent.CTRL_DOWN_MASK);
+
+    private ExtensionKeyboard extension;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        extension = new ExtensionKeyboard();
+        extension.getKeyboardParam().load(new ZapXmlConfiguration());
+    }
+
+    @Test
+    void shouldBindRegisteredActionToComponent() {
+        JPanel panel = new JPanel();
+        ZapAction action = new ZapAction(IDENTIFIER, "Test Action", DEFAULT_ACCELERATOR);
+
+        extension.registerAction(action, panel, JComponent.WHEN_FOCUSED, "Test Scope");
+
+        assertThat(
+                panel.getInputMap(JComponent.WHEN_FOCUSED).get(DEFAULT_ACCELERATOR),
+                is(equalTo(IDENTIFIER)));
+        assertThat(panel.getActionMap().get(IDENTIFIER), is(equalTo(action)));
+        assertThat(extension.getShortcut(IDENTIFIER), is(equalTo(DEFAULT_ACCELERATOR)));
+    }
+
+    @Test
+    void shouldRebindActionWhenShortcutChanges() {
+        JPanel panel = new JPanel();
+        ZapAction action = new ZapAction(IDENTIFIER, "Test Action", DEFAULT_ACCELERATOR);
+        KeyStroke newAccelerator = KeyStroke.getKeyStroke(KeyEvent.VK_K, KeyEvent.CTRL_DOWN_MASK);
+        extension.registerAction(action, panel, JComponent.WHEN_FOCUSED, "Test Scope");
+
+        extension.setShortcut(IDENTIFIER, newAccelerator);
+
+        assertThat(
+                panel.getInputMap(JComponent.WHEN_FOCUSED).get(DEFAULT_ACCELERATOR),
+                is(nullValue()));
+        assertThat(
+                panel.getInputMap(JComponent.WHEN_FOCUSED).get(newAccelerator),
+                is(equalTo(IDENTIFIER)));
+        assertThat(extension.getShortcut(IDENTIFIER), is(equalTo(newAccelerator)));
+    }
+
+    @Test
+    void shouldLoadConfiguredShortcutFromParam() throws Exception {
+        JPanel panel = new JPanel();
+        ZapAction action = new ZapAction(IDENTIFIER, "Test Action", DEFAULT_ACCELERATOR);
+        KeyStroke configuredAccelerator =
+                KeyStroke.getKeyStroke(KeyEvent.VK_L, KeyEvent.ALT_DOWN_MASK);
+        ZapXmlConfiguration configuration = new ZapXmlConfiguration();
+        configuration.setProperty("keyboard.shortcuts(0).menu", IDENTIFIER);
+        configuration.setProperty(
+                "keyboard.shortcuts(0).keycode", configuredAccelerator.getKeyCode());
+        configuration.setProperty(
+                "keyboard.shortcuts(0).modifiers", configuredAccelerator.getModifiers());
+        extension.getKeyboardParam().load(configuration);
+
+        extension.registerAction(action, panel, JComponent.WHEN_FOCUSED, "Test Scope");
+
+        assertThat(
+                panel.getInputMap(JComponent.WHEN_FOCUSED).get(configuredAccelerator),
+                is(equalTo(IDENTIFIER)));
+        assertThat(extension.getShortcut(IDENTIFIER), is(equalTo(configuredAccelerator)));
+    }
+
+    @Test
+    void shouldNotifyAcceleratorChangeListenerOnRegisterAndShortcutChange() {
+        JPanel panel = new JPanel();
+        ZapAction action = new ZapAction(IDENTIFIER, "Test Action", DEFAULT_ACCELERATOR);
+        List<KeyStroke> notifiedAccelerators = new ArrayList<>();
+        KeyStroke newAccelerator = KeyStroke.getKeyStroke(KeyEvent.VK_K, KeyEvent.CTRL_DOWN_MASK);
+
+        KeyStroke registeredAccelerator =
+                extension.registerAction(
+                        action,
+                        panel,
+                        JComponent.WHEN_FOCUSED,
+                        "Test Scope",
+                        notifiedAccelerators::add);
+
+        assertThat(registeredAccelerator, is(equalTo(DEFAULT_ACCELERATOR)));
+        assertThat(notifiedAccelerators, is(equalTo(List.of(DEFAULT_ACCELERATOR))));
+
+        extension.setShortcut(IDENTIFIER, newAccelerator);
+
+        assertThat(notifiedAccelerators, is(equalTo(List.of(DEFAULT_ACCELERATOR, newAccelerator))));
+    }
+}

--- a/zap/src/test/java/org/zaproxy/zap/view/ZapActionUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/view/ZapActionUnitTest.java
@@ -1,0 +1,74 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.view;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.awt.event.KeyEvent;
+import javax.swing.Action;
+import javax.swing.KeyStroke;
+import org.junit.jupiter.api.Test;
+
+/** Unit test for {@link ZapAction}. */
+class ZapActionUnitTest {
+
+    private static final String IDENTIFIER = "test.action";
+    private static final String NAME = "Test Action";
+    private static final KeyStroke DEFAULT_ACCELERATOR =
+            KeyStroke.getKeyStroke(KeyEvent.VK_T, KeyEvent.CTRL_DOWN_MASK);
+
+    @Test
+    void shouldExposeIdentifierNameAndDefaultAccelerator() {
+        ZapAction action = new ZapAction(IDENTIFIER, NAME, DEFAULT_ACCELERATOR);
+
+        assertThat(action.getIdentifier(), is(equalTo(IDENTIFIER)));
+        assertThat(action.getValue(Action.NAME), is(equalTo(NAME)));
+        assertThat(action.getDefaultAccelerator(), is(equalTo(DEFAULT_ACCELERATOR)));
+        assertThat(action.getAccelerator(), is(equalTo(DEFAULT_ACCELERATOR)));
+    }
+
+    @Test
+    void shouldUpdateAndResetAccelerator() {
+        ZapAction action = new ZapAction(IDENTIFIER, NAME, DEFAULT_ACCELERATOR);
+        KeyStroke newAccelerator = KeyStroke.getKeyStroke(KeyEvent.VK_A, KeyEvent.ALT_DOWN_MASK);
+
+        action.setAccelerator(newAccelerator);
+        assertThat(action.getAccelerator(), is(equalTo(newAccelerator)));
+
+        action.resetAccelerator();
+        assertThat(action.getAccelerator(), is(equalTo(DEFAULT_ACCELERATOR)));
+    }
+
+    @Test
+    void shouldRejectNullIdentifier() {
+        assertThrows(
+                NullPointerException.class, () -> new ZapAction(null, NAME, DEFAULT_ACCELERATOR));
+    }
+
+    @Test
+    void shouldRejectNullName() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new ZapAction(IDENTIFIER, null, DEFAULT_ACCELERATOR));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ZapAction` and `ExtensionKeyboard.registerAction()` / `registerGlobalAction()`
- Bind shortcuts via `InputMap`/`ActionMap` with scope support
- Migrate History Jump To to the action registry

## Stack
Part 3 of 3. **Depends on #9361** (and #9360). Merge in order: #9360 → #9361 → this PR. Diff will shrink as earlier parts land.

## Test plan
- [x] History panel Jump To shortcut works (default Ctrl+Option+J on macOS)
- [x] Jump To appears in Options with Global scope
- [x] Reassign shortcut and confirm popup label updates
- [x] `./gradlew :zap:test --tests "org.zaproxy.zap.extension.keyboard.*" --tests "org.zaproxy.zap.view.ZapActionUnitTest"`