### PR TITLE
Support sub-rule IDs in packaged scan configs

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the docker containers will be documented in this file.
 
+### 2026-08-21
+- Added support for scan sub-rule IDs in packaged scan `IGNORE` and `OUTOFSCOPE` configuration (Issue 9394).
+
 ### 2026-07-06
 - Default to the Client Spider when -j (the modern option) specified.
 

--- a/docker/tests/test_zap_baseline_plan.py
+++ b/docker/tests/test_zap_baseline_plan.py
@@ -176,6 +176,40 @@ class TestZapBaselinePlan(unittest.TestCase):
             self.assertTrue(any("-n" in message for message in log_capture.output))
             self.assertFalse(os.path.exists(plan_path))
 
+    def test_plan_only_rejects_sub_rule_config(self):
+        for config_content in [
+            "10055-7\tIGNORE\t(script-src unsafe-hashes)\n",
+            "10055-7\tOUTOFSCOPE\thttps://example\\.com/ignored\n",
+        ]:
+            with self.subTest(config_content=config_content):
+                zap_baseline = self.load_module()
+                args = ["--plan-only", "-t", self.target, "-c", "config.conf"]
+
+                with tempfile.TemporaryDirectory() as home_dir:
+                    plan_path = os.path.join(home_dir, "zap.yaml")
+                    config_path = os.path.join(home_dir, "config.conf")
+                    Path(config_path).write_text(config_content, encoding="utf-8")
+                    original_cwd = os.getcwd()
+                    os.chdir(home_dir)
+                    try:
+                        with patch.dict(os.environ, {"HOME": home_dir}, clear=True):
+                            with patch.object(zap_baseline, "check_zap_client_version"):
+                                with patch.object(zap_baseline, "running_in_docker", return_value=False):
+                                    with patch.object(
+                                            zap_baseline.Path,
+                                            "home",
+                                            return_value=Path(home_dir)):
+                                        with self.assertLogs(level="WARNING") as log_capture:
+                                            with self.assertRaises(SystemExit) as exc:
+                                                zap_baseline.main(args)
+                                        self.assertEqual(3, exc.exception.code)
+                    finally:
+                        os.chdir(original_cwd)
+
+                    self.assertTrue(
+                        any("sub-rule IDs" in message for message in log_capture.output))
+                    self.assertFalse(os.path.exists(plan_path))
+
     def test_plan_only_requires_mounted_workdir_in_docker(self):
         zap_baseline = self.load_module()
         args = ["--plan-only", "-t", self.target]

--- a/docker/tests/test_zap_common.py
+++ b/docker/tests/test_zap_common.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 from datetime import datetime
 from unittest.mock import Mock, PropertyMock, patch
@@ -8,27 +9,134 @@ import zapv2
 class TestZapCommon(unittest.TestCase):
 
     def setUp(self):
+        zap_common.zap_hooks = None
         zap_common.context_id = None
         zap_common.context_name = None
         zap_common.context_users = None
         zap_common.scan_user = None
 
     def tearDown(self):
+        zap_common.zap_hooks = None
         zap_common.context_id = None
         zap_common.context_name = None
         zap_common.context_users = None
         zap_common.scan_user = None
 
     def test_load_config(self):
-        pass
+        config_dict = {}
+        config_msg = {}
+        out_of_scope_dict = {}
+        config = [
+            "10055-7\tIGNORE\t(script-src unsafe-hashes)\tAccepted risk\n",
+            "10055-8,10055-9\tOUTOFSCOPE\thttps://example\\.com/ignored\n",
+        ]
+
+        zap_common.load_config(config, config_dict, config_msg, out_of_scope_dict)
+
+        self.assertEqual({"10055-7": "IGNORE"}, config_dict)
+        self.assertEqual({"10055-7": "Accepted risk"}, config_msg)
+        self.assertEqual({"10055-8", "10055-9"}, set(out_of_scope_dict))
+        self.assertEqual(
+            "https://example\\.com/ignored", out_of_scope_dict["10055-8"][0].pattern)
 
 
     def test_is_in_scope(self):
