### PR TITLE
Report malformed request header lines

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/network/HttpHeader.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpHeader.java
@@ -189,6 +189,9 @@ public abstract class HttpHeader implements java.io.Serializable {
             if (!this.parse(data)) {
                 mMalformedHeader = true;
             }
+        } catch (HttpMalformedHeaderException e) {
+            mMalformedHeader = true;
+            throw e;
         } catch (Exception e) {
             mMalformedHeader = true;
         }
@@ -450,7 +453,8 @@ public abstract class HttpHeader implements java.io.Serializable {
 
             if ((pos = token.indexOf(":")) < 0) {
                 mMalformedHeader = true;
-                return false;
+                throw new HttpMalformedHeaderException(
+                        "Header field does not contain a colon: " + token, i + 1);
             }
             name = token.substring(0, pos).trim();
             value = token.substring(pos + 1).trim();

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpMalformedHeaderException.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpMalformedHeaderException.java
@@ -29,11 +29,29 @@ public class HttpMalformedHeaderException extends IOException {
 
     private static final long serialVersionUID = 2328568976708794693L;
 
+    private final int lineNumber;
+
     public HttpMalformedHeaderException() {
-        super();
+        this(null);
     }
 
     public HttpMalformedHeaderException(String msg) {
         super(msg);
+        lineNumber = -1;
+    }
+
+    public HttpMalformedHeaderException(String msg, int lineNumber) {
+        super(msg);
+        this.lineNumber = lineNumber;
+    }
+
+    /**
+     * Gets the line number of the malformed header data.
+     *
+     * @return the one-based line number, or {@code -1} if not known.
+     * @since 2.18.0
+     */
+    public int getLineNumber() {
+        return lineNumber;
     }
 }

--- a/zap/src/main/java/org/parosproxy/paros/network/HttpRequestHeader.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpRequestHeader.java
@@ -305,7 +305,7 @@ public class HttpRequestHeader extends HttpHeader {
         } catch (Exception e) {
             LOGGER.error("Failed to parse:\n{}", data, e);
             mMalformedHeader = true;
-            throw new HttpMalformedHeaderException(e.getMessage());
+            throw new HttpMalformedHeaderException(e.getMessage(), 1);
         }
     }
 
