### PR TITLE
[WIP] Typescript type generation for GraalJS scripting

### DIFF
--- a/zap/src/zapApiTypes/java/package-info.java
+++ b/zap/src/zapApiTypes/java/package-info.java
@@ -1,0 +1,12 @@
+@Java2TS(
+        declare = {
+            @Type(value = java.nio.file.Files.class, export = true),
+            @Type(value = java.nio.file.Path.class),
+            @Type(value = java.nio.file.Paths.class, export = true),
+            @Type(value = java.util.Arrays.class, export = true),
+            @Type(value = java.net.URI.class, export = true)
+        })
+package org.zaproxy.zap.api;
+
+import org.bsc.processor.annotation.Java2TS;
+import org.bsc.processor.annotation.Type;

--- a/zap/zap.gradle.kts
+++ b/zap/zap.gradle.kts
@@ -28,6 +28,24 @@ plugins {
 group = "org.zaproxy"
 val versionBC = project.property("zap.japicmp.baseversion") as String
 
+// Classpath holding the java2ts annotation processor, used only by the generateZapApiTypes task.
+val zapApiTypesProcessor: Configuration by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
+// Patched java2typescript build (../java2typescript, built with `mvn -pl core,processor -am install`).
+// The patch loads classes without initializing them (avoids ExceptionInInitializerError on ZAP
+// classes whose static initializers need a running ZAP). metainf-services/javax.json are optional
+// deps the used code path never touches, so only these two jars are required.
+val java2tsHome = rootDir.parentFile.resolve("java2typescript")
+val java2tsJars =
+    files(
+        java2tsHome.resolve("core/target/java2ts-processor-core-2.0-20241009.jar"),
+        java2tsHome.resolve("processor/target/java2ts-processor-2.0-20241009.jar"),
+    )
+
+
 val versionLangFile = "1"
 val creationDate by extra { project.findProperty("creationDate") ?: LocalDate.now().toString() }
 val distDir = file("src/main/dist/")
@@ -118,6 +136,11 @@ dependencies {
     implementation(libs.flatlaf)
     implementation(libs.flatlaf.swingx)
 
+    // The processor (and the @Java2TS/@Type annotations it defines) is used only by the dedicated
+    // generateZapApiTypes task; the main compile has no dependency on java2typescript.
+    zapApiTypesProcessor(java2tsJars)
+
+
     runtimeOnly(libs.commons.logging)
     runtimeOnly(libs.xom) {
         setTransitive(false)
@@ -149,6 +172,72 @@ tasks.register<JavaExec>("run") {
     mainClass.set("org.zaproxy.zap.ZAP")
     classpath = sourceSets["main"].runtimeClasspath
     workingDir = distDir
+}
+
+// ---------------------------------------------------------------------------------------------
+// ZAP GraalJS API TypeScript declaration generation (bsorrentino/java2typescript)
+// ---------------------------------------------------------------------------------------------
+//
+// The processor resolves the types to declare via Class.forName() at processing time, i.e. from its
+// OWN annotation-processor classpath. Custom ZAP classes therefore have to be already compiled and
+// present on that classpath. This is impossible inside the main compileJava task (it is what
+// produces those classes), so generation runs as a separate compilation that depends on the main
+// output and puts the full runtime classpath + compiled classes on the annotation-processor path.
+//
+// Which types get declared is decided by the processor's -Ats.scan option: it reads the compiled
+// bytecode and keeps the public API surface (public types whose enclosing types are public too).
+// The list of included/skipped classes lands in build/generated/zap-api-types/j2ts/zap-api-scan.txt.
+
+val zapApiTypesOutputDir = layout.buildDirectory.dir("generated/zap-api-types")
+
+tasks.register<JavaCompile>("generateZapApiTypes") {
+    group = "build"
+    description = "Generates TypeScript declarations for the ZAP GraalJS API."
+
+    val main = sourceSets["main"]
+    dependsOn(tasks.named("classes"))
+
+    // Static trigger source: it carries the @Java2TS annotation javac needs to invoke the processor
+    // at all, plus the handful of JDK types to declare. The ZAP types come from -Ats.scan below.
+    source = fileTree("src/zapApiTypes/java")
+
+    // Compiled ZAP classes + all runtime dependencies must be resolvable so that both javac (to
+    // compile the @Type(...) references) and the processor's Class.forName() can find them.
+    val resolveClasspath = files(main.output, main.runtimeClasspath, zapApiTypesProcessor)
+    classpath = resolveClasspath
+    options.annotationProcessorPath = resolveClasspath
+
+    // Roots handed to -Ats.scan below. Also declared as an input: the compiler args are only built
+    // in doFirst, so nothing else tells Gradle that the ZAP classes drive this task's output.
+    val scanRoots = main.output.classesDirs
+    inputs.files(scanRoots).withPropertyName("zapClasses")
+
+    options.generatedSourceOutputDirectory.set(zapApiTypesOutputDir)
+    // Nothing is actually compiled to .class with -proc:only, but JavaCompile still needs a target.
+    destinationDirectory.set(layout.buildDirectory.dir("classes/zap-api-types"))
+
+    // The org.zaproxy.common convention plugin sets ["-Xlint:all", "-Werror", "-parameters"] on
+    // every JavaCompile via a withType(JavaCompile).configureEach { } action. Because that runs on
+    // task realization, a config-time assignment here is unreliable. Set the args in doFirst so it
+    // wins at execution time: annotation processing emits notes and warnings of its own (and the
+    // declared JDK types include deprecated members), so -Werror + -Xlint:all would fail the build.
+    doFirst {
+        options.compilerArgs =
+            listOf(
+                "-proc:only",
+                "-processor",
+                "org.bsc.processor.TypescriptProcessor",
+                "-Ats.outfile=zap-api",
+                "-Ats.registry=zapApi",
+                // Declare every public type found in the compiled ZAP classes. The processor loads
+                // them from its own (annotation processor) classpath, which is why the same files
+                // are both scanned here and set as annotationProcessorPath above.
+                "-Ats.scan=" + scanRoots.joinToString(File.pathSeparator),
+                // Suppress all lint (deprecation/removal/processing/...) and do not fail on it.
+                "-Xlint:none",
+                "-nowarn",
+            )
+    }
 }
 
 listOf("jar", "jarDaily", "jarWithBom").forEach {


### PR DESCRIPTION
Hi! 
I added a new Gradle task `:zap:generateZapApiTypes` to generate Typescript definitions of the public Java classes, to use for [JS scripting with GraalJS](https://www.zaproxy.org/docs/desktop/addons/script-console/).

it uses the  [bsorrentino/java2typescript](https://github.com/bsorrentino/java2typescript) lib that I heavily modified and [forked](https://github.com/LucasParsy/java2typescript). 

You can find the generated types and a rewrite of the JS examples in TS on my [Zaproxy_typescript_scripting_examples](https://github.com/LucasParsy/Zaproxy_typescript_scripting_examples) repo

### why WIP

I wanted to discuss with the Zap team if you found my initiative useful and worthy to include in the Zap build pipeline.
I know it requires trusting a random fork of a random library , review may be heavy 😅

I also created [Gradle config for types of the zap-extensions](https://github.com/LucasParsy/Zaproxy_typescript_scripting_examples/blob/master/gradle_zap_changes/zap-extensions/addOns/addOns.gradle.kts).
I didn't do another pull request on the [zap-extensions](https://github.com/zaproxy/zap-extensions) repo yet, but once discussed I could do both pull requests at the same time.

For now ***this commit is non-functional*** as it uses my local modified copy of java2typescript. 
You *could* clone my fork in the same parent folder as zaproxy,  and build it with `mvn -pl core,processor -am install` to make it work.

I just created a [pull request on the original java2typescript repo](https://github.com/bsorrentino/java2typescript/pull/59), I may publish a fork on maven if I don't get a reply.


### design choice discussion: building on 2 projects or only zap-extensions

As a design choice, we *could* build types for Zap and it's extensions on a single project, zap-extensions, but for now I chose to separate the two (so building in the two project). 
But technically the zap-extension builds already iterates on all Zap base classes (my java2typescript manages TS inheritance, so it checks which classes exist). 
Looking for feedback on this point.

Also note that the zap-extensions TS build can take 5~ minutes on a relatively beefy laptop.


### motivation

I started creating small JS scripts for Zap, but the documentation was lacking except the example JS scripts.
Autocomplete in the embedded editor worked 5% of the time and there was no error checking.

no other scripting language (python...) seemed to provide typings, so I settled for TS as  java2typescript seemed to do what I wanted.

Also other topic, but there seems to be very few and parcellar info about the Zap console *scripting API*, and it's shadowed by the *Zap API* (not the same thing) 