-        pass
+        out_of_scope_dict = {
+            "10055-7": [re.compile(r"https://example\.com/exact")],
+            "10055": [re.compile(r"https://example\.com/parent")],
+            "*": [re.compile(r"https://example\.com/global")],
+        }
+
+        self.assertFalse(
+            zap_common.is_in_scope(
+                "10055", "https://example.com/exact", out_of_scope_dict, "10055-7"))
+        self.assertTrue(
+            zap_common.is_in_scope(
+                "10055", "https://example.com/exact", out_of_scope_dict, "10055-8"))
+        self.assertFalse(
+            zap_common.is_in_scope(
+                "10055", "https://example.com/parent", out_of_scope_dict, "10055-8"))
+        self.assertFalse(
+            zap_common.is_in_scope(
+                "10055", "https://example.com/global", out_of_scope_dict, "10055-8"))
+        self.assertTrue(
+            zap_common.is_in_scope(
+                "10055", "https://example.com/other", out_of_scope_dict, None))
 
 
-    def zap_get_alerts(self):
-        pass
+    def test_zap_get_alerts_applies_out_of_scope_to_exact_sub_rule(self):
+        zap = Mock()
+        zap.core.alerts.side_effect = [
+            [
+                {
+                    "pluginId": "10055",
+                    "alertRef": "10055-7",
+                    "url": "https://example.com/ignored",
+                    "risk": "Medium",
+                },
+                {
+                    "pluginId": "10055",
+                    "alertRef": "10055-8",
+                    "url": "https://example.com/ignored",
+                    "risk": "Medium",
+                },
+            ],
+            [],
+        ]
+        out_of_scope_dict = {
+            "10055-7": [re.compile(r"https://example\.com/ignored")],
+        }
+
+        alert_dict = zap_common.zap_get_alerts(zap, "https://example.com", [], out_of_scope_dict)
+
+        self.assertEqual(["10055-8"], [alert["alertRef"] for alert in alert_dict["10055"]])
+
+    def test_group_alerts_by_explicitly_configured_sub_rule(self):
+        parent_alert = {"pluginId": "10055", "alertRef": "10055-1"}
+        sub_rule_alert = {"pluginId": "10055", "alertRef": "10055-7"}
+        alert_without_ref = {"pluginId": "10055"}
+        alert_dict = {"10055": [parent_alert, sub_rule_alert, alert_without_ref]}
+
+        grouped_alerts = zap_common.group_alerts_by_rule(
+            alert_dict, {"10055-7": "IGNORE"})
+
+        self.assertEqual(
+            {"10055": [parent_alert, alert_without_ref], "10055-7": [sub_rule_alert]},
+            grouped_alerts)
+
+    def test_group_alerts_keeps_parent_group_without_sub_rule_config(self):
+        alerts = [
+            {"pluginId": "10055", "alertRef": "10055-1"},
+            {"pluginId": "10055", "alertRef": "10055-7"},
+        ]
+        alert_dict = {"10055": alerts}
+
+        grouped_alerts = zap_common.group_alerts_by_rule(
+            alert_dict, {"10055": "IGNORE"})
+
+        self.assertIs(alert_dict, grouped_alerts)
+
+    def test_has_rule_alerts_in_grouped_sub_rule(self):
+        alert_dict = {
+            "10055-7": [{"pluginId": "10055", "alertRef": "10055-7"}],
+        }
+
+        self.assertTrue(zap_common.has_rule_alerts(alert_dict, "10055"))
+        self.assertFalse(zap_common.has_rule_alerts(alert_dict, "10056"))
+
+    def test_identifies_only_well_formed_sub_rule_ids(self):
+        for rule_id in ["10055-7", "1-0"]:
+            with self.subTest(rule_id=rule_id):
+                self.assertTrue(zap_common.is_sub_rule_id(rule_id))
+
+        for rule_id in ["10055", "-1", "10055-", "10055-a", "10055-7-1", "*"]:
+            with self.subTest(rule_id=rule_id):
+                self.assertFalse(zap_common.is_sub_rule_id(rule_id))
+
+    def test_detects_sub_rule_config_for_levels_and_out_of_scope(self):
+        self.assertTrue(zap_common.has_sub_rule_config({"10055-7": "IGNORE"}, {}))
+        self.assertTrue(zap_common.has_sub_rule_config({}, {"10055-7": []}))
+        self.assertFalse(zap_common.has_sub_rule_config({"10055": "IGNORE"}, {"*": []}))
 
 
     def test_zap_spider(self):
@@ -382,4 +490,3 @@ class TestZapCommon(unittest.TestCase):
             zap_common.zap_set_scan_user(zap, user_name)
 
         self.assertEqual(None, zap_common.scan_user)
-