@@ -454,7 +454,7 @@ public class HttpRequestHeader extends HttpHeader {
         if (!matcher.find()) {
             mMalformedHeader = true;
             throw new HttpMalformedHeaderException(
-                    "Failed to find pattern " + patternRequestLine + " in: " + mStartLine);
+                    "Failed to find pattern " + patternRequestLine + " in: " + mStartLine, 1);
         }
 
         mMethod = matcher.group(1);

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/HttpPanelViewModelUtils.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/HttpPanelViewModelUtils.java
@@ -19,6 +19,8 @@
  */
 package org.zaproxy.zap.extension.httppanel.view.impl.models.http;
 
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
 public final class HttpPanelViewModelUtils {
@@ -31,6 +33,14 @@ public final class HttpPanelViewModelUtils {
 
     public static void updateResponseContentLength(HttpMessage message) {
         message.getResponseHeader().setContentLength(message.getResponseBody().length());
+    }
+
+    public static String getMalformedHeaderMessage(HttpMalformedHeaderException exception) {
+        if (exception.getLineNumber() > 0) {
+            return Constant.messages.getString(
+                    "http.panel.model.header.warn.malformed.line", exception.getLineNumber());
+        }
+        return Constant.messages.getString("http.panel.model.header.warn.malformed");
     }
 
     /**

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestByteHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestByteHttpPanelViewModel.java
@@ -72,7 +72,7 @@ public class RequestByteHttpPanelViewModel extends AbstractHttpByteHttpPanelView
                 LOGGER.warn("Could not Save Header: {}", new String(data, 0, pos), e);
             }
             throw new InvalidMessageDataException(
-                    Constant.messages.getString("http.panel.model.header.warn.malformed"), e);
+                    HttpPanelViewModelUtils.getMalformedHeaderMessage(e), e);
         }
 
         httpMessage.getRequestBody().setBody(ArrayUtils.subarray(data, pos, data.length));

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestHeaderByteHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestHeaderByteHttpPanelViewModel.java
@@ -22,10 +22,10 @@ package org.zaproxy.zap.extension.httppanel.view.impl.models.http.request;
 import java.util.Arrays;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.zaproxy.zap.extension.httppanel.InvalidMessageDataException;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.AbstractHttpByteHttpPanelViewModel;
+import org.zaproxy.zap.extension.httppanel.view.impl.models.http.HttpPanelViewModelUtils;
 
 public class RequestHeaderByteHttpPanelViewModel extends AbstractHttpByteHttpPanelViewModel {
 
@@ -54,7 +54,7 @@ public class RequestHeaderByteHttpPanelViewModel extends AbstractHttpByteHttpPan
                 LOGGER.warn("Could not Save Header: {}", Arrays.toString(data), e);
             }
             throw new InvalidMessageDataException(
-                    Constant.messages.getString("http.panel.model.header.warn.malformed"), e);
+                    HttpPanelViewModelUtils.getMalformedHeaderMessage(e), e);
         }
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestHeaderStringHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestHeaderStringHttpPanelViewModel.java
@@ -21,11 +21,11 @@ package org.zaproxy.zap.extension.httppanel.view.impl.models.http.request;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.zaproxy.zap.extension.httppanel.InvalidMessageDataException;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.AbstractHttpStringHttpPanelViewModel;
+import org.zaproxy.zap.extension.httppanel.view.impl.models.http.HttpPanelViewModelUtils;
 
 public class RequestHeaderStringHttpPanelViewModel extends AbstractHttpStringHttpPanelViewModel {
 
@@ -53,7 +53,7 @@ public class RequestHeaderStringHttpPanelViewModel extends AbstractHttpStringHtt
         } catch (HttpMalformedHeaderException e) {
             LOGGER.warn("Could not Save Header: {}", header, e);
             throw new InvalidMessageDataException(
-                    Constant.messages.getString("http.panel.model.header.warn.malformed"), e);
+                    HttpPanelViewModelUtils.getMalformedHeaderMessage(e), e);
         }
     }
 }

--- a/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModel.java
+++ b/zap/src/main/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModel.java
@@ -21,11 +21,11 @@ package org.zaproxy.zap.extension.httppanel.view.impl.models.http.request;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.zaproxy.zap.extension.httppanel.InvalidMessageDataException;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.AbstractHttpStringHttpPanelViewModel;
+import org.zaproxy.zap.extension.httppanel.view.impl.models.http.HttpPanelViewModelUtils;
 
 public class RequestStringHttpPanelViewModel extends AbstractHttpStringHttpPanelViewModel {
 
@@ -57,7 +57,7 @@ public class RequestStringHttpPanelViewModel extends AbstractHttpStringHttpPanel
         } catch (HttpMalformedHeaderException e) {
             LOGGER.warn("Could not Save Header: {}", header, e);
             throw new InvalidMessageDataException(
-                    Constant.messages.getString("http.panel.model.header.warn.malformed"), e);
+                    HttpPanelViewModelUtils.getMalformedHeaderMessage(e), e);
         }
 
         String body = "";

--- a/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
+++ b/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties
@@ -1726,6 +1726,7 @@ http.panel.component.split.header = Header:
 http.panel.component.split.tooltip = Split Display for Header and Body
 http.panel.component.warn.datainvalid = Unable to switch components, failed to set the data to the message.
 http.panel.model.header.warn.malformed = Failed to parse the header, is it well-formed?
+http.panel.model.header.warn.malformed.line = Failed to parse the header at line {0}, is it well-formed?
 http.panel.model.header.warn.notfound = No header found.
 http.panel.name = Combined HTTP Panels Extension
 http.panel.noSuitableComponentFound = No suitable component has been found to display the message.

--- a/zap/src/test/java/org/parosproxy/paros/network/HttpHeaderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/network/HttpHeaderUnitTest.java
@@ -22,11 +22,37 @@ package org.parosproxy.paros.network;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class HttpHeaderUnitTest {
+
+    @Test
+    void shouldReportMalformedHeaderFieldLine() {
+        // Given
+        HttpHeader header = new HttpRequestHeader();
+        String value = "GET / HTTP/1.1\r\nValid: value\r\nMalformed";
+        // When
+        HttpMalformedHeaderException exception =
+                assertThrows(HttpMalformedHeaderException.class, () -> header.setMessage(value));
+        // Then
+        assertThat(exception.getLineNumber(), is(equalTo(3)));
+    }
+
+    @Test
+    void shouldReportMalformedHeaderFieldLineWithLfLineEndings() {
+        // Given
+        HttpHeader header = new HttpRequestHeader();
+        String value = "GET / HTTP/1.1\nValid: value\nAnother: value\nMalformed";
+        // When
+        HttpMalformedHeaderException exception =
+                assertThrows(HttpMalformedHeaderException.class, () -> header.setMessage(value));
+        // Then
+        assertThat(exception.getLineNumber(), is(equalTo(4)));
+    }
 
     @ParameterizedTest
     @ValueSource(

--- a/zap/src/test/java/org/parosproxy/paros/network/HttpRequestHeaderUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/network/HttpRequestHeaderUnitTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -73,6 +74,18 @@ class HttpRequestHeaderUnitTest {
         boolean empty = header.isEmpty();
         // Then
         assertThat(empty, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldReportMalformedRequestLine() {
+        // Given
+        String value = "Not a request line\r\nHost: example.com\r\n\r\n";
+        // When
+        HttpMalformedHeaderException exception =
+                assertThrows(
+                        HttpMalformedHeaderException.class, () -> new HttpRequestHeader(value));
+        // Then
+        assertThat(exception.getLineNumber(), is(equalTo(1)));
     }
 
     @ParameterizedTest

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/HttpPanelViewModelUtilsUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/HttpPanelViewModelUtilsUnitTest.java
@@ -31,14 +31,49 @@ import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.zaproxy.zap.network.HttpRequestBody;
 import org.zaproxy.zap.network.HttpResponseBody;
+import org.zaproxy.zap.utils.I18N;
 
 /** Unit test for {@link HttpPanelViewModelUtils}. */
 class HttpPanelViewModelUtilsUnitTest {
+
+    @Test
+    void shouldGetMalformedHeaderMessageWithLineNumber() {
+        // Given
+        I18N messages = mock(I18N.class);
+        Constant.messages = messages;
+        String expectedMessage = "Failed to parse the header at line 3.";
+        given(messages.getString("http.panel.model.header.warn.malformed.line", 3))
+                .willReturn(expectedMessage);
+        HttpMalformedHeaderException exception =
+                new HttpMalformedHeaderException("Malformed header field.", 3);
+        // When
+        String message = HttpPanelViewModelUtils.getMalformedHeaderMessage(exception);
+        // Then
+        assertThat(message, is(equalTo(expectedMessage)));
+    }
+
+    @Test
+    void shouldGetGenericMalformedHeaderMessageIfLineNumberNotKnown() {
+        // Given
+        I18N messages = mock(I18N.class);
+        Constant.messages = messages;
+        String expectedMessage = "Failed to parse the header.";
+        given(messages.getString("http.panel.model.header.warn.malformed"))
+                .willReturn(expectedMessage);
+        HttpMalformedHeaderException exception =
+                new HttpMalformedHeaderException("Malformed header.");
+        // When
+        String message = HttpPanelViewModelUtils.getMalformedHeaderMessage(exception);
+        // Then
+        assertThat(message, is(equalTo(expectedMessage)));
+    }
 
     @Test
     void shouldUpdateRequestContentLength() {

--- a/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModelUnitTest.java
+++ b/zap/src/test/java/org/zaproxy/zap/extension/httppanel/view/impl/models/http/request/RequestStringHttpPanelViewModelUnitTest.java
@@ -19,6 +19,10 @@
  */
 package org.zaproxy.zap.extension.httppanel.view.impl.models.http.request;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
@@ -27,15 +31,37 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import org.apache.commons.httpclient.URI;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.extension.httppanel.InvalidMessageDataException;
 import org.zaproxy.zap.extension.httppanel.view.impl.models.http.StringHttpPanelViewModelTest;
 import org.zaproxy.zap.network.HttpRequestBody;
 
 /** Unit test for {@link RequestStringHttpPanelViewModel}. */
 class RequestStringHttpPanelViewModelUnitTest
         extends StringHttpPanelViewModelTest<HttpRequestHeader, HttpRequestBody> {
+
+    @Test
+    void shouldReportMalformedHeaderLine() throws HttpMalformedHeaderException {
+        // Given
+        model.setMessage(message);
+        String expectedMessage = "Failed to parse the header at line 3.";
+        given(Constant.messages.getString("http.panel.model.header.warn.malformed.line", 3))
+                .willReturn(expectedMessage);
+        willThrow(new HttpMalformedHeaderException("Malformed header field.", 3))
+                .given(message)
+                .setRequestHeader(anyString());
+        // When
+        InvalidMessageDataException exception =
+                assertThrows(
+                        InvalidMessageDataException.class,
+                        () -> model.setData("GET / HTTP/1.1\nValid: value\nMalformed\n\n"));
+        // Then
+        assertThat(exception.getMessage(), is(equalTo(expectedMessage)));
+    }
 
     @Override
     protected RequestStringHttpPanelViewModel createModel() {


### PR DESCRIPTION
## Summary

- preserve the one-based line number when parsing malformed HTTP request headers
- show a localized line-specific error in every request editor representation, while retaining the generic fallback when the line is unknown
- cover CRLF and LF headers, first-line and later-field failures, fallback messaging, and the editor-facing regression

This lets users go directly to the malformed line instead of searching the full request manually. Valid request parsing and sending are unchanged.

Fixes #8972

## Validation

- Focused tests:
  `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH ./gradlew --no-daemon :zap:spotlessApply :zap:test --tests org.parosproxy.paros.network.HttpHeaderUnitTest --tests org.parosproxy.paros.network.HttpRequestHeaderUnitTest --tests org.zaproxy.zap.extension.httppanel.view.impl.models.http.HttpPanelViewModelUtilsUnitTest --tests org.zaproxy.zap.extension.httppanel.view.impl.models.http.request.RequestStringHttpPanelViewModelUnitTest`
  - 107 tests, 0 failures, 0 errors, 0 skipped
- Fresh full affected-module validation:
  `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH ./gradlew --no-daemon --no-build-cache --rerun-tasks :zap:spotlessCheck :zap:build :zap:jacocoTestCoverageVerification`
  - BUILD SUCCESSFUL; 32 tasks executed
  - 2,671 tests, 0 failures, 0 errors, 4 skipped
  - Spotless, JaCoCo coverage verification, and `japicmp` binary compatibility passed
  - packaged `ZAP_D-2026-08-22.zip`
- Fresh-profile UI smoke test with the packaged core and Requester add-on:
  - malformed line 3 displayed `Failed to parse the header at line 3, is it well-formed?`
  - the request remained available for correction
  - a corrected request reached a local HTTP server and displayed `HTTP/1.0 200 OK`; the server recorded one HTTP/1.1 GET

No known pre-existing unrelated failures were encountered.
