### PR TITLE
Use stable domain for Chrome itest

### DIFF
--- a/docker/chrome/chrome.yaml
+++ b/docker/chrome/chrome.yaml
@@ -3,7 +3,7 @@ env:
   contexts:
   - name: "Chrome Headless Test"
     urls:
-    - "https://demo.owasp-juice.shop"
+    - "https://www.zaproxy.com"
   parameters:
     failOnError: true
     failOnWarning: true
@@ -19,7 +19,7 @@ jobs:
     statistic: "spiderAjax.urls.added"
     site: ""
     operator: ">="
-    value: 20
+    value: 1
     type: "stats"
   name: "spiderAjax"
   type: "spiderAjax"


### PR DESCRIPTION
Use a domain that is more reliable (zaproxy.com), the JuiceShop one is currently non functional.