--- a/docker/zap-api-scan.py
+++ b/docker/zap-api-scan.py
@@ -499,7 +499,8 @@ def main(argv):
             scan_policy = 'Default Policy'
             zap.ascan.enable_all_scanners(scanpolicyname=scan_policy)
             for scanner, state in config_dict.items():
-                if state == 'IGNORE':
+                # A sub-rule cannot be disabled independently, filter its alerts instead.
+                if state == 'IGNORE' and not is_sub_rule_id(scanner):
                     # Dont bother checking the result - this will fail for pscan rules
                     zap.ascan.set_scanner_alert_threshold(id=scanner, alertthreshold='OFF', scanpolicyname=scan_policy)
 
@@ -517,6 +518,7 @@ def main(argv):
                 print('Total of ' + str(num_urls) + ' URLs')
 
             alert_dict = zap_get_alerts(zap, target, ignore_scan_rules, out_of_scope_dict)
+            alert_dict = group_alerts_by_rule(alert_dict, config_dict)
 
             all_ascan_rules = zap.ascan.scanners('Default Policy')
             all_pscan_rules = zap.pscan.scanners
@@ -549,13 +551,14 @@ def main(argv):
                 plugin_id = rule.get('id')
                 if plugin_id in ignore_scan_rules:
                     continue
-                if plugin_id not in alert_dict:
+                if not has_rule_alerts(alert_dict, plugin_id):
                     pass_dict[plugin_id] = rule.get('name')
             for rule in all_ascan_rules:
                 plugin_id = rule.get('id')
                 if plugin_id in ignore_scan_rules:
                     continue
-                if plugin_id not in alert_dict and not(plugin_id in config_dict and config_dict[plugin_id] == 'IGNORE'):
+                if not has_rule_alerts(alert_dict, plugin_id) and not(
+                        plugin_id in config_dict and config_dict[plugin_id] == 'IGNORE'):
                     pass_dict[plugin_id] = rule.get('name')
 
             if min_level == zap_conf_lvls.index("PASS") and detailed_output:

--- a/docker/zap-baseline.py
+++ b/docker/zap-baseline.py
@@ -421,6 +421,16 @@ def main(argv):
             logging.warning('Failed to read configs from ' + config_url)
             sys.exit(3)
 
+    if has_sub_rule_config(config_dict, out_of_scope_dict):
+        # The Automation Framework summary and alert filters accept integer rule IDs only.
+        # Use the API-based implementation, which can match the alertRef of a sub-rule.
+        af_supported, no_af_reason = add_af_unsupported(
+            af_supported,
+            no_af_reason,
+            af_unsupported_opts,
+            'sub-rule IDs in the config',
+            'subrule')
+
     if progress_file:
         # load progress file from filestore
         with open(os.path.join(base_dir, progress_file)) as f:
@@ -597,6 +607,7 @@ def main(argv):
                 print('Total of ' + str(num_urls) + ' URLs')
 
             alert_dict = zap_get_alerts(zap, target, ignore_scan_rules, out_of_scope_dict)
+            alert_dict = group_alerts_by_rule(alert_dict, config_dict)
 
             all_rules = zap.pscan.scanners
             all_dict = {}
@@ -622,7 +633,7 @@ def main(argv):
                 plugin_id = rule.get('id')
                 if plugin_id in ignore_scan_rules:
                     continue
-                if (plugin_id not in alert_dict):
+                if not has_rule_alerts(alert_dict, plugin_id):
                     pass_dict[plugin_id] = rule.get('name')
 
             if min_level == zap_conf_lvls.index("PASS") and detailed_output:

--- a/docker/zap-full-scan.py
+++ b/docker/zap-full-scan.py
@@ -372,7 +372,8 @@ def main(argv):
             # They have supplied a config file, use this to define the ascan rules
             zap.ascan.enable_all_scanners(scanpolicyname=scan_policy)
             for scanner, state in config_dict.items():
-                if state == 'IGNORE':
+                # A sub-rule cannot be disabled independently, filter its alerts instead.
+                if state == 'IGNORE' and not is_sub_rule_id(scanner):
                     # Dont bother checking the result - this will fail for pscan rules
                     zap.ascan.set_scanner_alert_threshold(id=scanner, alertthreshold='OFF', scanpolicyname=scan_policy)
 
@@ -389,6 +390,7 @@ def main(argv):
                 print('Total of ' + str(num_urls) + ' URLs')
 
             alert_dict = zap_get_alerts(zap, target, ignore_scan_rules, out_of_scope_dict)
