### PR TITLE
Update bluesky-post

### DIFF
--- a/.github/workflows/release-live-docker.yml
+++ b/.github/workflows/release-live-docker.yml
@@ -57,7 +57,7 @@ jobs:
             index:org.opencontainers.image.description=The nightly Docker image for the world’s most widely used web app scanner.
             index:org.opencontainers.image.licenses=Apache-2.0
       - name: "Publicise the release"
-        uses: myConsciousness/bluesky-post@00ba09c01fa9e5a7c64c086773e3bfc18a12995c # v6
+        uses: myConsciousness/bluesky-post@2d132869a6a51dea18183a26984a09f67744417e # v6.0.1
         if: ${{ ! cancelled() }}
         with:
           text: "The 'Nightly' @zaproxy.org #Docker image has just been updated https://hub.docker.com/r/zaproxy/zap-nightly"  


### PR DESCRIPTION
Use v6.0.1 to fix the build error.

---
e.g.: https://github.com/zaproxy/zaproxy/actions/runs/30775420653/job/91569919296
```
   Dockerfile:7
  --------------------
     5 |     WORKDIR /app
     6 |     COPY pubspec.* ./
     7 | >>> RUN dart pub get
     8 |     
     9 |     # Copy app source code and AOT compile it.
  --------------------
  ERROR: failed to build: failed to solve: process "/bin/sh -c dart pub get" did not complete successfully: exit code: 1
```