### PR TITLE
Override existing headers on poll verification

### DIFF
--- a/zap/src/main/java/org/zaproxy/zap/authentication/VerificationMethod.java
+++ b/zap/src/main/java/org/zaproxy/zap/authentication/VerificationMethod.java
@@ -21,8 +21,11 @@ package org.zaproxy.zap.authentication;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.regex.Pattern;
 import org.apache.commons.httpclient.URI;
@@ -282,11 +285,17 @@ public class VerificationMethod {
             setRequestBody(pollMsg, HttpRequestHeader.POST, getPollData());
         }
         if (this.getPollHeaders() != null && this.getPollHeaders().length() > 0) {
+            Set<String> seenHeaders = new HashSet<>();
             for (String header : this.getPollHeaders().split("\n")) {
                 String[] headerValue = header.split(":", 2);
                 if (headerValue.length == 2) {
-                    pollMsg.getRequestHeader()
-                            .addHeader(headerValue[0].trim(), headerValue[1].trim());
+                    String name = headerValue[0].trim();
+                    String value = headerValue[1].trim();
+                    if (seenHeaders.add(name.toLowerCase(Locale.ROOT))) {
+                        pollMsg.getRequestHeader().setHeader(name, value);
+                    } else {
+                        pollMsg.getRequestHeader().addHeader(name, value);
+                    }
                 } else {
                     LOGGER.error(
                             "Invalid header '{}' for poll request to {}",

--- a/zap/src/test/java/org/zaproxy/zap/authentication/VerificationMethodPollUrlUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/authentication/VerificationMethodPollUrlUnitTest.java
@@ -52,6 +52,8 @@ class VerificationMethodPollUrlUnitTest extends TestUtils {
 
     @BeforeEach
     void setUp() throws Exception {
+        HttpRequestHeader.setDefaultUserAgent("not-custom-value");
+
         vm = new VerificationMethod();
         vm.setAuthCheckingStrategy(AuthCheckingStrategy.EACH_RESP);
     }
@@ -403,6 +405,81 @@ class VerificationMethodPollUrlUnitTest extends TestUtils {
                 is("Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0:signature"));
         assertThat(requestHeader.getHeader("X-Custom-Time"), is("2025-07-19T10:30:45.123Z"));
         assertThat(requestHeader.getHeader("Content-Type"), is("application/json"));
+    }
+
+    @Test
+    void shouldOverrideExistingHeaderWithFirstPollHeaderOccurrence() throws Exception {
+        // Given
+        String pollUrl = "/pollUrl";
+        List<HttpMessage> pollMessages = new ArrayList<>();
+        setMessageHandler(pollMessages::add);
+
+        vm.setAuthCheckingStrategy(AuthCheckingStrategy.POLL_URL);
+        vm.setPollUrl(getHttpMessage(pollUrl).getRequestHeader().getURI().toString());
+        vm.setLoggedInIndicatorPattern(LOGGED_IN_INDICATOR);
+        vm.setPollHeaders("user-agent: custom-value");
+
+        User user = mock(User.class);
+        given(user.getAuthenticationState()).willReturn(new AuthenticationState());
+
+        // When
+        vm.pollAsUser(user);
+
+        // Then
+        assertThat(pollMessages, hasSize(1));
+        assertThat(
+                pollMessages.get(0).getRequestHeader().getHeaderValues("user-agent"),
+                is(List.of("custom-value")));
+    }
+
+    @Test
+    void shouldPreserveDuplicatePollHeaders() throws Exception {
+        // Given
+        String pollUrl = "/pollUrl";
+        List<HttpMessage> pollMessages = new ArrayList<>();
+        setMessageHandler(pollMessages::add);
+
+        vm.setAuthCheckingStrategy(AuthCheckingStrategy.POLL_URL);
+        vm.setPollUrl(getHttpMessage(pollUrl).getRequestHeader().getURI().toString());
+        vm.setLoggedInIndicatorPattern(LOGGED_IN_INDICATOR);
+        vm.setPollHeaders("X-Token: value1\nX-Token: value2");
+
+        User user = mock(User.class);
+        given(user.getAuthenticationState()).willReturn(new AuthenticationState());
+
+        // When
+        vm.pollAsUser(user);
+
+        // Then
+        assertThat(pollMessages, hasSize(1));
+        assertThat(
+                pollMessages.get(0).getRequestHeader().getHeaderValues("X-Token"),
+                is(List.of("value1", "value2")));
+    }
+
+    @Test
+    void shouldNotAffectHeadersNotInPollHeaders() throws Exception {
+        // Given
+        String pollUrl = "/pollUrl";
+        List<HttpMessage> pollMessages = new ArrayList<>();
+        setMessageHandler(pollMessages::add);
+
+        vm.setAuthCheckingStrategy(AuthCheckingStrategy.POLL_URL);
+        vm.setPollUrl(getHttpMessage(pollUrl).getRequestHeader().getURI().toString());
+        vm.setLoggedInIndicatorPattern(LOGGED_IN_INDICATOR);
+        vm.setPollHeaders("Authorization: Bearer token");
+
+        User user = mock(User.class);
+        given(user.getAuthenticationState()).willReturn(new AuthenticationState());
+
+        // When
+        vm.pollAsUser(user);
+
+        // Then
+        assertThat(pollMessages, hasSize(1));
+        HttpRequestHeader requestHeader = pollMessages.get(0).getRequestHeader();
+        assertThat(requestHeader.getHeader("Authorization"), is("Bearer token"));
+        assertThat(requestHeader.getHeader("user-agent"), is("not-custom-value"));
     }
 
     @Test


### PR DESCRIPTION
Use always the poll headers regardless of the ones that are already present on the message (e.g. to use custom user-agent).