### PR TITLE
Address NPEs related to script types

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/script/ExtensionScript.java
@@ -546,11 +546,17 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
      *
      * <p>The script is added to the tree of scripts and its scripts/templates loaded, if any.
      *
+     * <p>The call to this method has no effect if the given type or its name is null.
+     *
      * @param type the new type of script
      * @throws InvalidParameterException if a script type with same name is already registered
      * @see #removeScriptType(ScriptType)
      */
     public void registerScriptType(ScriptType type) {
+        if (type == null || type.getName() == null) {
+            return;
+        }
+
         if (typeMap.containsKey(type.getName())) {
             throw new InvalidParameterException("ScriptType already registered: " + type.getName());
         }
@@ -623,6 +629,10 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
      * @see #registerScriptType(ScriptType)
      */
     public void removeScriptType(ScriptType type) {
+        if (type == null || type.getName() == null) {
+            return;
+        }
+
         ScriptType scriptType = typeMap.remove(type.getName());
         if (scriptType != null) {
             getTreeModel().removeType(scriptType);
@@ -630,6 +640,9 @@ public class ExtensionScript extends ExtensionAdaptor implements CommandLineList
     }
 
     public ScriptType getScriptType(String name) {
+        if (name == null) {
+            return null;
+        }
         return this.typeMap.get(name);
     }
 

--- a/zap/src/test/java/org/zaproxy/zap/extension/script/ExtensionScriptUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/script/ExtensionScriptUnitTest.java
@@ -65,6 +65,59 @@ class ExtensionScriptUnitTest {
     }
 
     @Test
+    void shouldHandleRegistrationOfNullScriptType() {
+        // Given
+        ExtensionScript extensionScript = new ExtensionScript();
+        ScriptType scriptType = null;
+
+        // When / Then
+        assertDoesNotThrow(() -> extensionScript.registerScriptType(scriptType));
+    }
+
+    @Test
+    void shouldHandleRegistrationOfScriptTypeWithNullName() {
+        // Given
+        ExtensionScript extensionScript = new ExtensionScript();
+        ScriptType scriptType = new ScriptType(null, "i18n.type", null, false);
+
+        // When / Then
+        assertDoesNotThrow(() -> extensionScript.registerScriptType(scriptType));
+    }
+
+    @Test
+    void shouldHandleRemovalOfNullScriptType() {
+        // Given
+        ExtensionScript extensionScript = new ExtensionScript();
+        ScriptType scriptType = null;
+
+        // When / Then
+        assertDoesNotThrow(() -> extensionScript.removeScriptType(scriptType));
+    }
+
+    @Test
+    void shouldHandleRemovalOfScriptTypeWithNullName() {
+        // Given
+        ExtensionScript extensionScript = new ExtensionScript();
+        ScriptType scriptType = new ScriptType(null, "i18n.type", null, false);
+
+        // When / Then
+        assertDoesNotThrow(() -> extensionScript.removeScriptType(scriptType));
+    }
+
+    @Test
+    void shouldGetNullScriptTypeFromNullName() {
+        // Given
+        ExtensionScript extensionScript = new ExtensionScript();
+        String scriptTypeName = null;
+
+        // When
+        ScriptType type = extensionScript.getScriptType(scriptTypeName);
+
+        // Then
+        assertThat(type, is(nullValue()));
+    }
+
+    @Test
     void shouldCreateScriptsCache() {
         // Given
         ExtensionScript extensionScript = new ExtensionScript();


### PR DESCRIPTION
Guard against the usage of null keys when handling script types, the collection now in use does not support null keys.

---
Introduced by #9380.