### PR TITLE
Fix concurrency issue with script types

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -35,10 +35,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import javax.script.Invocable;
 import javax.script.ScriptContext;
@@ -126,7 +126,7 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
 
     private ScriptTreeModel treeModel = null;
     private List<ScriptEngineWrapper> engineWrappers = new ArrayList<>();
-    private Map<String, ScriptType> typeMap = new HashMap<>();
+    private Map<String, ScriptType> typeMap = new ConcurrentHashMap<>();
     private ProxyListenerScript proxyListener = null;
     private HttpSenderScriptListener httpSenderScriptListener;
 

--- a/zap/src/test/java/org/zaproxy/zap/extension/script/ExtensionScriptUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/script/ExtensionScriptUnitTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -30,6 +31,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.security.InvalidParameterException;
+import java.util.Iterator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,6 +50,18 @@ class ExtensionScriptUnitTest {
     @AfterEach
     void cleanUp() {
         Constant.messages = null;
+    }
+
+    @Test
+    void shouldReturnThreadSafeScriptTypesCollection() {
+        // Given
+        ExtensionScript extensionScript = new ExtensionScript();
+        extensionScript.hook(mock());
+        Iterator<ScriptType> it = extensionScript.getScriptTypes().iterator();
+        extensionScript.registerScriptType(new ScriptType("type", "i18n.type", null, true));
+
+        // When / Then
+        assertDoesNotThrow(it::next);
     }
 
     @Test


### PR DESCRIPTION
Use a concurrent map to allow iteration and modifications at the same time.

---
Addresses, e.g.:
```
308701 [AWT-EventQueue-0] ERROR org.zaproxy.zap.ZAP.UncaughtExceptionLogger - Exception in thread "AWT-EventQueue-0"
java.util.ConcurrentModificationException
	at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1606)
	at java.base/java.util.HashMap$ValueIterator.next(HashMap.java:1634)
	at org.zaproxy.zap.extension.zest.ExtensionZest.optionsLoaded(ExtensionZest.java:307)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:323)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:723)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:702)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
```