+            alert_dict = group_alerts_by_rule(alert_dict, config_dict)
 
             all_ascan_rules = zap.ascan.scanners('Default Policy')
             all_pscan_rules = zap.pscan.scanners
@@ -421,13 +423,14 @@ def main(argv):
                 plugin_id = rule.get('id')
                 if plugin_id in ignore_scan_rules:
                     continue
-                if plugin_id not in alert_dict:
+                if not has_rule_alerts(alert_dict, plugin_id):
                     pass_dict[plugin_id] = rule.get('name')
             for rule in all_ascan_rules:
                 plugin_id = rule.get('id')
                 if plugin_id in ignore_scan_rules:
                     continue
-                if plugin_id not in alert_dict and not(plugin_id in config_dict and config_dict[plugin_id] == 'IGNORE'):
+                if not has_rule_alerts(alert_dict, plugin_id) and not(
+                        plugin_id in config_dict and config_dict[plugin_id] == 'IGNORE'):
                     pass_dict[plugin_id] = rule.get('name')
 
             if min_level == zap_conf_lvls.index("PASS") and detailed_output:

--- a/docker/zap_common.py
+++ b/docker/zap_common.py
@@ -176,7 +176,18 @@ def load_config(config, config_dict, config_msg, out_of_scope_dict):
     logging.debug('Loaded config: {0}'.format(config_dict))
 
 
-def is_in_scope(plugin_id, url, out_of_scope_dict):
+def is_sub_rule_id(rule_id):
+    """Returns True if the ID identifies a scan sub-rule, for example 10055-7."""
+    parts = rule_id.split('-', 1)
+    return len(parts) == 2 and all(part.isdigit() for part in parts)
+
+
+def has_sub_rule_config(config_dict, out_of_scope_dict):
+    """Returns True if the scan configuration contains a scan sub-rule ID."""
+    return any(is_sub_rule_id(rule_id) for rule_id in set(config_dict) | set(out_of_scope_dict))
+
+
+def is_in_scope(plugin_id, url, out_of_scope_dict, alert_ref=None):
     """ Returns True if the url is in scope for the specified plugin_id """
     if '*' in out_of_scope_dict:
         for oos_prog in out_of_scope_dict['*']:
@@ -191,18 +202,48 @@ def is_in_scope(plugin_id, url, out_of_scope_dict):
             if oos_prog.match(url):
                 #print('OOS Ignoring ' + str(plugin_id) + ' ' + url)
                 return False
+    if alert_ref and alert_ref != plugin_id and alert_ref in out_of_scope_dict:
+        for oos_prog in out_of_scope_dict[alert_ref]:
+            if oos_prog.match(url):
+                return False
     #print 'Not in ' + plugin_id + ' dict'
     return True
 
 
-def print_rule(zap, action, alert_list, detailed_output, user_msg, in_progress_issues):
-    id = alert_list[0].get('pluginId')
-    if id in in_progress_issues:
-        print (action + '-IN_PROGRESS: ' + alert_list[0].get('alert') + ' [' + id + '] x ' + str(len(alert_list)) + ' ' + user_msg)
-        if in_progress_issues[id]["link"]:
-            print ('\tProgress link: ' + in_progress_issues[id]["link"])
+def group_alerts_by_rule(alert_dict, config_dict):
+    """Groups explicitly configured sub-rules separately from their parent scan rule."""
+    sub_rule_ids = {rule_id for rule_id in config_dict if is_sub_rule_id(rule_id)}
+    if not sub_rule_ids:
+        return alert_dict
+
+    grouped_alerts = {}
+    for plugin_id, alerts in alert_dict.items():
+        for alert in alerts:
+            alert_ref = alert.get('alertRef')
+            rule_id = alert_ref if alert_ref in sub_rule_ids else plugin_id
+            if rule_id not in grouped_alerts:
+                grouped_alerts[rule_id] = []
+            grouped_alerts[rule_id].append(alert)
+    return grouped_alerts
+
+
+def has_rule_alerts(alert_dict, plugin_id):
+    """Returns True if alerts exist for the scan rule or any of its grouped sub-rules."""
+    for rule_id, alerts in alert_dict.items():
+        if rule_id == plugin_id or (alerts and alerts[0].get('pluginId') == plugin_id):
+            return True
+    return False
+
+
+def print_rule(zap, action, rule_id, alert_list, detailed_output, user_msg, in_progress_issues):
+    plugin_id = alert_list[0].get('pluginId')
+    progress_id = rule_id if rule_id in in_progress_issues else plugin_id
+    if progress_id in in_progress_issues:
+        print (action + '-IN_PROGRESS: ' + alert_list[0].get('alert') + ' [' + rule_id + '] x ' + str(len(alert_list)) + ' ' + user_msg)
+        if in_progress_issues[progress_id]["link"]:
+            print ('\tProgress link: ' + in_progress_issues[progress_id]["link"])
     else:
