### PR TITLE
ITests: add AJAX Spider back

### DIFF
--- a/docker/integration_tests/af_plan_tests.sh
+++ b/docker/integration_tests/af_plan_tests.sh
@@ -20,7 +20,7 @@ do
 	echo
 	echo "Plan: $file"
 
-    /zap/zap.sh -cmd -autorun /zap/wrk/configs/plans/$file -dev
+    /zap/zap.sh -addoninstall spiderAjax -cmd -autorun /zap/wrk/configs/plans/$file -dev
     RET=$?
     
 	if [ "$RET" != 0 ] 


### PR DESCRIPTION
This _should_ fix the failing itests.
The AJAX spider tests are still useful, for now at least.