### PR TITLE
Fix #8056: Enforce solution presence in Vulnerability definitions

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/model/Vulnerability.java
+++ b/zap/src/main/java/org/zaproxy/zap/model/Vulnerability.java
@@ -35,7 +35,9 @@ public class Vulnerability {
 
     public Vulnerability(
             String id, String alert, String description, String solution, List<String> references) {
-        super();
+        if (solution == null || solution.trim().isEmpty()) {
+            throw new IllegalArgumentException("Vulnerability " + id + " must have a solution.");
+        }
         this.id = id;
         this.alert = alert;
         this.description = description;


### PR DESCRIPTION

### Description
This PR enforces that all vulnerabilities must have an appropriate solution defined. It adds a strict validation check in the `Vulnerability` constructor to throw an `IllegalArgumentException` if the parsed solution string is null or empty. This prevents future definitions from missing critical solution text.

### Testing
- Validated that existing vulnerabilities are successfully parsed.
- Ensure it throws appropriately on missing solution blocks.