-        print (action + '-NEW: ' + alert_list[0].get('alert') + ' [' + id + '] x ' + str(len(alert_list)) + ' ' + user_msg)
+        print (action + '-NEW: ' + alert_list[0].get('alert') + ' [' + rule_id + '] x ' + str(len(alert_list)) + ' ' + user_msg)
     if detailed_output:
         # Show (up to) first 5 urls, along with the response code (which we have to perform another request for)
         for alert in alert_list[0:5]:
@@ -221,8 +262,9 @@ def print_rules(zap, alert_dict, level, config_dict, config_msg, min_level, inc_
             if key in config_msg:
                 user_msg = config_msg[key]
             if min_level <= zap_conf_lvls.index(level):
-                print_rule(zap, level, alert_list, detailed_output, user_msg, in_progress_issues)
-            if key in in_progress_issues:
+                print_rule(zap, level, key, alert_list, detailed_output, user_msg, in_progress_issues)
+            plugin_id = alert_list[0].get('pluginId')
+            if key in in_progress_issues or plugin_id in in_progress_issues:
                 inprog_count += 1
             else:
                 count += 1
@@ -527,7 +569,7 @@ def zap_get_alerts(zap, baseurl, ignore_scan_rules, out_of_scope_dict):
             plugin_id = alert.get('pluginId')
             if plugin_id in ignore_scan_rules:
                 continue
-            if not is_in_scope(plugin_id, alert.get('url'), out_of_scope_dict):
+            if not is_in_scope(plugin_id, alert.get('url'), out_of_scope_dict, alert.get('alertRef')):
                 continue
             if alert.get('risk') == 'Informational':
                 # Ignore all info alerts - some of them may have been downgraded by security annotations


### PR DESCRIPTION
## Summary

Packaged scans currently treat scan-rule configuration keys as parent plugin IDs, while ZAP reports sub-rules through dashed `alertRef` values such as `10055-7`. This makes exact `IGNORE` and `OUTOFSCOPE` entries ineffective or causes the baseline Automation Framework path to reject them as non-integer rule IDs.

This change:

- matches exact dashed sub-rule IDs against each alert's `alertRef`
- groups only explicitly configured sub-rules separately, leaving normal parent-rule behavior unchanged
- keeps sibling alerts active when one sub-rule is ignored or excluded
- makes baseline scans use the API implementation when sub-rule configuration is present, because Automation Framework summary/filter rule IDs are integer-only
- adds regression and malformed-ID corner-case coverage
- documents the packaged-scan behavior change

## Impact

Users can now target an individual sub-rule in baseline, full, and API scan configuration without suppressing other alerts from the same parent scanner.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 /tmp/zap9394-venv.QojQif/bin/python docker/tests/suite.py` — 72 tests, 0 failures, 0 errors, 0 skips
- `python -m py_compile` for all four affected scan scripts and both changed test modules — passed
- `zap-baseline.py -h`, `zap-full-scan.py -h`, and `zap-api-scan.py -h` in the isolated test environment — all exited 0
- `git diff --check` — passed
- `./gradlew --no-daemon :addOns:commonlib:jarZapAddOn :addOns:custompayloads:jarZapAddOn :addOns:pscan:jarZapAddOn` in zap-extensions — BUILD SUCCESSFUL, 122 tasks (70 executed, 2 from cache, 50 up-to-date)
- Fresh-home local ZAP 2.18.0-SNAPSHOT smoke test with a live HTTP endpoint and built passive-scan add-ons:
  - ZAP emitted sibling alert refs `10055-7` and `10055-13`
  - exact `10055-7 IGNORE` produced a separate ignored group while retaining `10055-13`
  - exact `10055-7 OUTOFSCOPE` removed only that alert and retained `10055-13`
  - no relevant ZAP runtime errors were logged

The local Docker daemon was unavailable, so the smoke test used a fresh local ZAP daemon rather than launching the container image. The repository has no configured coverage task for this Python suite.

Fixes #9394
