### PR TITLE
Stop earlier when active scan stopped

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/common/ThreadPool.java
+++ b/zap/src/main/java/org/parosproxy/paros/common/ThreadPool.java
@@ -24,10 +24,14 @@
 // ZAP: 2019/06/05 Normalise format/style.
 package org.parosproxy.paros.common;
 
+import java.util.Objects;
+import java.util.stream.Stream;
+
 public class ThreadPool {
 
     private Thread[] pool = null;
     private final String threadsBaseName;
+    private boolean interrupted;
 
     public ThreadPool(int maxThreadCount) {
         this(maxThreadCount, null);
@@ -46,6 +50,9 @@ public class ThreadPool {
      *     if none available.
      */
     public synchronized Thread getFreeThreadAndRun(Runnable runnable) {
+        if (interrupted) {
+            return null;
+        }
 
         for (int i = 0; i < pool.length; i++) {
             if (pool[i] == null || !pool[i].isAlive()) {
@@ -69,13 +76,18 @@ public class ThreadPool {
      * @param waitInMillis the number of milliseconds to wait for the threads
      */
     public void waitAllThreadComplete(int waitInMillis) {
+        boolean waitInterrupted = false;
         for (int i = 0; i < pool.length; i++) {
             if (pool[i] != null && pool[i].isAlive()) {
                 try {
                     pool[i].join(waitInMillis);
                 } catch (InterruptedException e) {
+                    waitInterrupted = true;
                 }
             }
+        }
+        if (waitInterrupted) {
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -86,5 +98,11 @@ public class ThreadPool {
             }
         }
         return true;
+    }
+
+    public synchronized void interrupt() {
+        interrupted = true;
+
+        Stream.of(pool).filter(Objects::nonNull).forEach(Thread::interrupt);
     }
 }

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/HostProcess.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/HostProcess.java
@@ -347,6 +347,8 @@ public class HostProcess implements Runnable {
     public void stop() {
         isStop = true;
         getAnalyser().stop();
+
+        threadPool.interrupt();
     }
 
     /** Main execution method */
@@ -715,6 +717,10 @@ public class HostProcess implements Runnable {
     }
 
     private boolean obtainResponse(HistoryReference hRef, HttpMessage message) {
+        if (isStop()) {
+            return false;
+        }
+
         try {
             getHttpSender().sendAndReceive(message);
             notifyNewMessage(message);

--- a/zap/src/main/java/org/parosproxy/paros/core/scanner/Util.java
+++ b/zap/src/main/java/org/parosproxy/paros/core/scanner/Util.java
@@ -27,6 +27,7 @@ class Util {
         try {
             Thread.sleep(millis);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 }

--- a/zap/src/test/java/org/parosproxy/paros/common/ThreadPoolUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/common/ThreadPoolUnitTest.java
@@ -1,0 +1,94 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2026 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.parosproxy.paros.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+class ThreadPoolUnitTest {
+
+    @Test
+    void shouldInterruptRunningThreads() throws Exception {
+        // Given
+        ThreadPool pool = new ThreadPool(1);
+        CountDownLatch started = new CountDownLatch(1);
+        AtomicBoolean wasInterrupted = new AtomicBoolean();
+        Thread t =
+                pool.getFreeThreadAndRun(
+                        () -> {
+                            started.countDown();
+                            try {
+                                Thread.sleep(Long.MAX_VALUE);
+                            } catch (InterruptedException e) {
+                                wasInterrupted.set(true);
+                            }
+                        });
+        started.await();
+        // When
+        pool.interrupt();
+        t.join(2000);
+        // Then
+        assertThat(wasInterrupted.get(), is(true));
+    }
+
+    @Test
+    void shouldNotReturnThreadAfterInterrupt() {
+        // Given
+        ThreadPool pool = new ThreadPool(2);
+        pool.interrupt();
+        // When
+        Thread t = pool.getFreeThreadAndRun(() -> {});
+        // Then
+        assertThat(t, is(nullValue()));
+    }
+
+    @Test
+    void shouldRestoreInterruptedStateAfterWaitAllThreadComplete() throws Exception {
+        // Given
+        ThreadPool pool = new ThreadPool(1);
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        pool.getFreeThreadAndRun(
+                () -> {
+                    started.countDown();
+                    try {
+                        release.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+        started.await();
+        Thread.currentThread().interrupt();
+        // When
+        try {
+            pool.waitAllThreadComplete(5000);
+            // Then
+            assertThat(Thread.currentThread().isInterrupted(), is(true));
+        } finally {
+            Thread.interrupted();
+            release.countDown();
+        }
+    }
+}

--- a/zap/src/test/java/org/parosproxy/paros/core/scanner/UtilUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/core/scanner/UtilUnitTest.java
@@ -28,6 +28,16 @@ import org.junit.jupiter.api.Test;
 class UtilUnitTest {
 
     @Test
+    void shouldRestoreInterruptedStateWhenSleepIsInterrupted() {
+        // Given
+        Thread.currentThread().interrupt();
+        // When
+        Util.sleep(10);
+        // Then
+        assertThat(Thread.interrupted(), is(true));
+    }
+
+    @Test
     void shouldPauseForGivenDuration() {
         // Given
         int intendedPause = 500;


### PR DESCRIPTION
Do not try to obtain a response if stopped.
Interrupt the thread pool to allow other parts of the code to stop early as well and do not return new threads to not start more work.