### PR TITLE
Address exceptions related to statistics

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/utils/Statistics.java
+++ b/zap/src/main/java/org/zaproxy/zap/utils/Statistics.java
@@ -34,6 +34,10 @@ public class Statistics {
     }
 
     public void incCounter(String key, long inc) {
+        if (key == null) {
+            return;
+        }
+
         stats.compute(key, (k, v) -> (v != null ? v : 0) + inc);
     }
 
@@ -42,10 +46,18 @@ public class Statistics {
     }
 
     public void decCounter(String key, long dec) {
+        if (key == null) {
+            return;
+        }
+
         stats.compute(key, (k, v) -> (v != null ? v : 0) - dec);
     }
 
     public void setHighwaterMark(String key, long value) {
+        if (key == null) {
+            return;
+        }
+
         Long curValue = stats.get(key);
         if (curValue == null || value > curValue) {
             stats.put(key, value + 1);
@@ -53,6 +65,10 @@ public class Statistics {
     }
 
     public void setLowwaterMark(String key, long value) {
+        if (key == null) {
+            return;
+        }
+
         Long curValue = stats.get(key);
         if (curValue == null || value < curValue) {
             stats.put(key, value + 1);
@@ -60,11 +76,19 @@ public class Statistics {
     }
 
     public Long getStat(String key) {
+        if (key == null) {
+            return null;
+        }
+
         return stats.get(key);
     }
 
     public Map<String, Long> getStats(String keyPrefix) {
         Map<String, Long> map = new HashMap<>();
+        if (keyPrefix == null) {
+            return map;
+        }
+
         for (Entry<String, Long> stat : stats.entrySet()) {
             if (stat.getKey().startsWith(keyPrefix)) {
                 map.put(stat.getKey(), stat.getValue());
@@ -78,6 +102,10 @@ public class Statistics {
     }
 
     public void clear(String keyPrefix) {
+        if (keyPrefix == null) {
+            return;
+        }
+
         Iterator<Entry<String, Long>> iter = stats.entrySet().iterator();
         while (iter.hasNext()) {
             Entry<String, Long> entry = iter.next();

--- a/zap/src/test/java/org/zaproxy/zap/utils/StatisticsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/utils/StatisticsUnitTest.java
@@ -56,6 +56,16 @@ class StatisticsUnitTest {
     }
 
     @Test
+    void shouldIgnoreIncreaseCounterForNullKey() {
+        // Given
+        Statistics statistics = new Statistics();
+        // When
+        statistics.incCounter(null);
+        // Then
+        assertThat(statistics.getStat(null), is(nullValue()));
+    }
+
+    @Test
     void shouldIncreaseExistingCounter() throws Exception {
         // Given
         Statistics statistics = new Statistics();
@@ -74,6 +84,16 @@ class StatisticsUnitTest {
         statistics.incCounter(STAT_KEY, 5);
         // Then
         assertThat(statistics.getStat(STAT_KEY), is(equalTo(5L)));
+    }
+
+    @Test
+    void shouldIgnoreIncreaseCounterWithGivenValueForNullKey() {
+        // Given
+        Statistics statistics = new Statistics();
+        // When
+        statistics.incCounter(null, 5);
+        // Then
+        assertThat(statistics.getStat(null), is(nullValue()));
     }
 
     @Test
@@ -108,6 +128,16 @@ class StatisticsUnitTest {
     }
 
     @Test
+    void shouldIgnoreDecreaseCounterForNullKey() {
+        // Given
+        Statistics statistics = new Statistics();
+        // When
+        statistics.decCounter(null);
+        // Then
+        assertThat(statistics.getStat(null), is(nullValue()));
+    }
+
+    @Test
     void shouldDecreaseExistingCounter() throws Exception {
         // Given
         Statistics statistics = new Statistics();
@@ -126,6 +156,16 @@ class StatisticsUnitTest {
         statistics.decCounter(STAT_KEY, 5);
         // Then
         assertThat(statistics.getStat(STAT_KEY), is(equalTo(-5L)));
+    }
+
+    @Test
+    void shouldIgnoreDecreaseCounterWithGivenValueForNullKey() {
+        // Given
+        Statistics statistics = new Statistics();
+        // When
+        statistics.decCounter(null, 5);
+        // Then
+        assertThat(statistics.getStat(null), is(nullValue()));
     }
 
     @Test
@@ -183,6 +223,19 @@ class StatisticsUnitTest {
     }
 
     @Test
+    void shouldReturnNoStatsWithNullPrefix() {
+        // Given
+        Statistics statistics = new Statistics();
+        statistics.incCounter("other.stats.a");
+        statistics.incCounter("other.stats.b");
+        statistics.incCounter("other.stats.c");
+        // When
+        Map<String, Long> stats = statistics.getStats(null);
+        // Then
+        assertThat(stats.size(), is(equalTo(0)));
+    }
+
+    @Test
     void shouldClearAllStats() throws Exception {
         // Given
         Statistics statistics = new Statistics();
@@ -212,5 +265,44 @@ class StatisticsUnitTest {
         assertThat(statistics.getStat("stats.b"), is(nullValue()));
         assertThat(statistics.getStat("other.stats.a"), is(not(nullValue())));
         assertThat(statistics.getStat("other.stats.b"), is(not(nullValue())));
+    }
+
+    @Test
+    void shouldIgnoreClearStatsWithNullPrefix() {
+        // Given
+        Statistics statistics = new Statistics();
+        statistics.incCounter("stats");
+        statistics.incCounter("stats.a");
+        statistics.incCounter("stats.b");
+        statistics.incCounter("other.stats.a");
+        statistics.incCounter("other.stats.b");
+        // When
+        statistics.clear(null);
+        // Then
+        assertThat(statistics.getStat("stats"), is(equalTo(1L)));
+        assertThat(statistics.getStat("stats.a"), is(equalTo(1L)));
+        assertThat(statistics.getStat("stats.b"), is(equalTo(1L)));
+        assertThat(statistics.getStat("other.stats.a"), is(equalTo(1L)));
+        assertThat(statistics.getStat("other.stats.b"), is(equalTo(1L)));
+    }
+
+    @Test
+    void shouldIgnoreSetHighwaterMarkForNullKey() {
+        // Given
+        Statistics statistics = new Statistics();
+        // When
+        statistics.setHighwaterMark(null, 10);
+        // Then
+        assertThat(statistics.getStat(null), is(nullValue()));
+    }
+
+    @Test
+    void shouldIgnoreSetLowwaterMarkForNullKey() {
+        // Given
+        Statistics statistics = new Statistics();
+        // When
+        statistics.setLowwaterMark(null, 10);
+        // Then
+        assertThat(statistics.getStat(null), is(nullValue()));
     }
 }


### PR DESCRIPTION
Guard against the usage of null keys when handling statistics, the collection in use does not support null keys.

---
e.g.:
```
795268 [ZAP-Automation] ERROR org.zaproxy.zap.ZAP.UncaughtExceptionLogger - Exception in thread "ZAP-Automation"
java.lang.NullPointerException: Cannot invoke "Object.hashCode()" because "key" is null
	at java.base/java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:948)
	at org.zaproxy.zap.utils.Statistics.getStat(Statistics.java:63)
	at org.zaproxy.zap.extension.stats.InMemoryStats.getStat(InMemoryStats.java:139)
	at org.zaproxy.addon.automation.tests.AutomationStatisticTest.getStatistic(AutomationStatisticTest.java:211)
	at org.zaproxy.addon.automation.tests.AutomationStatisticTest.reset(AutomationStatisticTest.java:158)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1716)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:803)
	at org.zaproxy.addon.automation.AutomationJob.reset(AutomationJob.java:272)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1716)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:803)
	at org.zaproxy.addon.automation.AutomationPlan.resetProgress(AutomationPlan.java:214)
	at org.zaproxy.addon.automation.ExtensionAutomation.runPlan(ExtensionAutomation.java:516)
	at org.zaproxy.addon.automation.ExtensionAutomation.lambda$runPlanAsync$7(ExtensionAutomation.java:643)
	at java.base/java.lang.Thread.run(Thread.java:1474)
```