### PR TITLE
Reuse uninstall dialog on batch upgrade

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/ExtensionAutoUpdate.java
@@ -125,6 +125,10 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
     // Files currently being downloaded
     private List<Downloader> downloadFiles = new ArrayList<>();
 
+    private boolean batchUpgradeSessionActive;
+    private UninstallationProgressDialogue sharedUninstallDialogue;
+    private boolean batchUninstallHadFailures;
+
     private static final int ARG_CFU_INSTALL_IDX = 0;
     private static final int ARG_CFU_INSTALL_ALL_IDX = 1;
     private static final int ARG_CFU_UNINSTALL_IDX = 2;
@@ -591,93 +595,125 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
                 getModel().getOptionsParam().getCheckForUpdatesParam();
         List<Downloader> handledFiles = new ArrayList<>();
 
+        if (hasView() && countUpgradeInstallsInBatch() > 1) {
+            batchUpgradeSessionActive = true;
+            batchUninstallHadFailures = false;
+        }
+
         MutableBoolean allInstalled = new MutableBoolean(true);
+        try {
+            for (Downloader dl : downloadFiles) {
+                if (dl.getFinished() == null) {
+                    continue;
+                }
+                handledFiles.add(dl);
+                try {
+                    if (!dl.isValidated()) {
+                        LOGGER.debug("Ignoring unvalidated download: {}", dl.getUrl());
+                        allInstalled.setFalse();
+                        if (addonsDialog != null) {
+                            addonsDialog.notifyAddOnDownloadFailed(dl.getUrl().toString());
+                        } else {
+                            String url = dl.getUrl().toString();
+                            for (AddOn addOn : latestVersionInfo.getAddOns()) {
+                                if (url.equals(addOn.getUrl().toString())) {
+                                    addOn.setInstallationStatus(AddOn.InstallationStatus.AVAILABLE);
+                                    break;
+                                }
+                            }
+                        }
+                    } else if (AddOn.isAddOnFileName(dl.getTargetFile().getName())) {
+                        File f = dl.getTargetFile();
+                        if (!options.getDownloadDirectory()
+                                .equals(dl.getTargetFile().getParentFile())) {
+                            // Move the file to the specified directory - we do this after its been
+                            // downloaded
+                            // as these directories can be shared, and other ZAP instances could get
+                            // incomplete
+                            // add-ons
+                            try {
+                                f =
+                                        new File(
+                                                options.getDownloadDirectory(),
+                                                dl.getTargetFile().getName());
+                                LOGGER.info(
+                                        "Moving downloaded add-on from {} to {}",
+                                        dl.getTargetFile().getAbsolutePath(),
+                                        f.getAbsolutePath());
+                                FileUtils.moveFile(dl.getTargetFile(), f);
+                            } catch (Exception e) {
+                                if (!f.exists() && dl.getTargetFile().exists()) {
+                                    LOGGER.error(
+                                            "Failed to move downloaded add-on from {} to {} - left at original location",
+                                            dl.getTargetFile().getAbsolutePath(),
+                                            f.getAbsolutePath(),
+                                            e);
+                                    f = dl.getTargetFile();
+                                } else {
+                                    LOGGER.error(
+                                            "Failed to move downloaded add-on from {} to {} - skipping",
+                                            dl.getTargetFile().getAbsolutePath(),
+                                            f.getAbsolutePath(),
+                                            e);
+                                    allInstalled.setFalse();
+                                    continue;
+                                }
+                            }
+                        }
+
+                        AddOn.createAddOn(f.toPath())
+                                .ifPresent(
+                                        ao -> {
+                                            if (ao.canLoadInCurrentVersion()) {
+                                                allInstalled.setValue(
+                                                        allInstalled.booleanValue() & install(ao));
+                                            } else {
+                                                LOGGER.info(
+                                                        "Can't load add-on: {} Not before={} Not from={} Version={}",
+                                                        ao.getName(),
+                                                        ao.getNotBeforeVersion(),
+                                                        ao.getNotFromVersion(),
+                                                        Constant.PROGRAM_VERSION);
+                                            }
+                                        });
+                    }
+                } catch (Exception e) {
+                    LOGGER.error(e.getMessage(), e);
+                }
+            }
+
+            for (Downloader dl : handledFiles) {
+                // Can't remove in loop above as we're iterating through the list
+                this.downloadFiles.remove(dl);
+            }
+            this.installsCompleted = true;
+            this.installsOk = allInstalled.booleanValue();
+        } finally {
+            endBatchUpgradeSession();
+        }
+    }
+
+    private int countUpgradeInstallsInBatch() {
+        int count = 0;
         for (Downloader dl : downloadFiles) {
-            if (dl.getFinished() == null) {
+            if (dl.getFinished() == null || !dl.isValidated()) {
                 continue;
             }
-            handledFiles.add(dl);
-            try {
-                if (!dl.isValidated()) {
-                    LOGGER.debug("Ignoring unvalidated download: {}", dl.getUrl());
-                    allInstalled.setFalse();
-                    if (addonsDialog != null) {
-                        addonsDialog.notifyAddOnDownloadFailed(dl.getUrl().toString());
-                    } else {
-                        String url = dl.getUrl().toString();
-                        for (AddOn addOn : latestVersionInfo.getAddOns()) {
-                            if (url.equals(addOn.getUrl().toString())) {
-                                addOn.setInstallationStatus(AddOn.InstallationStatus.AVAILABLE);
-                                break;
-                            }
-                        }
-                    }
-                } else if (AddOn.isAddOnFileName(dl.getTargetFile().getName())) {
-                    File f = dl.getTargetFile();
-                    if (!options.getDownloadDirectory()
-                            .equals(dl.getTargetFile().getParentFile())) {
-                        // Move the file to the specified directory - we do this after its been
-                        // downloaded
-                        // as these directories can be shared, and other ZAP instances could get
-                        // incomplete
-                        // add-ons
-                        try {
-                            f =
-                                    new File(
-                                            options.getDownloadDirectory(),
-                                            dl.getTargetFile().getName());
-                            LOGGER.info(
-                                    "Moving downloaded add-on from {} to {}",
-                                    dl.getTargetFile().getAbsolutePath(),
-                                    f.getAbsolutePath());
-                            FileUtils.moveFile(dl.getTargetFile(), f);
-                        } catch (Exception e) {
-                            if (!f.exists() && dl.getTargetFile().exists()) {
-                                LOGGER.error(
-                                        "Failed to move downloaded add-on from {} to {} - left at original location",
-                                        dl.getTargetFile().getAbsolutePath(),
-                                        f.getAbsolutePath(),
-                                        e);
-                                f = dl.getTargetFile();
-                            } else {
-                                LOGGER.error(
-                                        "Failed to move downloaded add-on from {} to {} - skipping",
-                                        dl.getTargetFile().getAbsolutePath(),
-                                        f.getAbsolutePath(),
-                                        e);
-                                allInstalled.setFalse();
-                                continue;
-                            }
-                        }
-                    }
-
-                    AddOn.createAddOn(f.toPath())
-                            .ifPresent(
-                                    ao -> {
-                                        if (ao.canLoadInCurrentVersion()) {
-                                            allInstalled.setValue(
-                                                    allInstalled.booleanValue() & install(ao));
-                                        } else {
-                                            LOGGER.info(
-                                                    "Can't load add-on: {} Not before={} Not from={} Version={}",
-                                                    ao.getName(),
-                                                    ao.getNotBeforeVersion(),
-                                                    ao.getNotFromVersion(),
-                                                    Constant.PROGRAM_VERSION);
-                                        }
-                                    });
-                }
-            } catch (Exception e) {
-                LOGGER.error(e.getMessage(), e);
+            if (!AddOn.isAddOnFileName(dl.getTargetFile().getName())) {
+                continue;
+            }
+            File f = dl.getTargetFile();
+            if (!f.isFile()) {
+                continue;
+            }
+            if (AddOn.createAddOn(f.toPath())
+                    .filter(AddOn::canLoadInCurrentVersion)
+                    .filter(ao -> getLocalVersionInfo().getAddOn(ao.getId()) != null)
+                    .isPresent()) {
+                count++;
             }
         }
-
-        for (Downloader dl : handledFiles) {
-            // Can't remove in loop above as we're iterating through the list
-            this.downloadFiles.remove(dl);
-        }
-        this.installsCompleted = true;
-        this.installsOk = allInstalled.booleanValue();
+        return count;
     }
 
     public int getDownloadProgressPercent(URL url) throws Exception {
@@ -1265,7 +1301,10 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
         }
 
         if (addonsDialog != null) {
-            addonsDialog.notifyAddOnInstalled(ao);
+            AddOn installed = getLocalVersionInfo().getAddOn(ao.getId());
+            if (installed != null) {
+                addonsDialog.notifyAddOnInstalled(installed);
+            }
         }
         return true;
     }
@@ -1688,63 +1727,76 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
 
         final Window parent = getWindowParent(caller);
 
-        final UninstallationProgressDialogue waitDialogue =
-                new UninstallationProgressDialogue(parent, addOns);
-        waitDialogue.addAddOnUninstallListener(
-                new AddOnUninstallListener() {
+        final boolean reuseSharedDialogue =
+                batchUpgradeSessionActive && updates && addOns.size() == 1;
 
-                    @Override
-                    public void uninstallingAddOn(AddOn addOn, boolean updating) {
-                        if (updating) {
-                            getView()
-                                    .getOutputPanel()
-                                    .append(
-                                            Constant.messages.getString(
-                                                            "cfu.output.replacing",
-                                                            addOn.getName(),
-                                                            addOn.getVersion())
-                                                    + "\n");
+        final UninstallationProgressDialogue waitDialogue;
+        if (reuseSharedDialogue && sharedUninstallDialogue != null) {
+            waitDialogue = sharedUninstallDialogue;
+            waitDialogue.resetForAddOns(addOns);
+        } else {
+            waitDialogue = new UninstallationProgressDialogue(parent, addOns);
+            waitDialogue.addAddOnUninstallListener(
+                    new AddOnUninstallListener() {
+
+                        @Override
+                        public void uninstallingAddOn(AddOn addOn, boolean updating) {
+                            if (updating) {
+                                getView()
+                                        .getOutputPanel()
+                                        .append(
+                                                Constant.messages.getString(
+                                                                "cfu.output.replacing",
+                                                                addOn.getName(),
+                                                                addOn.getVersion())
+                                                        + "\n");
+                            }
                         }
-                    }
 
-                    @Override
-                    public void addOnUninstalled(AddOn addOn, boolean update, boolean uninstalled) {
-                        if (uninstalled) {
-                            if (!update && addonsDialog != null) {
-                                addonsDialog.notifyAddOnUninstalled(addOn);
-                            }
+                        @Override
+                        public void addOnUninstalled(
+                                AddOn addOn, boolean update, boolean uninstalled) {
+                            if (uninstalled) {
+                                if (!update && addonsDialog != null) {
+                                    addonsDialog.notifyAddOnUninstalled(addOn);
+                                }
 
-                            getView()
-                                    .getOutputPanel()
-                                    .append(
-                                            Constant.messages.getString(
-                                                            "cfu.output.uninstalled",
-                                                            addOn.getName(),
-                                                            addOn.getVersion())
-                                                    + "\n");
-                        } else {
-                            if (addonsDialog != null) {
-                                addonsDialog.notifyAddOnFailedUninstallation(addOn);
-                            }
-
-                            String message;
-                            if (update) {
-                                message =
-                                        Constant.messages.getString(
-                                                "cfu.output.replace.failed",
-                                                addOn.getName(),
-                                                addOn.getVersion());
+                                getView()
+                                        .getOutputPanel()
+                                        .append(
+                                                Constant.messages.getString(
+                                                                "cfu.output.uninstalled",
+                                                                addOn.getName(),
+                                                                addOn.getVersion())
+                                                        + "\n");
                             } else {
-                                message =
-                                        Constant.messages.getString(
-                                                "cfu.output.uninstall.failed",
-                                                addOn.getName(),
-                                                addOn.getVersion());
+                                if (addonsDialog != null) {
+                                    addonsDialog.notifyAddOnFailedUninstallation(addOn);
+                                }
+
+                                String message;
+                                if (update) {
+                                    message =
+                                            Constant.messages.getString(
+                                                    "cfu.output.replace.failed",
+                                                    addOn.getName(),
+                                                    addOn.getVersion());
+                                } else {
+                                    message =
+                                            Constant.messages.getString(
+                                                    "cfu.output.uninstall.failed",
+                                                    addOn.getName(),
+                                                    addOn.getVersion());
+                                }
+                                getView().getOutputPanel().append(message + "\n");
                             }
-                            getView().getOutputPanel().append(message + "\n");
                         }
-                    }
-                });
+                    });
+            if (reuseSharedDialogue) {
+                sharedUninstallDialogue = waitDialogue;
+                waitDialogue.setDisposeOnWorkerDone(false);
+            }
+        }
 
         SwingWorker<Void, UninstallationProgressEvent> a =
                 new SwingWorker<>() {
@@ -1786,7 +1838,45 @@ public class ExtensionAutoUpdate extends ExtensionAdaptor
         waitDialogue.setSynchronous(updates);
         waitDialogue.setVisible(true);
 
+        if (reuseSharedDialogue && !failedUninstallations.isEmpty()) {
+            batchUninstallHadFailures = true;
+        }
+
         return failedUninstallations.isEmpty();
+    }
+
+    private void endBatchUpgradeSession() {
+        final UninstallationProgressDialogue dialogue = sharedUninstallDialogue;
+        final boolean warn = batchUninstallHadFailures;
+        sharedUninstallDialogue = null;
+        batchUpgradeSessionActive = false;
+        batchUninstallHadFailures = false;
+
+        if (dialogue == null && !warn) {
+            return;
+        }
+
+        Runnable ui =
+                () -> {
+                    if (dialogue != null) {
+                        dialogue.dispose();
+                    }
+                    if (warn && getView() != null) {
+                        View.getSingleton()
+                                .showWarningDialog(
+                                        getView().getMainFrame(),
+                                        Constant.messages.getString("cfu.uninstall.failed"));
+                    }
+                };
+        if (EventQueue.isDispatchThread()) {
+            ui.run();
+        } else {
+            try {
+                EventQueue.invokeAndWait(ui);
+            } catch (InvocationTargetException | InterruptedException e) {
+                LOGGER.error("Failed to end batch upgrade session:", e);
+            }
+        }
     }
 
     /** No database tables used, so all supported */

--- a/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/UninstallationProgressDialogue.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/autoupdate/UninstallationProgressDialogue.java
@@ -77,6 +77,8 @@ class UninstallationProgressDialogue extends AbstractDialog {
 
     private boolean synchronous;
 
+    private boolean disposeOnWorkerDone = true;
+
     public UninstallationProgressDialogue(Window parent, Set<AddOn> addOns) {
         super(parent, true);
 
@@ -86,19 +88,7 @@ class UninstallationProgressDialogue extends AbstractDialog {
         setTitle(Constant.messages.getString("cfu.uninstallation.progress.dialogue.title"));
         setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
 
-        int max = 0;
-        for (AddOn addOn : addOns) {
-            max += addOn.getFiles().size();
-            max += addOn.getAscanrules().size();
-            max += addOn.getPscanrules().size();
-            max += addOn.getLoadedExtensions().size() * EXTENSION_UNINSTALL_WEIGHT;
-        }
-
-        getProgressBar().setValue(0);
-        getProgressBar().setMaximum(max);
-
-        getStatusLabel().setText(" ");
-        getCustomLabel().setText(" ");
+        resetForAddOns(addOns);
 
         JPanel panel = new JPanel();
         GroupLayout layout = new GroupLayout(panel);
@@ -184,7 +174,8 @@ class UninstallationProgressDialogue extends AbstractDialog {
     /**
      * Binds the given uninstallation worker to this dialogue.
      *
-     * <p>The dialogue is disposed once the worker finishes the uninstallation.
+     * <p>When {@link #setDisposeOnWorkerDone(boolean) disposeOnWorkerDone} is {@code true} (the
+     * default), the dialogue is disposed once the worker finishes. Otherwise it is only hidden.
      *
      * @param worker the uninstallation worker
      */
@@ -207,6 +198,37 @@ class UninstallationProgressDialogue extends AbstractDialog {
         this.synchronous = synchronous;
     }
 
+    void setDisposeOnWorkerDone(boolean disposeOnWorkerDone) {
+        this.disposeOnWorkerDone = disposeOnWorkerDone;
+    }
+
+    void resetForAddOns(Set<AddOn> addOns) {
+        currentType = null;
+        keyBaseStatusMessage = "";
+        currentAddOn = null;
+        update = false;
+        failedUninstallations = false;
+        done = false;
+        setVisibleInvoked = false;
+        startTime = System.currentTimeMillis();
+
+        getProgressBar().setValue(0);
+        getProgressBar().setMaximum(calculateUninstallMax(addOns));
+        getStatusLabel().setText(" ");
+        getCustomLabel().setText(" ");
+    }
+
+    private static int calculateUninstallMax(Set<AddOn> addOns) {
+        int max = 0;
+        for (AddOn addOn : addOns) {
+            max += addOn.getFiles().size();
+            max += addOn.getAscanrules().size();
+            max += addOn.getPscanrules().size();
+            max += addOn.getLoadedExtensions().size() * EXTENSION_UNINSTALL_WEIGHT;
+        }
+        return max;
+    }
+
     @Override
     public void setVisible(boolean show) {
         if (show && !synchronous) {
@@ -225,84 +247,72 @@ class UninstallationProgressDialogue extends AbstractDialog {
      * @param events the events generated during uninstallation
      */
     public void update(List<UninstallationProgressEvent> events) {
-        if (!isVisible()) {
-            if ((System.currentTimeMillis() - startTime) >= MS_TO_WAIT_BEFORE_SHOW) {
-                if (!done && !setVisibleInvoked) {
-                    setVisibleInvoked = true;
-                    EventQueue.invokeLater(
-                            new Runnable() {
-
-                                @Override
-                                public void run() {
+        for (UninstallationProgressEvent event : events) {
+            if (!isVisible()) {
+                if ((System.currentTimeMillis() - startTime) >= MS_TO_WAIT_BEFORE_SHOW) {
+                    if (!done && !setVisibleInvoked) {
+                        setVisibleInvoked = true;
+                        EventQueue.invokeLater(
+                                () -> {
                                     if (!done) {
                                         UninstallationProgressDialogue.super.setVisible(true);
                                     }
-                                }
-                            });
+                                });
+                    }
                 }
             }
-        }
 
-        int totalAmount = 0;
-        AddOn addOn = null;
+            if (UninstallationProgressEvent.Type.ADD_ON == event.getType()) {
+                currentAddOn = event.getAddOn();
+                update = event.isUpdate();
+                setCurrentAddOn(currentAddOn);
 
-        for (UninstallationProgressEvent event : events) {
-            totalAmount += event.getAmount();
-            if (UninstallationProgressEvent.Type.FINISHED_ADD_ON == event.getType()) {
                 for (AddOnUninstallListener listener : listeners) {
-                    failedUninstallations = !event.isUninstalled();
+                    listener.uninstallingAddOn(currentAddOn, update);
+                }
+            } else if (UninstallationProgressEvent.Type.FINISHED_ADD_ON == event.getType()) {
+                failedUninstallations |= !event.isUninstalled();
+                for (AddOnUninstallListener listener : listeners) {
                     listener.addOnUninstalled(currentAddOn, update, event.isUninstalled());
                 }
-            } else if (UninstallationProgressEvent.Type.ADD_ON == event.getType()) {
-                addOn = event.getAddOn();
-                currentAddOn = addOn;
-                update = event.isUpdate();
+            }
 
-                for (AddOnUninstallListener listener : listeners) {
-                    listener.uninstallingAddOn(addOn, update);
+            if (event.getAmount() != 0) {
+                incrementProgress(event.getAmount());
+            }
+
+            if (currentType != event.getType()) {
+                String keyMessage;
+                switch (event.getType()) {
+                    case FILE:
+                        keyMessage = "cfu.uninstallation.progress.dialogue.uninstallingFile";
+                        break;
+                    case ACTIVE_RULE:
+                        keyMessage =
+                                "cfu.uninstallation.progress.dialogue.uninstallingActiveScanner";
+                        break;
+                    case PASSIVE_RULE:
+                        keyMessage =
+                                "cfu.uninstallation.progress.dialogue.uninstallingPassiveScanner";
+                        break;
+                    case EXTENSION:
+                        keyMessage = "cfu.uninstallation.progress.dialogue.uninstallingExtension";
+                        break;
+                    default:
+                        keyMessage = "";
+                        break;
                 }
+                currentType = event.getType();
+                keyBaseStatusMessage = keyMessage;
             }
-        }
 
-        UninstallationProgressEvent last = events.get(events.size() - 1);
-
-        if (addOn != null) {
-            setCurrentAddOn(addOn);
-        }
-
-        if (totalAmount != 0) {
-            incrementProgress(totalAmount);
-        }
-
-        if (currentType != last.getType()) {
-            String keyMessage;
-            switch (last.getType()) {
-                case FILE:
-                    keyMessage = "cfu.uninstallation.progress.dialogue.uninstallingFile";
-                    break;
-                case ACTIVE_RULE:
-                    keyMessage = "cfu.uninstallation.progress.dialogue.uninstallingActiveScanner";
-                    break;
-                case PASSIVE_RULE:
-                    keyMessage = "cfu.uninstallation.progress.dialogue.uninstallingPassiveScanner";
-                    break;
-                case EXTENSION:
-                    keyMessage = "cfu.uninstallation.progress.dialogue.uninstallingExtension";
-                    break;
-                default:
-                    keyMessage = "";
-                    break;
+            if (keyBaseStatusMessage.isEmpty()) {
+                setCustomMessage("");
+            } else {
+                setCustomMessage(
+                        Constant.messages.getString(
+                                keyBaseStatusMessage, event.getValue(), event.getMax()));
             }
-            currentType = last.getType();
-            keyBaseStatusMessage = keyMessage;
-        }
-
-        if (keyBaseStatusMessage.isEmpty()) {
-            setCustomMessage("");
-        } else {
-            setCustomMessage(
-                    Constant.messages.getString(
-                            keyBaseStatusMessage, last.getValue(), last.getMax()));
         }
     }
 
@@ -471,14 +481,17 @@ class UninstallationProgressDialogue extends AbstractDialog {
             if ("state".equals(event.getPropertyName())
                     && SwingWorker.StateValue.DONE == event.getNewValue()) {
                 setVisible(false);
-                dispose();
                 done = true;
 
-                if (failedUninstallations) {
-                    View.getSingleton()
-                            .showWarningDialog(
-                                    getOwner(),
-                                    Constant.messages.getString("cfu.uninstall.failed"));
+                if (disposeOnWorkerDone) {
+                    dispose();
+
+                    if (failedUninstallations) {
+                        View.getSingleton()
+                                .showWarningDialog(
+                                        getOwner(),
+                                        Constant.messages.getString("cfu.uninstall.failed"));
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Reuse one UninstallationProgressDialogue across per-add-on upgrade uninstalls so Update all does not flash a new modal each time. Keeps modal blocking on the EDT.

This addresses zaproxy/zaproxy#7420
